### PR TITLE
Status / Monitoring - Pollyfill - Includes Method

### DIFF
--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
@@ -1152,6 +1152,30 @@ events.push(function() {
 
 		});
 	});
+
+	/***
+	**
+	** Polyfill for older browsers that don't yet have the newer "includes()" method implemented.
+	** Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes
+	** Documentation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes
+	** Documentation: http://www.w3schools.com/jsref/jsref_includes.asp
+	**
+	***/
+
+	if (!String.prototype.includes) {
+		String.prototype.includes = function(search, start) {
+			'use strict';
+			if (typeof start !== 'number') {
+				start = 0;
+			}
+    
+			if (start + search.length > this.length) {
+				return false;
+			} else {
+				return this.indexOf(search, start) !== -1;
+			}
+		};
+	}
 });
 //]]>
 </script>


### PR DESCRIPTION
Polyfill for older browsers that yet don't have the newer "includes()" method implemented.