### PR TITLE
Logic simplifications

### DIFF
--- a/sysutils/pfSense-pkg-System_Patches/Makefile
+++ b/sysutils/pfSense-pkg-System_Patches/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-System_Patches
-PORTVERSION=	1.1.3
+PORTVERSION=	1.1.4
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches.inc
+++ b/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches.inc
@@ -214,15 +214,15 @@ function patch_remove_shellcmd() {
 	global $config;
 	$a_earlyshellcmd = &$config['system']['earlyshellcmd'];
 	if (is_array($a_earlyshellcmd)) {
-		$removed = false;
+		$removed = 0;
 		foreach ($a_earlyshellcmd as $idx => $cmd) {
 			if (stristr($cmd, "apply_patches.php")) {
 				unset($a_earlyshellcmd[$idx]);
-				$removed = true;
+				$removed++;
 			}
 		}
-		if ($removed) {
-			write_config("System Patches package removed existing early shellcmd: apply patches");
+		if ($removed > 0) {
+			write_config("System Patches package removed {$removed} existing early shellcmd(s): apply patches");
 		}
 	}
 }

--- a/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches.inc
+++ b/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches.inc
@@ -194,6 +194,10 @@ function bootup_apply_patches() {
 
 function patch_add_shellcmd() {
 	global $config;
+
+	if (!isset($config['system']['earlyshellcmd'])) {
+	    $config['system']['earlyshellcmd'] = array();
+	}
 	$a_earlyshellcmd = &$config['system']['earlyshellcmd'];
 	$found = false;
 	if (is_array($a_earlyshellcmd)) {
@@ -212,6 +216,9 @@ function patch_add_shellcmd() {
 
 function patch_remove_shellcmd() {
 	global $config;
+	if (!isset($config['system']['earlyshellcmd'])) {
+	    $config['system']['earlyshellcmd'] = array();
+	}
 	$a_earlyshellcmd = &$config['system']['earlyshellcmd'];
 	if (is_array($a_earlyshellcmd)) {
 		$removed = 0;

--- a/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches.inc
+++ b/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches.inc
@@ -183,16 +183,11 @@ function bootup_apply_patches() {
 	$a_patches = &$config['installedpackages']['patches']['item'];
 
 	foreach ($a_patches as $patch) {
-		/* Skip the patch if it should not be automatically applied. */
-		if (!isset($patch['autoapply'])) {
-			continue;
-		}
-		/* If the patch can be reverted it is already applied, so skip it. */
-		if (!patch_test_revert($patch)) {
-			/* Only attempt to apply if it can be applied. */
-			if (patch_test_apply($patch)) {
-				patch_apply($patch);
-			}
+		/* Skip if it should not be automatically applied;
+		   only attempt to apply if it can be applied;
+		   and	if it can be reverted it is presumably already applied, so skip it. */
+		if (isset($patch['autoapply']) && patch_test_apply($patch) && !patch_test_revert($patch)) {  
+			patch_apply($patch);
 		}
 	}
 }
@@ -200,36 +195,35 @@ function bootup_apply_patches() {
 function patch_add_shellcmd() {
 	global $config;
 	$a_earlyshellcmd = &$config['system']['earlyshellcmd'];
-	if (!is_array($a_earlyshellcmd)) {
-		$a_earlyshellcmd = array();
-	}
 	$found = false;
-	foreach ($a_earlyshellcmd as $idx => $cmd) {
-		if (stristr($cmd, "apply_patches.php")) {
-			$found = true;
+	if (is_array($a_earlyshellcmd)) {
+		foreach ($a_earlyshellcmd as $idx => $cmd) {
+			if (stristr($cmd, "apply_patches.php")) {
+				$found = true;
+			}
 		}
 	}
 	if (!$found) {
+		// Implicitly creates array if needed
 		$a_earlyshellcmd[] = "/usr/local/bin/php-cgi -f /usr/local/bin/apply_patches.php";
-		write_config("System Patches package added a shellcmd");
+		write_config("System Patches package added an early shellcmd: apply patches");
 	}
 }
 
 function patch_remove_shellcmd() {
 	global $config;
 	$a_earlyshellcmd = &$config['system']['earlyshellcmd'];
-	if (!is_array($a_earlyshellcmd)) {
-		$a_earlyshellcmd = array();
-	}
-	$removed = false;
-	foreach ($a_earlyshellcmd as $idx => $cmd) {
-		if (stristr($cmd, "apply_patches.php")) {
-			unset($a_earlyshellcmd[$idx]);
-			$removed = true;
+	if (is_array($a_earlyshellcmd)) {
+		$removed = false;
+		foreach ($a_earlyshellcmd as $idx => $cmd) {
+			if (stristr($cmd, "apply_patches.php")) {
+				unset($a_earlyshellcmd[$idx]);
+				$removed = true;
+			}
 		}
-	}
-	if ($removed) {
-		write_config("System Patches package removed a shellcmd");
+		if ($removed) {
+			write_config("System Patches package removed existing early shellcmd: apply patches");
+		}
 	}
 }
 

--- a/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches.inc
+++ b/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches.inc
@@ -195,16 +195,14 @@ function bootup_apply_patches() {
 function patch_add_shellcmd() {
 	global $config;
 
-	if (!isset($config['system']['earlyshellcmd'])) {
+	if (!isset($config['system']['earlyshellcmd']) || !is_array($config['system']['earlyshellcmd'])) {
 	    $config['system']['earlyshellcmd'] = array();
 	}
 	$a_earlyshellcmd = &$config['system']['earlyshellcmd'];
 	$found = false;
-	if (is_array($a_earlyshellcmd)) {
-		foreach ($a_earlyshellcmd as $idx => $cmd) {
-			if (stristr($cmd, "apply_patches.php")) {
-				$found = true;
-			}
+	foreach ($a_earlyshellcmd as $idx => $cmd) {
+		if (stristr($cmd, "apply_patches.php")) {
+			$found = true;
 		}
 	}
 	if (!$found) {
@@ -216,21 +214,19 @@ function patch_add_shellcmd() {
 
 function patch_remove_shellcmd() {
 	global $config;
-	if (!isset($config['system']['earlyshellcmd'])) {
+	if (!isset($config['system']['earlyshellcmd']) || !is_array($config['system']['earlyshellcmd'])) {
 	    $config['system']['earlyshellcmd'] = array();
 	}
 	$a_earlyshellcmd = &$config['system']['earlyshellcmd'];
-	if (is_array($a_earlyshellcmd)) {
-		$removed = 0;
-		foreach ($a_earlyshellcmd as $idx => $cmd) {
-			if (stristr($cmd, "apply_patches.php")) {
-				unset($a_earlyshellcmd[$idx]);
-				$removed++;
-			}
+	$removed = 0;
+	foreach ($a_earlyshellcmd as $idx => $cmd) {
+		if (stristr($cmd, "apply_patches.php")) {
+			unset($a_earlyshellcmd[$idx]);
+			$removed++;
 		}
-		if ($removed > 0) {
-			write_config("System Patches package removed {$removed} existing early shellcmd(s): apply patches");
-		}
+	}
+	if ($removed > 0) {
+		write_config("System Patches package removed {$removed} existing early shellcmd(s): apply patches");
 	}
 }
 


### PR DESCRIPTION
1) Nested IF statements can be combined
2) Add/remove shellcmd contains logic that only needs to run if the early shellcmd array does/doesn't exist
3) Logs should be non-vague ("...added/removed a shellcmd" is better if it states the command added/removed, and for removal, clarify it removed an existing command)

Resubmit, as originally against old pfsense-packages, see https://github.com/pfsense/pfsense-packages/pull/1229