### PR TITLE
pfSense-pkg-snort 3.2.9.1_6 -- more Bootstrap bug fixes and binary update to 2.9.8.0

### DIFF
--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -34,7 +34,7 @@
 require_once("pfsense-utils.inc");
 require_once("config.inc");
 require_once("functions.inc");
-require_once("service-utils.inc");
+require_once("service-utils.inc"); // Need this to get RCFILEPREFIX definition
 require_once("pkg-utils.inc");
 require_once("filter.inc");
 require("/usr/local/pkg/snort/snort_defs.inc");

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -3685,11 +3685,11 @@ function snort_remove_dead_rules() {
 	$cats = array();
 
 	// If there is no "deprecated_rules" file, then exit
-	if (!file_exists("{$rulesdir}deprecated_rules"))
+	if (!file_exists("/usr/local/pkg/snort/deprecated_rules"))
 		return;
 
 	// Open a SplFileObject to read in deprecated rules
-	$file = new SplFileObject("{$rulesdir}/deprecated_rules");
+	$file = new SplFileObject("/usr/local/pkg/snort/deprecated_rules");
 	$file->setFlags(SplFileObject::READ_AHEAD | SplFileObject::SKIP_EMPTY | SplFileObject::DROP_NEW_LINE);
 	while (!$file->eof()) {
 		$line = $file->fgets();

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -5,7 +5,7 @@
  * Copyright (C) 2006 Scott Ullrich
  * Copyright (C) 2009-2010 Robert Zelaya
  * Copyright (C) 2011-2012 Ermal Luci
- * Copyright (C) 2013-2015 Bill Meeks
+ * Copyright (C) 2013-2016 Bill Meeks
  * part of pfSense
  * All rights reserved.
  *
@@ -50,7 +50,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 	if (!empty($snortver))
 		define("SNORT_BIN_VERSION", $snortver);
 	else
-		define("SNORT_BIN_VERSION", "2.9.7.6");
+		define("SNORT_BIN_VERSION", "2.9.8.0");
 }
 if (!defined("SNORT_SID_MODS_PATH"))
 	define('SNORT_SID_MODS_PATH', "{$g['vardb_path']}/snort/sidmods/");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_blocked.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_blocked.php
@@ -335,15 +335,15 @@ print($form);
 			</tbody>
 			<tfoot>
 				<tr>
-					<td colspan="4">
+					<td colspan="4" style="text-align:center;" class="alert-info">
 						<?php	if (!empty($blocked_ips_array)) {
 							if ($counter > 1)
-								echo "{$counter}" . gettext(" host IP addresses are currently being blocked.");
+								print($counter . gettext(" host IP addresses are currently being blocked by Snort."));
 							else
-								echo "{$counter}" . gettext(" host IP address is currently being blocked.");
+								print($counter . gettext(" host IP address is currently being blocked Snort."));
 						}
 						else {
-							echo gettext("There are currently no hosts being blocked by Snort.");
+							print(gettext("There are currently no hosts being blocked by Snort."));
 						}
 						?>
 					</td>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_blocked.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_blocked.php
@@ -61,7 +61,7 @@ if (isset($_POST['resolve'])) {
 	else
 		$response = array('resolve_ip' => $ip, 'resolve_text' => gettext("Cannot resolve"));
 	
-	echo json_encode(str_replace("\\","\\\\", $response)); // single escape chars can break JSON decode
+	print(json_encode(str_replace("\\","\\\\", $response))); // single escape chars can break JSON decode
 	exit;
 }
 # --- AJAX REVERSE DNS RESOLVE End ---
@@ -148,7 +148,7 @@ include("head.inc");
 
 /* refresh every 60 secs */
 if ($pconfig['brefresh'] == 'on')
-	echo "<meta http-equiv=\"refresh\" content=\"60;url=/snort/snort_blocked.php\" />\n";
+	print('<meta http-equiv="refresh" content="60;url=/snort/snort_blocked.php" />\n');
 
 /* Display Alert message */
 if ($input_errors) {
@@ -321,14 +321,14 @@ print($form);
 					$rdns_link .= "<i class=\"fa fa-search icon-pointer\" onclick=\"javascript:resolve_with_ajax('{$blocked_ip}');\" title=\"";
 					$rdns_link .= gettext("Resolve host via reverse DNS lookup") . "\" alt=\"Icon Reverse Resolve with DNS\"></i>";
 
-					/* use one echo to do the magic*/
-						echo "<tr class=\"text-nowrap\">
+					/* print the table row */
+						print("<tr class=\"text-nowrap\">
 							<td>{$counter}</td>
 							<td style=\"word-wrap:break-word; white-space:normal\">{$tmp_ip}<br/>{$rdns_link}</td>
 							<td style=\"word-wrap:break-word; white-space:normal\">{$blocked_desc}</td>
 							<td><i class=\"fa fa-times icon-pointer text-danger\" onClick=\"$('#ip').val('{$blocked_ip}');$('#mode').val('todelete');$('#formblock').submit();\" 
 							 title=\"" . gettext("Delete host from Blocked Table") . "\"></i></td>
-						</tr>\n";
+						</tr>\n");
 				}
 			}
 			?>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interface_logs.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interface_logs.php
@@ -173,7 +173,6 @@ if (isset($id)) {
 print($form);
 ?>
 
-<script type="text/javascript" src="/javascript/base64.js"></script>
 <script type="text/javascript">
 //<![CDATA[
 events.push(function() {

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interface_logs.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interface_logs.php
@@ -99,7 +99,7 @@ if ($savemsg)
 	print_info_box($savemsg);
 
 function build_logfile_list() {
-	global $snortlogdir;
+	global $snortlogdir, $if_real;
 
 	$list = array();
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces.php
@@ -226,9 +226,8 @@ if ($savemsg)
 <div class="panel panel-default">
 	<div class="panel-heading"><h2 class="panel-title"><?=gettext("Interface Settings Overview")?></h2></div>
 	<div class="panel-body">
-		<div class="table-responsive">
-
-	<table id="maintable" class="table table-striped table-hover table-condensed">
+		<div class=" content table-responsive">
+			<table id="maintable" class="table table-striped table-hover table-condensed">
 				<thead>
 				<tr id="frheader">
 					<th>&nbsp;</th>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_log_mgmt.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_log_mgmt.php
@@ -45,21 +45,24 @@ $snortdir = SNORTDIR;
 $pconfig = array();
 
 // Grab saved settings from configuration
-$pconfig['enable_log_mgmt'] = $config['installedpackages']['snortglobal']['enable_log_mgmt'] == 'on' ? 'on' : 'off';
-$pconfig['clearlogs'] = $config['installedpackages']['snortglobal']['clearlogs'];
-$pconfig['snortloglimit'] = $config['installedpackages']['snortglobal']['snortloglimit'];
-$pconfig['snortloglimitsize'] = $config['installedpackages']['snortglobal']['snortloglimitsize'];
-$pconfig['alert_log_limit_size'] = $config['installedpackages']['snortglobal']['alert_log_limit_size'];
-$pconfig['alert_log_retention'] = $config['installedpackages']['snortglobal']['alert_log_retention'];
-$pconfig['stats_log_limit_size'] = $config['installedpackages']['snortglobal']['stats_log_limit_size'];
-$pconfig['stats_log_retention'] = $config['installedpackages']['snortglobal']['stats_log_retention'];
-$pconfig['sid_changes_log_limit_size'] = $config['installedpackages']['snortglobal']['sid_changes_log_limit_size'];
-$pconfig['sid_changes_log_retention'] = $config['installedpackages']['snortglobal']['sid_changes_log_retention'];
-$pconfig['event_pkts_log_limit_size'] = '0';
-$pconfig['event_pkts_log_retention'] = $config['installedpackages']['snortglobal']['event_pkts_log_retention'];
-$pconfig['appid_stats_log_limit_size'] = $config['installedpackages']['snortglobal']['appid_stats_log_limit_size'];
-$pconfig['appid_stats_log_retention'] = $config['installedpackages']['snortglobal']['appid_stats_log_retention'];
-
+if (isset($_POST['save']))
+	$pconfig = $_POST;
+else {
+	$pconfig['enable_log_mgmt'] = $config['installedpackages']['snortglobal']['enable_log_mgmt'] == "on" ? 'on' : 'off';
+	$pconfig['clearlogs'] = $config['installedpackages']['snortglobal']['clearlogs'] == "on" ? 'on' : 'off';
+	$pconfig['snortloglimit'] = $config['installedpackages']['snortglobal']['snortloglimit'] == "on" ? 'on' : 'off';
+	$pconfig['snortloglimitsize'] = $config['installedpackages']['snortglobal']['snortloglimitsize'];
+	$pconfig['alert_log_limit_size'] = $config['installedpackages']['snortglobal']['alert_log_limit_size'];
+	$pconfig['alert_log_retention'] = $config['installedpackages']['snortglobal']['alert_log_retention'];
+	$pconfig['stats_log_limit_size'] = $config['installedpackages']['snortglobal']['stats_log_limit_size'];
+	$pconfig['stats_log_retention'] = $config['installedpackages']['snortglobal']['stats_log_retention'];
+	$pconfig['sid_changes_log_limit_size'] = $config['installedpackages']['snortglobal']['sid_changes_log_limit_size'];
+	$pconfig['sid_changes_log_retention'] = $config['installedpackages']['snortglobal']['sid_changes_log_retention'];
+	$pconfig['event_pkts_log_limit_size'] = '0';
+	$pconfig['event_pkts_log_retention'] = $config['installedpackages']['snortglobal']['event_pkts_log_retention'];
+	$pconfig['appid_stats_log_limit_size'] = $config['installedpackages']['snortglobal']['appid_stats_log_limit_size'];
+	$pconfig['appid_stats_log_retention'] = $config['installedpackages']['snortglobal']['appid_stats_log_retention'];
+}
 // Load up some arrays with selection values (we use these later).
 // The keys in the $retentions array are the retention period
 // converted to hours.  The keys in the $log_sizes array are
@@ -101,7 +104,7 @@ if (!isset($pconfig['sid_changes_log_limit_size']))
 if (!isset($pconfig['appid_stats_log_limit_size']))
 	$pconfig['appid_stats_log_limit_size'] = "1000";
 
-if ($_POST['ResetAll']) {
+if (isset($_POST['ResetAll'])) {
 
 	// Reset all settings to their defaults
 	$pconfig['alert_log_retention'] = "336";
@@ -120,9 +123,9 @@ if ($_POST['ResetAll']) {
 	$savemsg = gettext("All log management settings on this page have been reset to their defaults.  Click APPLY if you wish to keep these new settings.");
 }
 
-if ($_POST["save"] || $_POST['apply']) {
+if (isset($_POST['save']) || isset($_POST['apply'])) {
 	if ($_POST['enable_log_mgmt'] != 'on') {
-		$config['installedpackages']['snortglobal']['enable_log_mgmt'] = $_POST['enable_log_mgmt'] ? 'on' :'off';
+		$config['installedpackages']['snortglobal']['enable_log_mgmt'] = 'off';
 		write_config("Snort pkg: saved updated configuration for LOGS MGMT.");
 		conf_mount_rw();
 		sync_snort_package_config();
@@ -144,9 +147,9 @@ if ($_POST["save"] || $_POST['apply']) {
 	}
 
 	if (!$input_errors) {
-		$config['installedpackages']['snortglobal']['enable_log_mgmt'] = $_POST['enable_log_mgmt'] ? 'on' :'off';
+		$config['installedpackages']['snortglobal']['enable_log_mgmt'] = $_POST['enable_log_mgmt'] ? 'on' : 'off';
 		$config['installedpackages']['snortglobal']['clearlogs'] = $_POST['clearlogs'] ? 'on' : 'off';
-		$config['installedpackages']['snortglobal']['snortloglimit'] = $_POST['snortloglimit'];
+		$config['installedpackages']['snortglobal']['snortloglimit'] = $_POST['snortloglimit'] ? 'on' : 'off';
 		$config['installedpackages']['snortglobal']['snortloglimitsize'] = $_POST['snortloglimitsize'];
 		$config['installedpackages']['snortglobal']['alert_log_limit_size'] = $_POST['alert_log_limit_size'];
 		$config['installedpackages']['snortglobal']['alert_log_retention'] = $_POST['alert_log_retention'];
@@ -210,14 +213,14 @@ $section->addInput(new Form_Checkbox(
 	'clearlogs',
 	'Remove Snort Logs On Package Uninstall',
 	'Snort log files will be removed when the Snort package is uninstalled.',
-	$config['installedpackages']['snortglobal']['clearlogs'] == 'on' ? true:false,
+	$pconfig['clearlogs'] == 'on' ? true:false,
 	'on'
 ));
 $section->addInput(new Form_Checkbox(
 	'enable_log_mgmt',
 	'Auto Log Management',
 	'Enable automatic unattended management of Snort logs using parameters specified below.',
-	$config['installedpackages']['snortglobal']['enable_log_mgmt'] == 'on' ? true:false,
+	$pconfig['enable_log_mgmt'] == 'on' ? true:false,
 	'on'
 ));
 print($section);

--- a/security/pfSense-pkg-snort/files/usr/local/www/widgets/javascript/snort_alerts.js
+++ b/security/pfSense-pkg-snort/files/usr/local/www/widgets/javascript/snort_alerts.js
@@ -3,58 +3,21 @@ var snorttimer;
 var snortisBusy = false;
 var snortisPaused = false;
 
-if (typeof getURL == 'undefined') {
-	getURL = function(url, callback) {
-		if (!url)
-			throw 'No URL for getURL';
-		try {
-			if (typeof callback.operationComplete == 'function')
-				callback = callback.operationComplete;
-		} catch (e) {}
-			if (typeof callback != 'function')
-				throw 'No callback function for getURL';
-		var http_request = null;
-		if (typeof XMLHttpRequest != 'undefined') {
-		    http_request = new XMLHttpRequest();
-		}
-		else if (typeof ActiveXObject != 'undefined') {
-			try {
-				http_request = new ActiveXObject('Msxml2.XMLHTTP');
-			} catch (e) {
-				try {
-					http_request = new ActiveXObject('Microsoft.XMLHTTP');
-				} catch (e) {}
-			}
-		}
-		if (!http_request)
-			throw 'Both getURL and XMLHttpRequest are undefined';
-		http_request.onreadystatechange = function() {
-			if (http_request.readyState == 4) {
-				callback( { success : true,
-				  content : http_request.responseText,
-				  contentType : http_request.getResponseHeader("Content-Type") } );
-			}
-		}
-		http_request.open('GET', url, true);
-		http_request.send(null);
-	}
-}
-
 function snort_alerts_fetch_new_events_callback(callback_data) {
 	var data_split;
 	var new_data_to_add = Array();
-	var data = callback_data.content;
-	data_split = data.split("\n");
+	data_split = callback_data.split("\n");
 
 	// Loop through rows and generate replacement HTML
 	for(var x=0; x<data_split.length-1; x++) {
 		row_split = data_split[x].split("||");
 		var line = '';
-		line =  '<td class="listMRr">' + row_split[0] + '<br/>' + row_split[1] + '</td>';		
-		line += '<td class="listMRr" style="overflow: hidden; text-overflow: ellipsis;" nowrap>';
+		line =  '<td style="overflow: hidden; text-overflow: ellipsis;" nowrap>';
+		line += row_split[0] + '<br/>' + row_split[1] + '</td>';		
+		line += '<td style="overflow: hidden; text-overflow: ellipsis;" nowrap>';
 		line += '<div style="display:inline;" title="' + row_split[2] + '">' + row_split[2] + '</div><br/>';
 		line += '<div style="display:inline;" title="' + row_split[3] + '">' + row_split[3] + '</div></td>';
-		line += '<td class="listMRr"><div style="display: fixed; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; line-height: 1.2em; max-height: 2.4em; overflow: hidden; text-overflow: ellipsis;" title="' + row_split[4] + '">' + row_split[4] + '</div></td>';
+		line += '<td><div style="display: fixed; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; line-height: 1.2em; max-height: 2.4em; overflow: hidden; text-overflow: ellipsis;" title="' + row_split[4] + '">' + row_split[4] + '</div></td>';
 		new_data_to_add[new_data_to_add.length] = line;
 	}
 	snort_alerts_update_div_rows(new_data_to_add);
@@ -65,7 +28,7 @@ function snort_alerts_update_div_rows(data) {
 	if(snortisPaused)
 		return;
 
-	var rows = $$('#snort-alert-entries>tr');
+	var rows = $('#snort-alert-entries>tr');
 
 	// Number of rows to move by
 	var move = rows.length + data.length - snort_nentries;
@@ -76,7 +39,7 @@ function snort_alerts_update_div_rows(data) {
 		rows[i].innerHTML = rows[i - move].innerHTML;
 	}
 
-	var tbody = $$('#snort-alert-entries');
+	var tbody = $('#snort-alert-entries');
 	for (var i = data.length - 1; i >= 0; i--) {
 		if (i < rows.length) {
 			rows[i].innerHTML = data[i];
@@ -84,13 +47,6 @@ function snort_alerts_update_div_rows(data) {
 			var newRow = document.getElementById('snort-alert-entries').insertRow(0);
 			newRow.innerHTML = data[i];
 		}
-	}
-
-	// Add the even/odd class to each of the rows now
-	// they have all been added.
-	rows = $$('#snort-alert-entries>tr');
-	for (var i = 0; i < rows.length; i++) {
-		rows[i].className = i % 2 == 0 ? snortWidgetRowOddClass : snortWidgetRowEvenClass;
 	}
 }
 
@@ -100,7 +56,15 @@ function fetch_new_snortalerts() {
 	if(snortisBusy)
 		return;
 	snortisBusy = true;
-	getURL('/widgets/widgets/snort_alerts.widget.php?getNewAlerts=' + new Date().getTime(), snort_alerts_fetch_new_events_callback);
+
+	$.ajax({
+		url: '/widgets/widgets/snort_alerts.widget.php',
+		type: 'GET',
+		data: {
+			getNewAlerts: new Date().getTime()
+		      },
+		success: snort_alerts_fetch_new_events_callback
+	});
 }
 
 function snort_alerts_toggle_pause() {

--- a/security/pfSense-pkg-snort/files/usr/local/www/widgets/widgets/snort_alerts.widget.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/widgets/widgets/snort_alerts.widget.php
@@ -83,7 +83,7 @@ if (isset($_GET['getNewAlerts'])) {
 	$s_alerts = snort_widget_get_alerts();
 	$counter = 0;
 	foreach ($s_alerts as $a) {
-		$response .= $a['instanceid'] . " " . $a['dateonly'] . "||" . $a['timeonly'] . "||" . $a['src'] . "||";
+		$response .= $a['instanceid'] . "||" . $a['dateonly'] . " " . $a['timeonly'] . "||" . $a['src'] . "||";
 		$response .= $a['dst'] . "||" . $a['msg'] . "\n";
 		$counter++;
 		if($counter >= $snort_nentries)
@@ -134,7 +134,7 @@ function snort_widget_get_alerts() {
 						continue;
 
 					// Get the Snort interface this alert was received from
-					$snort_alerts[$counter]['instanceid'] = strtoupper($a_instance[$instanceid]['interface']);
+					$snort_alerts[$counter]['instanceid'] = convert_friendly_interface_to_friendly_descr($a_instance[$instanceid]['interface']);
 
 					// "fields[0]" is the complete timestamp in ASCII form. Convert
 					// to a UNIX timestamp so we can use it for various date and
@@ -191,7 +191,7 @@ function snort_widget_get_alerts() {
 	</colgroup>
 	<thead>
 		<tr>
-			<th><?=gettext("IF/Date");?></th>
+			<th><?=gettext("Interface/Time");?></th>
 			<th><?=gettext("Src/Dst Address");?></th>
 			<th><?=gettext("Description");?></th>
 		</tr>
@@ -202,12 +202,21 @@ function snort_widget_get_alerts() {
 		$counter=0;
 		if (is_array($snort_alerts)) {
 			foreach ($snort_alerts as $alert) {
-				$alertRowClass = $counter % 2 ? $alertRowEvenClass : $alertRowOddClass;
-				echo("	<tr class='" . $alertRowClass . "'>
-				<td class='listMRr'>" . $alert['instanceid'] . "&nbsp;" . $alert['dateonly'] . "<br/>" . $alert['timeonly'] . "</td>
-				<td class='listMRr' style='overflow: hidden; text-overflow: ellipsis;' nowrap><div style='display:inline;' title='" . $alert['src'] . "'>" . $alert['src'] . "</div><br/><div style='display:inline;' title='" . $alert['dst'] . "'>" . $alert['dst'] . "</div></td>
-				<td class='listMRr'><div style='display: fixed; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; line-height: 1.2em; max-height: 2.4em; overflow: hidden; text-overflow: ellipsis;' title='{$alert['msg']}'>" . $alert['msg'] . "</div></td></tr>");
-				$counter++;
+	?>			
+				<tr>
+					<td style="overflow: hidden; text-overflow: ellipsis;" nowrap><?=$alert['instanceid']; ?><br/>
+						<?=$alert['dateonly']; ?> <?=$alert['timeonly']; ?>
+					</td>
+					<td style="overflow: hidden; text-overflow: ellipsis;" nowrap>
+						<div style="display:inline;" title="<?=$alert['src']; ?>"><?=$alert['src']; ?></div><br/>
+						<div style="display:inline;" title="<?=$alert['dst']; ?>"><?=$alert['dst']; ?></div>
+					</td>
+					<td><div style="display: fixed; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; 
+						line-height: 1.2em; max-height: 2.4em; overflow: hidden; text-overflow: ellipsis;" 
+						title="<?=$alert['msg']; ?>"><?=$alert['msg']; ?></div>
+					</td>
+				</tr>
+	<?php			$counter++;
 				if($counter >= $snort_nentries)
 					break;
 			}
@@ -222,18 +231,23 @@ function snort_widget_get_alerts() {
 <div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
 	<input type="hidden" id="snort_alerts-config" name="snort_alerts-config" value="" />
 		<form action="/widgets/widgets/snort_alerts.widget.php" method="post" name="iformd" class="form-horizontal">
-			Enter number of recent alerts to display (default is 5)<br/>
-			<input type="text" size="5" name="widget_snort_display_lines" class="form-control" id="widget_snort_display_lines" value="<?= $config['widgets']['widget_snort_display_lines'] ?>" />
-			&nbsp;&nbsp;<input id="submitd" name="submitd" type="submit" class="formbtn" value="Save" />
+			<div class="form-group">
+				<label for="widget_snort_display_lines" class="col-sm-4 control-label"><?=gettext('Alerts to Display:')?></label>
+				<div class="col-sm-3">
+					<input type="number" name="widget_snort_display_lines" class="form-control" id="widget_snort_display_lines" 
+					value="<?= $config['widgets']['widget_snort_display_lines'] ?>" placeholder="5" min="1" max="20" />
+				</div>
+				<div class="col-sm-3">
+					<button id="submitd" name="submitd" type="submit" class="btn btn-sm btn-primary"><?=gettext('Save')?></button>
+				</div>
+			</div>
 		</form>
 
 <script type="text/javascript">
 //<![CDATA[
 <!-- needed in the snort_alerts.js file code -->
-	var snortupdateDelay = 10000; // update every 10 seconds
+	var snortupdateDelay = 5000; // update every 5 seconds
 	var snort_nentries = <?=$snort_nentries;?>; // number of alerts to display (5 is default)
-	var snortWidgetRowEvenClass = "<?=$alertRowEvenClass;?>"; // allows alternating background
-	var snortWidgetRowOddClass = "<?=$alertRowOddClass;?>"; // allows alternating background
 
 <!-- needed to display the widget settings menu -->
 	selectIntLink = "snort_alerts-configure";


### PR DESCRIPTION
This update corrects a few more GUI bugs from the recent Bootstrap conversion of Snort.

**Code Fixes:**
1. Stats log filename incorrect in drop-down on LOGS VIEW tab.
2. Receive system log error "open() "_/usr/local/www/javascript/base64.js_" failed from LOGS VIEW tab.
3. Settings not saving on LOGS MGMT tab.
4. Alerts Widget does not auto-update and does not display friendly interface names.
5. Add VIEW RULES button to RULES tab to allow viewing of raw rules content for selected category.
6. Improve feedback on UPDATES tab when updating rules via a temporary workaround.
7. Style footer of blocked IPs table on BLOCKED tab to "bg-info".
8. Fix up errant newlines in post-install code and tidy up status messages.
9. Fix Snort auto-start failure after upgrade or reinstall.
