### PR TITLE
Snort 2.9.8.0 binary update

### DIFF
--- a/security/snort/Makefile
+++ b/security/snort/Makefile
@@ -1,8 +1,8 @@
 # Created by: Dirk Froemberg <dirk@FreeBSD.org>
-# $FreeBSD$
+# $FreeBSD: head/security/snort/Makefile 405570 2016-01-08 16:50:34Z zi $
 
 PORTNAME=	snort
-PORTVERSION=	2.9.7.6
+PORTVERSION=	2.9.8.0
 CATEGORIES=	security
 MASTER_SITES=	https://snort.org/downloads/snort/ \
 		http://www.talosintel.com/downloads/ \
@@ -101,7 +101,7 @@ LIBNET_INCDIR=	${LIBNET_CFLAGS:M-I*:S/-I//}
 LIBNET_LIBDIR=	${LIBNET_LIBS:M-L*:S/-L//}
 
 CFLAGS+=	-fstack-protector
-CONFIGURE_ARGS+=--enable-reload --enable-pthread \
+CONFIGURE_ARGS+=--enable-reload \
 		--enable-mpls --enable-targetbased \
 		--enable-reload-error-restart \
 		--with-dnet-includes=${LIBNET_INCDIR} \

--- a/security/snort/distinfo
+++ b/security/snort/distinfo
@@ -1,2 +1,2 @@
-SHA256 (snort-2.9.7.6.tar.gz) = 842e8575e26d919a9e74b9ad0c10d1098f7b5ff2189a8422eb51a9a5b6ebbf63
-SIZE (snort-2.9.7.6.tar.gz) = 6198052
+SHA256 (snort-2.9.8.0.tar.gz) = bddd5d01d10d20c182836fa0199cd3549239b7a9d0fd5bbb10226feb8b42d231
+SIZE (snort-2.9.8.0.tar.gz) = 6323095

--- a/security/snort/files/patch-spoink-integration.diff
+++ b/security/snort/files/patch-spoink-integration.diff
@@ -1,6 +1,6 @@
-diff -urN ../snort-2.9.7.6.orig/src/output-plugins/Makefile.am ./src/output-plugins/Makefile.am
---- ../snort-2.9.7.6.orig/src/output-plugins/Makefile.am	2013-06-04 18:19:54.000000000 -0400
-+++ ./src/output-plugins/Makefile.am	2015-11-10 10:21:53.000000000 -0500
+diff -urN ../snort-2.9.8.0_orig/src/output-plugins/Makefile.am ./src/output-plugins/Makefile.am
+--- ../snort-2.9.8.0_orig/src/output-plugins/Makefile.am	2013-06-04 18:19:54.000000000 -0400
++++ ./src/output-plugins/Makefile.am	2016-03-02 11:46:04.000000000 -0500
 @@ -13,6 +13,7 @@
  spo_unified2.c spo_unified2.h \
  spo_log_ascii.c spo_log_ascii.h \
@@ -10,9 +10,9 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/Makefile.am ./src/output-plug
 +spo_pf.h spo_pf.c
  
  INCLUDES = @INCLUDES@
-diff -urN ../snort-2.9.7.6.orig/src/output-plugins/Makefile.in ./src/output-plugins/Makefile.in
---- ../snort-2.9.7.6.orig/src/output-plugins/Makefile.in	2015-08-28 02:53:36.000000000 -0400
-+++ ./src/output-plugins/Makefile.in	2015-11-10 10:21:53.000000000 -0500
+diff -urN ../snort-2.9.8.0_orig/src/output-plugins/Makefile.in ./src/output-plugins/Makefile.in
+--- ../snort-2.9.8.0_orig/src/output-plugins/Makefile.in	2015-11-20 12:11:56.000000000 -0500
++++ ./src/output-plugins/Makefile.in	2016-03-02 11:48:27.000000000 -0500
 @@ -101,7 +101,8 @@
  	spo_alert_unixsock.$(OBJEXT) spo_csv.$(OBJEXT) \
  	spo_log_null.$(OBJEXT) spo_log_tcpdump.$(OBJEXT) \
@@ -23,7 +23,7 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/Makefile.in ./src/output-plug
  libspo_a_OBJECTS = $(am_libspo_a_OBJECTS)
  AM_V_P = $(am__v_P_@AM_V@)
  am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
-@@ -313,7 +314,8 @@
+@@ -312,7 +313,8 @@
  spo_unified2.c spo_unified2.h \
  spo_log_ascii.c spo_log_ascii.h \
  spo_alert_sf_socket.h spo_alert_sf_socket.c \
@@ -33,12 +33,12 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/Makefile.in ./src/output-plug
  
  all: all-am
  
-diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins/spo_pf.c
---- ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/output-plugins/spo_pf.c	2015-11-10 11:31:52.000000000 -0500
-@@ -0,0 +1,762 @@
+diff -urN ../snort-2.9.8.0_orig/src/output-plugins/spo_pf.c ./src/output-plugins/spo_pf.c
+--- ../snort-2.9.8.0_orig/src/output-plugins/spo_pf.c	1969-12-31 19:00:00.000000000 -0500
++++ ./src/output-plugins/spo_pf.c	2016-03-02 11:55:23.000000000 -0500
+@@ -0,0 +1,758 @@
 +/*
-+* Copyright (c) 2015  Bill Meeks
++* Copyright (c) 2016  Bill Meeks
 +* Copyright (c) 2012  Ermal Luci
 +* Copyright (c) 2006  Antonio Benojar <zz.stalker@gmail.com>
 +* Copyright (c) 2005  Antonio Benojar <zz.stalker@gmail.com>
@@ -126,14 +126,14 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +#define MAX_RTMSG_SIZE 2048
 +
 +struct ipwlist {
-+  sfip_t waddr;
++  sfaddr_t waddr;
 +  LIST_ENTRY(ipwlist) elem;
 +};
 +
 +LIST_HEAD(wlist_head, ipwlist);
 +
 +struct iflist {
-+  sfip_t ifaddr;
++  sfaddr_t ifaddr;
 +  LIST_ENTRY(iflist) elem;
 +};
 +
@@ -163,14 +163,14 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +void AlertPfRestart(struct _SnortConfig *, int, void *);
 +void *s2c_monitor_iface_changes(void *);
 +
-+static int s2c_parse_ifam_address(char *, sfip_t *, int);
-+static void s2c_iflist_maint(sfip_t *, struct iflist_head *, u_char);
++static int s2c_parse_ifam_address(char *, sfaddr_t *, int);
++static void s2c_iflist_maint(sfaddr_t *, struct iflist_head *, u_char);
 +static int s2c_pf_init(void);
-+static int s2c_pf_block(SpoAlertPfData *, snort_ip *);
++static int s2c_pf_block(SpoAlertPfData *, sfaddr_t *);
 +static int s2c_pf_intbl(int, char *, int);
 +static int s2c_parse_line(char *, FILE*);
 +static int s2c_parse_load_wl(FILE*, struct wlist_head*, int);
-+static int s2c_parse_search_wl(snort_ip *, struct wlist_head, struct iflist_head);
++static int s2c_parse_search_wl(sfaddr_t *, struct wlist_head, struct iflist_head);
 +static int s2c_parse_free_wl(struct wlist_head*);
 +static int s2c_init_iface_list(struct iflist_head*);
 +static int s2c_free_iface_list(struct iflist_head*);
@@ -205,7 +205,7 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +void AlertPf(Packet *p, const char *msg, void *arg, Event *event)
 +{
 +    SpoAlertPfData *data = (SpoAlertPfData *)arg;
-+    snort_ip *ip;
++    sfaddr_t *ip;
 +    
 +    // Must create the interface IP change monitoring thread here instead
 +    // of in the AlertPfInit() function because that function is called
@@ -252,7 +252,7 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +	ssize_t len;
 +	char msg[MAX_RTMSG_SIZE];
 +	char ifname[IFNAMSIZ];
-+	sfip_t addr;
++	sfaddr_t addr;
 +	struct rt_msghdr *rtm;
 +	struct ifa_msghdr *ifam;
 +
@@ -322,7 +322,7 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +}
 +
 +static int
-+s2c_parse_ifam_address(char *cp, sfip_t *ip, int len)
++s2c_parse_ifam_address(char *cp, sfaddr_t *ip, int len)
 +{
 +	struct sockaddr *sa;
 +
@@ -339,16 +339,14 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +			if (((struct sockaddr_in *)(void *)sa)->sin_addr.s_addr == INADDR_ANY)
 +				return 0;
 +			ip->family = AF_INET;
-+			ip->bits = 32;
-+			memcpy(&ip->ip32, &((struct sockaddr_in *)(void *)sa)->sin_addr.s_addr, sizeof(ip->ip32));
++			memcpy(&ip->ia32, &((struct sockaddr_in *)(void *)sa)->sin_addr.s_addr, sizeof(ip->ia32));
 +			return 1;
 +
 +		case AF_INET6:
 +			if (IN6_IS_ADDR_UNSPECIFIED(&((struct sockaddr_in6 *)(void *)sa)->sin6_addr))
 +				return 0;
 +			ip->family = AF_INET6;
-+			ip->bits = 128;
-+			memcpy(&ip->ip8, &((struct sockaddr_in6 *)(void *)sa)->sin6_addr.s6_addr, sizeof(ip->ip8));
++			memcpy(&ip->ia8, &((struct sockaddr_in6 *)(void *)sa)->sin6_addr.s6_addr, sizeof(ip->ia8));
 +			return 1;
 +
 +		default:
@@ -358,7 +356,7 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +}
 +
 +static void
-+s2c_iflist_maint(sfip_t *ip, struct iflist_head *head, u_char action) {
++s2c_iflist_maint(sfaddr_t *ip, struct iflist_head *head, u_char action) {
 +
 +	struct iflist *aux1, *aux2;	
 +
@@ -381,7 +379,7 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +				ErrorMessage("spo_pf -> s2c_iflist_maint() could not allocate memory for new Interface IP List entry.\n");
 +				break;
 +			}
-+			memcpy(&(ifl->ifaddr), ip, sizeof(sfip_t));
++			memcpy(&(ifl->ifaddr), ip, sizeof(sfaddr_t));
 +			LIST_INSERT_HEAD(head, ifl, elem);
 +			LogMessage("spo_pf -> added address %s to automatic interface IP Pass List.\n", sfip_to_str(ip));
 +			break;
@@ -524,7 +522,7 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +}
 +
 +static int
-+s2c_pf_block(SpoAlertPfData *data, snort_ip *net_addr) 
++s2c_pf_block(SpoAlertPfData *data, sfaddr_t *net_addr) 
 +{ 
 +	struct pfioc_table io; 
 +    	struct pfr_table table; 
@@ -543,7 +541,7 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +            
 +        strlcpy(table.pfrt_name, data->pftable, PF_TABLE_NAME_SIZE); 
 +        
-+        net_addr->family == AF_INET ? memcpy(&addr.pfra_ip4addr.s_addr, net_addr->ip32, sizeof(in_addr_t)) : memcpy(&addr.pfra_ip6addr, net_addr->ip8, sizeof(struct in6_addr));
++        net_addr->family == AF_INET ? memcpy(&addr.pfra_ip4addr.s_addr, net_addr->ia32, sizeof(in_addr_t)) : memcpy(&addr.pfra_ip6addr, net_addr->ia8, sizeof(struct in6_addr));
 +
 +        addr.pfra_af  = net_addr->family; 
 +        addr.pfra_net = net_addr->family == AF_INET ? 32 : 128;; 
@@ -563,9 +561,9 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +		memset(&psk.psk_src.addr.v.a.mask, 0xff, sizeof(psk.psk_src.addr.v.a.mask));
 +		psk.psk_af = net_addr->family;
 +		if (psk.psk_af == AF_INET)
-+			memcpy(&psk.psk_src.addr.v.a.addr.v4.s_addr, net_addr->ip32, sizeof(in_addr_t));
++			memcpy(&psk.psk_src.addr.v.a.addr.v4.s_addr, net_addr->ia32, sizeof(in_addr_t));
 +		else if (psk.psk_af == AF_INET6)
-+			memcpy(&psk.psk_src.addr.v.a.addr.v6, net_addr->ip8, sizeof(struct in6_addr));
++			memcpy(&psk.psk_src.addr.v.a.addr.v6, net_addr->ia8, sizeof(struct in6_addr));
 +		else
 +			return (-1);
 +
@@ -576,9 +574,9 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +		memset(&psk.psk_dst.addr.v.a.mask, 0xff, sizeof(psk.psk_dst.addr.v.a.mask));
 +		psk.psk_af = net_addr->family;
 +		if (psk.psk_af == AF_INET)
-+			memcpy(&psk.psk_dst.addr.v.a.addr.v4.s_addr, net_addr->ip32, sizeof(in_addr_t));
++			memcpy(&psk.psk_dst.addr.v.a.addr.v4.s_addr, net_addr->ia32, sizeof(in_addr_t));
 +		else if (psk.psk_af == AF_INET6)
-+			memcpy(&psk.psk_dst.addr.v.a.addr.v6, net_addr->ip8, sizeof(struct in6_addr));
++			memcpy(&psk.psk_dst.addr.v.a.addr.v6, net_addr->ia8, sizeof(struct in6_addr));
 +		else
 +			return (-1);
 +
@@ -690,7 +688,7 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +}
 +
 +static int
-+s2c_parse_search_wl(snort_ip *ip, struct wlist_head wl, struct iflist_head ifl)
++s2c_parse_search_wl(sfaddr_t *ip, struct wlist_head wl, struct iflist_head ifl)
 +{
 +	struct iflist *aux1;	
 +	struct ipwlist *aux2;	
@@ -732,7 +730,7 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +{
 +	struct iflist *ifl = NULL;
 +	struct ifaddrs *ifap, *ifa;
-+	sfip_t addr;
++	sfaddr_t addr;
 +
 +	LIST_INIT(head);
 +
@@ -743,15 +741,13 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +				switch (ifa->ifa_addr->sa_family) {
 +					case AF_INET:
 +						addr.family = AF_INET;
-+						addr.bits = 32;
-+						memcpy(&addr.ip32, &((struct sockaddr_in *)ifa->ifa_addr)->sin_addr.s_addr, sizeof(addr.ip32));
++						memcpy(&addr.ia32, &((struct sockaddr_in *)ifa->ifa_addr)->sin_addr.s_addr, sizeof(addr.ia32));
 +						LogMessage("spo_pf -> adding firewall interface %s IPv4 address %s to automatic interface IP Pass List.\n", ifa->ifa_name, sfip_to_str(&addr));
 +						break;
 +
 +					case AF_INET6:
 +						addr.family = AF_INET6;
-+						addr.bits = 128;
-+						memcpy(&addr.ip8, &((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr.s6_addr, sizeof(addr.ip8));
++						memcpy(&addr.ia8, &((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr.s6_addr, sizeof(addr.ia8));
 +						LogMessage("spo_pf -> adding firewall interface %s IPv6 address %s to automatic interface IP Pass List.\n", ifa->ifa_name, sfip_to_str(&addr));
 +						break;
 +
@@ -765,7 +761,7 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +					ErrorMessage("Could not allocate memory for Interface List entry.\n");
 +					continue;
 +				}
-+				memcpy(&(ifl->ifaddr), &addr, sizeof(sfip_t));
++				memcpy(&(ifl->ifaddr), &addr, sizeof(sfaddr_t));
 +				LIST_INSERT_HEAD(head, ifl, elem);		
 +			}
 +		}
@@ -799,8 +795,8 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +	}
 +}
 +
-diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.h ./src/output-plugins/spo_pf.h
---- ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.h	1969-12-31 19:00:00.000000000 -0500
+diff -urN ../snort-2.9.8.0_orig/src/output-plugins/spo_pf.h ./src/output-plugins/spo_pf.h
+--- ../snort-2.9.8.0_orig/src/output-plugins/spo_pf.h	1969-12-31 19:00:00.000000000 -0500
 +++ ./src/output-plugins/spo_pf.h	2015-11-10 11:02:10.000000000 -0500
 @@ -0,0 +1,42 @@
 +/*
@@ -845,9 +841,9 @@ diff -urN ../snort-2.9.7.6.orig/src/output-plugins/spo_pf.h ./src/output-plugins
 +void AlertPfSetup(void);
 +
 +#endif 
-diff -urN ../snort-2.9.7.6.orig/src/plugbase.c ./src/plugbase.c
---- ../snort-2.9.7.6.orig/src/plugbase.c	2015-04-23 15:28:10.000000000 -0400
-+++ ./src/plugbase.c	2015-11-10 10:21:53.000000000 -0500
+diff -urN ../snort-2.9.8.0_orig/src/plugbase.c ./src/plugbase.c
+--- ../snort-2.9.8.0_orig/src/plugbase.c	2015-11-18 13:59:14.000000000 -0500
++++ ./src/plugbase.c	2016-03-02 14:30:01.000000000 -0500
 @@ -122,6 +122,7 @@
  #include "output-plugins/spo_csv.h"
  #include "output-plugins/spo_log_null.h"

--- a/security/snort/files/patch-spoink-integration.diff
+++ b/security/snort/files/patch-spoink-integration.diff
@@ -35,7 +35,7 @@ diff -urN ../snort-2.9.8.0_orig/src/output-plugins/Makefile.in ./src/output-plug
  
 diff -urN ../snort-2.9.8.0_orig/src/output-plugins/spo_pf.c ./src/output-plugins/spo_pf.c
 --- ../snort-2.9.8.0_orig/src/output-plugins/spo_pf.c	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/output-plugins/spo_pf.c	2016-03-02 11:55:23.000000000 -0500
++++ ./src/output-plugins/spo_pf.c	2016-03-02 19:47:35.000000000 -0500
 @@ -0,0 +1,758 @@
 +/*
 +* Copyright (c) 2016  Bill Meeks
@@ -126,7 +126,7 @@ diff -urN ../snort-2.9.8.0_orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +#define MAX_RTMSG_SIZE 2048
 +
 +struct ipwlist {
-+  sfaddr_t waddr;
++  sfcidr_t waddr;
 +  LIST_ENTRY(ipwlist) elem;
 +};
 +
@@ -339,14 +339,14 @@ diff -urN ../snort-2.9.8.0_orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +			if (((struct sockaddr_in *)(void *)sa)->sin_addr.s_addr == INADDR_ANY)
 +				return 0;
 +			ip->family = AF_INET;
-+			memcpy(&ip->ia32, &((struct sockaddr_in *)(void *)sa)->sin_addr.s_addr, sizeof(ip->ia32));
++			memcpy(sfaddr_get_ip4_ptr(ip), &((struct sockaddr_in *)(void *)sa)->sin_addr.s_addr, sizeof(in_addr_t));
 +			return 1;
 +
 +		case AF_INET6:
 +			if (IN6_IS_ADDR_UNSPECIFIED(&((struct sockaddr_in6 *)(void *)sa)->sin6_addr))
 +				return 0;
 +			ip->family = AF_INET6;
-+			memcpy(&ip->ia8, &((struct sockaddr_in6 *)(void *)sa)->sin6_addr.s6_addr, sizeof(ip->ia8));
++			memcpy(sfaddr_get_ip6_ptr(ip), &((struct sockaddr_in6 *)(void *)sa)->sin6_addr.s6_addr, sizeof(struct in6_addr));
 +			return 1;
 +
 +		default:
@@ -541,7 +541,7 @@ diff -urN ../snort-2.9.8.0_orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +            
 +        strlcpy(table.pfrt_name, data->pftable, PF_TABLE_NAME_SIZE); 
 +        
-+        net_addr->family == AF_INET ? memcpy(&addr.pfra_ip4addr.s_addr, net_addr->ia32, sizeof(in_addr_t)) : memcpy(&addr.pfra_ip6addr, net_addr->ia8, sizeof(struct in6_addr));
++        net_addr->family == AF_INET ? memcpy(&addr.pfra_ip4addr.s_addr, sfaddr_get_ip4_ptr(net_addr), sizeof(in_addr_t)) : memcpy(&addr.pfra_ip6addr, sfaddr_get_ip6_ptr(net_addr), sizeof(struct in6_addr));
 +
 +        addr.pfra_af  = net_addr->family; 
 +        addr.pfra_net = net_addr->family == AF_INET ? 32 : 128;; 
@@ -561,9 +561,9 @@ diff -urN ../snort-2.9.8.0_orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +		memset(&psk.psk_src.addr.v.a.mask, 0xff, sizeof(psk.psk_src.addr.v.a.mask));
 +		psk.psk_af = net_addr->family;
 +		if (psk.psk_af == AF_INET)
-+			memcpy(&psk.psk_src.addr.v.a.addr.v4.s_addr, net_addr->ia32, sizeof(in_addr_t));
++			memcpy(&psk.psk_src.addr.v.a.addr.v4.s_addr, sfaddr_get_ip4_ptr(net_addr), sizeof(in_addr_t));
 +		else if (psk.psk_af == AF_INET6)
-+			memcpy(&psk.psk_src.addr.v.a.addr.v6, net_addr->ia8, sizeof(struct in6_addr));
++			memcpy(&psk.psk_src.addr.v.a.addr.v6, sfaddr_get_ip6_ptr(net_addr), sizeof(struct in6_addr));
 +		else
 +			return (-1);
 +
@@ -574,9 +574,9 @@ diff -urN ../snort-2.9.8.0_orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +		memset(&psk.psk_dst.addr.v.a.mask, 0xff, sizeof(psk.psk_dst.addr.v.a.mask));
 +		psk.psk_af = net_addr->family;
 +		if (psk.psk_af == AF_INET)
-+			memcpy(&psk.psk_dst.addr.v.a.addr.v4.s_addr, net_addr->ia32, sizeof(in_addr_t));
++			memcpy(&psk.psk_dst.addr.v.a.addr.v4.s_addr, sfaddr_get_ip4_ptr(net_addr), sizeof(in_addr_t));
 +		else if (psk.psk_af == AF_INET6)
-+			memcpy(&psk.psk_dst.addr.v.a.addr.v6, net_addr->ia8, sizeof(struct in6_addr));
++			memcpy(&psk.psk_dst.addr.v.a.addr.v6, sfaddr_get_ip6_ptr(net_addr), sizeof(struct in6_addr));
 +		else
 +			return (-1);
 +
@@ -741,13 +741,13 @@ diff -urN ../snort-2.9.8.0_orig/src/output-plugins/spo_pf.c ./src/output-plugins
 +				switch (ifa->ifa_addr->sa_family) {
 +					case AF_INET:
 +						addr.family = AF_INET;
-+						memcpy(&addr.ia32, &((struct sockaddr_in *)ifa->ifa_addr)->sin_addr.s_addr, sizeof(addr.ia32));
++						memcpy(sfaddr_get_ip4_ptr(&addr), &((struct sockaddr_in *)ifa->ifa_addr)->sin_addr.s_addr, sizeof(in_addr_t));
 +						LogMessage("spo_pf -> adding firewall interface %s IPv4 address %s to automatic interface IP Pass List.\n", ifa->ifa_name, sfip_to_str(&addr));
 +						break;
 +
 +					case AF_INET6:
 +						addr.family = AF_INET6;
-+						memcpy(&addr.ia8, &((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr.s6_addr, sizeof(addr.ia8));
++						memcpy(sfaddr_get_ip6_ptr(&addr), &((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr.s6_addr, sizeof(struct in6_addr));
 +						LogMessage("spo_pf -> adding firewall interface %s IPv6 address %s to automatic interface IP Pass List.\n", ifa->ifa_name, sfip_to_str(&addr));
 +						break;
 +

--- a/security/snort/files/snort.in
+++ b/security/snort/files/snort.in
@@ -1,5 +1,5 @@
 #!/bin/sh
-# $FreeBSD$
+# $FreeBSD: head/security/snort/files/snort.in 340872 2014-01-24 00:14:07Z mat $
 
 # PROVIDE: snort
 # REQUIRE: DAEMON

--- a/security/snort/pkg-plist
+++ b/security/snort/pkg-plist
@@ -1,4 +1,4 @@
-@comment $FreeBSD$
+%%FILEINSPECT%%bin/file_server
 bin/snort
 bin/u2boat
 bin/u2spewfoo
@@ -34,6 +34,81 @@ etc/snort/unicode.map-sample
 @unexec if cmp  -s %D/etc/snort/file_magic.conf-sample %D/etc/snort/file_magic.conf; then rm -f %D/etc/snort/file_magic.conf; fi
 etc/snort/file_magic.conf-sample
 @exec if [ ! -f %D/etc/snort/file_magic.conf ] ; then cp -p %D/%F %B/file_magic.conf; fi
+include/snort/dynamic_output/bitop.h
+include/snort/dynamic_output/ipv6_port.h
+include/snort/dynamic_output/obfuscation.h
+include/snort/dynamic_output/output_api.h
+include/snort/dynamic_output/output_common.h
+include/snort/dynamic_output/output_lib.h
+include/snort/dynamic_output/preprocids.h
+include/snort/dynamic_output/sfPolicy.h
+include/snort/dynamic_output/sf_dynamic_common.h
+include/snort/dynamic_output/sf_ip.h
+include/snort/dynamic_output/sf_protocols.h
+include/snort/dynamic_output/sf_snort_packet.h
+include/snort/dynamic_output/sfrt.h
+include/snort/dynamic_output/sfrt_dir.h
+include/snort/dynamic_output/sfrt_trie.h
+include/snort/dynamic_output/snort_debug.h
+include/snort/dynamic_output/stream_api.h
+%%APPID%%include/snort/dynamic_preproc/md5.h
+%%APPID%%include/snort/dynamic_preproc/sfghash.h
+%%APPID%%include/snort/dynamic_preproc/sfhashfcn.h
+%%APPID%%include/snort/dynamic_preproc/sflsq.h
+%%APPID%%include/snort/dynamic_preproc/sfmemcap.h
+%%APPID%%include/snort/dynamic_preproc/sfprimetable.h
+%%APPID%%include/snort/dynamic_preproc/sfxhash.h
+include/snort/dynamic_preproc/bitop.h
+include/snort/dynamic_preproc/cpuclock.h
+include/snort/dynamic_preproc/file_api.h
+include/snort/dynamic_preproc/file_mail_common.h
+include/snort/dynamic_preproc/idle_processing.h
+include/snort/dynamic_preproc/ipv6_port.h
+include/snort/dynamic_preproc/mempool.h
+include/snort/dynamic_preproc/mpse_methods.h
+include/snort/dynamic_preproc/obfuscation.h
+include/snort/dynamic_preproc/packet_time.h
+include/snort/dynamic_preproc/perf_indicators.h
+include/snort/dynamic_preproc/preprocids.h
+include/snort/dynamic_preproc/profiler.h
+include/snort/dynamic_preproc/segment_mem.h
+include/snort/dynamic_preproc/session_api.h
+include/snort/dynamic_preproc/sfPolicy.h
+include/snort/dynamic_preproc/sfPolicyUserData.h
+include/snort/dynamic_preproc/sf_decompression.h
+include/snort/dynamic_preproc/sf_dynamic_common.h
+include/snort/dynamic_preproc/sf_dynamic_define.h
+include/snort/dynamic_preproc/sf_dynamic_engine.h
+include/snort/dynamic_preproc/sf_dynamic_meta.h
+include/snort/dynamic_preproc/sf_dynamic_preproc_lib.h
+include/snort/dynamic_preproc/sf_dynamic_preprocessor.h
+include/snort/dynamic_preproc/sf_ip.h
+include/snort/dynamic_preproc/sf_preproc_info.h
+include/snort/dynamic_preproc/sf_protocols.h
+include/snort/dynamic_preproc/sf_sdlist_types.h
+include/snort/dynamic_preproc/sf_seqnums.h
+include/snort/dynamic_preproc/sf_snort_packet.h
+include/snort/dynamic_preproc/sf_snort_plugin_api.h
+include/snort/dynamic_preproc/sfcommon.h
+include/snort/dynamic_preproc/sfcontrol.h
+include/snort/dynamic_preproc/sfdebug.h
+include/snort/dynamic_preproc/sfrt.h
+include/snort/dynamic_preproc/sfrt_dir.h
+include/snort/dynamic_preproc/sfrt_flat.h
+include/snort/dynamic_preproc/sfrt_flat_dir.h
+include/snort/dynamic_preproc/sfrt_trie.h
+include/snort/dynamic_preproc/sidechannel_define.h
+include/snort/dynamic_preproc/sip_common.h
+include/snort/dynamic_preproc/snort_bounds.h
+include/snort/dynamic_preproc/snort_debug.h
+include/snort/dynamic_preproc/ssl.h
+include/snort/dynamic_preproc/ssl_config.h
+include/snort/dynamic_preproc/ssl_ha.h
+include/snort/dynamic_preproc/ssl_include.h
+include/snort/dynamic_preproc/ssl_inspect.h
+include/snort/dynamic_preproc/ssl_session.h
+include/snort/dynamic_preproc/str_search.h
+include/snort/dynamic_preproc/stream_api.h
 lib/snort/dynamic_output/libsf_dynamic_output.a
 lib/snort/dynamic_preproc/libsf_dynamic_preproc.a
 lib/snort_dynamicengine/libsf_engine.a
@@ -107,12 +182,147 @@ lib/snort_dynamicpreprocessor/libsf_ssl_preproc.so.0.0.0
 libdata/pkgconfig/snort.pc
 libdata/pkgconfig/snort_output.pc
 libdata/pkgconfig/snort_preproc.pc
-@unexec rmdir >/dev/null 2>&1 /var/log/snort || :
-@dirrmtry lib/snort/dynamic_preproc
-@dirrmtry lib/snort/dynamic_output
-@dirrmtry lib/snort
-@dirrmtry lib/snort_dynamicpreprocessor
-@dirrmtry lib/snort_dynamicengine
-@dirrmtry etc/snort/rules
-@dirrmtry etc/snort/preproc_rules
-@dirrmtry etc/snort
+man/man8/snort.8.gz
+%%PORTDOCS%%%%DOCSDIR%%/AUTHORS
+%%PORTDOCS%%%%DOCSDIR%%/BUGS
+%%PORTDOCS%%%%DOCSDIR%%/CREDITS
+%%PORTDOCS%%%%DOCSDIR%%/INSTALL
+%%PORTDOCS%%%%DOCSDIR%%/NEWS
+%%PORTDOCS%%%%DOCSDIR%%/OpenDetectorDeveloperGuide.pdf
+%%PORTDOCS%%%%DOCSDIR%%/PROBLEMS
+%%PORTDOCS%%%%DOCSDIR%%/README
+%%PORTDOCS%%%%DOCSDIR%%/README.GTP
+%%PORTDOCS%%%%DOCSDIR%%/README.PLUGINS
+%%PORTDOCS%%%%DOCSDIR%%/README.PerfProfiling
+%%PORTDOCS%%%%DOCSDIR%%/README.SMTP
+%%PORTDOCS%%%%DOCSDIR%%/README.UNSOCK
+%%PORTDOCS%%%%DOCSDIR%%/README.WIN32
+%%PORTDOCS%%%%DOCSDIR%%/README.active
+%%PORTDOCS%%%%DOCSDIR%%/README.alert_order
+%%PORTDOCS%%%%DOCSDIR%%/README.appid
+%%PORTDOCS%%%%DOCSDIR%%/README.asn1
+%%PORTDOCS%%%%DOCSDIR%%/README.counts
+%%PORTDOCS%%%%DOCSDIR%%/README.csv
+%%PORTDOCS%%%%DOCSDIR%%/README.daq
+%%PORTDOCS%%%%DOCSDIR%%/README.dcerpc2
+%%PORTDOCS%%%%DOCSDIR%%/README.decode
+%%PORTDOCS%%%%DOCSDIR%%/README.decoder_preproc_rules
+%%PORTDOCS%%%%DOCSDIR%%/README.dnp3
+%%PORTDOCS%%%%DOCSDIR%%/README.dns
+%%PORTDOCS%%%%DOCSDIR%%/README.event_queue
+%%PORTDOCS%%%%DOCSDIR%%/README.file
+%%PORTDOCS%%%%DOCSDIR%%/README.file_ips
+%%FILEINSPECT%%%%PORTDOCS%%%%DOCSDIR%%/README.file_server
+%%PORTDOCS%%%%DOCSDIR%%/README.filters
+%%PORTDOCS%%%%DOCSDIR%%/README.flowbits
+%%PORTDOCS%%%%DOCSDIR%%/README.frag3
+%%PORTDOCS%%%%DOCSDIR%%/README.ftptelnet
+%%PORTDOCS%%%%DOCSDIR%%/README.gre
+%%PORTDOCS%%%%DOCSDIR%%/README.ha
+%%PORTDOCS%%%%DOCSDIR%%/README.http_inspect
+%%PORTDOCS%%%%DOCSDIR%%/README.imap
+%%PORTDOCS%%%%DOCSDIR%%/README.ipip
+%%PORTDOCS%%%%DOCSDIR%%/README.ipv6
+%%PORTDOCS%%%%DOCSDIR%%/README.modbus
+%%PORTDOCS%%%%DOCSDIR%%/README.multipleconfigs
+%%PORTDOCS%%%%DOCSDIR%%/README.normalize
+%%PORTDOCS%%%%DOCSDIR%%/README.pcap_readmode
+%%PORTDOCS%%%%DOCSDIR%%/README.pop
+%%PORTDOCS%%%%DOCSDIR%%/README.ppm
+%%PORTDOCS%%%%DOCSDIR%%/README.reload
+%%PORTDOCS%%%%DOCSDIR%%/README.reputation
+%%PORTDOCS%%%%DOCSDIR%%/README.sensitive_data
+%%PORTDOCS%%%%DOCSDIR%%/README.sfportscan
+%%PORTDOCS%%%%DOCSDIR%%/README.sip
+%%PORTDOCS%%%%DOCSDIR%%/README.ssh
+%%PORTDOCS%%%%DOCSDIR%%/README.ssl
+%%PORTDOCS%%%%DOCSDIR%%/README.stream5
+%%PORTDOCS%%%%DOCSDIR%%/README.tag
+%%PORTDOCS%%%%DOCSDIR%%/README.thresholding
+%%PORTDOCS%%%%DOCSDIR%%/README.u2boat
+%%PORTDOCS%%%%DOCSDIR%%/README.unified2
+%%PORTDOCS%%%%DOCSDIR%%/README.variables
+%%PORTDOCS%%%%DOCSDIR%%/RELEASE.NOTES
+%%PORTDOCS%%%%DOCSDIR%%/TODO
+%%PORTDOCS%%%%DOCSDIR%%/USAGE
+%%PORTDOCS%%%%DOCSDIR%%/WISHLIST
+%%PORTDOCS%%%%DOCSDIR%%/generators
+%%PORTDOCS%%%%DOCSDIR%%/snort_manual.pdf
+%%APPID%%src/snort_dynamicsrc/md5.h
+%%APPID%%src/snort_dynamicsrc/sfmemcap.h
+%%APPID%%src/snort_dynamicsrc/sfprimetable.h
+%%APPID%%src/snort_dynamicsrc/sfxhash.h
+src/snort_dynamicsrc/Unified2_common.h
+src/snort_dynamicsrc/bitop.h
+src/snort_dynamicsrc/event.h
+src/snort_dynamicsrc/file_api.h
+src/snort_dynamicsrc/file_mail_common.h
+src/snort_dynamicsrc/idle_processing.h
+src/snort_dynamicsrc/mpse_methods.h
+src/snort_dynamicsrc/obfuscation.h
+src/snort_dynamicsrc/pcap_pkthdr32.h
+src/snort_dynamicsrc/perf_indicators.h
+src/snort_dynamicsrc/plugin_enum.h
+src/snort_dynamicsrc/preprocids.h
+src/snort_dynamicsrc/profiler.h
+src/snort_dynamicsrc/rule_option_types.h
+src/snort_dynamicsrc/session_api.h
+src/snort_dynamicsrc/sfPolicyUserData.c
+src/snort_dynamicsrc/sfPolicyUserData.h
+src/snort_dynamicsrc/sf_base64decode.c
+src/snort_dynamicsrc/sf_base64decode.h
+src/snort_dynamicsrc/sf_decompression.h
+src/snort_dynamicsrc/sf_dynamic_common.h
+src/snort_dynamicsrc/sf_dynamic_define.h
+src/snort_dynamicsrc/sf_dynamic_engine.h
+src/snort_dynamicsrc/sf_dynamic_meta.h
+src/snort_dynamicsrc/sf_dynamic_preproc_lib.c
+src/snort_dynamicsrc/sf_dynamic_preproc_lib.h
+src/snort_dynamicsrc/sf_dynamic_preprocessor.h
+src/snort_dynamicsrc/sf_email_attach_decode.c
+src/snort_dynamicsrc/sf_email_attach_decode.h
+src/snort_dynamicsrc/sf_ip.h
+src/snort_dynamicsrc/sf_protocols.h
+src/snort_dynamicsrc/sf_seqnums.h
+src/snort_dynamicsrc/sf_snort_packet.h
+src/snort_dynamicsrc/sf_snort_plugin_api.h
+src/snort_dynamicsrc/sf_types.h
+src/snort_dynamicsrc/sfcontrol.h
+src/snort_dynamicsrc/sfdebug.h
+src/snort_dynamicsrc/sfghash.h
+src/snort_dynamicsrc/sfhashfcn.h
+src/snort_dynamicsrc/sfparser.c
+src/snort_dynamicsrc/sfsnort_dynamic_detection_lib.c
+src/snort_dynamicsrc/sfsnort_dynamic_detection_lib.h
+src/snort_dynamicsrc/sidechannel_define.h
+src/snort_dynamicsrc/signature.h
+src/snort_dynamicsrc/sip_common.h
+src/snort_dynamicsrc/snort_debug.h
+src/snort_dynamicsrc/ssl.c
+src/snort_dynamicsrc/ssl.h
+src/snort_dynamicsrc/ssl_config.c
+src/snort_dynamicsrc/ssl_config.h
+src/snort_dynamicsrc/ssl_ha.c
+src/snort_dynamicsrc/ssl_ha.h
+src/snort_dynamicsrc/ssl_include.h
+src/snort_dynamicsrc/ssl_inspect.c
+src/snort_dynamicsrc/ssl_inspect.h
+src/snort_dynamicsrc/ssl_session.h
+src/snort_dynamicsrc/str_search.h
+src/snort_dynamicsrc/stream_api.h
+src/snort_dynamicsrc/treenodes.h
+src/snort_dynamicsrc/util_unfold.c
+src/snort_dynamicsrc/util_unfold.h
+@unexec rmdir "/var/log/snort" >/dev/null 2>&1 || :
+@dir src/snort_dynamicsrc
+@dir src
+%%PORTDOCS%%@dir %%DOCSDIR%%
+@dir lib/snort/dynamic_preproc
+@dir lib/snort/dynamic_output
+@dir lib/snort
+@dir include/snort/dynamic_preproc
+@dir include/snort/dynamic_output
+@dir include/snort
+@dir etc/snort/rules
+@dir etc/snort/preproc_rules
+@dir etc/snort


### PR DESCRIPTION
This updates the Snort binary on pfSense 2.3-BETA to version 2.9.8.0 to sync with upstream.  Release notes for 2.9.8.0 can be found on the Snort.org web site here: 

https://www.snort.org/downloads/snort/release_notes_2.9.8.0.txt

This pfSense version of Snort contains a custom _alert-pf_ output plugin to implement IP address blocking using pf firewall system calls.