### PR TITLE
pfSense-pkg-suricata-3.0_5 - Bug fix update

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	3.0
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -328,7 +328,7 @@ function suricata_fetch_new_rules($file_url, $file_dst, $file_md5, $desc = "") {
 	
 		// Test integrity of the rules file.  Turn off update if file has wrong md5 hash
 		if ($file_md5 != trim(md5_file($file_dst))){
-			$update_status(gettext("{$desc} file MD5 checksum failed!") . "\n");
+			update_status(gettext("{$desc} file MD5 checksum failed!") . "\n");
 			log_error(gettext("[Suricata] {$desc} file download failed.  Bad MD5 checksum."));
         	        log_error(gettext("[Suricata] Downloaded File MD5: " . md5_file($file_dst)));
 			log_error(gettext("[Suricata] Expected File MD5: {$file_md5}"));

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -510,6 +510,11 @@ if ($savemsg) {
 	print_info_box($savemsg);
 }
 
+if ($pconfig['enable'] == 'on' && $pconfig['ips_mode'] == 'ips_mode_inline' && (!isset($config['system']['disablechecksumoffloading']) || !isset($config['system']['disablesegmentationoffloading']) || !isset($config['system']['disablelargereceiveoffloading']))) {
+	print_info_box(gettext('IPS inline mode requires that Hardware Checksum, Hardware TCP Segmentation and Hardware Large Receive Offloading ' .
+				'all be disabled on the ') . '<b>' . gettext('System > Advanced > Networking ') . '</b>' . gettext('tab.'));
+}
+
 $tab_array = array();
 $tab_array[] = array(gettext("Interfaces"), true, "/suricata/suricata_interfaces.php");
 $tab_array[] = array(gettext("Global Settings"), false, "/suricata/suricata_global.php");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
@@ -251,7 +251,7 @@ $section->addInput(new Form_Checkbox(
 	'enable_iprep',
 	'Enable',
 	'Use IP Reputation Lists on this interface. Default is NOT Checked.',
-	$pconfig['reverse'],
+	$pconfig['enable_iprep'],
 	'on'
 ));
 


### PR DESCRIPTION
This update addresses the following issues.

**Bug Fixes**

1. IP Reputation enable checkbox not "sticking" on IP REP tab.
2. Typo in function name causes crash dump when updating rule sets.
3. Displaying large rule set on RULES tab results in PHP memory error and blank page in browser.

**New Features**

1. When inline IPS mode is selected, the Netmap subsystem requires that Hardware Checksum, Hardware TCP Segmentation and Hardware Large Receive Offloading all be disabled.  Suricata now checks for this when inline IPS mode is selected for an interface, and a notification message is printed for the user if all three parameters are not disabled.  These parameters are located on the **System > Advanced > Networking** tab of pfSense.

