### PR TITLE
pfSense-pkg-snort-3.2.9.1_8 GUI Package Update

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	3.2.9.1
-PORTREVISION=	7
+PORTREVISION=	8
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,8 @@ COMMENT=	pfSense package snort
 
 LICENSE=	ESF
 
-RUN_DEPENDS=	${LOCALBASE}/bin/snort:${PORTSDIR}/security/snort
+RUN_DEPENDS=	${LOCALBASE}/bin/snort:${PORTSDIR}/security/snort \ 
+		${LOCALBASE}/bin/barnyard2:${PORTSDIR}/security/barnyard2
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -423,6 +423,10 @@ foreach ($a_instance as $id => $instance) {
 $pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Alerts"));
 include("head.inc");
 
+/* refresh every 60 secs */
+if ($pconfig['arefresh'] == 'on')
+	print '<meta http-equiv="refresh" content="60;url=/snort/snort_alerts.php?instance=' . $instanceid . '" />';
+
 if ($input_errors)
 	print_input_errors($input_errors);
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_blocked.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_blocked.php
@@ -51,6 +51,9 @@ if (empty($pconfig['blertnumber']))
 else
 	$bnentries = $pconfig['blertnumber'];
 
+if (empty($pconfig['brefresh']))
+	$bnentries = 'on';
+
 # --- AJAX REVERSE DNS RESOLVE Start ---
 if (isset($_POST['resolve'])) {
 	$ip = strtolower($_POST['resolve']);
@@ -148,7 +151,7 @@ include("head.inc");
 
 /* refresh every 60 secs */
 if ($pconfig['brefresh'] == 'on')
-	print('<meta http-equiv="refresh" content="60;url=/snort/snort_blocked.php" />\n');
+	print '<meta http-equiv="refresh" content="60;url=/snort/snort_blocked.php" />';
 
 /* Display Alert message */
 if ($input_errors) {

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
@@ -144,8 +144,6 @@ if (isset($_POST['clear'])) {
 }
 
 if (isset($_POST['mode'])) {
-//	header("Location: /snort/snort_download_rules.php");
-
 	if ($_POST['mode'] == 'force') {
 		// Mount file system R/W since we need to remove files
 		conf_mount_rw();
@@ -162,7 +160,15 @@ if (isset($_POST['mode'])) {
 	
 	// Go download the updates
 	include("/usr/local/pkg/snort/snort_check_for_rule_updates.php");
-	exit;
+
+	// Reload the page to update displayed values
+	header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
+	header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
+	header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+	header( 'Cache-Control: post-check=0, pre-check=0', false );
+	header( 'Pragma: no-cache' );
+	header("Location: /snort/snort_download_updates.php");
+	return;
 }
 
 $pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Update Rules"));

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
@@ -724,13 +724,11 @@ print($section);
 								$sid = $k2;
 								$gid = $k1;
 								$ruleset = $currentruleset;
-								$style = "";
 
 								if ($v['managed'] == 1) {
 									if ($v['disabled'] == 1) {
 										$textss = '<span class="text-muted">';
 										$textse = '</span>';
-										$style= 'style="opacity: 0.4; filter: alpha(opacity=40);"';
 										$iconb_class = 'class="fa fa-adn text-danger text-left"';
 										$title = gettext("Auto-disabled by settings on SID Mgmt tab");
 									}
@@ -792,43 +790,42 @@ print($section);
 								$destination_port = $rule_content[6]; //destination port field
 								$message = snort_get_msg($v['rule']); // description field
 								$sid_tooltip = gettext("View the raw text for this rule");
-
-								echo "<tr class=\"text-nowrap\"><td>{$textss}";
-								if ($v['managed'] == 1) {
-									echo "<i {$iconb_class} title='{$title}'</i>{$textse}";
-								}
-								else {
-									echo "<a id=\"rule_{$gid}_{$sid}\" href='#' onClick=\"doToggle('{$gid}', '{$sid}');\" 
-									{$iconb_class} title=\"{$title}\"></a>{$textse}";
-								}
-							       echo "</td>
-							       <td ondblclick=\"getRuleFileContents('{$currentruleset}','{$gid}','{$sid}');\">
-									{$textss}{$gid}{$textse}
+					?>
+							<tr class="text-nowrap">
+								<td><?=$textss; ?>
+						<?php if ($v['managed'] == 1) : ?>
+									<i <?=$iconb_class; ?> title="<?=$title; ?>"</i><?=$textse; ?>
+						<?php else : ?>
+									<a id="rule_<?=$gid; ?>_<?=$sid; ?>" href="#" onClick="doToggle('<?=$gid; ?>', '<?=$sid; ?>');" 
+									<?=$iconb_class; ?> title="<?=$title; ?>"></a><?=$textse; ?>
+						<?php endif; ?>
 							       </td>
-							       <td ondblclick=\"getRuleFileContents('{$currentruleset}','{$gid}','{$sid}');\">
-									<a href=\"javascript: void(0)\" 
-									onclick=\"getRuleFileContents('{$currentruleset}','{$gid}','{$sid}');\" 
-									title='{$sid_tooltip}'>{$textss}{$sid}{$textse}</a>
+							       <td ondblclick="getRuleFileContents('<?=$gid; ?>','<?=$sid; ?>');">
+									<?=$textss . $gid . $textse; ?>
 							       </td>
-							       <td ondblclick=\"getRuleFileContents('{$currentruleset}','{$gid}','{$sid}');\">
-									{$textss}{$protocol}{$textse}
+							       <td ondblclick="getRuleFileContents('<?=$gid; ?>','<?=$sid; ?>');">
+									<a href="javascript: void(0)" 
+									onclick="getRuleFileContents('<?=$gid; ?>','<?=$sid; ?>');" 
+									title="<?=$sid_tooltip; ?>"><?=$textss . $sid . $textse; ?></a>
 							       </td>
-							       <td style=\"text-overflow: ellipsis; overflow: hidden; white-space:no-wrap\" ondblclick=\"getRuleFileContents('{$currentruleset}','{$gid}','{$sid}');\">
-									{$srcspan}{$source}</span>
+							       <td ondblclick="getRuleFileContents('<?=$gid; ?>','<?=$sid; ?>');">
+									<?=$textss . $protocol . $textse; ?>
 							       </td>
-							       <td style=\"text-overflow: ellipsis; overflow: hidden; white-space:no-wrap\" ondblclick=\"getRuleFileContents('{$currentruleset}','{$gid}','{$sid}');\">
-									{$srcprtspan}{$source_port}</span>
+							       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="getRuleFileContents('<?=$gid; ?>','<?=$sid; ?>');">
+									<?=$srcspan . $source; ?></span>
 							       </td>
-							       <td style=\"text-overflow: ellipsis; overflow: hidden; white-space:no-wrap\" ondblclick=\"getRuleFileContents('{$currentruleset}','{$gid}','{$sid}');\">
-									{$dstspan}{$destination}</span>
+							       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="getRuleFileContents('<?=$gid; ?>','<?=$sid; ?>');">
+									<?=$srcprtspan . $source_port; ?></span>
 							       </td>
-							       <td style=\"text-overflow: ellipsis; overflow: hidden; white-space:no-wrap\" ondblclick=\"getRuleFileContents('{$currentruleset}','{$gid}','{$sid}');\">
-								       {$dstprtspan}{$destination_port}</span>
+							       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="getRuleFileContents('<?=$gid; ?>','<?=$sid; ?>');">
+									<?=$dstspan . $destination; ?></span>
 							       </td>
-								<td style=\"word-wrap:break-word; white-space:normal\" ondblclick=\"getRuleFileContents('{$currentruleset}','{$gid}','{$sid}');\">
-									{$textss}{$message}{$textse}
-							       </td>";
-						?>
+							       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="getRuleFileContents('<?=$gid; ?>','<?=$sid; ?>');">
+								       <?=$dstprtspan . $destination_port; ?></span>
+							       </td>
+								<td style="word-wrap:break-word; white-space:normal" ondblclick="getRuleFileContents('<?=$gid; ?>','<?=$sid; ?>');">
+									<?=$textss . $message . $textse; ?>
+							       </td>
 							</tr>
 						<?php
 								$counter++;
@@ -866,7 +863,6 @@ print($section);
 								foreach ($rules_map as $k1 => $rulem) {
 									foreach ($rulem as $k2 => $v) {
 										$ruleset = $currentruleset;
-										$style = "";
 										$sid = snort_get_sid($v['rule']);
 										$gid = snort_get_gid($v['rule']);
 
@@ -874,13 +870,12 @@ print($section);
 											if ($v['disabled'] == 1) {
 												$textss = "<span class=\"text-muted\">";
 												$textse = "</span>";
-												$style= "style=\"opacity: 0.4; filter: alpha(opacity=40);\"";
 												$iconb_class = 'class="fa fa-adn text-danger text-left"';
 												$title = gettext("Auto-disabled by settings on SID Mgmt tab");
 											}
 											else {
 												$textss = $textse = "";
-												$ruleset = "suricata.rules";
+												$ruleset = "snort.rules";
 												$iconb_class = 'class="fa fa-adn text-success text-left"';
 												$title = gettext("Auto-managed by settings on SID Mgmt tab");
 											}
@@ -925,35 +920,34 @@ print($section);
 											$policy = implode("<br/>", $matches[1]);
 										else
 											$policy = "none";
-
-										echo "<tr class=\"text-nowrap\"><td>{$textss}";
-										if ($v['managed'] == 1) {
-											echo "<i {$iconb_class} title='{$title}'</i>{$textse}";
-										}
-										else {
-											echo "<a id=\"rule_{$gid}_{$sid}\" href='#' onClick=\"doToggle('{$gid}, {$sid})';\" 
-											{$iconb_class} title=\"{$title}\"</a>{$textse}";
-										}
-									       echo "</td>
-									       <td ondblclick=\"getRuleFileContents('{$currentruleset}','{$gid}','{$sid}');\">
-											{$textss}{$gid}{$textse}
+							?>
+									<tr class="text-nowrap">
+										<td><?=$textss; ?>
+								<?php if ($v['managed'] == 1) : ?>
+											<i {$iconb_class} title='{$title}'</i>{$textse}";
+								<?php else : ?>
+											<a id="rule_<?=$gid; ?>_<?=$sid; ?>" href="#" onClick="doToggle('<?=$gid; ?>', '<?=$sid; ?>');" 
+											<?=$iconb_class; ?> title="<?=$title; ?>"</a><?=$textse; ?>
+								<?php endif; ?>
 									       </td>
-									       <td ondblclick=\"getRuleFileContents('{$currentruleset}','{$gid}','{$sid}');\">
-											<a href=\"javascript: void(0)\" 
-											onclick=\"getRuleFileContents('{$currentruleset}','{$gid}','{$sid}');\" 
-											title='{$sid_tooltip}'>{$textss}{$sid}{$textse}</a>
+									       <td ondblclick="getRuleFileContents('<?=$gid; ?>','<?=$sid; ?>');">
+											<?=$textss . $gid . $textse; ?>
 									       </td>
-										<td ondblclick=\"getRuleFileContents('{$currentruleset}','{$gid}','{$sid}');\">
-											{$textss}{$classtype}</span>
+									       <td ondblclick="getRuleFileContents('<?=$gid; ?>','<?=$sid; ?>');">
+											<a href="javascript: void(0)" 
+											onclick="getRuleFileContents('<?=$gid; ?>','<?=$sid; ?>');" 
+											title="<?=$sid_tooltip; ?>"><?=$textss . $sid . $textse; ?></a>
+									       </td>
+										<td ondblclick="getRuleFileContents('<?=$gid; ?>','<?=$sid; ?>');">
+											<?=$textss . $classtype; ?></span>
 							       			</td>
-							       			<td ondblclick=\"getRuleFileContents('{$currentruleset}','{$gid}','{$sid}');\">
-								       			{$textss}{$policy}</span>
+							       			<td ondblclick="getRuleFileContents('<?=$gid; ?>','<?=$sid; ?>');">
+								       			<?=$textss . $policy; ?></span>
 								       		</td>
-										<td style=\"word-wrap:break-word; white-space:normal\" ondblclick=\"getRuleFileContents('{$currentruleset}','{$gid}','{$sid}');\">
-											{$textss}{$message}{$textse}
-							       			</td>";
-									?>
-									   	</tr>
+										<td style="word-wrap:break-word; white-space:normal" ondblclick="getRuleFileContents('<?=$gid; ?>','<?=$sid; ?>');">
+											<?=$textss . $message . $textse; ?>
+							       			</td>
+									</tr>
 							<?php
 										$counter++;
 									}
@@ -973,8 +967,8 @@ print($section);
 	<div class="panel-body">
 		<div class="text-info content">
 			<b><?=gettext("Total Rules: ");?></b><?=gettext($counter);?>&nbsp;&nbsp;&nbsp;&nbsp; 
-			<b><?=gettext("Enabled: ");?></b><?=gettext($enable_cnt);?>&nbsp;&nbsp;&nbsp;&nbsp;
-			<b><?=gettext("Disabled: ");?></b><?=gettext($disable_cnt);?>&nbsp;&nbsp;&nbsp;&nbsp;
+			<b><?=gettext("Default Enabled: ");?></b><?=gettext($enable_cnt);?>&nbsp;&nbsp;&nbsp;&nbsp;
+			<b><?=gettext("Default Disabled: ");?></b><?=gettext($disable_cnt);?>&nbsp;&nbsp;&nbsp;&nbsp;
 			<b><?=gettext("User Enabled: ");?></b><?=gettext($user_enable_cnt);?>&nbsp;&nbsp;&nbsp;&nbsp;
 			<b><?=gettext("User Disabled: ");?></b><?=gettext($user_disable_cnt);?>&nbsp;&nbsp;&nbsp;&nbsp;
 			<b><?=gettext("Auto-Managed: ");?></b><?=gettext($managed_count);?>
@@ -1009,7 +1003,7 @@ print($form);
 		$('#iform').submit();
 	}
 
-	function getRuleFileContents(ruleset, gid, sid) {
+	function getRuleFileContents(gid, sid) {
 		var ajaxRequest;
 
 		ajaxRequest = $.ajax({
@@ -1017,7 +1011,7 @@ print($form);
 			type: "post",
 			data: { ajax: "ajax", 
 				id: $('#id').val(),
-				openruleset: ruleset,
+				openruleset: $('#selectbox').val(),
 				gid: gid,
 				sid: sid
 			}

--- a/security/pfSense-pkg-snort/files/usr/local/www/widgets/widgets/snort_alerts.widget.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/widgets/widgets/snort_alerts.widget.php
@@ -248,11 +248,6 @@ function snort_widget_get_alerts() {
 <!-- needed in the snort_alerts.js file code -->
 	var snortupdateDelay = 5000; // update every 5 seconds
 	var snort_nentries = <?=$snort_nentries;?>; // number of alerts to display (5 is default)
-
-<!-- needed to display the widget settings menu -->
-	selectIntLink = "snort_alerts-configure";
-	textlink = document.getElementById(selectIntLink);
-	textlink.style.display = "inline";
 //]]>
 </script>
 


### PR DESCRIPTION
This update corrects a few issues in the Snort package GUI.  No new features are added in this release.

**Bug Fixes**

1. Removed unnecessary code in the Snort Alerts widget that was causing a silent JavaScript error.
2. Eliminated the use of "echo" statements and cleaned up the code for the RULES tab.
3. Removed an extraneous newline character printed when auto-refresh was enabled on the BLOCKS tab.
4. Fixed the auto-refresh on the ALERTS tab so that it actually works now.
5. Added the required runtime dependency on Barnyard2 to the GUI package Makefile so that the Barnyard2 binary will be installed along with Snort.
6. Added code to reload the UPDATES tab page when finished downloading and installing updated rules so the new values are displayed.
