### PR TITLE
Change apinger to dpinger on the fly

### DIFF
--- a/sysutils/pfSense-pkg-Service_Watchdog/files/usr/local/pkg/servicewatchdog.inc
+++ b/sysutils/pfSense-pkg-Service_Watchdog/files/usr/local/pkg/servicewatchdog.inc
@@ -107,6 +107,10 @@ function servicewatchdog_check_services() {
 	$a_pwservices = &$config['installedpackages']['servicewatchdog']['item'];
 
 	foreach ($a_pwservices as $svc) {
+		// apinger became dpinger in pfSense 2.3
+		if ($svc['name'] == 'apinger') {
+			$svc['name'] = 'dpinger';
+		}
 		if (!get_service_status($svc)) {
 			$descr = strlen($svc['description']) > 50 ? substr($svc['description'], 0, 50) . "..." : $svc['description'];
 			$error_message = "Service Watchdog detected service {$svc['name']} stopped. Restarting {$svc['name']} ({$descr})";


### PR DESCRIPTION
when processing the Service Watchdog list.
Leave the permanent update of the list for when the user next edits Service Watchdog settings.
This is an alternate version of https://github.com/pfsense/FreeBSD-ports/pull/105