### PR TITLE
haproxy, fix 'host contains' should use hdr_sub instead of hdr_dir in config

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/Makefile
+++ b/net/pfSense-pkg-haproxy-devel/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-haproxy-devel
-PORTVERSION=	0.42
+PORTVERSION=	0.43
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -59,7 +59,7 @@ $a_acltypes["host_matches"] = array('name' => 'Host matches:',
 $a_acltypes["host_regex"] = array('name' => 'Host regex:',
 				'mode' =>'http', 'syntax' => 'hdr_reg(host) -i %1$s');
 $a_acltypes["host_contains"] = array('name' => 'Host contains:',
-				'mode' => 'http', 'syntax' => 'hdr_dir(host) -i %1$s');
+				'mode' => 'http', 'syntax' => 'hdr_sub(host) -i %1$s');
 $a_acltypes["path_starts_with"] = array('name' => 'Path starts with:',
 				'mode' => 'http', 'syntax' => 'path_beg -i %1$s');
 $a_acltypes["path_ends_with"] = array('name' => 'Path ends with:',

--- a/net/pfSense-pkg-haproxy/Makefile
+++ b/net/pfSense-pkg-haproxy/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-haproxy
-PORTVERSION=	0.42
+PORTVERSION=	0.43
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-haproxy/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy/files/usr/local/pkg/haproxy/haproxy.inc
@@ -59,7 +59,7 @@ $a_acltypes["host_matches"] = array('name' => 'Host matches:',
 $a_acltypes["host_regex"] = array('name' => 'Host regex:',
 				'mode' =>'http', 'syntax' => 'hdr_reg(host) -i %1$s');
 $a_acltypes["host_contains"] = array('name' => 'Host contains:',
-				'mode' => 'http', 'syntax' => 'hdr_dir(host) -i %1$s');
+				'mode' => 'http', 'syntax' => 'hdr_sub(host) -i %1$s');
 $a_acltypes["path_starts_with"] = array('name' => 'Path starts with:',
 				'mode' => 'http', 'syntax' => 'path_beg -i %1$s');
 $a_acltypes["path_ends_with"] = array('name' => 'Path ends with:',


### PR DESCRIPTION
haproxy, fix 'host contains' should use hdr_sub instead of hdr_dir in config