### PR TITLE
pfBlockerNG - version 2.0.8

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-pfBlockerNG
-PORTVERSION=	2.0.7
+PORTVERSION=	2.0.8
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng.xml
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng.xml
@@ -9,7 +9,7 @@
 	pfBlockerNG.xml
 
 	pfBlockerNG
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 	Based upon pfblocker for pfSense
@@ -248,19 +248,19 @@
 			<combinefields>end</combinefields>
 		</field>
 		<field>
-			<fielddescr>Enable De-Duplication</fielddescr>
+			<fielddescr>De-Duplication</fielddescr>
 			<fieldname>enable_dup</fieldname>
 			<type>checkbox</type>
 			<description>Only used for IPv4 Deny Lists</description>
 		</field>
 		<field>
-			<fielddescr>Enable CIDR Aggregation</fielddescr>
+			<fielddescr>CIDR Aggregation</fielddescr>
 			<fieldname>enable_agg</fieldname>
 			<type>checkbox</type>
 			<description>Optimise CIDRs (not recommended for slow systems with large lists)</description>
 		</field>
 		<field>
-			<fielddescr>Enable Suppression</fielddescr>
+			<fielddescr>Suppression</fielddescr>
 			<fieldname>suppression</fieldname>
 			<sethelp><![CDATA[This will prevent Selected IPs from being blocked. Only for IPv4 lists (/32 and /24).<div class="infoblock">
 					Country blocking lists cannot be suppressed. This will also remove any RFC1918 addresses from all lists.<br /><br />
@@ -272,11 +272,11 @@
 			<type>checkbox</type>
 		</field>
 		<field>
-			<fielddescr>Global Enable Logging</fielddescr>
+			<fielddescr>Global Logging</fielddescr>
 			<fieldname>enable_log</fieldname>
 			<type>checkbox</type>
-			<description>Firewall Rule logging - Enable Global logging to [ Status: System Logs: FIREWALL Log ]
-				This overrides any log settings in the Alias tabs.
+			<description><![CDATA[Firewall Rule logging - Enable Global logging to [ Status: System Logs: FIREWALL Log ]<br />
+				This overrides any log settings in the Continent/IPv4/6 Alias tabs. (DNSBL not included)]]>
 			</description>
 		</field>
 		<field>
@@ -310,7 +310,7 @@
 			<fielddescr>Logfile Size</fielddescr>
 			<fieldname>log_maxlines</fieldname>
 			<description><![CDATA[Default: <strong>20000</strong><br />
-				Select number of Lines to keep in the pfblockerng.log and dnsbl.log files]]>
+				Select number of Lines to keep in the pfblockerng.log, geoip.log, extras.log and dnsbl.log files]]>
 			</description>
 			<type>select</type>
 			<options>
@@ -457,10 +457,7 @@
 		</field>
 		<field>
 			<fielddescr>Support</fielddescr>
-			<description><![CDATA[<u>If you like this package, please support the developer</u>.&emsp;&emsp;
-				<a class="fa fa-cc-paypal fa-2x" title="Your support is appreciated. Thank you!" target="_blank"
-					href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RHZUKWX2Y85ZA"> support</a>]]>
-			</description>
+			<description><![CDATA[pfBlockerNG is developed by BBcan117, and can be reached at&emsp; [ bbcan177 'at' gmail 'dot' com ]]]></description>
 			<type>info</type>
 		</field>
 	</fields>

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng.xml
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng.xml
@@ -457,7 +457,7 @@
 		</field>
 		<field>
 			<fielddescr>Support</fielddescr>
-			<description><![CDATA[pfBlockerNG is developed by BBcan117, and can be reached at&emsp; [ bbcan177 'at' gmail 'dot' com ]]]></description>
+			<description><![CDATA[pfBlockerNG is developed by BBcan177, and can be reached at&emsp; [ bbcan177 'at' gmail 'dot' com ]]]></description>
 			<type>info</type>
 		</field>
 	</fields>

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3,7 +3,7 @@
 	pfBlockerNG.inc
 
 	pfBlockerNG
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 	Based upon pfBlocker by

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -124,7 +124,7 @@ foreach (array('existing', 'actual') as $pftype) {
 
 // Default cURL options
 $pfb['curl_defaults'] = array(  CURLOPT_USERAGENT	=> 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 Chrome/43.0.2357.65 Safari/537.36',
-				CURLOPT_SSL_CIPHER_LIST	=> 'TLSv1.2, TLSv1',
+				CURLOPT_SSL_CIPHER_LIST	=> 'TLSv1.2, TLSv1.1, TLSv1',
 				CURLOPT_FOLLOWLOCATION	=> true,
 				CURLOPT_SSL_VERIFYPEER	=> true,
 				CURLOPT_SSL_VERIFYHOST	=> true,
@@ -240,15 +240,29 @@ if ($uname['machine'] == 'amd64') {
 
 
 // Function to decode alias custom entry box.
-function pfbng_text_area_decode($text) {
+function pfbng_text_area_decode($text, $mode=FALSE) {
+
+	if ($mode) {
+		// Return customlist as an array (Split any '#' comment text)
+		$custom = array();
+	}
+
 	$customlist = explode("\r\n", base64_decode($text));
 	if (!empty($customlist)) {
 		foreach ($customlist as $line) {
 			if (substr(trim($line), 0, 1) != '#' && !empty($line)) {
 				if (strpos($line, '#') !== FALSE) {
-					$custom .= trim(strstr($line, '#', TRUE)) . "\n";
+					if ($mode) {
+						$custom[] = preg_split('/(?=#)/', $line);
+					} else {
+						$custom .= trim(strstr($line, '#', TRUE)) . "\n";
+					}
 				} else {
-					$custom .= $line . "\n";
+					if ($mode) {
+						$custom[][0] = $line;
+					} else {
+						$custom .= $line . "\n";
+					}
 				}
 			}
 		}
@@ -528,6 +542,21 @@ function pfb_create_suppression_file() {
 	if (!$pfbfound) {
 		pfb_create_suppression_alias();
 	}
+}
+
+
+// Collect existing suppression list (without '# comment' text details)
+function dnsbl_suppression() {
+	global $pfb;
+
+	$dnssupp_ex = array();
+	$suppression = pfbng_text_area_decode($pfb['dnsblconfig']['suppression'], TRUE);
+	if (isset($suppression)) {
+		foreach ($suppression as $dnssupp) {
+			$dnssupp_ex[] = $dnssupp[0];
+		}
+	}
+	return $dnssupp_ex;
 }
 
 
@@ -1174,7 +1203,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 					if ($retries == 1 && $pflex && in_array($curl_error, array( '35', '51', '60'))) {
 						curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 						curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
-						curl_setopt($ch, CURLOPT_SSL_CIPHER_LIST, 'TLSv1.2, TLSv1, SSLv3');
+						curl_setopt($ch, CURLOPT_SSL_CIPHER_LIST, 'TLSv1.2, TLSv1.1, TLSv1, SSLv3');
 						$log = "\n[ ! ] Downgrading SSL settings (Flex) ";
 						pfb_logger("{$log}", 1);
 					}
@@ -1223,17 +1252,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			}
 			else {
 				pfb_logger('.', 1);
-				$pfb_output = @fopen("{$file_dwn}.orig", 'w');
-				if (($fhandle = @gzopen("{$file_dwn}.raw", 'r')) !== FALSE) {
-					if (($fhandle = @gzopen("{$file_dwn}.raw", 'r')) !== FALSE) {
-						while (($line = @gzgets($fhandle, 1024)) !== FALSE) {
-							fwrite($pfb_output, $line);
-						}
-					}
-					$retval = 0;
-				}
-				@gzclose($fhandle);
-				@fclose($pfb_output);
+				exec("/usr/bin/gunzip -c {$file_dwn}.raw > {$file_dwn}.orig", $output, $retval);
 			}
 		}
 		elseif ($file_type == 'application/x-bzip2') {
@@ -1400,12 +1419,43 @@ function pfb_failures() {
 }
 
 
-// Convert alias name (via ascii table number) and return a 10 digit tracker id
-function pfb_tracker($alias) {
-	for ($i = 0; $i < strlen($alias); $i++) {
-		$pfbtracker += @ord($alias[$i]);
+// Convert unique Alias details (via ascii table number) and return a 10 digit tracker ID
+function pfb_tracker($alias, $int, $text) {
+
+	global $config, $pfb;
+
+	$pfbtracker	= 0;
+	$real_int	= get_real_interface($int);
+	$ipaddr		= get_interface_ip($int);
+
+	if (is_ipaddrv4($ipaddr)) {
+		$ipaddr = ip2long32($ipaddr);
+		$subnet = find_interface_subnet($real_int);
 	}
-	return '177' . str_pad($pfbtracker, 7, '0', STR_PAD_LEFT);
+	else {
+		$ipaddr = get_interface_ipv6($real_int);
+		$subnet = find_interface_subnetv6($real_int);
+	}
+
+	$search		= array( '1', '2', '3', '4', '5', '6', '7', '8', '9', '0' );
+	$replace	= array( 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'zero' );
+	$line		= "{$alias}{$int}{$text}{$real_int}{$ipaddr}{$subnet}";
+	$line		= str_replace($search, $replace, $line);
+
+	for ($i = 0; $i < strlen($line); $i++) {
+		$pfbtracker += @ord($line[$i]);
+	}
+
+	// If duplicate Tracker ID found, pre-define a Tracker ID (Starts at 1770000010)
+	if (in_array($pfbtracker, $pfb['trackerids'])) {
+		$pfbtracker = ($pfb['last_trackerid'] + 1);
+		$pfb['last_trackerid'] = $pfbtracker;
+		return $pfbtracker;
+	}
+	else {
+		$pfb['trackerids'][] = $pfbtracker;
+		return '177' . str_pad($pfbtracker, 7, '0', STR_PAD_LEFT);
+	}
 }
 
 
@@ -1421,7 +1471,6 @@ function pfb_firewall_rule($action, $pfb_alias, $vtype='', $pfb_log, $agateway_i
 		case 'Deny_Both':
 		case 'Deny_Outbound':
 			$rule = $pfb['base_rule'];
-			$rule['tracker'] = pfb_tracker("{$pfb_alias}{$vtype}deny_out");
 			$rule['type'] = "{$pfb['deny_action_outbound']}";
 			if ($vtype == '_v6') {
 				$rule['ipprotocol'] = 'inet6';
@@ -1459,7 +1508,6 @@ function pfb_firewall_rule($action, $pfb_alias, $vtype='', $pfb_log, $agateway_i
 			}
 		case 'Deny_Inbound':
 			$rule = $pfb['base_rule'];
-			$rule['tracker'] = pfb_tracker("{$pfb_alias}{$vtype}deny_in");
 			$rule['type'] = "{$pfb['deny_action_inbound']}";
 			if ($vtype == '_v6') {
 				$rule['ipprotocol'] = 'inet6';
@@ -1500,7 +1548,6 @@ function pfb_firewall_rule($action, $pfb_alias, $vtype='', $pfb_log, $agateway_i
 		case 'Permit_Outbound':
 			$rule = $pfb['base_rule'];
 			$rule['type'] = 'pass';
-			$rule['tracker'] = pfb_tracker("{$pfb_alias}{$vtype}permit_out");
 			if ($vtype == '_v6') {
 				$rule['ipprotocol'] = 'inet6';
 			}
@@ -1537,7 +1584,6 @@ function pfb_firewall_rule($action, $pfb_alias, $vtype='', $pfb_log, $agateway_i
 			}
 		case 'Permit_Inbound':
 			$rule = $pfb['base_rule'];
-			$rule['tracker'] = pfb_tracker("{$pfb_alias}{$vtype}permit_in");
 			$rule['type'] = 'pass';
 			if ($vtype == '_v6') {
 				$rule['ipprotocol'] = 'inet6';
@@ -1577,7 +1623,6 @@ function pfb_firewall_rule($action, $pfb_alias, $vtype='', $pfb_log, $agateway_i
 		case 'Match_Both':
 		case 'Match_Outbound':
 			$rule = $pfb['base_rule_float'];
-			$rule['tracker'] = pfb_tracker("{$pfb_alias}{$vtype}match_out");
 			$rule['type'] = 'match';
 			if ($vtype == '_v6') {
 				$rule['ipprotocol'] = 'inet6';
@@ -1613,7 +1658,6 @@ function pfb_firewall_rule($action, $pfb_alias, $vtype='', $pfb_log, $agateway_i
 			}
 		case 'Match_Inbound':
 			$rule = $pfb['base_rule_float'];
-			$rule['tracker'] = pfb_tracker("{$pfb_alias}{$vtype}match_in");
 			$rule['type'] = 'match';
 			if ($vtype == '_v6') {
 				$rule['ipprotocol'] = 'inet6';
@@ -1979,6 +2023,14 @@ function sync_package_pfblockerng($cron='') {
 	$new_aliases_list	= array();		// An array of alias names
 	$pfb_alias_lists	= array();		// An array of aliases that have updated lists via CRON/force update. ('Reputation' disabled)
 	$pfb_alias_lists_all	= array();		// An array of all active aliases. ('Reputation' enabled)
+
+
+	#################################
+	#	Tracker IDs		#
+	#################################
+
+	$pfb['trackerids']	= array();		// An array of pfBlockerNG Firewall rule Tracker IDs.
+	$pfb['last_trackerid']	= 1700000009;		// Pre-defined 'starting' Tracker ID (Only used if duplicates found)
 
 
 	#########################################
@@ -2428,10 +2480,7 @@ function sync_package_pfblockerng($cron='') {
 			}
 
 			// Collect suppression list
-			$pfb_dnssupp = array();
-			if (!empty($pfb['dnsblconfig']['suppression'])) {
-				$pfb_dnssupp = explode("\n", pfbng_text_area_decode($pfb['dnsblconfig']['suppression']));
-			}
+			$pfb_dnssupp = dnsbl_suppression();
 
 			// Call Alexa whitelist process
 			if ($pfb['dnsbl_alexa'] == 'on') {
@@ -2492,6 +2541,7 @@ function sync_package_pfblockerng($cron='') {
 				$lists_dnsbl_current	= array();		// Array of all active Lists in current alias
 				$pfb['aliasupdate']	= FALSE;		// Flag to signal changes to alias
 				$pfb['updateip']	= FALSE;		// Flag to signal updates to DNSBL IP lists
+				$pfb['domain_clear']	= FALSE;		// Flag to signal no Aliases defined or all Aliases disabled.
 				$alias_cnt		= 0;
 
 				if ($list['action'] != 'Disabled' && isset($list['row'])) {
@@ -2602,6 +2652,7 @@ function sync_package_pfblockerng($cron='') {
 								// Parse downloaded file for Domain names
 
 								$e_skip = $e_found = FALSE;	// Variables for Easylists
+								$iqrisk = FALSE;		// Variable for ET IQRisk
 								$fail_list = ''; $csvfail = $ipcount = $ip_cnt = 0;
 								if (($fhandle = @fopen("{$file_dwn}.orig", 'r')) !== FALSE) {
 									while (($line = @fgets($fhandle, 3072)) !== FALSE) {
@@ -2704,12 +2755,14 @@ function sync_package_pfblockerng($cron='') {
 											}
 
 											// Parse ET IQRisk IPRep domain list
-											elseif (!strpos($csvline[2], 'www.phishtank.com/phish_detail.php')){
-												if (strpos($csvline[1], '.') !== FALSE &&
-												   (int)$csvline[1] != 0 && count($csvline) == 3) {
-													$liteparser = TRUE;
-													$line = $csvline[0];
-												}
+											elseif ($iqrisk) {
+												$liteparser = TRUE;
+												$line = $csvline[0];
+											}
+
+											// Set flag to process ET IQRisk feed
+											if (!$iqrisk && $line == 'domain, category, score') {
+												$iqrisk = TRUE;
 											}
 										}
 										$line = trim($line);
@@ -2780,14 +2833,17 @@ function sync_package_pfblockerng($cron='') {
 
 										// Parser for all other domain feeds (Initial line preparation)
 										if (!$liteparser) {
-											// If 'space' character found, remove characters before space
-											if (strpos($line, ' ') !== FALSE) {
-												$line = strstr($line, ' ', FALSE);
-											}
-
 											// If '#' character found, remove characters after '#'
 											if (strpos($line, '#') !== FALSE) {
 												$line = strstr($line, '#', TRUE);
+											}
+
+											// Remove any leading/trailing whitespaces
+											$line = trim($line);
+
+											// If 'space' character found, remove characters before space
+											if (strpos($line, ' ') !== FALSE) {
+												$line = strstr($line, ' ', FALSE);
 											}
 
 											// Remove any leading/trailing whitespaces
@@ -2837,6 +2893,8 @@ function sync_package_pfblockerng($cron='') {
 										    substr($line, 0, 1) == '.' || strpos($line, '..') !== FALSE) {
 											continue;
 										}
+
+										$line = strtolower($line);
 
 										// Remove suppressed domain names
 										if (!in_array($line, $pfb_dnssupp)) {
@@ -3086,7 +3144,16 @@ function sync_package_pfblockerng($cron='') {
 			pfb_logger("{$log}", 1);
 		}
 	}
-
+	else {
+		// When DNSBL is enabled and no Aliases are defined, or all Aliases are Disabled. Set flag to clear out Unbound pfb_dnsbl.conf file.
+		if (empty($lists_dnsbl_all)) {
+			pfb_logger("\nClearing all DNSBL Feeds... ", 1);
+			$pfb['domain_clear'] = TRUE;
+			$pfb_output = @fopen("{$pfb['dnsbl_file']}.conf", 'w');
+			fwrite($pfb_output, '');
+			@fclose($pfb_output);
+		}
+	}
 
 	#################################
 	#	UNBOUND INTEGRATION	#
@@ -3099,7 +3166,7 @@ function sync_package_pfblockerng($cron='') {
 
 	if ($pfb['enable'] == 'on' && $pfb['dnsbl'] == 'on' && $pfb['unbound_state'] == 'on') {
 		// If new domain updates found, backup existing DNSBL domain feed
-		if ($pfb['domain_update']) {
+		if ($pfb['domain_update'] || $pfb['domain_clear']) {
 			if (file_exists ("{$pfb['dnsbl_file']}.conf")) {
 				@copy("{$pfb['dnsbl_file']}.conf", "{$pfb['dnsbl_file']}.bk");
 			}
@@ -3110,7 +3177,7 @@ function sync_package_pfblockerng($cron='') {
 		// Add 'include:' line in Unbound conf file if not found
 		if (isset($conf) && !strstr(implode($conf), 'pfb_dnsbl.conf')) {
 			if (file_exists("{$pfb['dnsbl_file']}.conf")) {
-				$log = " Adding Unbound Server:Include line...";
+				$log = "\nAdding Unbound Server:Include line...";
 				pfb_logger("{$log}", 1);
 
 				$pfbupdate = TRUE;
@@ -3120,7 +3187,7 @@ function sync_package_pfblockerng($cron='') {
 		}
 
 		// Validate new Unbound conf file before use.
-		if ($pfb['domain_update'] || $pfbupdate) {
+		if ($pfb['domain_update'] || $pfbupdate || $pfb['domain_clear']) {
 			pfb_validate_unbound('enabled');
 		}
 
@@ -3426,6 +3493,12 @@ function sync_package_pfblockerng($cron='') {
 							pfb_logger("{$log}", 1);
 							$file_dwn = "{$pfborig}/{$header}";
 
+							// Force 'Alias Native' setting to any Alias with 'Advanced Inbound/Outbound -Invert src/dst' settings.
+							// This will bypass Deduplication and Reputation features.
+							if ($pfbarr['aaddrnot_in'] == 'on' || $pfbarr['aaddrnot_out'] == 'on') {
+								pfb_logger("Using Alias Native\n", 1);
+							}
+
 							if (!$custom) {
 								pfb_logger(' .', 1);
 
@@ -3441,6 +3514,9 @@ function sync_package_pfblockerng($cron='') {
 
 									// Process Emerging Threats IQRisk if required
 									if (strpos($row['url'], 'iprepdata.txt') !== FALSE) {
+										if (file_exists("{$file_dwn}.raw")) {
+											exec("/usr/bin/gunzip -c {$file_dwn}.raw > {$file_dwn}.orig");
+										}
 										exec("{$pfb['script']} et {$header} x x x x x {$pfb['etblock']} {$pfb['etmatch']} {$elog}");
 									}
 								} else {
@@ -3872,7 +3948,6 @@ function sync_package_pfblockerng($cron='') {
 									);
 
 						// Define firewall rule settings
-						// Define firewall rule settings
 						pfb_firewall_rule($list['action'], $alias, '', $list['aliaslog'], $pfbarr['agateway_in'], $pfbarr['agateway_out'],
 						    $pfbarr['aaddrnot_in'], $pfbarr['aaddr_in'], $pfbarr['aports_in'], $pfbarr['aproto_in'], $pfbarr['anot_in'],
 						    $pfbarr['aaddrnot_out'], $pfbarr['aaddr_out'], $pfbarr['aports_out'], $pfbarr['aproto_out'], $pfbarr['anot_out']);
@@ -4045,7 +4120,7 @@ function sync_package_pfblockerng($cron='') {
 			if ($pfb['enable'] == 'on' && $pfb['dnsbl'] == 'on' && $pfb['dnsbl_rule'] != 'Disabled' && !empty($pfb['dnsblconfig']['dnsbl_allow_int'])) {
 				if (isset($implode_interfaces) && isset($pfb['dnsbl_vip'])) {
 					$rule			= $pfb['base_rule_float'];
-					$rule['tracker']	= pfb_tracker('pfB_DNSBL_Allow_access_to_VIP');
+					$rule['tracker']	= pfb_tracker('pfB_DNSBL_Allow_access_to_VIP', '', '');
 					$rule['type']		= 'pass';
 					$rule['direction']	= 'any';
 					$rule['interface']	= $implode_interfaces;
@@ -4072,6 +4147,7 @@ function sync_package_pfblockerng($cron='') {
 					if ($pfbrunonce && !empty($pfb['match_inbound'])) {
 						foreach ($pfb['match_inbound'] as $cb_rules) {
 							$cb_rules['interface'] = $pfb['inbound_floating'];
+							$cb_rules['tracker'] = pfb_tracker($cb_rules['descr'], $inbound_interface, 'match_in');
 							$new_rules[] = $cb_rules;
 							$pfbrunonce = FALSE;
 						}
@@ -4079,6 +4155,7 @@ function sync_package_pfblockerng($cron='') {
 					if ($pfb['order'] != 'order_0' && !empty($pfb['permit_inbound'])) {
 						foreach ($pfb['permit_inbound'] as $cb_rules) {
 							$cb_rules['interface'] = $inbound_interface;
+							$cb_rules['tracker'] = pfb_tracker($cb_rules['descr'], $inbound_interface, 'permit_in');
 							$new_rules[] = $cb_rules;
 						}
 					}
@@ -4101,12 +4178,14 @@ function sync_package_pfblockerng($cron='') {
 					if (!empty($pfb['deny_inbound'])) {
 						foreach ($pfb['deny_inbound'] as $cb_rules) {
 							$cb_rules['interface'] = $inbound_interface;
+							$cb_rules['tracker'] = pfb_tracker($cb_rules['descr'], $inbound_interface, 'deny_in');
 							$new_rules[] = $cb_rules;
 						}
 					}
 					if ($pfb['order'] == 'order_0' && !empty($pfb['permit_inbound'])) {
 						foreach ($pfb['permit_inbound'] as $cb_rules) {
 							$cb_rules['interface'] = $inbound_interface;
+							$cb_rules['tracker'] = pfb_tracker($cb_rules['descr'], $inbound_interface, 'permit_in');
 							$new_rules[] = $cb_rules;
 						}
 					}
@@ -4128,6 +4207,7 @@ function sync_package_pfblockerng($cron='') {
 					if ($pfbrunonce && !empty($pfb['match_outbound'])) {
 						foreach ($pfb['match_outbound'] as $cb_rules) {
 							$cb_rules['interface'] = $pfb['outbound_floating'];
+							$cb_rules['tracker'] = pfb_tracker($cb_rules['descr'], $outbound_interface, 'match_out');
 							$new_rules[] = $cb_rules;
 							$pfbrunonce = FALSE;
 						}
@@ -4135,6 +4215,7 @@ function sync_package_pfblockerng($cron='') {
 					if ($pfb['order'] != 'order_0' && !empty($pfb['permit_outbound'])) {
 						foreach ($pfb['permit_outbound'] as $cb_rules) {
 							$cb_rules['interface'] = $outbound_interface;
+							$cb_rules['tracker'] = pfb_tracker($cb_rules['descr'], $outbound_interface, 'permit_out');
 							$new_rules[] = $cb_rules;
 						}
 					}
@@ -4148,12 +4229,14 @@ function sync_package_pfblockerng($cron='') {
 					if (!empty($pfb['deny_outbound'])) {
 						foreach ($pfb['deny_outbound'] as $cb_rules) {
 							$cb_rules['interface'] = $outbound_interface;
+							$cb_rules['tracker'] = pfb_tracker($cb_rules['descr'], $outbound_interface, 'deny_out');
 							$new_rules[] = $cb_rules;
 						}
 					}
 					if ($pfb['order'] == 'order_0' && !empty($pfb['permit_outbound'])) {
 						foreach ($pfb['permit_outbound'] as $cb_rules) {
 							$cb_rules['interface'] = $outbound_interface;
+							$cb_rules['tracker'] = pfb_tracker($cb_rules['descr'], $outbound_interface, 'permit_out');
 							$new_rules[] = $cb_rules;
 						}
 					}
@@ -4321,6 +4404,7 @@ function sync_package_pfblockerng($cron='') {
 		pfb_logger("{$log}", 1);
 
 		$tablesin = $tablesout = array();
+		// Collect all 'pfB_' Rules that are 'Block/Reject' and do not have bypass states enabled
 		if (isset($config['aliases']['alias'])) {
 			foreach ($config['aliases']['alias'] as $alias) {
 				if ($alias['type'] == 'urltable' && strpos($alias['name'], 'pfB_') !== FALSE && strpos($alias['descr'], '[s]') === FALSE) {
@@ -4385,6 +4469,26 @@ function sync_package_pfblockerng($cron='') {
 		// Remove any duplicate IPs
 		$pfb_supp = array_unique($pfb_supp);
 
+		// Collect any 'Permit' Customlist IPs to suppress
+		$custom_supp = array();
+		foreach (array('pfblockernglistsv4', 'pfblockernglistsv6') as $ip_type) {
+			if (!empty($config['installedpackages'][$ip_type]['config'])) {
+				foreach ($config['installedpackages'][$ip_type]['config'] as $list) {
+					if (!empty($list['custom']) && strpos($list['action'], 'Permit_') !== FALSE) {
+						$custom = explode(PHP_EOL, pfbng_text_area_decode($list['custom']));
+						$custom_supp = array_merge($custom_supp, $custom);
+					}
+				}
+			}
+		}
+		$custom_supp = array_unique(array_filter($custom_supp));
+		// Append '/32' CIDR as required
+		foreach ($custom_supp as &$custom) {
+			if (strpos($custom, '/') === FALSE) {
+				$custom = $custom . '/32';
+			}
+		}
+
 		$statesin = $statesout = array();
 		exec("{$pfb['pfctl']} -s state", $s_matches);
 		if (!empty($s_matches)) {
@@ -4446,33 +4550,45 @@ function sync_package_pfblockerng($cron='') {
 		foreach (array('<-' => $statesin, '->' => $statesout) as $s_type => $s_state_ips) {
 			foreach ($s_state_ips as $s_ip) {
 				if (!in_array($s_ip, $pfb_supp)) {
-					if ($s_type == '<-') {
-						$type = '-Inbound';
-						$s_tables = $tablesin;
-					} else {
-						$type = '-Outbound';
-						$s_tables = $tablesout;
+
+					// Bypass any 'Permit' Customlist IPs
+					$pfb_suppress = FALSE;
+					foreach ($custom_supp as $custom) {
+						if (ip_in_subnet($s_ip, $custom)) {
+							$pfb_suppress = TRUE;
+							break;
+						}
 					}
 
-					foreach ($s_tables as $s_table) {
-						$result = substr(exec("{$pfb['pfctl']} -t {$s_table} -T test {$s_ip} 2>&1"), 0, 1);
-						if ($result > 0) {
-							$pfbfound = TRUE;
-							$log = " [ {$s_table}{$type} ] Removed state(s) for [ {$s_ip} ]\n";
-							pfb_logger("{$log}", 1);
-							foreach ($s_matches as $s_line) {
-								if (strpos($s_line, $s_type) !== FALSE && strpos($s_line, $s_ip) !== FALSE) {
-									pfb_logger(" {$s_line}\n", 1);
-								}
-							}
+					if (!$pfb_suppress) {
+						if ($s_type == '<-') {
+							$type = '-Inbound';
+							$s_tables = $tablesin;
+						} else {
+							$type = '-Outbound';
+							$s_tables = $tablesout;
+						}
 
-							// Remove states
-							if ($s_type == '<-') {
-								// Kill all state entries originating from $s_ip
-								exec("{$pfb['pfctl']} -k {$s_ip}");
-							} else {
-								// Kill all state entries to the target $s_ip
-								exec("{$pfb['pfctl']} -k 0.0.0.0/0 -k {$s_ip}");
+						foreach ($s_tables as $s_table) {
+							$result = substr(exec("{$pfb['pfctl']} -t {$s_table} -T test {$s_ip} 2>&1"), 0, 1);
+							if ($result > 0) {
+								$pfbfound = TRUE;
+								$log = " [ {$s_table}{$type} ] Removed state(s) for [ {$s_ip} ]\n";
+								pfb_logger("{$log}", 1);
+								foreach ($s_matches as $s_line) {
+									if (strpos($s_line, $s_type) !== FALSE && strpos($s_line, $s_ip) !== FALSE) {
+										pfb_logger(" {$s_line}\n", 1);
+									}
+								}
+
+								// Remove states
+								if ($s_type == '<-') {
+									// Kill all state entries originating from $s_ip
+									exec("{$pfb['pfctl']} -k {$s_ip}");
+								} else {
+									// Kill all state entries to the target $s_ip
+									exec("{$pfb['pfctl']} -k 0.0.0.0/0 -k {$s_ip}");
+								}
 							}
 						}
 					}
@@ -4594,6 +4710,9 @@ function pfblockerng_validate_input($post, &$input_errors) {
 			if (substr($value, 0, 1) == ' ' || empty($value)) {
 				$input_errors[] = 'Header field must be defined.';
 			}
+			if (preg_match("/\W/", $value)) {
+				$input_errors[] = 'Header field cannot contain special or international characters.';
+			}
 		}
 
 		if ($key == 'pfb_dnsbl' && $value == 'on') {
@@ -4627,6 +4746,10 @@ function pfblockerng_php_deinstall_command() {
 	sync_package_pfblockerng();
 	rmdir_recursive('/usr/local/pkg/pfblockerng');
 	rmdir_recursive('/usr/local/www/pfblockerng');
+
+	// Clear any existing pfBlockerNG CRON jobs
+	install_cron_job('pfblockerng.php cron', false);
+	install_cron_job('pfblockerng.php dc', false);
 
 	// Maintain pfBlockerNG settings and database files if $pfb['keep'] is ON.
 	if ($pfb['keep'] != 'on') {

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -253,15 +253,15 @@ function pfbng_text_area_decode($text, $mode=FALSE) {
 			if (substr(trim($line), 0, 1) != '#' && !empty($line)) {
 				if (strpos($line, '#') !== FALSE) {
 					if ($mode) {
-						$custom[] = preg_split('/(?=#)/', $line);
+						$custom[] = preg_split('/\s+(?=#)/', trim($line));
 					} else {
 						$custom .= trim(strstr($line, '#', TRUE)) . "\n";
 					}
 				} else {
 					if ($mode) {
-						$custom[][0] = $line;
+						$custom[][0] = trim($line);
 					} else {
-						$custom .= $line . "\n";
+						$custom .= trim($line) . "\n";
 					}
 				}
 			}

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # pfBlockerNG IP Reputation Script - By BBcan177@gmail.com - 04-12-14
-# Copyright (c) 2016 BBcan177@gmail.com
+# Copyright (c) 2015-2016 BBcan177@gmail.com
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License Version 2 as

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_dnsbl.xml
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_dnsbl.xml
@@ -9,7 +9,7 @@
 	pfBlockerNG_dnsbl.xml
 
 	pfBlockerNG
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 */

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_dnsbl_easylist.xml
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_dnsbl_easylist.xml
@@ -9,7 +9,7 @@
 	pfBlockerNG_dnsbl_easylist.xml
 
 	pfBlockerNG
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 */

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_dnsbl_lists.xml
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_dnsbl_lists.xml
@@ -9,7 +9,7 @@
 	pfBlockerNG_dnsbl_lists.xml
 
 	pfBlockerNG
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 */

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3,7 +3,7 @@
 	pfBlockerNG_extra.inc
 
 	pfBlockerNG
-	Copyright (c) 2015 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -3,7 +3,7 @@
 	pfBlockerNG_install.inc
 
 	pfBlockerNG
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -78,7 +78,7 @@ if (!file_exists("{$pfb['geoipshare']}/{$pfb['maxmind'][0]['file']}") ||
 			}
 
 			curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 Chrome/43.0.2357.65 Safari/537.36');
-			curl_setopt($ch, CURLOPT_SSL_CIPHER_LIST, 'TLSv1.2, TLSv1');
+			curl_setopt($ch, CURLOPT_SSL_CIPHER_LIST, 'TLSv1.2, TLSv1.1, TLSv1');
 			curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, true);
@@ -253,6 +253,59 @@ EOF;
 	update_status("Starting DNSBL Service...");
 	restart_service('dnsbl');
 	update_status(" done.\n");
+}
+
+
+// Upgrade - Adv. Inbound settings to new variable names. 
+update_status("Upgrading Adv. Inbound firewall rule settings ...");
+$ufound = FALSE;
+$upgrade_type = array('pfblockernglistsv4', 'pfblockernglistsv6', 'pfblockerngdnsblsettings', 'pfblockerngafrica', 'pfblockerngantartica',
+		    'pfblockerngasia', 'pfblockerngeurope', 'pfblockerngnorthamerica', 'pfblockerngoceania', 'pfblockerngsouthamerica',
+		    'pfblockerngtopspammers', 'pfblockerngproxyandsatellite');
+
+foreach ($upgrade_type as $type) {
+	$conf_config = &$config['installedpackages'][$type]['config'];
+	if (isset($conf_config)) {
+		foreach ($conf_config as $key => $utype) {
+			if (isset($utype['autoports'])) {
+				$ufound = TRUE;
+				if ($utype['autoports'] == 'on' && !empty($utype['aliasports']) && !isset($conf_config[$key]['autoports_in'])) {
+					$conf_config[$key]['autoports_in'] = 'on';
+					$conf_config[$key]['aliasports_in'] = $utype['aliasports'];
+				}
+				unset($conf_config[$key]['autoports']);
+				unset($conf_config[$key]['aliasports']);
+			}
+			if (isset($utype['autodest'])) {
+				$ufound = TRUE;
+				if ($utype['autodest'] == 'on' && !empty($utype['aliasdest']) && !isset($conf_config[$key]['autoaddr_in'])) {
+					$conf_config[$key]['autoaddr_in'] = 'on';
+					$conf_config[$key]['aliasaddr_in'] = $utype['aliasdest'];
+				}
+				unset($conf_config[$key]['autodest']);
+				unset($conf_config[$key]['aliasdest']);
+			}
+			if (isset($utype['autonot'])) {
+				$ufound = TRUE;
+				if ($utype['autonot'] == 'on' && !isset($conf_config[$key]['autonot_in'])) {
+					$conf_config[$key]['autonot_in'] = $utype['autonot'];
+				}
+				unset($conf_config[$key]['autonot']);
+			}
+			if (isset($utype['autoproto'])) {
+				$ufound = TRUE;
+				$conf_config[$key]['autoproto_in'] = $utype['autoproto'];
+				unset($conf_config[$key]['autoproto']);
+			}
+		}
+	}
+}
+
+if ($ufound) {
+	write_config('pfBlockerNG: Upgrade Adv. Inbound Settings.');
+	update_status(" saving new changes ... done.\n");
+} else {
+	update_status(" no changes required ... done.\n");
 }
 
 unset($g['pfblockerng_install']);	// Remove 'Install flag'

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_sync.xml
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_sync.xml
@@ -9,7 +9,7 @@
 	pfBlockerNG_sync.xml
 
 	pfBlockerNG
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 	Based upon pfblocker for pfSense

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_top20.xml
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_top20.xml
@@ -9,7 +9,7 @@
 	pfBlockerNG_Top20.xml
 
 	pfBlockerNG
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 	Based upon pfblocker for pfSense
@@ -417,7 +417,7 @@
 			<fielddescr>Custom Port</fielddescr>
 			<fieldname>aliasports_out</fieldname>
 			<description><![CDATA[<a target="_blank" href="/firewall_aliases.php?tab=port">Click Here to add/edit Aliases</a>
-				Do not manually enter port numbers.<br />Do not use 'pfB_' in the Port Alias name.]]>
+				Do not manually enter port numbers. <br />Do not use 'pfB_' in the Port Alias name.]]>
 			</description>
 			<width>6</width>
 			<type>aliases</type>

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_v4lists.xml
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_v4lists.xml
@@ -9,7 +9,7 @@
 	pfBlockerNG_v4lists.xml
 
 	pfBlockerNG
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 	Based upon pfblocker for pfSense

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_v6lists.xml
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_v6lists.xml
@@ -9,7 +9,7 @@
 	pfBlockerNG_v6lists.xml
 
 	pfBlockerNG
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 	Based upon pfblocker for pfSense

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng.php
@@ -683,7 +683,7 @@ $xml = <<<EOF
 	pfblockerng_{$cont_name}.xml
 
 	pfBlockerNG
-	Copyright (C) 2016 BBcan177@gmail.com
+	Copyright (C) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 	Based upon pfblocker for pfSense
@@ -1188,7 +1188,7 @@ $xmlrep = <<<EOF
 	pfBlockerNG_Reputation.xml
 
 	pfBlockerNG
-	Copyright (C) 2016 BBcan177@gmail.com
+	Copyright (C) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 	Based upon pfblocker for pfSense

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng.php
@@ -3,7 +3,7 @@
 	pfBlockerNG.php
 
 	pfBlockerNG
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 	Based upon pfBlocker by
@@ -1465,7 +1465,7 @@ $xmlrep = <<<EOF
 					<ul>https://rules.emergingthreatspro.com/XXXXXXXXXXXXXXXX/reputation/iprepdata.txt.gz</ul>
 					Select the <strong>ET IQRisk'</strong> format. The URL should use the .gz File Type.<br />
 					Enter your "ETPRO" code in URL. Further information can be found @
-					<a target="_blank" href="http://emergingthreats.net/solutions/iqrisk-suite/">ET IQRisk IP Reputation</a><br /><br />
+					<a target="_blank" href="https://www.proofpoint.com/us/solutions/products/threat-intelligence">Proofpoint IQRisk</a><br /><br />
 					To use <strong>'Match'</strong> Lists, Create a new 'Alias' and select one of the <strong>
 					Action 'Match'</strong> Formats and <br />
 					enter the 'Localfile' as: <ul>/var/db/pfblockerng/match/ETMatch.txt</ul>

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_alerts_ar.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_alerts_ar.php
@@ -3,7 +3,7 @@
 	pfBlockerNG_Alerts_AR.php
 
 	pfBlockerNG
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 	Portions of this code are based on original work done for

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -3,7 +3,7 @@
 	pfBlockerNG_Log.php
 
 	pfBlockerNG
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 	Portions of this code are based on original work done for the

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_threats.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_threats.php
@@ -3,7 +3,7 @@
 	pfBlockerNG_threats.php
 
 	pfBlockerNG
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -197,6 +197,11 @@ include('head.inc');
 					<td><i class="fa fa-globe pull-right"></i></td>
 					<td><a target="_blank" href="http://www.tcpiputils.com/browse/domain/<?php echo $domain; ?>/">
 						<?=gettext("TCPUtils");?></a></td>
+				</tr>
+				<tr>
+					<td><i class="fa fa-globe pull-right"></i></td>
+					<td><a target="_blank" href="https://www.google.com/safebrowsing/diagnostic?site=<?php echo $domain; ?>/">
+                                        	<?=gettext("Google SafeBrowsing");?></a></td>
 				</tr>
 			<?php endif; ?>
 			</tbody>

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -3,7 +3,7 @@
 /* pfBlockerNG_Update.php
 
 	pfBlockerNG
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 	Portions of this code are based on original work done for
@@ -343,7 +343,7 @@ $section->add($group);
 $group = new Form_Group(NULL);
 $btn_run = new Form_Button(
 	'run',
-	' ' . 'Run',
+	'Run',
 	NULL,
 	'fa-play-circle'
 );
@@ -351,16 +351,16 @@ $btn_run->removeClass('btn-primary')->addClass('btn-primary btn-xs')->setWidth(1
 
 // Alternate view/end view button text
 if (!isset($pconfig['log_view'])) {
-	$pconfig['log_view'] = ' View';
-} elseif($pconfig['log_view'] == ' View') {
-	$pconfig['log_view'] = ' End View' ;
+	$pconfig['log_view'] = 'View';
+} elseif($pconfig['log_view'] == 'View') {
+	$pconfig['log_view'] = 'End View' ;
 } else {
-	$pconfig['log_view'] = ' View';
+	$pconfig['log_view'] = 'View';
 }
 
 // Alternate view/end view title text
 $btn_logview_title = 'Click to End Log View';
-if ($pconfig['log_view'] == ' View') {
+if ($pconfig['log_view'] == 'View') {
 	$btn_logview_title = 'Click to View a running Cron Update.';
 }
 
@@ -374,7 +374,7 @@ $btn_logview->removeClass('btn-primary')->addClass('btn-primary btn-xs')->setWid
 	    ->setAttribute('title', $btn_logview_title);
 $group->add(new Form_StaticText(
 		NULL,
-		$btn_run . '&emsp;' . $btn_logview
+		$btn_run . $btn_logview
 ));
 
 $section->add($group);
@@ -401,7 +401,7 @@ print($form);
 
 // Execute the viewer output window
 if (isset($pconfig['log_view'])) {
-	if ($pconfig['log_view'] !== ' View') {
+	if ($pconfig['log_view'] !== 'View') {
 		pfbupdate_status(gettext("Log Viewing in progress.    ** Press 'END VIEW' to Exit ** "));
 		pfb_livetail($pfb['log'], 'view');
 	} else {

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/www/index.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/www/index.php
@@ -3,7 +3,7 @@
 	index.php
 
 	pfBlockerNG (DNSBL)
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 */
 header("Cache-Control: private, no-store, no-cache, must-revalidate, max-age=0");

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/widgets/javascript/pfblockerng.js
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/widgets/javascript/pfblockerng.js
@@ -1,5 +1,5 @@
 /* pfBlockerNG update engine
- * Part of pfBlockerNG by BBCan177@gmail.com (c) 2016
+ * Part of pfBlockerNG by BBCan177@gmail.com (c) 2015-2016
  * Javascript and Integration modifications by J. Nieuwenhuizen and J. Van Breedam
  */
 

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -3,7 +3,7 @@
 	pfBlockerNG.widget.php
 
 	pfBlockerNG
-	Copyright (c) 2016 BBcan177@gmail.com
+	Copyright (c) 2015-2016 BBcan177@gmail.com
 	All rights reserved.
 
 	Based Upon pfblocker :
@@ -461,9 +461,7 @@ $entries = count($results);
 				<i class="<?=$dnsbl_status?>" title="<?=gettext($dnsbl_msg)?>"></i>
 			</td>
 			<td>
-				<?php if ($scount != 0): ?>
-					<?=("<small>DNSBL:<strong>{$scount}</strong></small>")?>
-				<?php endif; ?>
+				<?=("<small>DNSBL:<strong>{$scount}</strong></small>")?>
 			</td>
 			<td></td><td></td><td></td><td></td>
 			<td>


### PR DESCRIPTION
* Add TLSv1.1 to cURL SSL Options
* Improve 'Max daily download failure threshold' feature
* Improve function pfbng_text_area_decode() add $mode variable to account for '#' comment lines in DNSBL Suppression Alias
* Improve dnsbl_suppression() function
* 'Advanced In/Outbound Firewall Rules' - Force any Invert Source/Destination Alias to use 'Alias Native' settings
* Improve GZIP archive extraction function
* Re-factor Tracker IDs. (Convert all unique Alias details (via ascii table number) and return a 10 digit tracker ID)
If a duplicate Tracker ID is found, default to a pre-determined Tracker ID format starting with '1700000010'
* When DNSBL is enabled, but all Aliases/Feeds are 'Disabled', clear existing DNSBL Unbound Database properly.
* Improve Proofpoint/Emerging Threats IQRisk integrations
* Improve DNSBL domain name parser
* Force all DNSBL domains to lowercase
* Improve 'Kill States' feature - Collect all 'pfB_' Rules that are 'Block/Reject' and do not have bypass states enabled
* Improve 'Kill States' feature - Collect any 'Permit' Customlist IPs to suppress
* Add Input Validation for Header/Label field - Whitespace, special or International characters not allowed
* Fix broken URL for Proofpoint/Emerging Threats IQRisk
* Improve DNSBL Suppression to also suppress any CNAMES associated with domain name.
Hardcode drill command with @8.8.8.8 (May have to add option in future to allow user to override DNS server entry)
* Upgrade existing 'Advanced Outbound Firewall Rules' variables to new variable format
* Add Threat IOC lookup to 'Google SafeBrowsing'
* Remove workaround for CSS issue with FA embeded icons w/text (Previously required an extra space)