### PR TITLE
servicewatchdog_cron_job declare default parameter value

### DIFF
--- a/sysutils/pfSense-pkg-Service_Watchdog/files/usr/local/pkg/servicewatchdog.inc
+++ b/sysutils/pfSense-pkg-Service_Watchdog/files/usr/local/pkg/servicewatchdog.inc
@@ -83,7 +83,7 @@ function servicewatchdog_is_service_watched($svc) {
 	return false;
 }
 
-function servicewatchdog_cron_job($force_remove) {
+function servicewatchdog_cron_job($force_remove = false) {
 	global $config;
 	if (!is_array($config['installedpackages']['servicewatchdog']['item'])) {
 		$config['installedpackages']['servicewatchdog']['item'] = array();


### PR DESCRIPTION
This stops a "dashboard crash dump" that is not very informative (it would be nice if it gave a reason as well as quoting the line number of the call to servicewatchdog_cron_job). No idea why this is not a problem in 2.2.5 - I guess the newer PHP and associated ini now gives a warning if a function is called with seemingly missing parameter(s).
You can do whatever to bump the version number if you wish :)

					Crash report begins.  Anonymous machine information:

amd64
10.2-STABLE
FreeBSD 10.2-STABLE #228 54cf5d1(devel): Mon Dec  7 15:57:12 CST 2015     root@pfs23-amd64-builder:/usr/home/pfsense/pfsense/tmp/obj/usr/home/pfsense/pfsense/tmp/FreeBSD-src/sys/pfSense

Crash report details:

PHP Errors:
[08-Dec-2015 11:23:16 Asia/Kathmandu] PHP Stack trace:
[08-Dec-2015 11:23:16 Asia/Kathmandu] PHP   1. {main}() /usr/local/www/services_servicewatchdog.php:0
[08-Dec-2015 11:23:16 Asia/Kathmandu] PHP   2. servicewatchdog_cron_job() /usr/local/www/services_servicewatchdog.php:145
[08-Dec-2015 11:24:10 Asia/Kathmandu] PHP Stack trace:
[08-Dec-2015 11:24:10 Asia/Kathmandu] PHP   1. {main}() /usr/local/www/services_servicewatchdog_add.php:0
[08-Dec-2015 11:24:10 Asia/Kathmandu] PHP   2. servicewatchdog_cron_job() /usr/local/www/services_servicewatchdog_add.php:64