### PR TITLE
haproxy-devel, switch to ports/net/haproxy-devel (currently 1.7 version)

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/Makefile
+++ b/net/pfSense-pkg-haproxy-devel/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-haproxy-devel
-PORTVERSION=	0.44
-PORTREVISION=	1
+PORTVERSION=	0.45
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +12,7 @@ COMMENT=	pfSense package haproxy-devel
 
 LICENSE=	ESF
 
-RUN_DEPENDS=	${LOCALBASE}/sbin/haproxy:${PORTSDIR}/net/haproxy
+RUN_DEPENDS=	${LOCALBASE}/sbin/haproxy:${PORTSDIR}/net/haproxy-devel
 
 CONFLICTS=	pfSense-pkg-haproxy-[0-9]*
 


### PR DESCRIPTION
haproxy-devel, switch to ports/net/haproxy-devel (currently 1.7 version)