### PR TITLE
Status Monitoring - Settings Panel Collapsible

### DIFF
--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
@@ -229,6 +229,19 @@ foreach ($databases as $db) {
 
 }
 
+## Get the configured options for Show/Hide monitoring settings panel.
+$monitoring_settings_form_hidden = isset($config['system']['webgui']['statusmonitoringsettingspanel']) ? false : true;
+
+if ($monitoring_settings_form_hidden) {
+	$panel_state = 'out';
+	$panel_body_state = 'in';
+} else {
+	$panel_state = 'in';
+	$panel_body_state = 'in';
+}
+
+$status_monitoring = true;
+
 $pgtitle = array(gettext("Status"), gettext("Monitoring"));
 
 include("head.inc");
@@ -240,12 +253,18 @@ include("head.inc");
 
 <link href="/vendor/nvd3/nv.d3.css" media="screen, projection" rel="stylesheet" type="text/css">
 
-<form class="form-horizontal auto-submit" method="post" action="/status_graph.php?if=wan"><input type="hidden" name="__csrf_magic" value="sid:1f9306cd710f4110c117a7c9d792153199338441,1456357903">
-	<div class="panel panel-default">
+<form class="form-horizontal collapse <?=$panel_state?> auto-submit" method="post" action="/status_graph.php?if=wan" id="monitoring-settings-form"><input type="hidden" name="__csrf_magic" value="sid:1f9306cd710f4110c117a7c9d792153199338441,1456357903">
+	<div class="panel panel-default" id="monitoring-settings-panel">
 		<div class="panel-heading">
-			<h2 class="panel-title">Settings</h2>
+			<h2 class="panel-title"><?=gettext("Settings"); ?>
+				<span class="widget-heading-icon">
+					<a data-toggle="collapse" href="#monitoring-settings-panel_panel-body">
+						<i class="fa fa-plus-circle"></i>
+					</a>
+				</span>
+			</h2>
 		</div>
-		<div class="panel-body">
+		<div id="monitoring-settings-panel_panel-body" class="panel-body collapse <?=$panel_body_state?>">
 			<div class="form-group">
 				<label class="col-sm-2 control-label">
 					Left Axis
@@ -383,16 +402,12 @@ include("head.inc");
 	</div>
 </form>
 
-<p>
-	<button id="update" class="btn btn-primary">Update</button>
-	<span id="loading-msg">Loading Graph...</span>
-</p>
-
 <div class="panel panel-default">
 	<div class="panel-heading">
 		<h2 class="panel-title">Interactive Graph</h2>
 	</div>
 	<div class="panel-body">
+		<span id="loading-msg">Loading Graph...</span>
 		<div id="chart-error" class="alert alert-danger" style="display: none;"></div>
 		<div id="chart" class="with-3d-shadow with-transitions">
 			<svg></svg> <!-- TODO add loading symbol -->


### PR DESCRIPTION
Make the status monitoring settings panel collapsible with page load state configurable in general setup associated panels show/hide.
Replace Update button with refresh icon on title bar.

Requires pfSense pull request # 2722 Status Monitoring - Settings Panel Collapsible.
https://github.com/pfsense/pfsense/pull/2722