### PR TITLE
Snort 3.2.9.1_3 Bootstrap Conversion Bug Fixes

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	3.2.9.1
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -167,6 +167,9 @@ if (isset($_POST['instance']) && is_numericint($_POST['instance']))
 	$instanceid = $_POST['instance'];
 elseif (isset($_GET['instance']) && is_numericint($_GET['instance']))
 	$instanceid = htmlspecialchars($_GET['instance']);
+elseif (isset($_POST['id']))
+	$instanceid = $_POST['id'];
+
 if (empty($instanceid) || !is_numericint($instanceid))
 	$instanceid = 0;
 
@@ -181,6 +184,7 @@ $enablesid = snort_load_sid_mods($a_instance[$instanceid]['rule_sid_on']);
 $disablesid = snort_load_sid_mods($a_instance[$instanceid]['rule_sid_off']);
 
 $pconfig = array();
+$pconfig['instance'] = $instanceid;
 if (is_array($config['installedpackages']['snortglobal']['alertsblocks'])) {
 	$pconfig['arefresh'] = $config['installedpackages']['snortglobal']['alertsblocks']['arefresh'];
 	$pconfig['alertnumber'] = $config['installedpackages']['snortglobal']['alertsblocks']['alertnumber'];
@@ -583,8 +587,8 @@ $form->add($section);
 
 if (isset($instanceid)) {
 	$form->addGlobal(new Form_Input(
-		'instance',
-		'instance',
+		'id',
+		'id',
 		'hidden',
 		$instanceid
 	));

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
@@ -175,9 +175,6 @@ if ($savemsg) {
 	print_info_box($savemsg, 'success');
 }
 
-require_once('classes/Form.class.php');
-require_once('classes/Modal.class.php');
-
 $tab_array = array();
 	$tab_array[] = array(gettext("Snort Interfaces"), false, "/snort/snort_interfaces.php");
 	$tab_array[] = array(gettext("Global Settings"), false, "/snort/snort_interfaces_global.php");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
@@ -459,12 +459,17 @@ if ($_POST['save'] && !$input_errors) {
 }
 
 function snort_get_config_lists($lists) {
+	global $config;
 
 	// This returns the array of lists identified by $lists
-	// stored in the config file if one exists.
+	// stored in the config file if one exists.  Always
+	// return at least the single entry, "default".
 	$result = array();
-	if (is_array($config['installedpackages']['snortglobal'][$lists]['item']))
-		$result = $config['installedpackages']['snortglobal'][$lists]['item'];
+	$result['default'] = 'default';
+	if (is_array($config['installedpackages']['snortglobal'][$lists]['item'])) {
+		foreach ($config['installedpackages']['snortglobal'][$lists]['item'] as $v)
+		$result[$v['name']] = $v['name'];
+	}
 	return $result;
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
@@ -291,7 +291,7 @@ if ($g['platform'] == "nanobsd") {
 	))->addClass('text-danger');
 }
 else {
-	$group = new Form_Group('Remove Snort Logs On Package Uninstall');
+	$group = new Form_Group('Enable Automatic SID State Management');
 	$group->add(new Form_Checkbox(
 		'auto_manage_sids',
 		'',


### PR DESCRIPTION
This package update addresses the following user reported bugs in the initial Bootstrap conversion of the Snort GUI package.

1. PASS LIST, HOME NET, EXTERNAL NET and SUPPRESS LIST drop-downs not populating with available list names on SNORT INTERFACES tab, and existing value from an old config are not shown when the package is upgraded.
2. DEFAULT values are missing from the drop-downs for HOME NET, EXTERNAL NET, PASS LIST and SUPPRESS LIST.
3. Not able to select alternate interfaces on ALERTS tab.
4. Wrong short description for checkbox control label on SID MGMT tab.
