### PR TITLE
pfSense-pkg-suricata-3.0_1 - More Bootstrap and other bug fixes

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	3.0
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -1220,18 +1220,22 @@ function suricata_load_rules_map($rules_path) {
 	 *  map[gid][sid]['rule']['category']['action']['disabled']['managed']['flowbits']
 	 *
 	 *  where:
-	 *   gid      = Generator ID from rule, or 1 if general text 
-	 *              rule
-	 *   sid      = Signature ID from rule
-         *   rule     = Complete rule text
-	 *   category = File name of file containing the rule
-	 *   action   = alert, drop, reject or pass
-	 *   disabled = 1 if rule is disabled (commented out), 0 if 
-	 *              rule is enabled
-	 *    managed = 1 if rule is auto-managed by SID MGMT process,
-	 *              0 if not auto-managed 
-	 *   flowbits = Array of applicable flowbits if rule contains 
-	 *              flowbits options
+	 *   gid           = Generator ID from rule, or 1 if general text 
+	 *                   rule
+	 *   sid           = Signature ID from rule
+         *   rule          = Complete rule text
+	 *   category      = File name of file containing the rule
+	 *   action        = alert, drop, reject or pass
+	 *   disabled      = 1 if rule is disabled (commented out), 0 if 
+	 *                   rule is enabled
+	 *   managed       = 1 if rule is auto-managed by SID MGMT process,
+	 *                   0 if not auto-managed 
+	 *   state_toggled = 1 if rule was toggled by SID MGMT process,
+	 *                   0 if not toggled
+	 *   modified      = 1 if rule action or content is modified by SID MGMT process,
+	 *                   0 if not modified
+	 *   flowbits      = Array of applicable flowbits if rule contains 
+	 *                   flowbits options
 	 ************************************************************************************/
 
 	// First check if we were passed a directory, a single file
@@ -1315,6 +1319,8 @@ function suricata_load_rules_map($rules_path) {
 				$map_ref[$gid][$sid] = array();
 			$map_ref[$gid][$sid]['rule'] = $rule;
 			$map_ref[$gid][$sid]['category'] = basename($file, ".rules");
+			$map_ref[$gid][$sid]['state_toggled'] = 0;
+			$map_ref[$gid][$sid]['modified'] = 0;
 
 			// Grab the rule action
 			$matches = array();
@@ -1801,11 +1807,12 @@ function suricata_sid_mgmt_auto_categories($suricatacfg, $log_results = FALSE) {
 	$sid_mods = array();
 	$enables = array();
 	$disables = array();
+	$drops = array();
 
 	// Check if auto-mgmt of SIDs is enabled, exit if not
 	if ($config['installedpackages']['suricata']['config'][0]['auto_manage_sids'] != 'on')
 		return array();
-	if (empty($suricatacfg['disable_sid_file']) && empty($suricatacfg['enable_sid_file']))
+	if (empty($suricatacfg['disable_sid_file']) && empty($suricatacfg['enable_sid_file']) && empty($suricatacfg['drop_sid_file']))
 		return array();
 
 	// Configure the interface's logging subdirectory if log results is enabled
@@ -2210,6 +2217,7 @@ function suricata_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results 
 					$rule_map[$k1][$k2]['rule'] = ltrim($rule_map[$k1][$k2]['rule'], " \t#");
 					$rule_map[$k1][$k2]['disabled'] = 0;
 					$rule_map[$k1][$k2]['managed'] = 1;
+					$rule_map[$k1][$k2]['state_toggled'] = 1;
 					$changecount++;
 					$modcount++;
 				}
@@ -2217,21 +2225,16 @@ function suricata_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results 
 					$rule_map[$k1][$k2]['rule'] = "# " . $rule_map[$k1][$k2]['rule'];
 					$rule_map[$k1][$k2]['disabled'] = 1;
 					$rule_map[$k1][$k2]['managed'] = 1;
+					$rule_map[$k1][$k2]['state_toggled'] = 1;
 					$changecount++;
 					$modcount++;
 				}
 				elseif ($action == 'drop' && $rule_map[$k1][$k2]['action'] != 'drop') {
-					if ($rule_map[$k1][$k2]['disabled'] == 1) {
-						$tmp = ltrim($rule_map[$k1][$k2]['rule'], " \t#");
-					}
-					else {
-						$tmp = $rule_map[$k1][$k2]['rule'];
-					}
-					if ($tmp = preg_replace('/^alert/', 'drop', $tmp)) {
+					if ($tmp = preg_replace('/alert/', 'drop', $rule_map[$k1][$k2]['rule'], 1)) {
 						$rule_map[$k1][$k2]['rule'] = $tmp;
-						$rule_map[$k1][$k2]['disabled'] = 0;
 						$rule_map[$k1][$k2]['action'] = 'drop';
 						$rule_map[$k1][$k2]['managed'] = 1;
+						$rule_map[$k1][$k2]['modified'] = 1;
 						$changecount++;
 						$modcount++;
 					}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -42,7 +42,7 @@
 /* This module is called once during the Suricata package installation to   */
 /* perform required post-installation setup.  It should only be executed    */
 /* from the Package Manager process via the custom-post-install hook in     */
-/* the snort.xml package configuration file.                                */
+/* the suricata.xml package configuration file.                                */
 /****************************************************************************/
 
 require_once("config.inc");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
@@ -55,7 +55,7 @@
 * Copyright (C) 2006 Scott Ullrich (copyright assigned to ESF)
 * Copyright (C) 2009 Robert Zelaya Sr. Developer
 * Copyright (C) 2012 Ermal Luci  (copyright assigned to ESF)
-* Copyright (C) 2014 Bill Meeks
+* Copyright (C) 2016 Bill Meeks
 *
 */
 require_once("guiconfig.inc");
@@ -664,8 +664,14 @@ if ($importalias) {
 									<th><?=gettext("Name")?></th>
 									<th><?=gettext("Bind-To Address Alias")?></th>
 									<th>
-										<input type="submit" name="import_alias" class="btn btn-sm btn-primary" title="<?=gettext("Import server configuration from existing Aliases")?>" value="Import"/>
-										<input type="submit" name="add_libhtp_policy" class="btn btn-sm btn-success" title="<?=gettext("Add a new server configuration")?>" value="Add">
+										<button type="submit" name="import_alias" class="btn btn-sm btn-primary" title="<?=gettext("Import server configuration from existing Aliases")?>" value="Import">
+											<i class="fa fa-upload icon-embed-btn"></i>
+											<?=gettext("Import"); ?>
+										</button>
+										<button type="submit" name="add_libhtp_policy" class="btn btn-sm btn-success" title="<?=gettext("Add a new server configuration")?>" value="Add">
+											<i class="fa fa-plus icon-embed-btn"></i>
+											<?=gettext("Add"); ?>
+										</button>
 									</th>
 								</tr>
 							</thead>
@@ -675,11 +681,22 @@ if ($importalias) {
 									<td><?=gettext($v['name'])?></td>
 									<td class="text-center"><?=gettext($v['bind_to'])?></td>
 									<td class="text-right">
-										<input type="submit" name="edit_libhtp_policy[]" value="Edit" class="btn btn-sm btn-primary" onclick="document.getElementById('eng_id').value='<?=$f?>'" title="<?=gettext("Edit this server configuration")?>"/>
+										<button type="submit" name="edit_libhtp_policy[]" value="Edit" class="btn btn-sm btn-primary" onclick="document.getElementById('eng_id').value='<?=$f?>'" title="<?=gettext("Edit this server configuration")?>">
+											<i class="fa fa-pencil icon-embed-btn"></i>
+											<?=gettext("Edit"); ?>
+
+										</button>
 									<?php if ($v['bind_to'] != "all") : ?>
-										<input type="submit" name="del_libhtp_policy[]" value="Delete" class="btn btn-sm btn-danger" onclick="document.getElementById('eng_id').value='<?=$f?>';return confirm('Are you sure you want to delete this entry?');" title="<?=gettext("Delete this server configuration")?>">
+										<button type="submit" name="del_libhtp_policy[]" value="Delete" class="btn btn-sm btn-danger" onclick="document.getElementById('eng_id').value='<?=$f?>';return confirm('Are you sure you want to delete this entry?');" title="<?=gettext("Delete this server configuration")?>">
+											<i class="fa fa-trash icon-embed-btn"></i>
+											<?=gettext("Delete"); ?>
+
+										</button>
 									<?php else : ?>
-										<input type="submit" name="del_libhtp_policy[]" value="Delete" class="btn btn-sm btn-danger" title="<?=gettext("Delete this server configuration")?>" disabled>
+										<button type="submit" name="del_libhtp_policy[]" value="Delete" class="btn btn-sm btn-danger" title="<?=gettext("Delete this server configuration")?>" disabled>
+											<i class="fa fa-trash icon-embed-btn"></i>
+											<?=gettext("Delete"); ?>
+										</button>
 									<?php endif ?>
 									</td>
 								</tr>
@@ -694,6 +711,7 @@ if ($importalias) {
 
 	<div class="col-sm-10 col-sm-offset-2">
 		<button type="submit" id="save" name="save" value="Save" class="btn btn-primary" title="<?=gettext('Save App Parsers settings');?>">
+			<i class="fa fa-save icon-embed-btn"></i>
 			<?=gettext('Save');?>
 		</button>
 	</div>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
@@ -123,6 +123,7 @@ if (isset($id) && $a_nat[$id]) {
 // "selectalias", when true, displays radio buttons to limit
 // multiple selections.
 if ($_POST['import_alias']) {
+	$eng_id = $libhtp_engine_next_id;
 	$importalias = true;
 	$selectalias = false;
 	$title = "HTTP Server Policy";
@@ -191,7 +192,7 @@ if ($_POST['save_libhtp_policy']) {
 
 		// if no errors, write new entry to conf
 		if (!$input_errors) {
-			if (isset($eng_id) && $a_nat[$id]['libhtp_policy']['item'][$eng_id]) {
+			if (isset($eng_id) && isset($a_nat[$id]['libhtp_policy']['item'][$eng_id])) {
 				$a_nat[$id]['libhtp_policy']['item'][$eng_id] = $engine;
 			}
 			else
@@ -220,7 +221,14 @@ if ($_POST['save_libhtp_policy']) {
 
 			// Now write the new engine array to conf
 			write_config("Suricata pkg: saved updated HTTP server configuration for " . convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']));
-			$pconfig['libhtp_policy']['item'] = $a_nat[$id]['libhtp_policy']['item'];
+			$add_edit_libhtp_policy = false;
+			header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
+			header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
+			header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+			header( 'Cache-Control: post-check=0, pre-check=0', false );
+			header( 'Pragma: no-cache' );
+			header("Location: suricata_app_parsers.php?id=$id");
+			exit;
 		}
 		else {
 			$add_edit_libhtp_policy = true;
@@ -250,10 +258,18 @@ elseif ($_POST['del_libhtp_policy']) {
 		unset($natent['libhtp_policy']['item'][$_POST['eng_id']]);
 		$pconfig = $natent;
 	}
-	if (isset($id) && $a_nat[$id]) {
+	if (isset($id) && isset($a_nat[$id])) {
 		$a_nat[$id] = $natent;
 		write_config("Suricata pkg: deleted a HTTP server configuration for " . convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']));
 	}
+	$add_edit_libhtp_policy = false;
+	header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
+	header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
+	header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+	header( 'Cache-Control: post-check=0, pre-check=0', false );
+	header( 'Pragma: no-cache' );
+	header("Location: suricata_app_parsers.php?id=$id");
+	exit;
 }
 elseif ($_POST['cancel_libhtp_policy']) {
 	$add_edit_libhtp_policy = false;
@@ -364,6 +380,13 @@ elseif ($_POST['save_import_alias']) {
 			// Write the new engine array to config file
 			write_config("Suricata pkg: saved an updated HTTP server configuration for " . convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']));
 			$importalias = false;
+			header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
+			header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
+			header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+			header( 'Cache-Control: post-check=0, pre-check=0', false );
+			header( 'Pragma: no-cache' );
+			header("Location: suricata_app_parsers.php?id=$id");
+			exit;
 		}
 	}
 }
@@ -497,26 +520,27 @@ $tab_array[] = array($menu_iface . gettext("IP Rep"), false, "/suricata/suricata
 display_top_tabs($tab_array, true);
 ?>
 
-<form action="suricata_app_parsers.php" method="post" name="iform" id="iform" class="form-horizontal">
-	<input name="id" type="hidden" value="<?=$id?>"/>
-	<input type="hidden" name="eng_id" id="eng_id" value="<?=$eng_id?>"/>
-
 <?php
 
 if ($importalias) {
 
-	include("/usr/local/www/suricata/suricata_import_aliases.php");
+	print('<form action="suricata_app_parsers.php" method="post" name="iform" id="iform" class="form-horizontal">');
+	print('<input name="id" type="hidden" value="' . $id . '"/>');
+	print('<input type="hidden" name="eng_id" id="eng_id" value="' . $eng_id . '"/>');
 
 	if ($selectalias) {
-		echo '<input type="hidden" name="eng_name" value="' . $eng_name . '"/>';
-		echo '<input type="hidden" name="eng_bind" value="' . $eng_bind . '"/>';
-		echo '<input type="hidden" name="eng_personality" value="' . $eng_personality . '"/>';
-		echo '<input type="hidden" name="eng_req_body_limit" value="' . $eng_req_body_limit . '"/>';
-		echo '<input type="hidden" name="eng_resp_body_limit" value="' . $eng_resp_body_limit . '"/>';
-		echo '<input type="hidden" name="eng_enable_double_decode_path" value="' . $eng_enable_double_decode_path . '"/>';
-		echo '<input type="hidden" name="eng_enable_double_decode_query" value="' . $eng_enable_double_decode_query . '"/>';
-		echo '<input type="hidden" name="eng_enable_uri_include_all" value="' . $eng_enable_uri_include_all . '"/>';
+		print('<input type="hidden" name="eng_name" value="' . $eng_name . '"/>');
+		print('<input type="hidden" name="eng_bind" value="' . $eng_bind . '"/>');
+		print('<input type="hidden" name="eng_personality" value="' . $eng_personality . '"/>');
+		print('<input type="hidden" name="eng_req_body_limit" value="' . $eng_req_body_limit . '"/>');
+		print('<input type="hidden" name="eng_resp_body_limit" value="' . $eng_resp_body_limit . '"/>');
+		print('<input type="hidden" name="eng_enable_double_decode_path" value="' . $eng_enable_double_decode_path . '"/>');
+		print('<input type="hidden" name="eng_enable_double_decode_query" value="' . $eng_enable_double_decode_query . '"/>');
+		print('<input type="hidden" name="eng_enable_uri_include_all" value="' . $eng_enable_uri_include_all . '"/>');
 	}
+
+	include("/usr/local/www/suricata/suricata_import_aliases.php");
+	print('</form>');
 
 } elseif ($add_edit_libhtp_policy) {
 
@@ -524,7 +548,9 @@ if ($importalias) {
 
 } else {
 
-	$form = new Form(false);
+	print('<form action="suricata_app_parsers.php" method="post" name="iform" id="iform" class="form-horizontal">');
+	print('<input name="id" type="hidden" value="' . $id . '"/>');
+	print('<input type="hidden" name="eng_id" id="eng_id" value=""/>');
 
 	$section = new Form_Section('Abstract Syntax One Settings');
 	$section->addInput(new Form_Input(
@@ -681,19 +707,17 @@ if ($importalias) {
 									<td><?=gettext($v['name'])?></td>
 									<td class="text-center"><?=gettext($v['bind_to'])?></td>
 									<td class="text-right">
-										<button type="submit" name="edit_libhtp_policy[]" value="Edit" class="btn btn-sm btn-primary" onclick="document.getElementById('eng_id').value='<?=$f?>'" title="<?=gettext("Edit this server configuration")?>">
+										<button type="submit" name="edit_libhtp_policy" value="Edit" class="btn btn-sm btn-primary" onclick="$('#eng_id').val('<?=$f?>')" title="<?=gettext("Edit this server configuration")?>">
 											<i class="fa fa-pencil icon-embed-btn"></i>
 											<?=gettext("Edit"); ?>
-
 										</button>
 									<?php if ($v['bind_to'] != "all") : ?>
-										<button type="submit" name="del_libhtp_policy[]" value="Delete" class="btn btn-sm btn-danger" onclick="document.getElementById('eng_id').value='<?=$f?>';return confirm('Are you sure you want to delete this entry?');" title="<?=gettext("Delete this server configuration")?>">
+										<button type="submit" name="del_libhtp_policy" value="Delete" class="btn btn-sm btn-danger" onclick="$('#eng_id').val('<?=$f?>');" title="<?=gettext("Delete this server configuration")?>">
 											<i class="fa fa-trash icon-embed-btn"></i>
 											<?=gettext("Delete"); ?>
-
 										</button>
 									<?php else : ?>
-										<button type="submit" name="del_libhtp_policy[]" value="Delete" class="btn btn-sm btn-danger" title="<?=gettext("Delete this server configuration")?>" disabled>
+										<button type="submit" name="del_libhtp_policy" value="Delete" class="btn btn-sm btn-danger" title="<?=gettext("Delete this server configuration")?>" disabled>
 											<i class="fa fa-trash icon-embed-btn"></i>
 											<?=gettext("Delete"); ?>
 										</button>
@@ -716,9 +740,9 @@ if ($importalias) {
 		</button>
 	</div>
 
-<?php } ?>
-
 </form>
+
+<?php } ?>
 
 <?php include("foot.inc"); ?>
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
@@ -56,7 +56,7 @@
 * Copyright (C) 2006 Scott Ullrich (copyright assigned to ESF)
 * Copyright (C) 2009 Robert Zelaya Sr. Developer
 * Copyright (C) 2012 Ermal Luci  (copyright assigned to ESF)
-* Copyright (C) 2014 Bill Meeks
+* Copyright (C) 2016 Bill Meeks
 *
 */
 
@@ -497,15 +497,16 @@ display_top_tabs($tab_array, true);
 
 <?php
 
-
 	if ($importalias) {
-
-		$form = new Form($svbtn);
-
 		$svbtn = new Form_Button(
 			'save_os_policy',
-			'Save OS Policy'
+			'Save OS Policy',
+			null,
+			'fa-save'
 		);
+		$svbtn->addClass("btn-primary");
+
+		$form = new Form($svbtn);
 
 		$form->addGlobal(new Form_Input(
 			'id',
@@ -548,8 +549,11 @@ display_top_tabs($tab_array, true);
 
 		$svbtn = new Form_Button(
 			'save_os_policy',
-			'Save'
+			'Save',
+			null,
+			'fa-save'
 		);
+		$svbtn->addClass("btn-primary");
 
 		$form = new Form($svbtn);
 
@@ -594,8 +598,14 @@ display_top_tabs($tab_array, true);
 									<th><?=gettext("Name")?></th>
 									<th><?=gettext("Bind-To Address Alias")?></th>
 									<th>
-										<input type="submit" name="import_alias[]" class="btn btn-sm btn-primary" title="<?=gettext("Import policy configuration from existing Aliases")?>" value="Import" />
-										<input type="submit" name="add_os_policy[]" class="btn btn-sm btn-success" title="<?=gettext("Add a new policy configuration")?>" value="Add"/>
+										<button type="submit" name="import_alias[]" class="btn btn-sm btn-primary" title="<?=gettext("Import policy configuration from existing Aliases")?>" value="Import">
+											<i class="fa fa-upload icon-embed-btn"></i>
+											<?=gettext("Import"); ?>
+										</button>
+										<button type="submit" name="add_os_policy[]" class="btn btn-sm btn-success" title="<?=gettext("Add a new policy configuration")?>" value="Add">
+											<i class="fa fa-plus icon-embed-btn"></i>
+											<?=gettext("Add"); ?>
+										</button>
 									</th>
 								</tr>
 							</thead>
@@ -605,11 +615,20 @@ display_top_tabs($tab_array, true);
 										<td><?=gettext($v['name'])?></td>
 										<td><?=gettext($v['bind_to'])?></td>
 										<td>
-											<input type="submit" name="edit_os_policy[]" class="btn btn-sm btn-primary" value="Edit" onclick="document.getElementById('eng_id').value='<?=$f?>'" title="<?=gettext("Edit this policy configuration")?>"/>
+											<button type="submit" name="edit_os_policy[]" class="btn btn-sm btn-primary" value="Edit" onclick="document.getElementById('eng_id').value='<?=$f?>'" title="<?=gettext("Edit this policy configuration")?>">
+												<i class="fa fa-pencil icon-embed-btn"></i>
+												<?=gettext("Edit"); ?>
+											</button>
 								<?php if ($v['bind_to'] != "all") : ?>
-											<input type="submit" name="del_os_policy[]" class="btn btn-sm btn-danger" value="Delete" onclick="document.getElementById('eng_id').value='<?=$f?>';return confirm('Are you sure you want to delete this entry?');" title="<?=gettext("Delete this policy configuration")?>"/>
+											<button type="submit" name="del_os_policy[]" class="btn btn-sm btn-danger" value="Delete" onclick="document.getElementById('eng_id').value='<?=$f?>';return confirm('Are you sure you want to delete this entry?');" title="<?=gettext("Delete this policy configuration")?>">
+												<i class="fa fa-trash icon-embed-btn"></i>
+												<?=gettext("Delete"); ?>
+											</button>
 								<?php else : ?>
-								<input type="submit" name="del_os_policy[]" class="btn btn-sm btn-danger" value="Delete" title="<?=gettext("Default policy configuration cannot be deleted")?>" disabled/>
+											<button type="submit" name="del_os_policy[]" class="btn btn-sm btn-danger" value="Delete" title="<?=gettext("Default policy configuration cannot be deleted")?>" disabled>
+												<i class="fa fa-trash icon-embed-btn"></i>
+												<?=gettext("Delete"); ?>
+											</button>
 								<?php endif ?>
 										</td>
 									</tr>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
@@ -121,6 +121,7 @@ if (isset($id) && $a_nat[$id]) {
 // "selectalias", when true, displays radio buttons to limit
 // multiple selections.
 if ($_POST['import_alias']) {
+	$eng_id = $host_os_policy_engine_next_id;
 	$importalias = true;
 	$selectalias = false;
 	$title = "Host Operating System Policy";
@@ -207,7 +208,13 @@ if ($_POST['save_os_policy']) {
 
 			// Now write the new engine array to conf
 			write_config();
-			$pconfig['host_os_policy']['item'] = $a_nat[$id]['host_os_policy']['item'];
+			header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
+			header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
+			header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+			header( 'Cache-Control: post-check=0, pre-check=0', false );
+			header( 'Pragma: no-cache' );
+			header("Location: suricata_flow_stream.php?id=$id");
+			exit;
 		}
 	}
 }
@@ -235,6 +242,13 @@ elseif ($_POST['del_os_policy']) {
 		$a_nat[$id] = $natent;
 		write_config();
 	}
+	header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
+	header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
+	header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+	header( 'Cache-Control: post-check=0, pre-check=0', false );
+	header( 'Pragma: no-cache' );
+	header("Location: suricata_flow_stream.php?id=$id");
+	exit;
 }
 elseif ($_POST['cancel_os_policy']) {
 	$add_edit_os_policy = false;
@@ -433,6 +447,13 @@ elseif ($_POST['save_import_alias']) {
 			write_config();
 			$importalias = false;
 			$selectalias = false;
+			header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
+			header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
+			header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+			header( 'Cache-Control: post-check=0, pre-check=0', false );
+			header( 'Pragma: no-cache' );
+			header("Location: suricata_flow_stream.php?id=$id");
+			exit;
 		}
 	}
 }
@@ -496,93 +517,33 @@ display_top_tabs($tab_array, true);
 ?>
 
 <?php
-
 	if ($importalias) {
-		$svbtn = new Form_Button(
-			'save_os_policy',
-			'Save OS Policy',
-			null,
-			'fa-save'
-		);
-		$svbtn->addClass("btn-primary");
 
-		$form = new Form($svbtn);
-
-		$form->addGlobal(new Form_Input(
-			'id',
-			'id',
-			'hidden',
-			$id
-		));
-
-		$form->addGlobal(new Form_Input(
-			'eng_id',
-			'eng_id',
-			'hidden',
-			$eng_id
-		));
+		print('<form action="suricata_flow_stream.php" method="post" name="iform" id="iform" class="form-horizontal">');
+		print('<input type="hidden" name="eng_id" id="eng_id" value="<?=$eng_id?>"/>');
+		print('<input type="hidden" name="id" id="id" value="<?=$id?>"/>');
 
 		if ($selectalias) {
-			$form->addGlobal(new Form_Input(
-				'eng_name',
-				'eng_name',
-				'hidden',
-				$eng_name
-			));
-			$form->addGlobal(new Form_Input(
-				'eng_bind',
-				'eng_bind',
-				'hidden',
-				$eng_bind
-			));
-			$form->addGlobal(new Form_Input(
-				'eng_policy',
-				'eng_policy',
-				'hidden',
-				$eng_policy
-			));
+			print('<input type="hidden" name="eng_name" value="' . $eng_name . '"/>');
+			print('<input type="hidden" name="eng_bind" value="' . $eng_bind . '"/>');
+			print('<input type="hidden" name="eng_policy" value="' . $eng_policy . '"/>');
 		}
 
 		include("/usr/local/www/suricata/suricata_import_aliases.php");
+		print('</form>');
 
 	} elseif ($add_edit_os_policy) {
 
-		$svbtn = new Form_Button(
-			'save_os_policy',
-			'Save',
-			null,
-			'fa-save'
-		);
-		$svbtn->addClass("btn-primary");
-
-		$form = new Form($svbtn);
-
-		$form->addGlobal(new Form_Input(
-			'id',
-			'id',
-			'hidden',
-			$id
-		));
-
-		$form->addGlobal(new Form_Input(
-			'eng_id',
-			'eng_id',
-			'hidden',
-			$eng_id
-		));
-
-		$form->addGlobal(new Form_Button(
-			'cancel_os_policy',
-			'Cancel'
-		))->removeClass('btn-primary')->addClass('btn-warning');
-
+		$form = new Form(false);
 		include("/usr/local/www/suricata/suricata_os_policy_engine.php");
 
 	} else {
 ?>
-<form action="suricata_flow_stream.php" method="post" name="iform" id="iform">
+
+<form action="suricata_flow_stream.php" method="post" name="iform" id="iform" class="form-horizontal">
 <input type="hidden" name="eng_id" id="eng_id" value="<?=$eng_id?>"/>
 <input type="hidden" name="id" id="id" value="<?=$id?>"/>
+
 	<div class="panel panel-default">
 		<div class="panel-heading"><h2 class="panel-title"><?=gettext("Host-Specific Defrag and Stream Settings")?></h2></div>
 		<div class="panel-body">
@@ -620,7 +581,7 @@ display_top_tabs($tab_array, true);
 												<?=gettext("Edit"); ?>
 											</button>
 								<?php if ($v['bind_to'] != "all") : ?>
-											<button type="submit" name="del_os_policy[]" class="btn btn-sm btn-danger" value="Delete" onclick="document.getElementById('eng_id').value='<?=$f?>';return confirm('Are you sure you want to delete this entry?');" title="<?=gettext("Delete this policy configuration")?>">
+											<button type="submit" name="del_os_policy[]" class="btn btn-sm btn-danger" value="Delete" onclick="document.getElementById('eng_id').value='<?=$f?>';" title="<?=gettext("Delete this policy configuration")?>">
 												<i class="fa fa-trash icon-embed-btn"></i>
 												<?=gettext("Delete"); ?>
 											</button>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_import_aliases.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_import_aliases.php
@@ -99,7 +99,6 @@
 	}
 ?>
 
-<form action="suricata_flow_stream.php" method="post" name="iform" id="iform">
 <div class="panel panel-default">
 	<div class="panel-heading"><h2 class="panel-title"><?=$header?></h2></div>
 	<div class="panel-body">
@@ -161,7 +160,6 @@
 					  </td>
 					</tr>
 				  <?php $i++; endforeach; ?>
-					</tr>
 				</tbody>
 				<tfoot>
 					<tr>
@@ -202,5 +200,5 @@
 		</div>
 	</div>
 </div>
-</form>
+
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_import_aliases.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_import_aliases.php
@@ -56,7 +56,7 @@
 * Copyright (C) 2006 Scott Ullrich (copyright assigned to ESF)
 * Copyright (C) 2009 Robert Zelaya Sr. Developer
 * Copyright (C) 2012 Ermal Luci  (copyright assigned to ESF)
-* Copyright (C) 2014 Bill Meeks
+* Copyright (C) 2016 Bill Meeks
 *
 */
 
@@ -161,33 +161,46 @@
 					  </td>
 					</tr>
 				  <?php $i++; endforeach; ?>
-				<?php if (!$selectablealias): ?>
-					<tr>
-						<td colspan="4" class="text-center"><b><?=gettext("There are currently no defined Aliases eligible for import.")?></b></td>
-					</tr>
-					<tr>
-						<td colspan="4" class="text-center">
-							<input type="Submit" name="cancel_import_alias" value="Cancel" id="cancel_import_alias" class="btn btn-warning" title="<?=gettext("Cancel import operation and return")?>"/>
-						</td>
-					</tr>
-					<?php else: ?>
-					<tr>
-						<td colspan="4" >
-							<input type="Submit" name="save_import_alias" value="Save" id="save_import_alias" class="btn btn-primary" title="<?=gettext("Import selected item and return")?>"/>
-							<input type="Submit" name="cancel_import_alias" value="Cancel" id="cancel_import_alias" class="btn btn-default" title="<?=gettext("Cancel import operation and return")?>"/>
-						</td>
-					</tr>
-					<?php endif; ?>
-					<tr>
-						<td colspan="4">
-							<span class="text-danger"><strong><?=gettext("Note:"); ?></strong></span> <?=gettext("Fully-Qualified Domain Name (FQDN) host Aliases cannot be used as Suricata configuration parameters.  Aliases resolving to a single FQDN value are disabled in the list above.  In the case of nested Aliases where one or more of the nested values is a FQDN host, the FQDN host will not be included in the {$title} configuration.")?>
-						</td>
 					</tr>
 				</tbody>
+				<tfoot>
+					<tr>
+						<td colspan="4">
+							<div class="infoblock blockopen">
+							<?=print_info_box("<b>" . gettext("Note: ") . "</b>" . gettext("Fully-Qualified Domain Name (FQDN) host Aliases cannot be used as " . 
+							"Suricata configuration parameters. Aliases resolving to a single FQDN value are disabled in the list above.  " . 
+							"In the case of nested Aliases where one or more of the nested values is a FQDN host, the FQDN host will not " . 
+							"be included in the {$title} configuration."), "info", false);?>
+							</div>
+						</td>
+					</tr>
+				</tfoot>
 			</table>
+		</div>
+
+		<div class="content table-responsive">
+			<?php if (!$selectablealias): ?>
+				<div class="text-center">
+					<b><?=gettext("There are currently no defined Aliases eligible for import.")?></b>
+				</div>
+				<div class="text-center">
+					<button type="Submit" name="cancel_import_alias" value="Cancel" id="cancel_import_alias" class="btn btn-warning" title="<?=gettext("Cancel import operation and return")?>">
+						<?=gettext("Cancel"); ?>
+					</button>
+				</div>
+			<?php else: ?>
+				<div class="text-left">
+					<button type="Submit" name="save_import_alias" value="Save" id="save_import_alias" class="btn btn-primary" title="<?=gettext("Import selected item and return")?>">
+						<i class="fa fa-save icon-embed-btn"></i>
+						<?=gettext("Save"); ?>
+					</button>
+					<button type="Submit" name="cancel_import_alias" value="Cancel" id="cancel_import_alias" class="btn btn-warning" title="<?=gettext("Cancel import operation and return")?>">
+						<?=gettext("Cancel"); ?>
+					</button>
+				</div>
+			<?php endif; ?>
 		</div>
 	</div>
 </div>
 </form>
-
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -478,7 +478,7 @@ include_once("head.inc"); ?>
 							<div class="col-md-6">
 								<p>
 									<i class="fa fa-lg fa-check-circle" alt="Running"></i> <i class="fa fa-lg fa-times" alt="Not Running"></i> icons will show current Suricata and barnyard2 status<br/>
-									Click on the <i class="fa fa-lg fa-repeat" alt="Start"></i> or <i class="fa fa-lg fa-stop-circle-o" alt="Stop"></i> icons to start/stop Suricata and Barnyard2.
+									Click the <i class="fa fa-lg fa-play-circle" alt="Start"></i> or <i class="fa fa-lg fa-repeat" alt="Restart"></i> or <i class="fa fa-lg fa-stop-circle-o" alt="Stop"></i> icons to start/restart/stop Suricata and Barnyard2.
 								</p>
 							</div>
 						</div>', info, false)?>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1084,6 +1084,7 @@ events.push(function(){
 		if ($('#ips_mode').val() == 'ips_mode_inline') {
 			hideCheckbox('blockoffenderskill', true);
 			hideSelect('blockoffendersip', true);
+			hideClass('passlist', true);
 		}
 	}
 
@@ -1273,10 +1274,12 @@ events.push(function(){
 		if ($('#ips_mode').val() == 'ips_mode_inline') {
 			hideCheckbox('blockoffenderskill', true);
 			hideSelect('blockoffendersip', true);
+			hideClass('passlist', true);
 		}
 		else {
 			hideCheckbox('blockoffenderskill', false);
 			hideSelect('blockoffendersip', false);
+			hideClass('passlist', false);
 		}
 	});
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_libhtp_policy_engine.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_libhtp_policy_engine.php
@@ -56,7 +56,7 @@
 * Copyright (C) 2006 Scott Ullrich (copyright assigned to ESF)
 * Copyright (C) 2009 Robert Zelaya Sr. Developer
 * Copyright (C) 2012 Ermal Luci  (copyright assigned to ESF)
-* Copyright (C) 2014 Bill Meeks
+* Copyright (C) 2016 Bill Meeks
 *
 */
 
@@ -88,10 +88,7 @@
  **************************************************************************************/
 
 
-$form = new Form(new Form_Button(
-	'save_libhtp_policy',
-	'Save'
-));
+$form = new Form(false);
 
 $section = new Form_Section('Suricata Target-Based HTTP Server Policy Configuration');
 $section->addInput(new Form_Input(
@@ -152,6 +149,13 @@ $section->addInput(new Form_Checkbox(
 	'on'
 ));
 $form->add($section);
+
+$form->addGlobal(new Form_Button(
+	'save_libhtp_policy',
+	'Save',
+	null,
+	'fa-save'
+))->addClass("btn-primary");
 
 $form->addGlobal(new Form_Button(
 	'cancel_libhtp_policy',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_mgmt.php
@@ -298,15 +298,15 @@ $form = new Form;
 $section = new Form_Section('General Settings');
 $section->addInput(new Form_Checkbox(
 	'clearlogs',
-	'Remove Snort Logs On Package Uninstall',
-	'Snort log files will be removed when the Snort package is uninstalled.',
+	'Remove Suricata Logs On Package Uninstall',
+	'Suricata log files will be removed when the Suricata package is uninstalled.',
 	$config['installedpackages']['suricata']['config'][0]['clearlogs'] == 'on' ? true:false,
 	'on'
 ));
 $section->addInput(new Form_Checkbox(
 	'enable_log_mgmt',
 	'Auto Log Management',
-	'Enable automatic unattended management of Snort logs using parameters specified below.',
+	'Enable automatic unattended management of Suricata logs using parameters specified below.',
 	$config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 'on' ? true:false,
 	'on'
 ));
@@ -325,7 +325,7 @@ $section->addInput(new Form_Input(
 	'Log Limit Size in MB',
 	'text',
 	$pconfig['suricataloglimitsize']
-))->setHelp('This setting imposes a hard-limit on the combined log directory size of all Snort interfaces.  When the size limit set is reached, rotated logs for all interfaces will be removed, and any active logs pruned to zero-length.   (default is 20% of available free disk space)');
+))->setHelp('This setting imposes a hard-limit on the combined log directory size of all Suricata interfaces.  When the size limit set is reached, rotated logs for all interfaces will be removed, and any active logs pruned to zero-length.   (default is 20% of available free disk space)');
 $form->add($section);
 
 $section = new Form_Section("Log Size and Retention Limits");
@@ -553,7 +553,7 @@ events.push(function(){
 		enable_change();
 	});
 
-	// When 'snortloglimit_on' is clicked, disable/enable the other page form controls
+	// When 'suricataloglimit_on' is clicked, disable/enable the other page form controls
 	$('#suricataloglimit').click(function() {
 		enable_change_dirSize();
 	});

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_os_policy_engine.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_os_policy_engine.php
@@ -90,20 +90,37 @@ $section->addInput(new Form_Input(
 	$pengcfg['name']
 ))->setHelp('Name or description for this engine. (Max 25 characters). Unique name or description for this engine configuration. Default value is default.');
 
-$group = new Form_Group('Bind-To IP Address Alias');
-$group->add(new Form_Input(
-	'policy_bind_to',
-	'Bind-To IP Address Alias',
-	'text',
-	$pengcfg['bind_to']
-))->setHelp('IP List to bind this engine to (Cannot be blank). This policy will apply for packets with destination addresses contained within this IP List. Supplied value must be a pre-configured Alias or the keyword "all".');
-$group->add(new Form_Button(
-	'select_alias',
-	'Aliases',
-	null,
-	'fa-upload'
-))->removeClass('btn-primary')->addClass('btn-sm btn-success');
-$section->add($group);
+if ($pengcfg['name'] <> "default") {
+	$bind_to = new Form_Input(
+		'policy_bind_to',
+		'',
+		'text',
+		$pengcfg['bind_to']
+	);
+	$bind_to->setAttribute('title', trim(filter_expand_alias($pconfig['bind_to'])));
+	$bind_to->setHelp('IP List to bind this engine to. (Cannot be blank)');
+	$btnaliases = new Form_Button(
+		'select_alias',
+		' ' . 'Aliases',
+		null,
+		'fa-search-plus'
+	);
+	$btnaliases->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-success')->addClass('btn-sm');
+	$btnaliases->setAttribute('title', gettext("Select an existing IP alias"));
+	$group = new Form_Group('Bind-To IP Address Alias');
+	$group->add($bind_to);
+	$group->add($btnaliases);
+	$group->setHelp(gettext("Supplied value must be a pre-configured Alias or the keyword 'all'."));
+	$section->add($group);
+}
+else {
+	$section->addInput( new Form_Input(
+		'policy_bind_to',
+		'Bind-To IP Address Alias',
+		'text',
+		$pengcfg['bind_to']
+	))->setReadonly()->setHelp('The default engine is required and only runs for packets with destination addresses not matching other engine IP Lists.');
+}
 
 $section->addInput(new Form_Select(
 	'policy',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_os_policy_engine.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_os_policy_engine.php
@@ -56,7 +56,7 @@
 * Copyright (C) 2006 Scott Ullrich (copyright assigned to ESF)
 * Copyright (C) 2009 Robert Zelaya Sr. Developer
 * Copyright (C) 2012 Ermal Luci  (copyright assigned to ESF)
-* Copyright (C) 2014 Bill Meeks
+* Copyright (C) 2016 Bill Meeks
 *
 */
 
@@ -99,8 +99,10 @@ $group->add(new Form_Input(
 ))->setHelp('IP List to bind this engine to (Cannot be blank). This policy will apply for packets with destination addresses contained within this IP List. Supplied value must be a pre-configured Alias or the keyword "all".');
 $group->add(new Form_Button(
 	'select_alias',
-	'Aliases'
-))->removeClass('btn-primary')->addClass('btn-info');
+	'Aliases',
+	null,
+	'fa-upload'
+))->removeClass('btn-primary')->addClass('btn-sm btn-success');
 $section->add($group);
 
 $section->addInput(new Form_Select(
@@ -114,8 +116,6 @@ $form->add($section);
 print($form);
 ?>
 
-<script type="text/javascript" src="/javascript/autosuggest.js"></script>
-<script type="text/javascript" src="/javascript/suggestions.js"></script>
 <script type="text/javascript">
 //<![CDATA[
 	var addressarray = <?= json_encode(get_alias_list(array("host", "network"))) ?>;

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_os_policy_engine.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_os_policy_engine.php
@@ -82,6 +82,19 @@
 	cancel_os_policy --> Submit button to cancel operation and exit
  **************************************************************************************/
 
+$form->addGlobal(new Form_Input(
+	'id',
+	'id',
+	'hidden',
+	$id
+));
+$form->addGlobal(new Form_Input(
+	'eng_id',
+	'eng_id',
+	'hidden',
+	$eng_id
+));
+
 $section = new Form_Section('Suricata Target-Based Host OS Policy Engine Configuration');
 $section->addInput(new Form_Input(
 	'policy_name',
@@ -101,7 +114,7 @@ if ($pengcfg['name'] <> "default") {
 	$bind_to->setHelp('IP List to bind this engine to. (Cannot be blank)');
 	$btnaliases = new Form_Button(
 		'select_alias',
-		' ' . 'Aliases',
+		'Aliases',
 		null,
 		'fa-search-plus'
 	);
@@ -130,20 +143,31 @@ $section->addInput(new Form_Select(
 ))->setHelp('Choose the OS target policy appropriate for the protected hosts. The default is BSD.');
 $form->add($section);
 
+$form->addGlobal(new Form_Button(
+	'save_os_policy',
+	'Save',
+	null,
+	'fa-save'
+))->addClass("btn-primary");
+
+$form->addGlobal(new Form_Button(
+	'cancel_os_policy',
+	'Cancel',
+	null
+))->removeClass("btn-primary")->addClass("btn-warning");
+
 print($form);
 ?>
 
 <script type="text/javascript">
 //<![CDATA[
+events.push(function() {
 	var addressarray = <?= json_encode(get_alias_list(array("host", "network"))) ?>;
 
-function createAutoSuggest() {
-	<?php
-		echo "\tvar objAlias = new AutoSuggestControl(document.getElementById('policy_bind_to'), new StateSuggestions(addressarray));\n";
-	?>
-}
-
-setTimeout("createAutoSuggest();", 500);
+	$('#policy_bind_to').autocomplete({
+		source: addressarray
+	});
+});
 //]]>
 </script>
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
@@ -248,7 +248,7 @@ $tab_array[] = array(gettext("Sync"), false, "/pkg_edit.php?xml=suricata/suricat
 $tab_array[] = array(gettext("IP Lists"), false, "/suricata/suricata_ip_list_mgmt.php");
 display_top_tabs($tab_array, true);
 
-$form = new Form;
+$form = new Form(FALSE);
 $section = new Form_Section('General Information');
 $section->addInput(new Form_Input(
 	'name',
@@ -270,13 +270,6 @@ $section->addInput(new Form_Checkbox(
 	'Local Networks',
 	'Add firewall Locally-Attached Networks to the list (excluding WAN).',
 	$pconfig['localnets'] == 'yes' ? true:false,
-	'yes'
-));
-$section->addInput(new Form_Checkbox(
-	'wanips',
-	'WAN IPs',
-	'Add WAN interface IPs to the list.',
-	$pconfig['wanips'] == 'yes' ? true:false,
 	'yes'
 ));
 $section->addInput(new Form_Checkbox(
@@ -310,12 +303,40 @@ $section->addInput(new Form_Checkbox(
 $form->add($section);
 
 $section = new Form_Section('Custom IP Address from Configured Alias');
-$section->addInput(new Form_Input(
+$group = new Form_Group('Assigned Alias');
+$group->add(new Form_Input(
 	'address',
 	'Assigned Alias',
 	'text',
 	$pconfig['address']
-))->setHelp('Enter the name of an existing Alias.')->setAttribute('title', gettext(trim(filter_expand_alias($pconfig['address']))));
+))->setHelp('Enter the name of an existing Alias.')->setAttribute('title', trim(filter_expand_alias($pconfig['address'])));
+$group->add(new Form_Button(
+	'btnSelectAlias',
+	'Aliases',
+	'javascript:selectAlias();',
+	'fa-upload'
+))->removeClass('btn-default')->addClass('btn-sm btn-success')->setAttribute('title', gettext('View and select from available aliases'));
+$section->add($group);
+$form->add($section);
+
+$section = new Form_Section('');
+$btnsave = new Form_Button(
+	'save',
+	'Save',
+	null,
+	'fa-save'
+);
+$btncancel = new Form_Button(
+	'cancel',
+	'Cancel'
+);
+$btnsave->addClass('btn-primary')->addClass('btn-default');
+$btncancel->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-warning');
+
+$section->addInput(new Form_StaticText(
+	null,
+	$btnsave . $btncancel
+));
 $form->add($section);
 
 // Include the Pass List ID in a hidden form field with any $_POST
@@ -341,20 +362,20 @@ function selectAlias() {
 
 	// Scrape current form field values and add to
 	// the select alias URL as a query string.
-	var loc = '/suricata/suricata_select_alias.php?id=<?=$id?>&act=import&type=host|network';
+	var loc = '/suricata/suricata_select_alias.php?id=<?=$id;?>&act=import&type=host|network';
 	loc = loc + '&varname=address&multi_ip=yes';
-	loc = loc + '&returl=<?=urlencode($_SERVER['PHP_SELF'])?>';
-	loc = loc + '&uuid=<?=$passlist_uuid?>';
+	loc = loc + '&returl=<?=urlencode($_SERVER['PHP_SELF']);?>';
+	loc = loc + '&uuid=<?=$passlist_uuid;?>';
 
 	// Iterate over just the specific form fields we want to pass to
 	// the select alias URL.
 	fields.forEach(function(entry) {
-		var tmp = $(entry).serialize();
+		var tmp = $('#' + entry).serialize();
 		if (tmp.length > 0)
 			loc = loc + '&' + tmp;
 	});
-
-	window.parent.location = loc;
+	
+	window.parent.location = loc; 
 }
 
 events.push(function() {
@@ -369,5 +390,5 @@ events.push(function() {
 });
 //]]>
 </script>
-
 <?php include("foot.inc"); ?>
+

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
@@ -314,7 +314,7 @@ $group->add(new Form_Button(
 	'btnSelectAlias',
 	'Aliases',
 	'javascript:selectAlias();',
-	'fa-upload'
+	'fa-search-plus'
 ))->removeClass('btn-default')->addClass('btn-sm btn-success')->setAttribute('title', gettext('View and select from available aliases'));
 $section->add($group);
 $form->add($section);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -56,7 +56,7 @@
 * Copyright (C) 2006 Scott Ullrich (copyright assigned to ESF)
 * Copyright (C) 2009 Robert Zelaya Sr. Developer
 * Copyright (C) 2012 Ermal Luci  (copyright assigned to ESF)
-* Copyright (C) 2014 Bill Meeks
+* Copyright (C) 2016 Bill Meeks
 *
 */
 
@@ -252,7 +252,7 @@ if (isset($_POST['toggle']) && is_numeric($_POST['sid']) && is_numeric($_POST['g
 	// Set a scroll-to anchor location
 	$anchor = "rule_{$gid}_{$sid}";
 }
-elseif ($_POST['disable_all'] && !empty($rules_map)) {
+elseif (isset($_POST['disable_all']) && !empty($rules_map)) {
 
 	// Mark all rules in the currently selected category "disabled".
 	foreach (array_keys($rules_map) as $k1) {
@@ -293,7 +293,7 @@ elseif ($_POST['disable_all'] && !empty($rules_map)) {
 
 	write_config("Suricata pkg: disabled all rules in category {$currentruleset} for {$a_rule[$id]['interface']}.");
 }
-elseif ($_POST['enable_all'] && !empty($rules_map)) {
+elseif (isset($_POST['enable_all']) && !empty($rules_map)) {
 
 	// Mark all rules in the currently selected category "enabled".
 	foreach (array_keys($rules_map) as $k1) {
@@ -333,7 +333,7 @@ elseif ($_POST['enable_all'] && !empty($rules_map)) {
 
 	write_config("Suricata pkg: enable all rules in category {$currentruleset} for {$a_rule[$id]['interface']}.");
 }
-elseif ($_POST['resetcategory'] && !empty($rules_map)) {
+elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 
 	// Reset any modified SIDs in the current rule category to their defaults.
 	foreach (array_keys($rules_map) as $k1) {
@@ -375,7 +375,7 @@ elseif ($_POST['resetcategory'] && !empty($rules_map)) {
 
 	write_config("Suricata pkg: remove enablesid/disablesid changes for category {$currentruleset} on {$a_rule[$id]['interface']}.");
 }
-elseif ($_POST['resetall'] && !empty($rules_map)) {
+elseif (isset($_POST['resetall']) && !empty($rules_map)) {
 
 	// Remove all modified SIDs from config.xml and save the changes.
 	unset($a_rule[$id]['rule_sid_on']);
@@ -387,7 +387,7 @@ elseif ($_POST['resetall'] && !empty($rules_map)) {
 	/* Update the config.xml file. */
 	write_config("Suricata pkg: remove all enablesid/disablesid changes for {$a_rule[$id]['interface']}.");
 }
-elseif ($_POST['clear']) {
+elseif (isset($_POST['clear'])) {
 	unset($a_rule[$id]['customrules']);
 	write_config("Suricata pkg: clear all custom rules for {$a_rule[$id]['interface']}.");
 	$rebuild_rules = true;
@@ -400,11 +400,11 @@ elseif ($_POST['clear']) {
 	// Sync to configured CARP slaves if any are enabled
 	suricata_sync_on_changes();
 }
-elseif ($_POST['cancel']) {
+elseif (isset($_POST['cancel'])) {
 	$pconfig['customrules'] = base64_decode($a_rule[$id]['customrules']);
 	clear_subsystem_dirty('suricata_rules');
 }
-elseif ($_POST['save']) {
+elseif (isset($_POST['save'])) {
 	$pconfig['customrules'] = $_POST['customrules'];
 	if ($_POST['customrules'])
 		$a_rule[$id]['customrules'] = base64_encode(str_replace("\r\n", "\n", $_POST['customrules']));
@@ -423,7 +423,7 @@ elseif ($_POST['save']) {
 	// Sync to configured CARP slaves if any are enabled
 	suricata_sync_on_changes();
 }
-elseif ($_POST['apply']) {
+elseif (isset($_POST['apply'])) {
 
 	/* Save new configuration */
 	write_config("Suricata pkg: new rules configuration for {$a_rule[$id]['interface']}.");
@@ -479,68 +479,6 @@ function build_cat_list() {
 	return(['custom.rules' => 'custom.rules'] + $list);
 }
 
-function build_actions() {
-	global $currentruleset, $id;
-
-	$actions  = '<dl class="dl-horizontal responsive">';
-	$actions .= '<dt>';
-	$actions .= '<a name="resetcategory" type="button" title="' . gettext("Click to remove enable/disable changes for rules in the selected category only") . '" ';
-	$actions .= 'onClick="submitAction(' . '\'resetcategory[]\'' . ')">';
-	$actions .= '<i class="fa fa-times icon-pointer"></i>';
-	$actions .= '</a>';
-	$actions .= '</dt><dd>';
-	$actions .= gettext("Remove Enable/Disable changes in the selected category.");
-	$actions .= '</dd>';
-
-	$actions .= '<dl class="dl-horizontal responsive">';
-	$actions .= '<dt>';
-	$actions .= '<a name="resetall" type="button" title="' . gettext("Click to remove enable/disable changes for rules in all categories") . '" ';
-	$actions .= 'onClick="submitAction(' . '\'resetall[]\'' . ')">';
-	$actions .= '<i class="fa fa-times icon-pointer"></i>';
-	$actions .= '</a>';
-	$actions .= '</dt><dd>';
-	$actions .= gettext("Remove all Enable/Disable changes in all Categories");
-	$actions .= '</dd>';
-
-	$actions .= '<dt>';
-	$actions .= '<a name="diasble_all" type="button" title="' . gettext("Disable all rules in the selected Category") . '" ';
-	$actions .= 'onClick="submitAction(' . '\'diasble_all[]\'' . ')">';
-	$actions .= '<i class="fa fa-arrow-down icon-pointer"></i>';
-	$actions .= '</a>';
-	$actions .= '</dt><dd>';
-	$actions .= gettext("Disable all rules in the current Category");
-	$actions .= '</dd>';
-
-	$actions .= '<dt>';
-	$actions .= '<a name="enable_all" type="button" title="' . gettext("Enable all rules in the current Category") . '" ';
-	$actions .= 'onClick="submitAction(' . '\'enable_all[]\'' . ')">';
-	$actions .= '<i class="fa fa-arrow-up icon-pointer"></i>';
-	$actions .= '</a>';
-	$actions .= '</dt><dd>';
-	$actions .= gettext("Enable all rules in the current Category");
-	$actions .= '</dd>';
-
-	$actions .= '<dt>';
-	$actions .= '<a href="javascript: void(0)" ';
-	$actions .= 'onclick="wopen(\'suricata_rules_edit.php?id=' . $id . '&openruleset=' . $currentruleset . '\',\'FileViewer\')"'  . ' title="' . gettext("View full file contents for the current Category") . '">';
-	$actions .= '<i class="fa fa-folder-open-o icon-pointer"></i>';
-	$actions .= '</a>';
-	$actions .= '</dt><dd>';
-	$actions .= gettext("View full file contents for the current Category");
-	$actions .= '</dd>';
-
-	$actions .= '</dl>';
-
-	if ($currentruleset == 'Auto-Flowbit Rules') {
-		$actions .= '<span class="text-danger"' . '<b>' . gettext('WARNING: ') . '</b></span>' . 
-			gettext('You should not disable flowbit rules!  Add Suppress List entries for them instead by ') . 
-			'<a href="suricata_rules_flowbits.php?id=' . $id . '" title="' . gettext('Add Suppress List entry for Flowbit Rule') . '">' . 
-			gettext("clicking here") . '.</a>';
-	}
-
-	return($actions);
-}
-
 $if_friendly = convert_friendly_interface_to_friendly_descr($pconfig['interface']);
 $pgtitle = array(gettext("Suricata"), gettext("Interface ") . $if_friendly, gettext("Rules: ") . $currentruleset);
 include_once("head.inc");
@@ -585,16 +523,24 @@ $tab_array[] = array($menu_iface . gettext("IP Rep"), false, "/suricata/suricata
 display_top_tabs($tab_array, true);
 
 $form = new Form(false);
+$form->setAttribute('id', 'iform');
 
 $section = new Form_Section("Available rule categories");
-
-$section->addInput(new Form_Select(
+$group = new Form_Group("Category");
+$group->add(new Form_Select(
 	'selectbox',
 	'Category',
 	$currentruleset,
 	build_cat_list()
 ))->setHelp("Select the rule category to view.")
   ->setOnchange("go();");
+$group->add(new Form_Button(
+	'',
+	'View All',
+	'javascript:wopen(\'suricata_rules_edit.php?id=' . $id . '&openruleset=' . $currentruleset . '\',\'FileViewer\');',
+	'fa-file-text-o'
+))->removeClass("btn-default")->addClass("btn-sm btn-success")->setAttribute('title', gettext("View raw text for all rules in selected category"));
+$section->add($group);
 
 if ($currentruleset == 'custom.rules') {
 
@@ -613,19 +559,48 @@ if ($currentruleset == 'custom.rules') {
 } else {
 	$form->add($section);
 
-	$section = new Form_Section("Rule Signature ID (SID) Enable/Disable Overrides");
-
-	$section->addInput(new Form_StaticText(
-		'Rule actions',
-		build_actions()
-	));
-
-	$section->addInput(new Form_Button(
-		'apply',
-		'Apply'
-	))->setHelp('Click Apply to send any SID enable/disable changes made on this tab to the running Suricata process.')
-	  ->removeClass('btn-primary')
-	  ->addClass('btn-success btn-sm');
+$section = new Form_Section('Rule Signature ID (SID) Enable/Disable Overrides');
+$group = new Form_Group('SID Actions');
+$group->add(new Form_Button(
+	'apply',
+	'Apply',
+	null,
+	'fa-save'
+))->setAttribute('title', gettext('Apply changes made on this tab and rebuild the interface rules'))->addClass('btn-primary btn-sm');
+$group->add(new Form_Button(
+	'resetall',
+	'Reset All',
+	null,
+	'fa-repeat'
+))->setAttribute('title', gettext('Remove user overrides for all rule categories'))->addClass('btn-sm btn-warning');
+$group->add(new Form_Button(
+	'resetcategory',
+	'Reset Current',
+	null,
+	'fa-repeat'
+))->setAttribute('title', gettext('Remove user overrides for only the currently selected category'))->addClass('btn-sm btn-warning');
+$group->add(new Form_Button(
+	'disable_all',
+	'Disable All',
+	null,
+	'fa-times-circle-o'
+))->setAttribute('title', gettext('Disable all rules in the currently selected category'))->addClass('btn-sm btn-danger');
+$group->add(new Form_Button(
+	'enable_all',
+	'Enable All',
+	null,
+	'fa-check-circle-o'
+))->setAttribute('title', gettext('Enable all rules in the currently selected category'))->addClass('btn-sm btn-success');
+if ($currentruleset == 'Auto-Flowbit Rules') {
+	$msg = '<b>' . gettext('Note: ') . '</b>' . gettext('You should not disable flowbit rules!  Add Suppress List entries for them instead by ');
+	$msg .= '<a href="snort_rules_flowbits.php?id=' . $id . '" title="' . gettext('Add Suppress List entry for Flowbit Rule') . '">';
+	$msg .= gettext('clicking here.') . '</a>';
+	$group->setHelp('When finished, click APPLY to save and send any SID enable/disable changes made on this tab to Snort.<br/>' . $msg);
+}
+else {
+	$group->setHelp('When finished, click APPLY to save and send any SID enable/disable changes made on this tab to Snort.');
+}
+$section->add($group);
 
 	$form->add($section);
 }
@@ -671,12 +646,14 @@ print($form);
 						<td style="padding-left: 8px;"><i class="fa fa-check-circle-o text-success"></i></td><td style="padding-left: 4px;"><small><?=gettext('Default Enabled');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-check-circle text-success"></i></td><td style="padding-left: 4px;"><small><?=gettext('Enabled by user');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-adn text-success"></i></td><td style="padding-left: 4px;"><small><?=gettext('Auto-enabled by SID Mgmt');?></small></td>
+						<td style="padding-left: 8px;"><i class="fa fa-adn text-warning"></i></td><td style="padding-left: 4px;"><small><?=gettext('Action and/or content modified by SID Mgmt');?></small></td>
 					</tr>
 					<tr>
 						<td></td>
 						<td style="padding-left: 8px;"><i class="fa fa-times-circle-o text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Default Disabled');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-times-circle text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Disabled by user');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-adn text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Auto-disabled by SID Mgmt');?></small></td>
+						<td></td>
 					</tr>
 				</tbody>
 			</table>
@@ -684,7 +661,7 @@ print($form);
 
 		<table  style="table-layout: fixed; width: 100%;" class="table table-striped table-hover table-condensed">
 			<colgroup>
-				<col width="3%">
+				<col width="5%">
 				<col width="4%">
 				<col width="9%">
 				<col width="5%">
@@ -696,15 +673,15 @@ print($form);
 			</colgroup>
 			<thead>
 			   <tr>
-				<th>Icon</th>
-				<th><?=gettext("GID")?></th>
-				<th><?=gettext("SID")?></th>
-				<th><?=gettext("Proto")?></th>
-				<th><?=gettext("Source")?></th>
-				<th><?=gettext("SPort")?></th>
-				<th><?=gettext("Destination")?></th>
-				<th><?=gettext("DPort")?></th>
-				<th><?=gettext("Message")?></th>
+				<th><?=gettext("State");?></th>
+				<th><?=gettext("GID");?></th>
+				<th><?=gettext("SID");?></th>
+				<th><?=gettext("Proto");?></th>
+				<th><?=gettext("Source");?></th>
+				<th><?=gettext("SPort");?></th>
+				<th><?=gettext("Destination");?></th>
+				<th><?=gettext("DPort");?></th>
+				<th><?=gettext("Message");?></th>
 			   </tr>
 			</thead>
 			<tbody>
@@ -718,23 +695,20 @@ print($form);
 							$style = "";
 
 							if ($v['managed'] == 1) {
-								if ($v['disabled'] == 1) {
+								if ($v['disabled'] == 1 && $v['state_toggled'] == 1) {
 									$textss = '<span class="text-muted">';
 									$textse = '</span>';
-									$style= 'style="opacity: 0.4; filter: alpha(opacity=40);"';
-									$iconb_class = 'class="fa fa-adn text-danger text-left"';
+									$iconm_class = 'class="fa fa-adn text-danger text-left"';
 									$title = gettext("Auto-disabled by settings on SID Mgmt tab");
 								}
-								else {
+								elseif ($v['disabled'] == 0 && $v['state_toggled'] == 1) {
 									$textss = $textse = "";
-									$ruleset = "suricata.rules";
-									$iconb_class = 'class="fa fa-adn text-success text-left"';
-									$title = gettext("Auto-managed by settings on SID Mgmt tab");
+									$iconm_class = 'class="fa fa-adn text-success text-left"';
+									$title = gettext("Auto-enabled by settings on SID Mgmt tab");
 								}
-								$iconb = "icon_advanced.gif";
 								$managed_count++;
 							}
-							elseif (isset($disablesid[$gid][$sid])) {
+							if (isset($disablesid[$gid][$sid])) {
 								$textss = "<span class=\"text-muted\">";
 								$textse = "</span>";
 								$disable_cnt++;
@@ -742,7 +716,7 @@ print($form);
 								$iconb_class = 'class="fa fa-times-circle text-danger text-left"';
 								$title = gettext("Disabled by user. Click to toggle to enabled state");
 							}
-							elseif (($v['disabled'] == 1) && (!isset($enablesid[$gid][$sid]))) {
+							elseif (($v['disabled'] == 1) && ($v['state_toggled'] == 0) && (!isset($enablesid[$gid][$sid]))) {
 								$textss = "<span class=\"text-muted\">";
 								$textse = "</span>";
 								$disable_cnt++;
@@ -783,48 +757,46 @@ print($form);
 							$destination_port = $rule_content[6]; //destination port field
 							$message = suricata_get_msg($v['rule']); // description field
 							$sid_tooltip = gettext("View the raw text for this rule");
-
-							echo "<tr class=\"text-nowrap\"><td>{$textss}";
-							if ($v['managed'] == 1) {
-								echo "<i {$iconb_class} title='{$title}'</i>{$textse}";
-							}
-							else {
-								echo "<a id=\"rule_{$gid}_{$sid}\" href='#' onClick=\"toggleRule('{$sid}', '{$gid}');\" 
-								{$iconb_class} title=\"{$title}\"></a>{$textse}";
-							}
-							echo "</td>";
 				?>
-							       <td ondblclick="wopen('suricata_rules_edit.php?id=<?=$id?>&openruleset=<?=$ruleset?>&sid=<?=$sid?>&gid=<?=$gid?>','FileViewer');">
+							<tr class="text-nowrap">
+								<td><?=$textss; ?>
+									<a id="rule_<?=$gid; ?>_<?=$sid; ?>" href="#" onClick="toggleRule('<?=$sid; ?>', '<?=$gid; ?>');" 
+									<?=$iconb_class; ?> title="<?=$title; ?>"></a><?=$textse; ?>
+				<?php if ($v['managed'] == 1 && $v['modified'] == 1) : ?>
+								<i class="fa fa-adn text-warning text-left" title="<?=gettext('Action or content modified by settings on SID Mgmt tab'); ?>"></i><?=$textse; ?>
+				<?php endif; ?>
+								</td>
+							       <td ondblclick="showRuleContents('<?=base64_encode($v['rule']);?>');">
 									<?=$textss . $gid . $textse;?>
 							       </td>
-							       <td ondblclick="wopen('suricata_rules_edit.php?id=<?=$id?>&openruleset=<?=$ruleset?>&sid=<?=$sid?>&gid=<?=$gid?>','FileViewer');">
+							       <td ondblclick="showRuleContents('<?=base64_encode($v['rule']);?>');">
 									<a href="javascript: void(0)" 
-									onclick="wopen('suricata_rules_edit.php?id=<?=$id?>&openruleset=<?=$ruleset?>&sid=<?=$sid?>&gid=<?=$gid?>','FileViewer');" 
+									onclick="showRuleContents('<?=base64_encode($v['rule']);?>');" 
 									title="<?=$sid_tooltip;?>"><?=$textss . $sid . $textse;?></a>
 							       </td>
-							       <td ondblclick="wopen('suricata_rules_edit.php?id=<?=$id?>&openruleset=<?=$ruleset?>&sid=<?=$sid?>&gid=<?=$gid?>','FileViewer');">
+							       <td ondblclick="showRuleContents('<?=base64_encode($v['rule']);?>');">
 									<?=$textss . $protocol . $textse;?>
 							       </td>
-							       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="wopen('suricata_rules_edit.php?id=<?=$id?>&openruleset=<?=$ruleset?>&sid=<?=$sid?>&gid=<?=$gid?>','FileViewer');">
+							       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=base64_encode($v['rule']);?>');">
 									<?=$srcspan . $source;?></span>
 							       </td>
-							       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="wopen('suricata_rules_edit.php?id=<?=$id?>&openruleset=<?=$ruleset?>&sid=<?=$sid?>&gid=<?=$gid?>','FileViewer');">
+							       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=base64_encode($v['rule']);?>');">
 									<?=$srcprtspan . $source_port;?></span>
 							       </td>
-							       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="wopen('suricata_rules_edit.php?id=<?=$id?>&openruleset=<?=$ruleset?>&sid=<?=$sid?>&gid=<?=$gid?>','FileViewer');">
+							       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=base64_encode($v['rule']);?>');">
 									<?=$dstspan . $destination;?></span>
 							       </td>
-							       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="wopen('suricata_rules_edit.php?id=<?=$id?>&openruleset=<?=$ruleset?>&sid=<?=$sid?>&gid=<?=$gid?>','FileViewer');">
+							       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=base64_encode($v['rule']);?>');">
 								       <?=$dstprtspan . $destination_port;?></span>
 							       </td>
-								<td style="word-wrap:break-word; white-space:normal" ondblclick="wopen('suricata_rules_edit.php?id=<?=$id?>&openruleset=<?=$ruleset?>&sid=<?=$sid?>&gid=<?=$gid?>','FileViewer');">
+								<td style="word-wrap:break-word; white-space:normal" ondblclick="showRuleContents('<?=base64_encode($v['rule']);?>');">
 									<?=$textss . $message . $textse;?>
 							       </td>
-					</tr>
+							</tr>
 				<?php
-					$counter++;
+							$counter++;
+						}
 					}
-				}
 				unset($rulem, $v);
 				?>
 		    </tbody>
@@ -846,27 +818,38 @@ print($form);
 	</div>
 </div>
 
-<!-- </form> -->
+<?php
+// Create a Modal object to display text of user-clicked rules
+$form = new Form(FALSE);
+$modal = new Modal('View Rules Text', 'rulesviewer', 'large', 'Close');
+$modal->addInput(new Form_StaticText (
+	'Category',
+	'<div class="text-left" id="modal_rule_category"></div>'
+));
+$modal->addInput(new Form_Textarea (
+	'rulesviewer_text',
+	'Rule Text',
+	'...Loading...'
+))->removeClass('form-control')->addClass('row-fluid col-sm-10')->setAttribute('rows', '10')->setAttribute('wrap', 'soft');
+$form->add($modal);
+print($form);
+?>
+
 <script language="javascript" type="text/javascript">
+//<![CDATA[
 
 function toggleRule(sid, gid) {
 	$('#sid').val(sid);
 	$('#gid').val(gid);
 	$('#openruleset').val($('#selectbox').val());
-	$('<input name="toggle" value="1" />').appendTo($(form));
-	$(form).submit();
-
-}
-
-function submitAction(nm) {
-	$('<input type="hidden" name="' + nm + '"/>').appendTo(form);
-	$(form).submit();
+	$('<input name="toggle" value="1" />').appendTo($('#iform'));
+	$('#iform').submit();
 }
 
 function go()
 {
 	$('#openruleset').val($('#selectbox').val());
-	$(form).submit();
+	$('#iform').submit();
 }
 
 function wopen(url, name)
@@ -878,6 +861,15 @@ function wopen(url, name)
     win.focus();
 }
 
+function showRuleContents(content) {
+		// Show the modal dialog with rule text
+		$('#rulesviewer').modal('show');
+		$('#modal_rule_category').html($('#selectbox').val());
+		$('#rulesviewer_text').text(atob(content));
+		$('#rulesviewer_text').attr('readonly', true);
+}
+
+//]]>
 </script>
 
 <?php include("foot.inc"); ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -593,12 +593,12 @@ $group->add(new Form_Button(
 ))->setAttribute('title', gettext('Enable all rules in the currently selected category'))->addClass('btn-sm btn-success');
 if ($currentruleset == 'Auto-Flowbit Rules') {
 	$msg = '<b>' . gettext('Note: ') . '</b>' . gettext('You should not disable flowbit rules!  Add Suppress List entries for them instead by ');
-	$msg .= '<a href="snort_rules_flowbits.php?id=' . $id . '" title="' . gettext('Add Suppress List entry for Flowbit Rule') . '">';
+	$msg .= '<a href="suricata_rules_flowbits.php?id=' . $id . '" title="' . gettext('Add Suppress List entry for Flowbit Rule') . '">';
 	$msg .= gettext('clicking here.') . '</a>';
-	$group->setHelp('When finished, click APPLY to save and send any SID enable/disable changes made on this tab to Snort.<br/>' . $msg);
+	$group->setHelp('When finished, click APPLY to save and send any SID enable/disable changes made on this tab to Suricata.<br/>' . $msg);
 }
 else {
-	$group->setHelp('When finished, click APPLY to save and send any SID enable/disable changes made on this tab to Snort.');
+	$group->setHelp('When finished, click APPLY to save and send any SID enable/disable changes made on this tab to Suricata.');
 }
 $section->add($group);
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules_edit.php
@@ -56,7 +56,7 @@
 * Copyright (C) 2006 Scott Ullrich (copyright assigned to ESF)
 * Copyright (C) 2009 Robert Zelaya Sr. Developer
 * Copyright (C) 2012 Ermal Luci  (copyright assigned to ESF)
-* Copyright (C) 2014 Bill Meeks
+* Copyright (C) 2016 Bill Meeks
 *
 */
 
@@ -160,7 +160,7 @@ $btnclear = new Form_Button(
 	'Close'
 );
 
-$btnclear->removeClass('btn-primary')->addClass('btn-default');
+$btnclear->addClass('btn-primary');
 $btnclear->setType('button');
 $btnclear->setOnclick('window.close()');
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -56,7 +56,7 @@
 * Copyright (C) 2006 Scott Ullrich (copyright assigned to ESF)
 * Copyright (C) 2009 Robert Zelaya Sr. Developer
 * Copyright (C) 2012 Ermal Luci  (copyright assigned to ESF)
-* Copyright (C) 2014 Bill Meeks
+* Copyright (C) 2016 Bill Meeks
 *
 */
 
@@ -588,10 +588,10 @@ else:
 								echo "<input type='hidden' name='toenable[]' value='{$file}' />\n";
 							if ($cat_mods[$file] == 'enabled') {
 								$CHECKED = "enabled";
-								echo "	\n<i class=\"fa fa-adn text-success\" title=\"" . gettext('Auto-enabled by settings on SID Mgmt tab') . "></i>\n";
+								echo "	\n<i class=\"fa fa-adn text-success\" title=\"" . gettext('Auto-enabled by settings on SID Mgmt tab') . "\"></i>\n";
 							}
-							else {
-								echo "	\n<i class=\"fa fa-adn text-danger\" title=\"" . gettext('Auto-disabled by settings on SID Mgmt tab') . "></i>\n";
+							elseif ($cat_mods[$file] == 'disabled') {
+								echo "	\n<i class=\"fa fa-adn text-danger\" title=\"" . gettext('Auto-disabled by settings on SID Mgmt tab') . "\"></i>\n";
 							}
 						}
 						else {
@@ -624,10 +624,10 @@ else:
 								echo "<input type='hidden' name='toenable[]' value='{$file}' />\n";
 							if ($cat_mods[$file] == 'enabled') {
 								$CHECKED = "enabled";
-								echo "	\n<i class=\"fa fa-adn text-success\" title=\"" . gettext('Auto-enabled by settings on SID Mgmt tab') . "></i>\n";
+								echo "	\n<i class=\"fa fa-adn text-success\" title=\"" . gettext('Auto-enabled by settings on SID Mgmt tab') . "\"></i>\n";
 							}
 							else {
-								echo "	\n<i class=\"fa fa-adn text-danger\" title=\"" . gettext('Auto-disabled by settings on SID Mgmt tab') . "></i>\n";
+								echo "	\n<i class=\"fa fa-adn text-danger\" title=\"" . gettext('Auto-disabled by settings on SID Mgmt tab') . "\"></i>\n";
 							}
 						}
 						else {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
@@ -330,13 +330,13 @@ display_top_tabs($tab_array, true);
 						<input type="checkbox" id="auto_manage_sids" name="auto_manage_sids" value="on"
 						<?php if ($pconfig['auto_manage_sids'] == 'on') echo " checked"; ?>
 						onclick="enable_sid_conf();" />
-						<?=gettext("Enable automatic management of rule state and content using configuration files.")?>
+						<?=gettext("Enable automatic management of rule state and content using configuration files.  Default is Not Checked.")?>
 					</label>
 					<span class="help-block">
-						<?=sprintf(gettext("If  Default is %sNot Checked%s "), "<strong>", "</strong>") .
-						gettext("Suricata will automatically enable/disable/modify text rules upon each update using criteria specified in configuration files.  ") .
-						gettext("The supported configuration file format is the same as that used in the PulledPork and Oinkmaster enablesid.conf, disablesid.conf and ") .
-						gettext("modifysid.conf files.  You can either upload existing files or create your own."); ?>
+						<?=gettext("When checked, Suricata will automatically enable/disable/modify text rules upon each update using criteria ") . 
+						gettext("specified in configuration files.  The supported configuration file format is the same as that used ") . 
+						gettext("by PulledPork and Oinkmaster.  See the included sample conf files for usage examples.  ") . 
+						gettext("Either upload existing files to the firewall or create new ones by clicking ADD below."); ?>
 					</span>
 				</div>
 			</div>
@@ -424,18 +424,22 @@ display_top_tabs($tab_array, true);
 							<span aria-hidden="true">&times;</span>
 						</button>
 
-						<h3 class="modal-title" id="myModalLabel"><?=gettext("SID editor")?></h3>
+						<h3 class="modal-title" id="myModalLabel"><?=gettext("SID Auto-Management File Editor")?></h3>
 					</div>
 
 					<div class="modal-body">
 						<?=gettext("File Name: ");?>
 						<input type="text" size="45" class="form-control file" id="sidlist_name" name="sidlist_name" value="<?=$sidmodlist_name;?>" /><br />
-						<input type="submit" class="btn btn-sm btn-primary" id="save" name="save" value="<?=gettext(" Save ");?>" title="<?=gettext("Save changes and close editor");?>" />
-						<input type="button" class="btn btn-sm btn-default" id="cancel" name="cancel" value="<?=gettext("Cancel");?>" data-dismiss="modal" title="<?=gettext("Abandon changes and quit editor");?>" /><br /><br />
+						<button type="submit" class="btn btn-sm btn-primary" id="save" name="save" value="<?=gettext("Save");?>" title="<?=gettext("Save changes and close editor");?>">
+							<i class="fa fa-save icon-embed-btn"></i>
+							<?=gettext("Save");?>
+						</button>
+						<button type="button" class="btn btn-sm btn-warning" id="cancel" name="cancel" value="<?=gettext("Cancel");?>" data-dismiss="modal" title="<?=gettext("Abandon changes and quit editor");?>">
+							<?=gettext("Cancel");?>
+						</button><br /><br />
 
 						<textarea class="form-control" wrap="off" cols="80" rows="20" name="sidlist_data" id="sidlist_data"
 						><?=$sidmodlist_data;?></textarea>
-
 
 						<?php echo gettext("Note:"); ?></strong>
 						<br/><?php echo gettext("SID Mods Lists are stored as local files on the firewall and their contents are " .
@@ -454,17 +458,16 @@ display_top_tabs($tab_array, true);
 		</button>
 
 		<button data-toggle="modal" data-target="#uploader" role="button" aria-expanded="false" type="button" name="sidlist_import" id="sidlist_import" class="btn btn-info btn-sm" title="<?=gettext('Import/upload SID Mods List');?>">
-			<i class="fa fa-download icon-embed-btn"></i>
+			<i class="fa fa-upload icon-embed-btn"></i>
 			<?=gettext("Import")?>
 		</button>
 
 		<button type="input" name="sidlist_dnload_all" id="sidlist_dnload_all" class="btn btn-info btn-sm" title="<?=gettext('Download all SID Mods List files in a single gzip archive');?>">
-			<i class="fa fa-cloud-download icon-embed-btn"></i>
+			<i class="fa fa-download icon-embed-btn"></i>
 			<?=gettext("Download")?>
 		</button>
 
 	</nav>
-
 
 	<div class="panel panel-default">
 		<div class="panel-heading"><h2 class="panel-title"><?=gettext("Interface SID Management File Assignments")?></h2></div>
@@ -565,7 +568,10 @@ display_top_tabs($tab_array, true);
 			</div>
 		</div>
 
-		<input type="submit" id="save_auto_sid_conf" name="save_auto_sid_conf" class="btn btn-primary" value="<?=gettext("Save");?>" title="<?=gettext("Save SID Management configuration");?>" />
+		<button type="submit" id="save_auto_sid_conf" name="save_auto_sid_conf" class="btn btn-primary" value="<?=gettext("Save");?>" title="<?=gettext("Save SID Management configuration");?>" >
+			<i class="fa fa-save icon-embed-btn"></i>
+			<?=gettext("Save");?>
+		</button>
 		&nbsp;&nbsp;<?=gettext("Remember to save changes before exiting this page"); ?>
 
 </form>
@@ -575,16 +581,16 @@ display_top_tabs($tab_array, true);
 <?php
 	print_info_box(
 		'<p>' .
-			gettext("Check the box beside an interface to immediately apply new auto-SID management changes and signal Suricata to live-load the new rules for the interface when clicking Save; " .
-					"otherwise only the new file assignments will be saved.") .
+			gettext("Check the box beside an interface to immediately apply new auto-SID management changes and signal Suricata to live-load the new rules for the interface when clicking Save; " . 
+				"otherwise only the new file assignments will be saved.") .
 		'</p>' .
 		'<p>' .
-			gettext("SID State Order controls the order in which enable and disable state modifications are performed. An example would be to disable an entire category and later enable only a rule or two from it. " .
-					" In this case you would choose 'disable,enable' for the State Order.  Note that the last action performed takes priority.") .
+			gettext("SID State Order controls the order in which enable and disable state modifications are performed. An example would be to disable an entire category and later enable only a rule or two from it. " . 
+				" In this case you would choose 'disable,enable' for the State Order.  Note that the last action performed takes priority.") .
 		'</p>' .
 		'<p>' .
-			gettext("The Enable SID File, Disable SID File and Modify SID File controls specify which rule modification files are run automatically for the interface.  Setting a file control to 'None' disables that modification.  " .
-					"Setting all file controls for an interface to 'None' disables automatic SID state management for the interface.") .
+			gettext("The Enable SID File, Disable SID File, Modify SID File and Drop SID File drop-down controls specify which rule modification files are run automatically for the interface.  Setting a file control to 'None' disables that modification. " . 
+				"Setting all file controls for an interface to 'None' disables automatic SID state management for the interface.") .
 		'</p>', 'info', false);
 ?>
 </div>
@@ -612,7 +618,7 @@ events.push(function() {
 		$(form).submit();
 	});
 
-	// If hte user is editing a file, open the modal on page load
+	// If the user is editing a file, open the modal on page load
 <?php if ($sidmodlist_edit_style == "show") : ?>
 	$("#sidlist_editor").modal('show');
 <?php endif ?>
@@ -622,6 +628,4 @@ events.push(function() {
 
 <?php
 include("foot.inc"); ?>
-
-
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress.php
@@ -56,7 +56,7 @@
 * Copyright (C) 2006 Scott Ullrich (copyright assigned to ESF)
 * Copyright (C) 2009 Robert Zelaya Sr. Developer
 * Copyright (C) 2012 Ermal Luci  (copyright assigned to ESF)
-* Copyright (C) 2014 Bill Meeks
+* Copyright (C) 2016 Bill Meeks
 *
 */
 
@@ -77,9 +77,9 @@ function suricata_suppresslist_used($supplist) {
 	/****************************************************************/
 	/* This function tests if the passed Suppress List is currently */
 	/* assigned to an interface.  It returns TRUE if the list is	*/
-	/* in use.													  */
-	/*															  */
-	/* Returns:  TRUE if list is in use, else FALSE				 */
+	/* in use.							*/
+	/*								*/
+	/* Returns:  TRUE if list is in use, else FALSE			*/
 	/****************************************************************/
 
 	global $config;
@@ -99,10 +99,10 @@ function suricata_find_suppresslist_interface($supplist) {
 	/****************************************************************/
 	/* This function finds the first (if more than one) interface   */
 	/* configured to use the passed Suppress List and returns the   */
-	/* index of the interface in the ['rule'] config array.		 */
-	/*															  */
-	/* Returns: index of interface in ['rule'] config array or	  */
-	/*		  FALSE if no interface found.						*/
+	/* index of the interface in the ['rule'] config array.		*/
+	/*								*/
+	/* Returns: index of interface in ['rule'] config array or	*/
+	/*		  FALSE if no interface found.			*/
 	/****************************************************************/
 
 	global $config;


### PR DESCRIPTION
This update corrects a number of issues identified during user testing of the new Bootstrap-converted inline IPS mode package.

**Bug Fixes**
1. Help text under Enable checkbox on SID MGMT tab is incorrect.
2. Icons are missing from several buttons on the FLOW/STREAM and APP PARSERS tabs.
3. Update Info Block icons at bottom of INTERFACES tab to show start, restart and stop icons.
4. When IPS mode is Inline, hide Pass List drop-down on INTERFACE SETTINGS tab since it is not used in IPS mode inline.
5. Adjust icons on Flowbits Rules view page to match Snort and widen the column for displaying SID.
6. Change RULES tab to match Snort.  Put View rules button next to drop-down and change to buttons in Overrides section.
7. Fix many logic issues in implementation of new _dropsid.conf_ support on SID MGMT tab.
8. The "default" engine's bind-to address is not read-only on the OS Policy and HTTP Policy engine pages.
9. Alias auto-suggest not working for alias fields on OS Policy and HTTP Policy engine pages.
10. Select Alias button missing on Pass List Edit page.
11. Auto-managed rule categories not being flagged correctly on CATEGORIES tab.
12. Display additional icon to show rules modified by _dropsid_ or _modifysid_ on RULES tab.
13. Allow clearing of _sid_changes.log_ when selected on LOGS VIEW tab.

