### PR TITLE
Redmine #6106 Remove close button from info box

### DIFF
--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
@@ -522,7 +522,7 @@ if ($savemsg) {
 </div>
 
 <div class="infoblock">
-	<div class="alert alert-info clearfix" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+	<div class="alert alert-info clearfix" role="alert">
 		<div class="pull-left">
 			<p>This tool allows comparison of RRD databases on two different Y axes.</p>
 


### PR DESCRIPTION
Info boxes don't have close buttons - the "i" icon is used to open and close the box.