### PR TITLE
OpenBGPD - remove obsolete pre-2.3 stuff

### DIFF
--- a/net/pfSense-pkg-OpenBGPD/Makefile
+++ b/net/pfSense-pkg-OpenBGPD/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-OpenBGPD
-PORTVERSION=	0.9.3.9
+PORTVERSION=	0.9.3.10
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-OpenBGPD/files/usr/local/pkg/openbgpd.inc
+++ b/net/pfSense-pkg-OpenBGPD/files/usr/local/pkg/openbgpd.inc
@@ -30,33 +30,13 @@
 require_once("config.inc");
 require_once("functions.inc");
 require_once("service-utils.inc");
+require_once("util.inc");
 
 define('PKG_BGPD_CONFIG_BASE', '/var/etc/openbgpd');
-
-$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
-if ($pf_version == "2.1" || $pf_version == "2.2") {
-	define('PKG_BGPD_BIN', '/usr/pbi/openbgpd-' . php_uname("m") . '/sbin');
-} else {
-	define('PKG_BGPD_BIN','/usr/local/sbin');
-}
-
-define('PKG_BGPD_LOGIN', "_bgpd");
-define('PKG_BGPD_UID', "130");
-define('PKG_BGPD_GROUP', "_bgpd");
-define('PKG_BGPD_GID', "130");
-define('PKG_BGPD_GECOS', "BGP Daemon");
-define('PKG_BGPD_HOMEDIR', "/var/empty");
-define('PKG_BGPD_SHELL', "/usr/sbin/nologin");
+define('PKG_BGPD_BIN','/usr/local/sbin');
 
 function openbgpd_install_conf() {
 	global $config, $g;
-	$pkg_login = PKG_BGPD_LOGIN;
-	$pkg_uid = PKG_BGPD_UID;
-	$pkg_group = PKG_BGPD_GROUP;
-	$pkg_gid = PKG_BGPD_GID;
-	$pkg_gecos = PKG_BGPD_GECOS;
-	$pkg_homedir = PKG_BGPD_HOMEDIR;
-	$pkg_shell = PKG_BGPD_SHELL;
 	$pkg_bin = PKG_BGPD_BIN;
 
 	conf_mount_rw();
@@ -209,41 +189,20 @@ function openbgpd_install_conf() {
 
 	$carp_ip_status_check = "";
 	if (is_ipaddr($openbgpd_conf['carpstatusip'])) {
-
-		$pfs_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
-		switch ($pfs_version) {
-			case "2.0":
-			case "2.1":
-				/* Check for 2.1 and before */
-				$carpcheckinterface = trim(find_carp_interface($openbgpd_conf['carpstatusip']));
-				$carp_ip_status_check = <<<EOF
-
-CARP_STATUS=`/sbin/ifconfig {$carpcheckinterface} | /usr/bin/grep carp: | /usr/bin/awk '{print \$2;}'`
-if [ \${CARP_STATUS} != "MASTER" ]; then
-	exit;
-fi
-
-EOF;
-				break;
-			case "2.2":
-			default:
-				/* Check for 2.2 and later */
-				if (is_array($config['virtualip']['vip'])) {
-					foreach ($config['virtualip']['vip'] as $vip) {
-						if (($vip['mode'] == "carp") && ($vip['subnet'] == $openbgpd_conf['carpstatusip'])) {
-							$carpcheckinterface = escapeshellarg(get_real_interface($vip['interface']));
-							$vhid = escapeshellarg($vip['vhid']);
-							$carp_ip_status_check = <<<EOF
+		if (is_array($config['virtualip']['vip'])) {
+			foreach ($config['virtualip']['vip'] as $vip) {
+				if (($vip['mode'] == "carp") && ($vip['subnet'] == $openbgpd_conf['carpstatusip'])) {
+					$carpcheckinterface = escapeshellarg(get_real_interface($vip['interface']));
+					$vhid = escapeshellarg($vip['vhid']);
+					$carp_ip_status_check = <<<EOF
 
 CARP_STATUS=`/sbin/ifconfig {$carpcheckinterface} | /usr/bin/grep 'carp:' | /usr/bin/grep 'vhid {$vhid}' | /usr/bin/awk '{print \$2;}'`
 if [ \${CARP_STATUS} != "MASTER" ]; then
 	exit;
 fi
 EOF;
-						}
-					}
 				}
-				break;
+			}
 		}
 	}
 
@@ -252,13 +211,6 @@ EOF;
 /usr/bin/killall -TERM bgpd
 EOF;
 	$rc_file_start = <<<EOF
-
-if [ `/usr/sbin/pw groupshow {$pkg_group} 2>&1 | /usr/bin/grep -c "pw: unknown group"` -gt 0 ]; then
-	/usr/sbin/pw groupadd {$pkg_group} -g {$pkg_gid}
-fi
-if [ `/usr/sbin/pw usershow {$pkg_login} 2>&1 | /usr/bin/grep -c "pw: no such user"` -gt 0 ]; then
-	/usr/sbin/pw useradd {$pkg_login} -u {$pkg_uid} -g {$pkg_gid} -c "{$pkg_gecos}" -d {$pkg_homedir} -s {$pkg_shell}
-fi
 
 /bin/mkdir -p {$bgpd_config_base}
 /usr/sbin/chown -R root:wheel {$bgpd_config_base}
@@ -280,7 +232,6 @@ EOF;
 	);
 	unset($rc_file_start, $rc_file_stop);
 
-	$_gb = exec("/sbin/sysctl net.inet.ip.ipsec_in_use=1");
 	// Is bgpd process running? If so, reload, else start.
 
 	// Kick off newly created rc.d script

--- a/net/pfSense-pkg-OpenBGPD/files/usr/local/pkg/openbgpd.xml
+++ b/net/pfSense-pkg-OpenBGPD/files/usr/local/pkg/openbgpd.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>OpenBGPD</name>
-	<version>0.9.3.9</version>
+	<version>0.9.3.10</version>
 	<title>Services: OpenBGPD</title>
 	<include_file>/usr/local/pkg/openbgpd.inc</include_file>
 	<service>
@@ -158,7 +158,6 @@
 			<description>
 				<![CDATA[
 				IP address used to determine the CARP status. When the VIP is in BACKUP status, bgpd will not be started.<br />
-				NOTE: On 2.1.x and before this requires changes to /etc/rc.carpmaster to start bgpd and /etc/rc.carpbackup to stop bgpd or it will not be fully effective. On pfSense 2.2.x and later, full support is automatic.
 				]]>
 			</description>
 			<type>input</type>

--- a/net/pfSense-pkg-OpenBGPD/files/usr/local/pkg/openbgpd_groups.xml
+++ b/net/pfSense-pkg-OpenBGPD/files/usr/local/pkg/openbgpd_groups.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>OpenBGPDGroups</name>
-	<version>0.9.3.6</version>
+	<version>0.9.3.10</version>
 	<title>Services: OpenBGPD Groups</title>
 	<include_file>/usr/local/pkg/openbgpd.inc</include_file>
 	<tabs>

--- a/net/pfSense-pkg-OpenBGPD/files/usr/local/pkg/openbgpd_neighbors.xml
+++ b/net/pfSense-pkg-OpenBGPD/files/usr/local/pkg/openbgpd_neighbors.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>OpenBGPDNeighbors</name>
-	<version>0.9.3.6</version>
+	<version>0.9.3.10</version>
 	<title>Services: OpenBGPD Neighbors</title>
 	<include_file>/usr/local/pkg/openbgpd.inc</include_file>
 	<tabs>

--- a/net/pfSense-pkg-OpenBGPD/files/usr/local/share/pfSense-pkg-OpenBGPD/info.xml
+++ b/net/pfSense-pkg-OpenBGPD/files/usr/local/share/pfSense-pkg-OpenBGPD/info.xml
@@ -5,18 +5,11 @@
 		<descr><![CDATA[OpenBGPD is a free implementation of the Border Gateway Protocol, version 4. It allows ordinary machines to be used as routers exchanging routes with other systems speaking the BGP protocol.&lt;br /&gt;
 			&lt;strong&gt;WARNING! Installs files to the same place as Quagga OSPF. Installing both will result in a broken state, remove this package before installing Quagga OSPF.&lt;/strong&gt;]]></descr>
 		<category>Network Management</category>
-		<config_file>https://packages.pfsense.org/packages/config/openbgpd/openbgpd.xml</config_file>
-		<port_category>net</port_category>
-		<run_depends>sbin/bgpctl:net/openbgpd</run_depends>
 		<conflicts>Quagga_OSPF</conflicts>
-		<build_pbi>
-			<port>net/openbgpd</port>
-		</build_pbi>
-		<version>0.9.3.9</version>
+		<version>0.9.3.10</version>
 		<status>RELEASE</status>
 		<pkginfolink>https://doc.pfsense.org/index.php/OpenBGPD_package</pkginfolink>
-		<required_version>2.2</required_version>
+		<required_version>2.3</required_version>
 		<configurationfile>openbgpd.xml</configurationfile>
-		<depends_on_package_pbi>openbgpd-5.2.20121209-##ARCH##.pbi</depends_on_package_pbi>
 	</package>
 </pfsensepkgs>

--- a/net/pfSense-pkg-OpenBGPD/files/usr/local/www/openbgpd_raw.php
+++ b/net/pfSense-pkg-OpenBGPD/files/usr/local/www/openbgpd_raw.php
@@ -42,10 +42,8 @@ $openbgpd_raw = openbgpd_get_raw_config();
 
 $pgtitle = array("OpenBGPD", "Raw config");
 include("head.inc");
-
+include("fbegin.inc");
 ?>
-<body link="#0000CC" vlink="#0000CC" alink="#0000CC">
-<?php include("fbegin.inc"); ?>
 
 <?php if ($savemsg) print_info_box($savemsg); ?>
 
@@ -78,7 +76,4 @@ include("head.inc");
 </table>
 </div>
 
-<?php include("fend.inc"); ?>
-
-</body>
-</html>
+<?php include("foot.inc"); ?>

--- a/net/pfSense-pkg-OpenBGPD/files/usr/local/www/openbgpd_status.php
+++ b/net/pfSense-pkg-OpenBGPD/files/usr/local/www/openbgpd_status.php
@@ -151,7 +151,6 @@ function execCmds() {
 }
 
 ?>
-<body link="#0000CC" vlink="#0000CC" alink="#0000CC">
 
 <script type="text/javascript">
 //<![CDATA[
@@ -255,7 +254,4 @@ else
 </table>
 </div>
 
-<?php include("fend.inc"); ?>
-
-</body>
-</html>
+<?php include("foot.inc"); ?>


### PR DESCRIPTION
- nuke various PBI junk
- no need to add user/group any more
- nuke usage of net.inet.ip.ipsec_in_use (https://redmine.pfsense.org/issues/5370)