### PR TITLE
Automatically update apinger to dpinger

### DIFF
--- a/sysutils/pfSense-pkg-Service_Watchdog/files/usr/local/pkg/servicewatchdog.inc
+++ b/sysutils/pfSense-pkg-Service_Watchdog/files/usr/local/pkg/servicewatchdog.inc
@@ -106,7 +106,12 @@ function servicewatchdog_check_services() {
 	}
 	$a_pwservices = &$config['installedpackages']['servicewatchdog']['item'];
 
-	foreach ($a_pwservices as $svc) {
+	foreach ($a_pwservices as $idx => $svc) {
+		// apinger became dpinger in pfSense 2.3
+		if ($svc['name'] == 'apinger') {
+			$a_pwservices[$idx]['name'] = $svc['name'] = 'dpinger';
+			write_config(gettext("Service Watchdog updated service apinger to dpinger"));
+		}
 		if (!get_service_status($svc)) {
 			$descr = strlen($svc['description']) > 50 ? substr($svc['description'], 0, 50) . "..." : $svc['description'];
 			$error_message = "Service Watchdog detected service {$svc['name']} stopped. Restarting {$svc['name']} ({$descr})";


### PR DESCRIPTION
in the Service Watchdog watch list.
Forum: https://forum.pfsense.org/index.php?topic=109770.msg611158#msg611158

Doing it here means that people will get the automatic change as soon as they upgrade to 2.3 and the upgrade installs the Service Watchdog code from here. The other place it could be done is in upgrade_config.inc - but then that will not be distributed to them until pfSense 2.3.1 happens - rather too late.