### PR TITLE
Status Monitoring - Quality Graph Tooltip Values

### DIFF
--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
@@ -1198,15 +1198,16 @@ events.push(function() {
 						var trueValue = data.series[v].value;
 					}
 
-					valueUnits = "";
-					if (tempKey.includes('delay')) {
+					valueUnits = ' ';
+					if (tempKey.includes('delay average') || tempKey.includes('delay std. dev.')) {
 						trueValue *= 1000;	// Show delay values in same units as graph axis.  Fewer digits is human friendlier.
-						valueUnits = " ms";
+						valueUnits += 'ms';
+					} else if (tempKey.includes('packet loss')) {
+						valueUnits += '%';
+					} else {
+						valueUnits = '';
 					}
 
-					if (tempKey.includes('packet loss')) {
-						valueUnits = " %";
-					}
 
 					//change decimal places to round to if a really small number
 					if(trueValue < .01) {

--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
@@ -1198,6 +1198,16 @@ events.push(function() {
 						var trueValue = data.series[v].value;
 					}
 
+					valueUnits = "";
+					if (tempKey.includes('delay')) {
+						trueValue *= 1000;	// Show delay values in same units as graph axis.  Fewer digits is human friendlier.
+						valueUnits = "m";
+					}
+
+					if (tempKey.includes('packet loss')) {
+						valueUnits = "%";
+					}
+
 					//change decimal places to round to if a really small number
 					if(trueValue < .01) {
 						var adjustedTrueValue = d3.format(',')(trueValue.toFixed(6)); //TODO dynamically calculate number of zeros after decimal and base off that

--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
@@ -1201,11 +1201,11 @@ events.push(function() {
 					valueUnits = "";
 					if (tempKey.includes('delay')) {
 						trueValue *= 1000;	// Show delay values in same units as graph axis.  Fewer digits is human friendlier.
-						valueUnits = "m";
+						valueUnits = " ms";
 					}
 
 					if (tempKey.includes('packet loss')) {
-						valueUnits = "%";
+						valueUnits = " %";
 					}
 
 					//change decimal places to round to if a really small number
@@ -1216,6 +1216,7 @@ events.push(function() {
 					}
 
 					content += '<tr><td class="legend-color-guide"><div style="background-color: ' + data.series[v].color + '"></div></td><td>' + data.series[v].key + '</td><td class="value"><strong>' + adjustedTrueValue + '</strong></td></tr>';
+					content += '<tr><td class="legend-color-guide"><div style="background-color: ' + data.series[v].color + '"></div></td><td>' + data.series[v].key + '</td><td class="value"><strong>' + adjustedTrueValue + valueUnits + '</strong></td></tr>';
 				}
 
 				content += '</tbody></table>';


### PR DESCRIPTION
Don't know what may be planned for making the values more humanly friendly.  So sharing this that I like.
We mere humans just don't relate well to long strings of digits.  Displaying the quality graph delay in milliseconds is much more human friendly.

Probably a more elegant means but this will suffice for now.