### PR TITLE
status/monitoring fix tooltip unit_acronyms

### DIFF
--- a/sysutils/pfSense-Status_Monitoring/Makefile
+++ b/sysutils/pfSense-Status_Monitoring/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-Status_Monitoring
-PORTVERSION=	0.9.8
+PORTVERSION=	0.9.9
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/rrd_fetch_json.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/rrd_fetch_json.php
@@ -96,6 +96,8 @@ $graph_unit_lookup = array(
 	"memory"    => "%",
 	"wireless"  => "dBi",
 	"mbuf"      => "",
+	"dhcpd"     => "",
+	"vpnusers"  => "",
 	"cellular"  => "dB"
 );
 
@@ -220,6 +222,12 @@ if ($left != "null") {
 			$unit_acronym = "Mb";
 			break;
 		case "channel":
+			$unit_acronym = "";
+			break;
+		case "concurrentusers":
+			$unit_acronym = "";
+			break;
+		case "loggedinusers":
 			$unit_acronym = "";
 			break;
 		}
@@ -443,6 +451,12 @@ if ($right != "null") {
 			$unit_acronym = "Mb";
 			break;
 		case "channel":
+			$unit_acronym = "";
+			break;
+		case "concurrentusers":
+			$unit_acronym = "";
+			break;
+		case "loggedinusers":
 			$unit_acronym = "";
 			break;
 		}


### PR DESCRIPTION
this also needs to be looked at for "queues" & "queuedrops" => I don't have a clue what unit they are supposed to have.

![tooltip](https://cloud.githubusercontent.com/assets/10275257/14123645/da7e446a-f601-11e5-9941-13e8841cf818.png)
