### PR TITLE
pfSense-pkg-suricata 3.0_2 - Fix user-reported issues and a few other things

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	3.0
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -54,7 +54,7 @@ require("/usr/local/pkg/suricata/suricata_defs.inc");
 global $g, $config;
 
 // Suricata GUI needs some extra PHP memory space to manipulate large rules arrays
-ini_set("memory_limit", "256M");
+ini_set("memory_limit", "512M");
 
 function suricata_generate_id() {
 	global $config;

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -2137,7 +2137,7 @@ function suricata_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results 
 		}
 		// Test the SID token for the PCRE: keyword
 		elseif (preg_match('/(^pcre\:)(.+)/i', $tok, $matches)) {
-			$regex = '/' . preg_quote($matches[2], '/') . '/i';
+			$regex = '/' . $matches[2] . '/i';
 
 			// Now search through the $rule_map in the 'rule'
 			// element for any matches to the regex and get
@@ -2152,7 +2152,7 @@ function suricata_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results 
 		}
 		// Test the SID token for the MS reference keyword
 		elseif (preg_match('/^MS\d+-.+/i', $tok, $matches)) {
-			$regex = "/" . preg_quote($matches[0], '/') . "/i";
+			$regex = "/" . $matches[0] . "/i";
 
 			// Now search through the $rule_map in the 'rule'
 			// element for any matches to the regex and get

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_etiqrisk_update.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_etiqrisk_update.php
@@ -13,7 +13,7 @@
  * All rights reserved.
  *
  * Adapted for Suricata by:
- * Copyright (C) 2014 Bill Meeks
+ * Copyright (C) 2016 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,48 +43,6 @@ require_once("functions.inc");
 require_once("/usr/local/pkg/suricata/suricata.inc");
 require("/usr/local/pkg/suricata/suricata_defs.inc");
 
-/*************************************************************************
- * Hack for backwards compatibility with older 2.1.x pfSense versions    *
- * that did not contain the new "download_file()" utility function       *
- * present in 2.2 and higher.                                            *
- *************************************************************************/
-if(!function_exists("download_file")) {
-	function download_file($url, $destination, $verify_ssl = false, $connect_timeout = 60, $timeout = 0) {
-		global $config, $g;
-
-		$fp = fopen($destination, "wb");
-
-		if (!$fp)
-			return false;
-
-		$ch = curl_init();
-		curl_setopt($ch, CURLOPT_URL, $url);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $verify_ssl);
-		curl_setopt($ch, CURLOPT_FILE, $fp);
-		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $connect_timeout);
-		curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
-		curl_setopt($ch, CURLOPT_HEADER, false);
-		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-		curl_setopt($ch, CURLOPT_USERAGENT, $g['product_name'] . '/' . rtrim(file_get_contents("/etc/version")));
-
-		if (!empty($config['system']['proxyurl'])) {
-			curl_setopt($ch, CURLOPT_PROXY, $config['system']['proxyurl']);
-			if (!empty($config['system']['proxyport']))
-				curl_setopt($ch, CURLOPT_PROXYPORT, $config['system']['proxyport']);
-			if (!empty($config['system']['proxyuser']) && !empty($config['system']['proxypass'])) {
-				@curl_setopt($ch, CURLOPT_PROXYAUTH, CURLAUTH_ANY | CURLAUTH_ANYSAFE);
-				curl_setopt($ch, CURLOPT_PROXYUSERPWD, "{$config['system']['proxyuser']}:{$config['system']['proxypass']}");
-			}
-		}
-
-		@curl_exec($ch);
-		$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-		fclose($fp);
-		curl_close($ch);
-		return ($http_code == 200) ? true : $http_code;
-	}
-}
-
 function suricata_check_iprep_md5($filename) {
 
 	/**********************************************************/
@@ -102,7 +60,7 @@ function suricata_check_iprep_md5($filename) {
 	/*           error occurred.                              */
 	/**********************************************************/
 
-	global $iqRisk_tmppath, $iprep_path;
+	global $config, $iqRisk_tmppath, $iprep_path;
 	$new_md5 = $old_md5 = "";
 	$et_iqrisk_url = str_replace("_xxx_", $config['installedpackages']['suricata']['config'][0]['iqrisk_code'], ET_IQRISK_DNLD_URL);
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
@@ -13,7 +13,7 @@
  * All rights reserved.
  *
  * Adapted for Suricata by:
- * Copyright (C) 2014 Bill Meeks
+ * Copyright (C) 2016 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -46,48 +46,6 @@ require_once("config.inc");
 require_once("functions.inc");
 require("/usr/local/pkg/suricata/suricata_defs.inc");
 
-/*************************************************************************
- * Hack for backwards compatibility with older 2.1.x pfSense versions    *
- * that did not contain the new "download_file()" utility function       *
- * present in 2.2 and higher.                                            *
- *************************************************************************/
-if(!function_exists("download_file")) {
-	function download_file($url, $destination, $verify_ssl = false, $connect_timeout = 60, $timeout = 0) {
-		global $config, $g;
-
-		$fp = fopen($destination, "wb");
-
-		if (!$fp)
-			return false;
-
-		$ch = curl_init();
-		curl_setopt($ch, CURLOPT_URL, $url);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $verify_ssl);
-		curl_setopt($ch, CURLOPT_FILE, $fp);
-		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $connect_timeout);
-		curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
-		curl_setopt($ch, CURLOPT_HEADER, false);
-		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-		curl_setopt($ch, CURLOPT_USERAGENT, $g['product_name'] . '/' . rtrim(file_get_contents("/etc/version")));
-
-		if (!empty($config['system']['proxyurl'])) {
-			curl_setopt($ch, CURLOPT_PROXY, $config['system']['proxyurl']);
-			if (!empty($config['system']['proxyport']))
-				curl_setopt($ch, CURLOPT_PROXYPORT, $config['system']['proxyport']);
-			if (!empty($config['system']['proxyuser']) && !empty($config['system']['proxypass'])) {
-				@curl_setopt($ch, CURLOPT_PROXYAUTH, CURLAUTH_ANY | CURLAUTH_ANYSAFE);
-				curl_setopt($ch, CURLOPT_PROXYUSERPWD, "{$config['system']['proxyuser']}:{$config['system']['proxypass']}");
-			}
-		}
-
-		@curl_exec($ch);
-		$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-		fclose($fp);
-		curl_close($ch);
-		return ($http_code == 200) ? true : $http_code;
-	}
-}
-
 /**********************************************************************
  * Start of main code                                                 *
  **********************************************************************/
@@ -100,7 +58,6 @@ if ($config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] == 
 	exit(0);
 else
 	log_error(gettext("[Suricata] Updating the GeoIP country database files..."));
-
 
 // Download the free GeoIP Legacy country name databases for IPv4 and IPv6
 // to a temporary location.

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -941,7 +941,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 				$sidsupplink .= ' title="' . gettext("Add this alert to the Suppress List") . '"></i>';
 			}
 			else {
-				$sidsupplink .= '&nbsp;<i class="fa fa-info-circle" ';
+				$sidsupplink = '&nbsp;<i class="fa fa-info-circle" ';
 				$sidsupplink .= "title='" . gettext("This alert is already in the Suppress List") . "'></i>";
 			}
 			/* Add icon for toggling rule state */

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -698,17 +698,17 @@ print($form);
 								if ($v['disabled'] == 1 && $v['state_toggled'] == 1) {
 									$textss = '<span class="text-muted">';
 									$textse = '</span>';
-									$iconm_class = 'class="fa fa-adn text-danger text-left"';
+									$iconb_class = 'class="fa fa-adn text-danger text-left"';
 									$title = gettext("Auto-disabled by settings on SID Mgmt tab");
 								}
 								elseif ($v['disabled'] == 0 && $v['state_toggled'] == 1) {
 									$textss = $textse = "";
-									$iconm_class = 'class="fa fa-adn text-success text-left"';
+									$iconb_class = 'class="fa fa-adn text-success text-left"';
 									$title = gettext("Auto-enabled by settings on SID Mgmt tab");
 								}
 								$managed_count++;
 							}
-							if (isset($disablesid[$gid][$sid])) {
+							elseif (isset($disablesid[$gid][$sid])) {
 								$textss = "<span class=\"text-muted\">";
 								$textse = "</span>";
 								$disable_cnt++;

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -319,6 +319,7 @@ else:
 <form action="/suricata/suricata_rulesets.php" method="post" enctype="multipart/form-data" name="iform" id="iform" class="form-horizontal">
 <input type="hidden" name="id" id="id" value="<?=$id;?>" />
 <?php
+
 	$section = new Form_Section("Automatic flowbit resolution");
 
 	$section->addInput(new Form_Checkbox(
@@ -663,16 +664,8 @@ else:
 
 <script language="javascript" type="text/javascript">
 //<![CDATA[
-events.push(function() {
-	function wopen(url, name, w, h)
-	{
-		var win = window.open(url,
-			name,
-			'location=no, menubar=no, ' +
-			'status=no, toolbar=no, scrollbars=yes, resizable=yes');
 
-		win.focus();
-	}
+events.push(function() {
 
 	function enable_change()
 	{
@@ -680,16 +673,24 @@ events.push(function() {
 
 		hideInput('ips_policy', endis);
 
-		$('[type=checkbox]').each(function() {
-			var str = this.value;
+		$('input[type="checkbox"]').each(function() {
+			var str = $(this).val();
 
-			if (str.substr(0,6) == "snort_")
-				this.attr('disabled', !endis);
+			if (str.substr(0,6) == "snort_") {
+				$(this).attr('disabled', !endis);
+			}
 		});
 	}
 
+	//------- Click handlers -----------------------------------------
+	// 
+	$('#ips_policy_enable').click(function() {
+		enable_change();
+	});
+
 	// Set initial state of dynamic HTML form controls
 	enable_change();
+
 });
 //]]>
 </script>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
@@ -284,19 +284,6 @@ $sidmodselections = array_merge(Array( "None" ), $sidmodfiles);
 $pgtitle = gettext("Suricata: SID Management");
 include_once("head.inc");
 
-if ($g['platform'] == "nanobsd") {
-	$input_errors[] = gettext("SID auto-management is not supported on NanoBSD installs");
-}
-
-/* Display Alert message, under form tag or no refresh */
-if ($input_errors) {
-	print_input_errors($input_errors);
-}
-
-if ($savemsg) {
-	print_info_box($savemsg, 'success');
-}
-
 $tab_array = array();
 $tab_array[] = array(gettext("Interfaces"), false, "/suricata/suricata_interfaces.php");
 $tab_array[] = array(gettext("Global Settings"), false, "/suricata/suricata_global.php");
@@ -312,7 +299,21 @@ $tab_array[] = array(gettext("Sync"), false, "/pkg_edit.php?xml=suricata/suricat
 $tab_array[] = array(gettext("IP Lists"), false, "/suricata/suricata_ip_list_mgmt.php");
 display_top_tabs($tab_array, true);
 
+if ($g['platform'] == "nanobsd") {
+	$input_errors[] = gettext("SID auto-management is not supported on NanoBSD installs");
+}
+
+/* Display Alert message, under form tag or no refresh */
+if ($input_errors) {
+	print_input_errors($input_errors);
+}
+
+if ($savemsg) {
+	print_info_box($savemsg, 'success');
+}
+
 ?>
+
 <form action="suricata_sid_mgmt.php" method="post" enctype="multipart/form-data" name="iform" id="iform">
 	<input type="hidden" name="MAX_FILE_SIZE" value="100000000" />
 	<input type="hidden" name="sidlist_fname" id="sidlist_fname" value=""/>


### PR DESCRIPTION
This update corrects some user-reported bugs and some more Bootstrap conversion issues.

**Bug Fixes**

1. Rules auto-managed by SID MGMT tab files are not tagged correctly on the RULES tab.
2. IQRisk IP Reputation files not downloading for users with subscription code.
3. Icons indicating rule GID:SID added to Supress Lists get duplicated when IPs are the same on ALERTS tab.
4. Snort VRT rules checkboxes not auto-disabled when IPS-Policy is selected on CATEGORIES tab.
5. PCRE selection of SIDs not working correctly for auto-SID management.