### PR TITLE
Suricata 2.1.9.1 _5 - Bug fixes for Bootstrap conversion

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	2.1.9.1
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -50,7 +50,7 @@ require_once("functions.inc");
 require_once("/usr/local/pkg/suricata/suricata.inc");
 require("/usr/local/pkg/suricata/suricata_defs.inc");
 
-global $config, $g, $rebuild_rules, $pkg_interface, $suricata_gui_include, $static_output;
+global $config, $g, $rebuild_rules, $pkg_interface, $suricata_gui_include;
 
 /****************************************
  * Define any new constants here that   *
@@ -160,7 +160,7 @@ if ($cron_count > 0)
 // remake saved settings if previously flagged
 if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] == 'on') {
 	log_error(gettext("[Suricata] Saved settings detected... rebuilding installation with saved settings..."));
-	update_status(gettext("Saved settings detected..."));
+	update_status(gettext("Saved settings detected...") . "\n");
 
 	/****************************************************************/
 	/* Do test and fix for duplicate UUIDs if this install was      */
@@ -201,16 +201,14 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 	/****************************************************************/
 
 	/* Do one-time settings migration for new version configuration */
-	$static_output .= gettext("\nMigrating settings to new configuration...");
-	update_output_window($static_output);
+	update_status(gettext("Migrating settings to new configuration...") . "\n");
 	include('/usr/local/pkg/suricata/suricata_migrate_config.php');
-	$static_output .= gettext(" done.\n");
-	update_output_window($static_output);
+	update_status(gettext(" done.") . "\n");
 	log_error(gettext("[Suricata] Downloading and updating configured rule types..."));
 	if ($pkg_interface <> "console")
 		$suricata_gui_include = true;
 	include('/usr/local/pkg/suricata/suricata_check_for_rule_updates.php');
-	update_status(gettext("Generating suricata.yaml configuration file from saved settings..."));
+	update_status("\n" . gettext("Generating suricata.yaml configuration file from saved settings...") . "\n");
 	$rebuild_rules = true;
 	conf_mount_rw();
 
@@ -220,8 +218,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 		$if_real = get_real_interface($suricatacfg['interface']);
 		$suricata_uuid = $suricatacfg['uuid'];
 		$suricatacfgdir = "{$suricatadir}suricata_{$suricata_uuid}_{$if_real}";
-		$static_output .= gettext("Generating YAML configuration file for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . "...");
-		update_output_window($static_output);
+		update_status(gettext("Generating YAML configuration file for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . "..."));
 
 		// Pull in the PHP code that generates the suricata.yaml file
 		// variables that will be substituted further down below.
@@ -241,8 +238,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 		if ($suricatacfg['barnyard_enable'] == 'on')
 			suricata_generate_barnyard2_conf($suricatacfg, $if_real);
 
-		$static_output .= gettext(" done.\n");
-		update_output_window($static_output);
+		update_status(gettext(" done.") . "\n");
 	}
 
 	// create Suricata bootup file suricata.sh
@@ -265,8 +261,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 
 	$rebuild_rules = false;
 	if ($pkg_interface <> "console") {
-		$static_output .= gettext("Finished rebuilding Suricata configuration from saved settings.\n");
-		update_output_window($static_output);
+		update_status(gettext("Finished rebuilding Suricata configuration from saved settings.") . "\n");
 	}
 	log_error(gettext("[Suricata] Finished rebuilding installation from saved settings..."));
 
@@ -274,11 +269,8 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 	if (!$g['booting']) {
 		if ($pkg_interface <> "console") {
 			update_status(gettext("Starting Suricata using rebuilt configuration..."));
-			$static_output .= gettext("Starting Suricata using the rebuilt configuration...");
-			update_output_window($static_output);
 			mwexec_bg("{$rcdir}suricata.sh start");
-			$static_output .= gettext(" done.\n");
-			update_output_window($static_output);
+			update_status(gettext(" done.") . "\n");
 		}
 		else
 			mwexec_bg("{$rcdir}suricata.sh start");
@@ -300,7 +292,6 @@ write_config("Suricata pkg v{$config['installedpackages']['package'][get_pkg_id(
 // Done with post-install, so clear flag
 unset($g['suricata_postinstall']);
 log_error(gettext("[Suricata] Package post-installation tasks completed..."));
-update_status("");
 return true;
 
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -951,10 +951,6 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 	</div>
 </div>
 
-<?php
-include("foot.inc");
-?>
-
 <script type="text/javascript">
 //<![CDATA[
 
@@ -1028,4 +1024,7 @@ events.push(function() {
 });
 //]]>
 </script>
+<?php
+include("foot.inc");
+?>
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -281,10 +281,10 @@ if ($_POST['unblock'] && $_POST['ip']) {
 	}
 }
 
-if (($_POST['addsuppress_srcip'] || $_POST['addsuppress_dstip'] || $_POST['addsuppress']) && is_numeric($_POST['sidid']) && is_numeric($_POST['gen_id'])) {
-	if ($_POST['addsuppress_srcip'])
+if (($_POST['mode'] == 'addsuppress_srcip' || $_POST['mode'] == 'addsuppress_dstip' || $_POST['mode'] == 'addsuppress') && is_numeric($_POST['sidid']) && is_numeric($_POST['gen_id'])) {
+	if ($_POST['mode'] == 'addsuppress_srcip')
 		$method = "by_src";
-	elseif ($_POST['addsuppress_dstip'])
+	elseif ($_POST['mode'] == 'addsuppress_dstip')
 		$method = "by_dst";
 	else
 		$method ="all";
@@ -492,13 +492,14 @@ $tab_array[] = array(gettext("IP Lists"), false, "/suricata/suricata_ip_list_mgm
 display_top_tabs($tab_array, true);
 
 $form = new Form(false);
+$form->setAttribute('name', 'formalert')->setAttribute('id', 'formalert');
 
 $section = new Form_Section('Alert Log View Settings');
 
 $section->addInput(new Form_Select(
 	'instance',
 	'Instance to View',
-	$id,
+	$instanceid,
 	build_instance_list()
 ))->setHelp('Choose which instance alerts you want to inspect.');
 
@@ -686,6 +687,13 @@ $form->addGlobal(new Form_Input(
 ));
 
 $form->addGlobal(new Form_Input(
+	'mode',
+	'mode',
+	'hidden',
+	''
+));
+
+$form->addGlobal(new Form_Input(
 	'descr',
 	null,
 	'hidden',
@@ -839,7 +847,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 				if (!suricata_is_alert_globally_suppressed($supplist, $fields['gid'], $fields['sid']) &&
 				    !isset($supplist[$fields['gid']][$fields['sid']]['by_src'][$fields['src']])) {
 					$alert_ip_src .= "&nbsp;&nbsp;<i class=\"fa fa-plus-square-o icon-pointer\" title=\"" . gettext('Add this alert to the Suppress List and track by_src IP') . '"';
-					$alert_ip_src .= " onClick=\"encRuleSig('{$fields[1]}','{$fields[2]}','{$fields[6]}','{$alert_descr}');$('#mode').val('addsuppress_srcip');$('#formalert').submit();\"></i>";
+					$alert_ip_src .= " onClick=\"encRuleSig('{$fields['gid']}','{$fields['sid']}','{$fields['src']}','{$alert_descr}');$('#mode').val('addsuppress_srcip');$('#formalert').submit();\"></i>";
 				}
 				elseif (isset($supplist[$fields['gid']][$fields['sid']]['by_src'][$fields['src']])) {
 					$alert_ip_src .= '&nbsp;<i class="fa fa-info-circle" ';
@@ -847,7 +855,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 				}
 				/* Add icon for auto-removing from Blocked Table if required */
 				if (isset($tmpblocked[$fields['src']])) {
-					$alert_ip_src .= "&nbsp;&nbsp;<i class=\"fa fa-times icon-pointer text-danger\" onClick=\"$('#ip').val('{$fields[6]}');$('#mode').val('todelete');$('#formalert').submit();\"";
+					$alert_ip_src .= "&nbsp;&nbsp;<i class=\"fa fa-times icon-pointer text-danger\" onClick=\"$('#ip').val('{$fields['src']}');$('#mode').val('todelete');$('#formalert').submit();\"";
 					$alert_ip_src .= ' title="' . gettext("Remove host from Blocked Table") . '"></i>';
 				}
 			}
@@ -874,7 +882,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 				/* Add icons for auto-adding to Suppress List if appropriate */
 				if (!suricata_is_alert_globally_suppressed($supplist, $fields['gid'], $fields['sid']) &&
 				    !isset($supplist[$fields['gid']][$fields['sid']]['by_dst'][$fields['dst']])) {
-					$alert_ip_dst .= "&nbsp;&nbsp;<i class=\"fa fa-plus-square-o icon-pointer\" onClick=\"encRuleSig('{$fields[1]}','{$fields[2]}','{$fields[8]}','{$alert_descr}');$('#mode').val('addsuppress_dstip');$('#formalert').submit();\"";
+					$alert_ip_dst .= "&nbsp;&nbsp;<i class=\"fa fa-plus-square-o icon-pointer\" onClick=\"encRuleSig('{$fields['gid']}','{$fields['sid']}','{$fields['dst']}','{$alert_descr}');$('#mode').val('addsuppress_dstip');$('#formalert').submit();\"";
 					$alert_ip_dst .= ' title="' . gettext("Add this alert to the Suppress List and track by_dst IP") . '"></i>';
 				}
 				elseif (isset($supplist[$fields['gid']][$fields['sid']]['by_dst'][$fields['dst']])) {
@@ -884,7 +892,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 
 				/* Add icon for auto-removing from Blocked Table if required */
 				if (isset($tmpblocked[$fields['dst']])) {
-					$alert_ip_dst .= "&nbsp;&nbsp;<i name=\"todelete[]\" class=\"fa fa-times icon-pointer text-danger\" onClick=\"$('#ip').val('{$fields[8]}');$('#mode').val('todelete');$('#formalert').submit();\" ";
+					$alert_ip_dst .= "&nbsp;&nbsp;<i name=\"todelete[]\" class=\"fa fa-times icon-pointer text-danger\" onClick=\"$('#ip').val('{$fields['dst']}');$('#mode').val('todelete');$('#formalert').submit();\" ";
 					$alert_ip_dst .= ' title="' . gettext("Remove host from Blocked Table") . '"></i>';
 				}
 			}
@@ -898,7 +906,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 			/* SID */
 			$alert_sid_str = "{$fields['gid']}:{$fields['sid']}";
 			if (!suricata_is_alert_globally_suppressed($supplist, $fields['gid'], $fields['sid'])) {
-				$sidsupplink = "<i class=\"fa fa-plus-square-o icon-pointer\" onClick=\"encRuleSig('{$fields[1]}','{$fields[2]}','','{$alert_descr}');$('#mode').val('addsuppress');$('#formalert').submit();\"";
+				$sidsupplink = "<i class=\"fa fa-plus-square-o icon-pointer\" onClick=\"encRuleSig('{$fields['gid']}','{$fields['sid']}','','{$alert_descr}');$('#mode').val('addsuppress');$('#formalert').submit();\"";
 				$sidsupplink .= ' title="' . gettext("Add this alert to the Suppress List") . '"></i>';
 			}
 			else {
@@ -907,11 +915,11 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 			}
 			/* Add icon for toggling rule state */
 			if (isset($disablesid[$fields['gid']][$fields['sid']])) {
-				$sid_dsbl_link = "<i class=\"fa fa-times-circle icon-pointer text-warning\" onClick=\"encRuleSig('{$fields[1]}','{$fields[2]}','','');$('#mode').val('togglesid');$('#formalert').submit();\"";
+				$sid_dsbl_link = "<i class=\"fa fa-times-circle icon-pointer text-warning\" onClick=\"encRuleSig('{$fields['gid']}','{$fields['sid']}','','');$('#mode').val('togglesid');$('#formalert').submit();\"";
 				$sid_dsbl_link .= ' title="' . gettext("Rule is forced to a disabled state. Click to remove the force-disable action from this rule.") . '"></i>';
 			}
 			else {
-				$sid_dsbl_link = "<i class=\"fa fa-times icon-pointer text-danger\" onClick=\"encRuleSig('{$fields[1]}','{$fields[2]}','','');$('#mode').val('togglesid');$('#formalert').submit();\"";
+				$sid_dsbl_link = "<i class=\"fa fa-times icon-pointer text-danger\" onClick=\"encRuleSig('{$fields['gid']}','{$fields['sid']}','','');$('#mode').val('togglesid');$('#formalert').submit();\"";
 				$sid_dsbl_link .= ' title="' . gettext("Force-disable this rule and remove it from current rules set.") . '"></i>';
 			}
 			/* DESCRIPTION */
@@ -1010,6 +1018,14 @@ function htmlspecialchars(str) {
     return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;');
 }
 
+events.push(function() {
+
+	//-- Click handlers ------------------------------------------------------
+	$('#instance').on('change', function() {
+		$('#formalert').submit();
+	});
+
+});
 //]]>
 </script>
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
@@ -396,10 +396,10 @@ print($form);
 			}
 		}
 		?>
-					</tbody>
-					<tfoot>
-						<tr>
-							<td colspan="4" style="text-align:center;" class="alert-info">
+				</tbody>
+				<tfoot>
+					<tr>
+						<td colspan="4" style="text-align:center;" class="alert-info">
 
 <?php	if (!empty($blocked_ips_array)) {
 			if ($counter > 1)
@@ -410,18 +410,12 @@ print($form);
 			print(gettext("There are currently no hosts being blocked by Suricata."));
 	}
 ?>
-							</td>
-						</tr>
-					</tfoot>
-				</table>
-			</div>
-		</div>
+						</td>
+					</tr>
+				</tfoot>
+		</table>
 	</div>
-</form>
-
-<?php
-include("foot.inc");
-?>
+</div>
 
 <!-- The following AJAX code was borrowed from the diag_logs_filter.php -->
 <!-- file in pfSense.  See copyright info at top of this page.          -->
@@ -454,4 +448,8 @@ function htmlspecialchars(str) {
 }
 //]]>
 </script>
+
+<?php
+include("foot.inc");
+?>
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -437,7 +437,6 @@ include_once("head.inc"); ?>
 				</tr>
 				</tbody>
 			</table>
-			</form>
 		</div>
 	</div>
 </div>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -90,7 +90,7 @@ if (isset($_POST['del_x'])) {
 		conf_mount_rw();
 		foreach ($_POST['rule'] as $rulei) {
 			$if_real = get_real_interface($a_nat[$rulei]['interface']);
-			$if_friendly = convert_friendly_interface_to_friendly_descr($snortcfg['interface']);
+			$if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$rulei]['interface']);
 			$suricata_uuid = $a_nat[$rulei]['uuid'];
 			suricata_stop($a_nat[$rulei], $if_real);
 			rmdir_recursive("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}");
@@ -127,7 +127,7 @@ if (isset($_POST['del_x'])) {
 
 	if (is_numeric($delbtn_list) && $a_nat[$delbtn_list]) {
 		$if_real = get_real_interface($a_nat[$delbtn_list]['interface']);
-		$if_friendly = convert_friendly_interface_to_friendly_descr($snortcfg['interface']);
+		$if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$delbtn_list]['interface']);
 		$suricata_uuid = $a_nat[$delbtn_list]['uuid'];
 		log_error("Stopping Suricata on {$if_friendly}({$if_real}) due to interface deletion...");
 		suricata_stop($a_nat[$delbtn_list], $if_real);
@@ -139,7 +139,7 @@ if (isset($_POST['del_x'])) {
 		log_error("Deleted Suricata instance on {$if_friendly}({$if_real}) per user request...");
 
 		// Save updated configuration
-		write_config("Snort pkg: deleted one or more Snort interfaces.");
+		write_config("Suricata pkg: deleted one or more Suricata interfaces.");
 		sleep(2);
 		conf_mount_rw();
 		sync_suricata_package_config();
@@ -196,7 +196,7 @@ if ($_POST['toggle']) {
 				suricata_start($suricatacfg, $if_real);
 			} else {
 				log_error("Toggle (suricata starting) for {$if_friendly}({$suricatacfg['descr']})...");
-				// set flag to rebuild interface rules before starting Snort
+				// set flag to rebuild interface rules before starting Suricata
 				suricata_start($suricatacfg, $if_real);
 			}
 			break;
@@ -349,21 +349,22 @@ include_once("head.inc"); ?>
 					ondblclick="document.location='suricata_interfaces_edit.php?id=<?=$nnats?>';">
 <?php
 					$check_suricata_info = $config['installedpackages']['suricata']['rule'][$nnats]['enable'];
+?>
+					<?php if ($check_suricata_info == "on") : ?>
+						<?php if (suricata_is_running($suricata_uuid, $if_real)) : ?>
+							<i class="fa fa-check-circle text-success icon-primary" title="<?=gettext('Suricata is running on ' . $natend_friendly);?>"></i>
+							&nbsp;
+							<i class="fa fa-repeat icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext($icon_suricata_msg);?>"></i>
+							<i class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Click to stop Suricata on ' . $natend_friendly);?>"></i>
+						<?php else: ?>
+							<i class="fa fa-times-circle text-warning icon-primary" title="<?=gettext('Suricata is stopped on ' . $natend_friendly);?>"></i>
+							&nbsp;
+							<i class="fa fa-play-circle icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext($icon_suricata_msg);?>"></i>
+						<?php endif; ?>
+					<?php else : ?>
+						<?=gettext('DISABLED');?>&nbsp;
+					<?php endif; ?>
 
-					if ($check_suricata_info == "on") {
-						if (suricata_is_running($suricata_uuid, $if_real)) {
-							print('<i class="fa fa-check-circle text-success icon-primary"></i>');
-						} else {
-							print('<i class="fa fa-times-circle text-warning icon-primary"></i>');
-						}
-?>
-						<i class="fa fa-repeat icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>'); " title="<?=gettext($icon_suricata_msg);?>"></i>
-						<i class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('stop',  '<?=$nnats?>');" title="<?=gettext('Click to stop Suricata on ' . $natend_friendly);?>"></i>
-<?php
-					} else {
-						print(gettext("Disabled"));
-					}
-?>
 					</td>
 
 					<td
@@ -399,15 +400,17 @@ include_once("head.inc"); ?>
 					</td>
 
 					<td id="frd<?=$nnats?>" ondblclick="document.location='suricata_interfaces_edit.php?id=<?=$nnats?>';">
-						<?php if ($config['installedpackages']['suricatal']['rule'][$nnats]['barnyard_enable'] == 'on') : ?>
+						<?php if ($config['installedpackages']['suricata']['rule'][$nnats]['barnyard_enable'] == 'on') : ?>
 							<?php if (suricata_is_running($suricata_uuid, $if_real, 'barnyard2')) : ?>
 								<i class="fa fa-check-circle text-success icon-primary" title="<?=gettext('Barnyard2 is running on ' . $natend_friendly);?>"></i>
+								&nbsp;
+								<i class="fa fa-repeat icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext($icon_by2_msg);?>"></i>
+								<i class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Click to stop Barnyard2 on ' . $natend_friendly);?>"></i>
 							<?php else: ?>
 								<i class="fa fa-times-circle text-warning icon-primary" title="<?=gettext('Barnyard2 is stopped on ' . $natend_friendly);?>"></i>
+								&nbsp;
+								<i class="fa fa-play-circle icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext($icon_by2_msg);?>"></i>
 							<?php endif; ?>
-							&nbsp;&nbsp;
-							<i class="fa fa-repeat icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext($icon_by2_msg);?>"></i>
-							<i class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Click to stop Barnyard2 on ' . $natend_friendly);?>"></i>
 						<?php else : ?>
 							<?=gettext('DISABLED');?>&nbsp;
 						<?php endif; ?>
@@ -423,7 +426,7 @@ include_once("head.inc"); ?>
 							<a href="suricata_interfaces_edit.php?id=<?=$nnats?>&action=dup" class="fa fa-clone" title="<?=gettext('Clone this Suricata instance to an available interface');?>"></a>
 						<?php endif; ?>
 						<a style="cursor:pointer;" class="fa fa-trash no-confirm icon-primary" id="Xldel_<?=$nnats?>" title="<?=gettext('Delete this Suricata interface mapping'); ?>"></a>
-						<button style="display: none;" class="btn btn-xs btn-warning" type="submit" id="ldel_<?=$nnats?>" name="ldel_<?=$nnats?>" value="ldel_<?=$nnats?>" title="<?=gettext('Delete this Suricata interface mapping'); ?>">Delete this Snort interface mapping</button>
+						<button style="display: none;" class="btn btn-xs btn-warning" type="submit" id="ldel_<?=$nnats?>" name="ldel_<?=$nnats?>" value="ldel_<?=$nnats?>" title="<?=gettext('Delete this Suricata interface mapping'); ?>">Delete this Suricata interface mapping</button>
 					</td>
 
 				</tr>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
@@ -201,6 +201,7 @@ if ($_POST['save']) {
 	}
 }
 
+$if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']);
 $pgtitle = array(gettext("Suricata"), $if_friendly, gettext("IP Reputation Preprocessor"));
 include_once("head.inc");
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
@@ -314,8 +314,8 @@ print($form);
 				<tr>
 					<td><?=htmlspecialchars($pconfig['iprep_catlist']);?></td>
 					<td> <?=$filedate;?></td>
-					<td><button class="btn btn-xs btn-danger" name="iprep_catlist_delX" id="iprep_catlist_delX" title="<?=gettext('Remove this Categories file');?>">
-					<i class="fa fa-times"></i><?=gettext("Delete")?></button>
+					<td><button class="btn btn-sm btn-danger" name="iprep_catlist_delX" id="iprep_catlist_delX" title="<?=gettext('Remove this Categories file');?>">
+					<i class="fa fa-times icon-embed-btn"></i><?=gettext("Delete")?></button>
 					</td>
 				</tr>
 			<?php endif; ?>
@@ -324,7 +324,10 @@ print($form);
 	</div>
 </div>
 <nav class="action-buttons">
-	<button class="btn btn-xs btn-success" name="iprep_catlist_add" id="iprep_catlist_add"  title="<?=gettext('Assign a Categories file');?>"><?=gettext("Add")?><i class="fa fa-plus"></i></button>
+	<button class="btn btn-sm btn-success" name="iprep_catlist_add" id="iprep_catlist_add"  title="<?=gettext('Assign a Categories file');?>">
+		<i class="fa fa-plus icon-embed-btn"></i>
+		<?=gettext("Add")?>
+	</button>
 </nav>
 
 <div class="panel panel-default">
@@ -333,47 +336,46 @@ print($form);
 		<!-- iprep_catlist_chooser -->
 		<div id="iplistChooser" name="iplistChooser" style="display:none; border:1px dashed gray; width:98%;" class="table-responsive"></div>
 		<table class="table table-hover table-condensed">
-				<!-- iplist_chooser -->
+			<!-- iplist_chooser -->
 
-						<thead>
-							<tr>
-								<th class="col-sm-6"><?php echo gettext("IP Reputation List Filename"); ?></th>
-								<th class="col-sm-4"><?php echo gettext("Modification Time"); ?></th>
-								<th><?=gettext("Action")?></th>
-							</tr>
-						</thead>
-						<tbody>
+				<thead>
+					<tr>
+						<th class="col-sm-6"><?php echo gettext("IP Reputation List Filename"); ?></th>
+						<th class="col-sm-4"><?php echo gettext("Modification Time"); ?></th>
+						<th><?=gettext("Action")?></th>
+					</tr>
+				</thead>
+				<tbody>
 <?php
-						if (is_array($pconfig['iplist_files']['item'])) :
-							foreach($pconfig['iplist_files']['item'] as $k => $f) :
-								if (!file_exists("{$iprep_path}{$f}")) {
-									$filedate = gettext("Unknown -- file missing");
-								}
-								else
-									$filedate = date('M-d Y   g:i a', filemtime("{$iprep_path}{$f}"));
-						 ?>
-							<tr>
-								<td><?=htmlspecialchars($f);?></td>
-								<td><?=$filedate;?></td>
-								<td>
-									<button class="btn btn-xs btn-danger" name="iplist_delX[]" id="iplist_delX[]" value="<?=$k;?>" title="<?php echo gettext('Remove this IP reputation file');?>">
-									<i class="fa fa-times"></i><?=gettext("Delete")?></button>
-								</td>
-							</tr>
-<?php 							endforeach;
-						endif;
+				if (is_array($pconfig['iplist_files']['item'])) :
+					foreach($pconfig['iplist_files']['item'] as $k => $f) :
+						if (!file_exists("{$iprep_path}{$f}")) {
+							$filedate = gettext("Unknown -- file missing");
+						}
+						else
+							$filedate = date('M-d Y   g:i a', filemtime("{$iprep_path}{$f}"));
+				 ?>
+					<tr>
+						<td><?=htmlspecialchars($f);?></td>
+						<td><?=$filedate;?></td>
+						<td>
+							<button class="btn btn-sm btn-danger" name="iplist_delX[]" id="iplist_delX[]" value="<?=$k;?>" title="<?php echo gettext('Remove this IP reputation file');?>">
+							<i class="fa fa-times icon-embed-btn"></i><?=gettext("Delete")?></button>
+						</td>
+					</tr>
+<?php 					endforeach;
+				endif;
 ?>
-						</tbody>
-					</table>
-				</td>
-			</tr>
-			</tbody>
+				</tbody>
 		</table>
 	</div>
 </div>
 
 <nav class="action-buttons">
-	<button class="btn btn-xs btn-success" name="iplist_add" id="iplist_add" class="fa fa-plus" title="<?php echo gettext('Assign a whitelist file');?>"><?=gettext("Add")?><i class="fa fa-plus"></i></button>
+	<button class="btn btn-sm btn-success" name="iplist_add" id="iplist_add" title="<?php echo gettext('Assign a whitelist file');?>">
+		<i class="fa fa-plus icon-embed-btn"></i>
+		<?=gettext("Add")?>
+	</button>
 </nav>
 
 
@@ -400,7 +402,7 @@ $('[id^=iplist_delX]').click(function() {
 	$(form).submit();
 });
 
-// Delete a reptation category file
+// Delete a reputation category file
 $('#iprep_catlist_delX').click(function() {
 	$('#list_id').val('0');
 	$('<input name="iprep_catlist_del[]" id="iprep_catlist_del[]" type="hidden" value="0"/>').appendTo($(form));

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_browser.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_browser.php
@@ -201,7 +201,7 @@ print($form);
 				{
 					type: 'post',
 					data: {
-						instance:  $("#instance").val(),
+						instance:  $("#instance").find('option:selected').val(),
 						action:    'load',
 						file: $("#logFile").val()
 					},
@@ -241,19 +241,26 @@ events.push(function() {
         loadFile();
     });
 
+    $('#instance').on('change', function() {
+	$("#fbTarget").html("");
+        loadFile();
+    });
+
     $('#refresh').on('click', function() {
         loadFile();
     });
 
-    //-- Do initial page load -----------------------
-    loadFile();
+    //-- Show nothing on initial page load -----------
+<?php if(empty($_POST['file'])): ?>
+	document.getElementById("logFile").selectedIndex=-1;
+<?php endif; ?>
 
 });
 //]]>
 </script>
 
 <div class="panel panel-default" id="fileOutput">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Logs')?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Log Contents')?></h2></div>
 		<div class="panel-body">
 			<textarea id="fileContent" name="fileContent" style="width:100%;" rows="30" wrap="off" disabled></textarea>
 		</div>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_browser.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_browser.php
@@ -158,7 +158,7 @@ $section = new Form_Section('Logs Browser Selections');
 $section->addInput(new Form_Select(
 	'instance',
 	'Instance to View',
-	$id,
+	$instanceid,
 	build_instance_list()
 ))->setHelp('Choose which instance logs you want to view.');
 
@@ -176,11 +176,11 @@ $section->addInput(new Form_StaticText(
 	'<strong id="fileStatus"></strong>' .
 	'</span>' .
 	'<p style="display:none;" id="filePathBox">' .
-	'<strong >' . gettext("Log File Path") . '</strong>' . '</p>' .
-	'<span style="display:inline;" id="fbTarget"></span>' .
-	'<p style="padding-right:15px; display:none;" id="fileRefreshBtn">' .
-		'<input type="button" class="btn btn-sm btn-info" name="refresh" id="refresh" value="Refresh" class="formbtn" onclick="loadFile();" title="<?=gettext("Refresh current display");?>' .
-	'</p>'
+	'<strong>' . gettext("Log File Path") . '</strong>' . '</p>' . 
+	'<span style="display:inline;" id="fbTarget"></span>' . 
+	'<p style="padding-right:15px; display:none;" id="fileRefreshBtn">' . 
+		'<input type="button" class="btn btn-sm btn-info" name="refresh" id="refresh" value="Refresh" class="form-control" onclick="loadFile();" title="' . 
+		gettext("Refresh current display") . '"/>' . '</p>'
 ));
 
 $form->add($section);
@@ -190,8 +190,6 @@ print($form);
 
 <script>
 //<![CDATA[
-events.push(function() {
-
 	function loadFile() {
 		$("#fileStatus").html("<?=gettext("Loading file"); ?> ...");
 		$("#fileStatusBox").show(250);
@@ -235,13 +233,20 @@ events.push(function() {
 		}
 	}
 
+events.push(function() {
+
+    //-- Click handlers -----------------------------
     $('#logFile').on('change', function() {
+	$("#fbTarget").html("");
         loadFile();
     });
 
     $('#refresh').on('click', function() {
         loadFile();
     });
+
+    //-- Do initial page load -----------------------
+    loadFile();
 
 });
 //]]>
@@ -252,7 +257,6 @@ events.push(function() {
 		<div class="panel-body">
 			<textarea id="fileContent" name="fileContent" style="width:100%;" rows="30" wrap="off" disabled></textarea>
 		</div>
-	</div>
 </div>
 
 <?php include("foot.inc"); ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
@@ -237,12 +237,7 @@ $tab_array[] = array(gettext("SID Mgmt"), false, "/suricata/suricata_sid_mgmt.ph
 $tab_array[] = array(gettext("Sync"), false, "/pkg_edit.php?xml=suricata/suricata_sync.xml");
 $tab_array[] = array(gettext("IP Lists"), false, "/suricata/suricata_ip_list_mgmt.php");
 display_top_tabs($tab_array, true);
-?>
 
-<script type="text/javascript" src="/javascript/autosuggest.js"></script>
-<script type="text/javascript" src="/javascript/suggestions.js"></script>
-
-<?php
 $form = new Form;
 $section = new Form_Section('General Information');
 $section->addInput(new Form_Input(
@@ -327,27 +322,7 @@ print($form);
 ?>
 
 <script type="text/javascript">
-<?php
-		$isfirst = 0;
-		$aliases = "";
-		$addrisfirst = 0;
-		$aliasesaddr = "";
-		if(isset($config['aliases']['alias']) && is_array($config['aliases']['alias']))
-				foreach($config['aliases']['alias'] as $alias_name) {
-			if ($alias_name['type'] != "host" && $alias_name['type'] != "network")
-				continue;
-						if($addrisfirst == 1) $aliasesaddr .= ",";
-						$aliasesaddr .= "'" . $alias_name['name'] . "'";
-						$addrisfirst = 1;
-				}
-?>
-		var addressarray=new Array(<?=$aliasesaddr; ?>);
-
-function createAutoSuggest() {
-<?php
-	echo "objAlias = new AutoSuggestControl(document.getElementById('address'), new StateSuggestions(addressarray));\n";
-?>
-}
+//<![CDATA[
 
 function selectAlias() {
 
@@ -372,8 +347,17 @@ function selectAlias() {
 	window.parent.location = loc;
 }
 
-setTimeout("createAutoSuggest();", 500);
+events.push(function() {
 
+	// ---------- Autocomplete --------------------------------------------------------------------
+
+	var addressarray = <?= json_encode(get_alias_list(array("host", "network", "openvpn"))) ?>;
+
+	$('#address').autocomplete({
+		source: addressarray
+	});
+});
+//]]>
 </script>
 
 <?php include("foot.inc"); ?>


### PR DESCRIPTION
This update for the Suricata GUI package addresses some reported bugs in the Bootstrap conversion.

**Bug Fixes**
1. Unable to select alternate interfaces for display on the ALERTS tab.

2. "Add to Suppress" and "Remove from Blocked" icons not working when clicked on ALERTS tab.

3. Selected interface not working properly on LOGS VIEW tab and not updating log contents when changed.

4. Interface name missing in title of IP REP tab.

5. Table columns not properly hiding overflow text with ellipsis on RULES tab.

6. Fix auto-suggest errors with Alias on PASS LIST EDIT page.

7. Fix invalid references to 'Snort' on INTERFACES tab.

8. Fix HTML validation errors on various pages due to extraneous markup tags.