### PR TITLE
pfSense-pkg-suricata-3.0_6 -- Bug Fix Update

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	3.0
-PORTREVISION=	5
+PORTREVISION=	6
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -215,7 +215,7 @@ if (is_array($config['installedpackages']['suricata']['alertsblocks'])) {
 if (empty($pconfig['alertnumber']))
 	$pconfig['alertnumber'] = '250';
 if (empty($pconfig['arefresh']))
-	$pconfig['arefresh'] = 'off';
+	$pconfig['arefresh'] = 'on';
 $anentries = $pconfig['alertnumber'];
 
 # --- AJAX REVERSE DNS RESOLVE Start ---
@@ -336,7 +336,7 @@ if (($_POST['mode'] == 'addsuppress_srcip' || $_POST['mode'] == 'addsuppress_dst
 		$input_errors[] = gettext("Suppress List '{$a_instance[$instanceid]['suppresslistname']}' is defined for this interface, but it could not be found!");
 }
 
-if ($_POST['togglesid'] && is_numeric($_POST['sidid']) && is_numeric($_POST['gen_id'])) {
+if ($_POST['mode'] == 'togglesid' && is_numeric($_POST['sidid']) && is_numeric($_POST['gen_id'])) {
 	// Get the GID and SID tags embedded in the clicked rule icon.
 	$gid = $_POST['gen_id'];
 	$sid= $_POST['sidid'];
@@ -439,7 +439,7 @@ if ($_POST['download']) {
 /* Load up an array with the current Suppression List GID,SID values */
 $supplist = suricata_load_suppress_sigs($a_instance[$instanceid], true);
 
-$pgtitle = array(gettext("Suricata"), gettext("Alerts"));
+$pgtitle = array(gettext("Services"), gettext("Suricata"), gettext("Alerts"));
 
 function build_instance_list() {
 	global $a_instance;
@@ -471,7 +471,7 @@ include_once("head.inc");
 
 /* refresh every 60 secs */
 if ($pconfig['arefresh'] == 'on')
-	echo "<meta http-equiv=\"refresh\" content=\"60;url=/suricata/suricata_alerts.php?instance={$instanceid}\" />\n";
+	print '<meta http-equiv="refresh" content="60;url=/suricata/suricata_alerts.php?instance=' . $instanceid . '" />';
 
 /* Display Alert message */
 if ($input_errors) {
@@ -524,7 +524,7 @@ $group->add(new Form_Button(
 	null,
 	'fa-trash'
 ))->removeClass('btn-default')->addClass('btn-danger btn-sm')
-  ->setHelp('All log files will be saved');
+  ->setHelp('All log files will be cleared');
 
 $section->add($group);
 
@@ -544,14 +544,14 @@ $group->add(new Form_Checkbox(
 	'Refresh',
 	($config['installedpackages']['suricata']['alertsblocks']['arefresh'] == "on"),
 	'on'
-))->setHelp('Deault is ON');
+))->setHelp('Default is ON');
 
 $group->add(new Form_Input(
 	'alertnumber',
 	'Alert Entries',
 	'number',
 	$anentries
-	))->setHelp('Number of log entries to view. Default is 250');
+	))->setHelp('Number of alerts to display. Default is 250');
 
 $section->add($group);
 
@@ -738,19 +738,19 @@ if ($filterlogentries && count($filterfieldsarray)) {
 			<span class="text-danger"><?=gettext('highlighted ');?></span><?=gettext('rows below.');?><span>
 		</div>
 	<?php endif; ?>
-		<table class="table table-striped table-hover table-condensed">
+		<table class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>
 			<thead>
-			   <tr>
-				<th><?=gettext("Date"); ?></th>
-				<th><?=gettext("Pri"); ?></th>
+			   <tr class="sortableHeaderRowIdentifier text-nowrap">
+				<th data-sortable-type="date"><?=gettext("Date"); ?></th>
+				<th data-sortable-type="numeric"><?=gettext("Pri"); ?></th>
 				<th><?=gettext("Proto"); ?></th>
 				<th><?=gettext("Class"); ?></th>
 				<th><?=gettext("Src"); ?></th>
-				<th><?=gettext("SPort"); ?></th>
+				<th data-sortable-type="numeric"><?=gettext("SPort"); ?></th>
 				<th><?=gettext("Dst"); ?></th>
-				<th><?=gettext("DPort"); ?></th>
-				<th><?=gettext("GID:SID"); ?></th>
-				<th><?=gettext("Description"); ?></th>
+				<th data-sortable-type="numeric"><?=gettext("DPort"); ?></th>
+				<th data-sortable-type="numeric"><?=gettext("GID:SID"); ?></th>
+				<th data-sortable-type="alpha"><?=gettext("Description"); ?></th>
 			   </tr>
 			</thead>
 			<tbody>
@@ -871,7 +871,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 				/* Add zero-width space as soft-break opportunity after each colon if we have an IPv6 address */
 				$alert_ip_src = str_replace(":", ":&#8203;", $alert_ip_src);
 				/* Add Reverse DNS lookup icon */
-				$alert_ip_src .= '&nbsp;&nbsp;<i class="fa fa-search" onclick="javascript:resolve_with_ajax(\'' . $fields['src'] . '\');" title="';
+				$alert_ip_src .= '<br /><i class="fa fa-search" onclick="javascript:resolve_with_ajax(\'' . $fields['src'] . '\');" title="';
 				$alert_ip_src .= gettext("Resolve host via reverse DNS lookup") . "\"  alt=\"Icon Reverse Resolve with DNS\" ";
 				$alert_ip_src .= " style=\"cursor: pointer;\"></i>";
 				/* Add icons for auto-adding to Suppress List if appropriate */
@@ -906,7 +906,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 				/* Add zero-width space as soft-break opportunity after each colon if we have an IPv6 address */
 				$alert_ip_dst = str_replace(":", ":&#8203;", $alert_ip_dst);
 				/* Add Reverse DNS lookup icons */
-				$alert_ip_dst .= "&nbsp;&nbsp;<i class=\"fa fa-search\" onclick=\"javascript:resolve_with_ajax('{$fields['dst']}');\" title=\"";
+				$alert_ip_dst .= "<br /><i class=\"fa fa-search\" onclick=\"javascript:resolve_with_ajax('{$fields['dst']}');\" title=\"";
 				$alert_ip_dst .= gettext("Resolve host via reverse DNS lookup") . "\" alt=\"Icon Reverse Resolve with DNS\" ";
 				$alert_ip_dst .= " style=\"cursor: pointer;\"></i>";
 
@@ -917,13 +917,13 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 					$alert_ip_dst .= ' title="' . gettext("Add this alert to the Suppress List and track by_dst IP") . '"></i>';
 				}
 				elseif (isset($supplist[$fields['gid']][$fields['sid']]['by_dst'][$fields['dst']])) {
-					$alert_ip_src .= '&nbsp;<i class="fa fa-info-circle" ';
-					$alert_ip_dst .= "title='" . gettext("This alert track by_dst IP is already in the Suppress List") . "'></i>";
+					$alert_ip_dst .= '&nbsp;<i class="fa fa-info-circle" ';
+					$alert_ip_dst .= 'title="' . gettext("This alert track by_dst IP is already in the Suppress List") . '"></i>';
 				}
 
 				/* Add icon for auto-removing from Blocked Table if required */
 				if (isset($tmpblocked[$fields['dst']])) {
-					$alert_ip_dst .= "&nbsp;&nbsp;<i name=\"todelete[]\" class=\"fa fa-times icon-pointer text-danger\" onClick=\"$('#ip').val('{$fields['dst']}');$('#mode').val('todelete');$('#formalert').submit();\" ";
+					$alert_ip_dst .= '&nbsp;&nbsp;<i name="todelete[]" class="fa fa-times icon-pointer text-danger" onClick="$(\'#ip\').val(\'' . $fields['dst'] . '\');$(\'#mode\').val(\'todelete\');$(\'#formalert\').submit();" ';
 					$alert_ip_dst .= ' title="' . gettext("Remove host from Blocked Table") . '"></i>';
 				}
 			}
@@ -963,14 +963,14 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 	<?php endif; ?>
 				<td><?=$alert_date;?><br/><?=$alert_time;?></td>
 				<td><?=$alert_priority;?></td>
-				<td><?=$alert_proto;?></td>
-				<td style="word-wrap:break-word;"><?=$alert_class;?></td>
-				<td><?=$alert_ip_src;?></td>
+				<td style="word-wrap:break-word; white-space:normal"><?=$alert_proto;?></td>
+				<td style="word-wrap:break-word; white-space:normal"><?=$alert_class;?></td>
+				<td style="word-wrap:break-word; white-space:normal"><?=$alert_ip_src;?></td>
 				<td><?=$alert_src_p;?></td>
-				<td><?=$alert_ip_dst;?></td>
+				<td style="word-wrap:break-word; white-space:normal"><?=$alert_ip_dst;?></td>
 				<td><?=$alert_dst_p;?></td>
 				<td><?=$alert_sid_str;?><br/><?=$sidsupplink;?>&nbsp;&nbsp;<?=$sid_dsbl_link;?></td>
-				<td><?=$alert_descr;?></td>
+				<td style="word-wrap:break-word; white-space:normal"><?=$alert_descr;?></td>
 			</tr>
 	<?php
 			$counter++;

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -213,10 +213,13 @@ if (is_array($config['installedpackages']['suricata']['alertsblocks'])) {
 }
 
 if (empty($pconfig['alertnumber']))
-	$pconfig['alertnumber'] = '250';
+	$pconfig['alertnumber'] = 250;
 if (empty($pconfig['arefresh']))
 	$pconfig['arefresh'] = 'on';
 $anentries = $pconfig['alertnumber'];
+if (!is_numeric($anentries)) {
+	$anentries = 250;
+}	
 
 # --- AJAX REVERSE DNS RESOLVE Start ---
 if (isset($_POST['resolve'])) {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
@@ -75,11 +75,12 @@ $pconfig['brefresh'] = $config['installedpackages']['suricata']['alertsblocks'][
 $pconfig['blertnumber'] = $config['installedpackages']['suricata']['alertsblocks']['blertnumber'];
 
 if (empty($pconfig['blertnumber'])) {
-	$bnentries = '500';
+	$pconfig['blertnumber'] = 500;
 }
 if (empty($pconfig['brefresh'])) {
 	$pconfig['brefresh'] = 'on';
 }
+$bnentries = $pconfig['blertnumber'];
 
 # --- AJAX REVERSE DNS RESOLVE Start ---
 if (isset($_POST['resolve'])) {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
@@ -74,10 +74,12 @@ if (!is_array($config['installedpackages']['suricata']['alertsblocks']))
 $pconfig['brefresh'] = $config['installedpackages']['suricata']['alertsblocks']['brefresh'];
 $pconfig['blertnumber'] = $config['installedpackages']['suricata']['alertsblocks']['blertnumber'];
 
-if (empty($pconfig['blertnumber']))
+if (empty($pconfig['blertnumber'])) {
 	$bnentries = '500';
-else
-	$bnentries = $pconfig['blertnumber'];
+}
+if (empty($pconfig['brefresh'])) {
+	$pconfig['brefresh'] = 'on';
+}
 
 # --- AJAX REVERSE DNS RESOLVE Start ---
 if (isset($_POST['resolve'])) {
@@ -171,12 +173,12 @@ if ($_POST['save'])
 
 }
 
-$pgtitle = array(gettext("Suricata"), gettext("Blocked Hosts"));
+$pgtitle = array(gettext("Services"), gettext("Suricata"), gettext("Blocked Hosts"));
 include_once("head.inc");
 
 /* refresh every 60 secs */
 if ($pconfig['brefresh'] == 'on') {
-	echo "<meta http-equiv=\"refresh\" content=\"60;url=/suricata/suricata_blocked.php\" />\n";
+	print '<meta http-equiv="refresh" content="60;url=/suricata/suricata_blocked.php" />';
 }
 
 /* Display Alert message */
@@ -224,7 +226,7 @@ $group->add(new Form_Button(
 	null,
 	'fa-trash'
 ))->removeClass('btn-default')->addClass('btn-danger btn-sm')
-  ->setHelp('All blocked hosts will be saved');
+  ->setHelp('All blocked hosts will be cleared');
 
 $section->add($group);
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
@@ -141,7 +141,7 @@ if ($_POST['clear']) {
 }
 
 if ($_REQUEST['updatemode']) {
-	if ($_REQUES['updatemode'] == 'force') {
+	if ($_REQUEST['updatemode'] == 'force') {
 		// Mount file system R/W since we need to remove files
 		conf_mount_rw();
 
@@ -276,11 +276,11 @@ include_once("head.inc");
 			</p>
 			<p>
 				<?php if ($snortdownload != 'on' && $emergingthreats != 'on' && $etpro != 'on'): ?>
-					<br/><button class="btn btn-primary" disabled="disabled">
+					<br/><button class="btn btn-primary" disabled>
 						<i class="fa fa-check icon-embed-btn"></i>
 						<?=gettext("Update"); ?>
 					</button>&nbsp;&nbsp;&nbsp;&nbsp;
-					<button class="btn btn-warning" disabled="disabled">
+					<button class="btn btn-warning" disabled>
 						<i class="fa fa-download icon-embed-btn"></i>
 						<?=gettext("Force"); ?>
 					</button>
@@ -419,7 +419,7 @@ function doRuleUpdates(mode) {
 		$('#updbtn').toggleClass('fa-check fa-spinner');
 	}
 	if (mode == "force") {
-		$('#forcedbtn').toggleClass('fa-download fa-spinner');
+		$('#forcebtn').toggleClass('fa-download fa-spinner');
 	}
 
 	ajaxRequest1 = $.ajax({

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
@@ -171,7 +171,7 @@ if ($_REQUEST['ajax'] == 'status') {
 	if (is_numeric($_REQUEST['pid'])) {
 		// Check for the PID launched as the rules update task
 		$rc = shell_exec("/bin/ps -o pid= -p {$_REQUEST['pid']}");
-		if (!empty($rc) && $rc == $_REQUEST['pid']) {
+		if (!empty($rc)) {
 			print("RUNNING");
 		} else {
 			print("DONE");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
@@ -140,8 +140,8 @@ if ($_POST['clear']) {
 		unlink_if_exists("{$suricata_rules_upd_log}");
 }
 
-if (isset($_POST['mode'])) {
-	if ($_POST['mode'] == 'force') {
+if ($_REQUEST['updatemode']) {
+	if ($_REQUES['updatemode'] == 'force') {
 		// Mount file system R/W since we need to remove files
 		conf_mount_rw();
 
@@ -154,12 +154,34 @@ if (isset($_POST['mode'])) {
 		conf_mount_ro();
 	}
 	
-	// Go download the updates
-	include("/usr/local/pkg/suricata/suricata_check_for_rule_updates.php");
+	// Launch a background process to download the updates
+	$upd_pid = 0;
+	$upd_pid = mwexec_bg("/usr/local/bin/php -f /usr/local/pkg/suricata/suricata_check_for_rule_updates.php");
+	print($upd_pid);
 
-	// Reload the page to update displayed values
-	print '<script type="text/javascript">window.location = "/suricata/suricata_download_updates.php";</script>';
-	return;
+	// If we failed to launch our background process, throw up an error for the user.
+	if ($upd_pid == 0) {
+		$input_errors[] = gettext("Failed to launch the background rules package update routine!  Rules update will not be done.");
+	} else {
+		exit;
+	}
+}
+
+if ($_REQUEST['ajax'] == 'status') {
+	if (is_numeric($_REQUEST['pid'])) {
+		if (shell_exec("/bin/ps aux | grep " . $_REQUEST['pid'] . " | wc -l") > 0) {
+			print("RUNNING");
+			exit;
+		}
+		else {
+			print("DONE");
+			exit;
+		}
+	}
+	else {
+		print("DONE");
+	}
+	exit;
 }
 
 /* check for logfile */
@@ -192,8 +214,6 @@ include_once("head.inc");
 	}
 ?>
 
-<form action="suricata_download_updates.php" enctype="multipart/form-data" class="form-horizontal" method="post" name="iform" id="iform">
-
 <?php
 	$tab_array = array();
 	$tab_array[] = array(gettext("Interfaces"), false, "/suricata/suricata_interfaces.php");
@@ -210,6 +230,8 @@ include_once("head.inc");
 	$tab_array[] = array(gettext("IP Lists"), false, "/suricata/suricata_ip_list_mgmt.php");
 	display_top_tabs($tab_array, true);
 ?>
+
+<form action="suricata_download_updates.php" enctype="multipart/form-data" class="form-horizontal" method="post" name="iform" id="iform">
 
 <div class="panel panel-default">
 	<div class="panel-heading"><h2 class="panel-title"><?=gettext("INSTALLED RULE SET MD5 SIGNATURES")?></h2></div>
@@ -270,11 +292,11 @@ include_once("head.inc");
 					<br/>
 					<button name="update" id="update" class="btn btn-primary" 
 						title="<?=gettext("Check for and apply new update to enabled rule sets"); ?>">
-						<i class="fa fa-check icon-embed-btn"></i>
+						<i id="updbtn" class="fa fa-check icon-embed-btn"></i>
 						<?=gettext("Update"); ?>
 					</button>&nbsp;&nbsp;&nbsp;&nbsp;
 					<button name="force" id="force" class="btn btn-warning" title="<?=gettext("Force an update of all enabled rule sets")?>">
-						<i class="fa fa-download icon-embed-btn"></i>
+						<i id="forcebtn" class="fa fa-download icon-embed-btn"></i>
 						<?=gettext("Force"); ?>
 					</button>
 					<br/><br/>
@@ -335,7 +357,8 @@ $form = new Form(FALSE);
 $modal = new Modal('Rules Update Task', 'updrulesdlg', false, 'Close');
 $modal->addInput(new Form_StaticText (
 	null,
-	'Checking for updated rule sets may take a while ... please wait ' . '<i class="content fa fa-spinner fa-pulse fa-lg text-center text-info"></i>'
+	'Updating rule sets may take a while ... please wait for the process to complete.<br/><br/>This dialog will auto-close when the update is finished.<br/><br/>' . 
+	'<i class="content fa fa-spinner fa-pulse fa-lg text-center text-info"></i>'
 ));
 $form->add($modal);
 print($form);
@@ -347,37 +370,81 @@ print($form);
 
 <script type="text/javascript">
 //<![CDATA[
-events.push(function(){
 
-	function doRuleUpdates(mode) {
-		var ajaxRequest;
-		if (typeof mode == "undefined") {
-			var mode = "update";
-		}
+function checkUpdateStatus(pid) {
+	//See if update process is still running
+	var repeat = true;
+	var ajaxRequest2;
+	var processID = pid;
+	ajaxRequest2 = $.ajax({
+		url: "suricata_download_updates.php",
+		type: "post",
+		data: { ajax: 'status',
+			pid: processID
+		      }
+	});
 
-		// Show the "please wait" modal
-		$('#updrulesdlg').modal('show');
-
-		ajaxRequest = $.ajax({
-			url: "/suricata/suricata_download_updates.php",
-			type: "post",
-			data: { mode: mode }
-		});
-
-		// Deal with the results of the above ajax call
-		ajaxRequest.done(function (response, textStatus, jqXHR) {
-
+	ajaxRequest2.done(function (response, textStatus, jqXHR) {
+		console.log("AJAX status is " + response);
+		if (response == "DONE") {
 			// Close the "please wait" modal
 			$('#updrulesdlg').modal('hide');
-		});
+			repeat = false;
+
+			// Reload the page to refresh displayed data
+			location.reload(true);
+		}
+		else {
+			$('#updrulesdlg').modal('show');
+			repeat = true;
+		}
+		if (repeat) {
+			setTimeout(function(){
+				checkUpdateStatus(pid);
+				}, 500);
+		}
+	});
+}
+
+function doRuleUpdates(mode) {
+	var ajaxRequest1;
+	if (typeof mode == "undefined") {
+		var mode = "update";
 	}
+
+	// Show the "please wait" modal
+	$('#updrulesdlg').modal('show');
+
+	if (mode == "update") {
+		$('#updbtn').toggleClass('fa-check fa-spinner');
+	}
+	if (mode == "force") {
+		$('#forcedbtn').toggleClass('fa-download fa-spinner');
+	}
+
+	ajaxRequest1 = $.ajax({
+		url: "suricata_download_updates.php",
+		type: "post",
+		data: { updatemode: mode }
+	});
+
+	// Deal with the results of the above ajax call
+	ajaxRequest1.done(function (response, textStatus, jqXHR) {
+		checkUpdateStatus(response);
+	});
+}
+
+events.push(function(){
+
 	//-- Click handlers ---------------------------------
 	$('#update').click(function() {
 		doRuleUpdates('update');
+		return false;
 	});
 
 	$('#force').click(function() {
 		doRuleUpdates('force');
+		return false;
 	});
 
 });

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
@@ -169,16 +169,14 @@ if ($_REQUEST['updatemode']) {
 
 if ($_REQUEST['ajax'] == 'status') {
 	if (is_numeric($_REQUEST['pid'])) {
-		if (shell_exec("/bin/ps aux | grep " . $_REQUEST['pid'] . " | wc -l") > 0) {
+		// Check for the PID launched as the rules update task
+		$rc = shell_exec("/bin/ps -o pid= -p {$_REQUEST['pid']}");
+		if (!empty($rc) && $rc == $_REQUEST['pid']) {
 			print("RUNNING");
-			exit;
-		}
-		else {
+		} else {
 			print("DONE");
-			exit;
 		}
-	}
-	else {
+	} else {
 		print("DONE");
 	}
 	exit;
@@ -385,7 +383,6 @@ function checkUpdateStatus(pid) {
 	});
 
 	ajaxRequest2.done(function (response, textStatus, jqXHR) {
-		console.log("AJAX status is " + response);
 		if (response == "DONE") {
 			// Close the "please wait" modal
 			$('#updrulesdlg').modal('hide');
@@ -395,7 +392,6 @@ function checkUpdateStatus(pid) {
 			location.reload(true);
 		}
 		else {
-			$('#updrulesdlg').modal('show');
 			repeat = true;
 		}
 		if (repeat) {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
@@ -307,7 +307,7 @@ include_once("head.inc");
 					</button>
 					<br/>
 				<?php else: ?>
-					<button class="btn btn-info icon-embed-btn" disabled='disabled'>
+					<button class="btn btn-info" disabled>
 						<i class="fa fa-file-text-o icon-embed-btn"></i>
 						<?=gettext("View Log"); ?>
 					</button><br/><?=gettext("Log is empty."); ?><br/>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
@@ -156,7 +156,10 @@ if (isset($_POST['mode'])) {
 	
 	// Go download the updates
 	include("/usr/local/pkg/suricata/suricata_check_for_rule_updates.php");
-	exit;
+
+	// Reload the page to update displayed values
+	print '<script type="text/javascript">window.location = "/suricata/suricata_download_updates.php";</script>';
+	return;
 }
 
 /* check for logfile */

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -952,18 +952,18 @@ $group = new Form_Group('Pass List');
 $group->addClass('passlist');
 
 $group->add(new Form_Select(
-	'whitelistname',
+	'passlistname',
 	'Pass List',
-	$pconfig['whitelistname'],
-	suricata_get_config_lists('whitelist')
+	$pconfig['passlistname'],
+	suricata_get_config_lists('passlist')
 ))->setHelp('Choose the Pass List you want this interface to use. Addresses in a Pass List are never blocked. ');
 
 $group->add(new Form_Button(
-	'btnWhitelist',
+	'btnPasslist',
 	' ' . 'View List',
 	'#',
 	'fa-file-text-o'
-))->removeClass('btn-primary')->addClass('btn-info')->addClass('btn-sm')->setAttribute('data-target', '#whitelist')->setAttribute('data-toggle', 'modal');
+))->removeClass('btn-primary')->addClass('btn-info')->addClass('btn-sm')->setAttribute('data-target', '#passlist')->setAttribute('data-toggle', 'modal');
 
 $group->setHelp('The default Pass List adds local networks, WAN IPs, Gateways, VPNs and VIPs.  Create an Alias to customize.' . '<br />' .
 				'This option will only be used when block offenders is on.');
@@ -997,10 +997,10 @@ $modal->addInput(new Form_Textarea (
 $form->add($modal);
 
 // Add view PASS_LIST modal pop-up
-$modal = new Modal('View PASS LIST', 'whitelist', 'large', 'Close');
+$modal = new Modal('View PASS LIST', 'passlist', 'large', 'Close');
 
 $modal->addInput(new Form_Textarea (
-	'whitelist_text',
+	'passlist_text',
 	'',
 	'...Loading...'
 ))->removeClass('form-control')
@@ -1223,8 +1223,8 @@ events.push(function(){
 		getListContents($('#externallistname option:selected' ).text(), 'externalnet', 'externalnet_text');
 	});
 
-	$('#whitelist').on('shown.bs.modal', function() {
-		getListContents($('#whitelistname option:selected' ).text(), 'passlist', 'whitelist_text');
+	$('#passlist').on('shown.bs.modal', function() {
+		getListContents($('#passlistname option:selected' ).text(), 'passlist', 'passlist_text');
 	});
 
 	$('#suppresslist').on('shown.bs.modal', function() {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_browser.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_browser.php
@@ -108,7 +108,7 @@ if ($_POST['action'] == 'clear') {
 	exit;
 }
 
-$pgtitle = gettext("Suricata: Logs Browser");
+$pgtitle = array(gettext("Services"), gettext("Suricata"), gettext("Logs View"));
 include_once("head.inc");
 
 if ($input_errors) {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_mgmt.php
@@ -109,6 +109,8 @@ $log_sizes = array( '0' => gettext('NO LIMIT'), '50' => gettext('50 KB'), '150' 
 			'5000' => gettext("5 MB"), '10000' => gettext("10 MB") );
 
 // Set sensible defaults for any unset parameters
+if (empty($pconfig['enable_log_mgmt']))
+	$pconfig['enable_log_mgmt'] = 'on';
 if (empty($pconfig['suricataloglimit']))
 	$pconfig['suricataloglimit'] = 'on';
 if (empty($pconfig['suricataloglimitsize'])) {
@@ -299,15 +301,15 @@ $section = new Form_Section('General Settings');
 $section->addInput(new Form_Checkbox(
 	'clearlogs',
 	'Remove Suricata Logs On Package Uninstall',
-	'Suricata log files will be removed when the Suricata package is uninstalled.',
-	$config['installedpackages']['suricata']['config'][0]['clearlogs'] == 'on' ? true:false,
+	'Suricata log files will be removed when the Suricata package is uninstalled.  Default is not checked.',
+	$pconfig['clearlogs'] == 'on' ? true:false,
 	'on'
 ));
 $section->addInput(new Form_Checkbox(
 	'enable_log_mgmt',
 	'Auto Log Management',
-	'Enable automatic unattended management of Suricata logs using parameters specified below.',
-	$config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 'on' ? true:false,
+	'Enable automatic unattended management of Suricata logs using parameters specified below.  Default is checked.',
+	$pconfig['enable_log_mgmt'] == 'on' ? true:false,
 	'on'
 ));
 $form->add($section);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
@@ -281,7 +281,7 @@ if (isset($_POST['sidlist_dnload_all'])) {
 $sidmodfiles = return_dir_as_array($sidmods_path);
 $sidmodselections = array_merge(Array( "None" ), $sidmodfiles);
 
-$pgtitle = gettext("Suricata: SID Management");
+$pgtitle = array(gettext("Services"), gettext("Suricata"), gettext("SID Management"));
 include_once("head.inc");
 
 $tab_array = array();

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress.php
@@ -121,7 +121,7 @@ if (isset($_POST['del_btn'])) {
 	if (is_array($_POST['del']) && count($_POST['del'])) {
 		foreach ($_POST['del'] as $itemi) {
 			/* make sure list is not being referenced by any interface */
-			if (suricata_suppresslist_used($a_suppress[$_POST['list_id']]['name'])) {
+			if (suricata_suppresslist_used($a_suppress[$itemi]['name'])) {
 				$input_errors[] = gettext("Suppression List '{$a_suppress[$itemi]['name']}' is currently assigned to a Suricata interface and cannot be deleted.  Unassign it from all Suricata interfaces first.");
 			} else {
 				unset($a_suppress[$itemi]);
@@ -138,35 +138,10 @@ if (isset($_POST['del_btn'])) {
 		}
 	}
 }
-else {
-	unset($delbtn_list);
-	$need_save = false;
-
-	foreach ($_POST as $pn => $pd) {
-		if (preg_match("/cdel_(\d+)/", $pn, $matches)) {
-			$delbtn_list = $matches[1];
-		}
-	}
-	if (is_numeric($delbtn_list) && $a_suppress[$delbtn_list]) {
-		if (suricata_suppresslist_used($a_suppress[$_POST['list_id']]['name'])) {
-			$input_errors[] = gettext("This Suppression List '{$$a_suppress[$delbtn_list]['name']}' is currently assigned to a Suricata interface and cannot be deleted.  Unassign it from all Suricata interfaces first.");
-		}
-		else {
-			unset($a_suppress[$delbtn_list]);
-			write_config("suricata pkg: deleted SUPPRESSION LIST.");
-			conf_mount_rw();
-			sync_suricata_package_config();
-			conf_mount_ro();
-			header("Location: /suricata/suricata_suppress.php");
-			return;
-		}
-	}
-}
 
 $pgtitle = array(gettext("Services"), gettext("Suricata"), gettext("Suppression Lists"));
 include_once("head.inc");
 
-if($pfsense_stable == 'yes'){echo '<p class="pgtitle">' . $pgtitle . '</p>';}
 if ($input_errors) {
 	print_input_errors($input_errors);
 }
@@ -213,7 +188,7 @@ display_top_tabs($tab_array, true);
 					?>
 					<tr>
 						<td>
-							<input type="checkbox" id="frc<?=$i?>" name="del[]" value="<?=$i?>" onclick="fr_bgcolor('<?=$i?>')" />
+							<input type="checkbox" name="del[]" value="<?=$i?>" />
 						</td>
 						<td>
 							<?=htmlspecialchars($list['name'])?> <?=$icon?>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/widgets/widgets/suricata_alerts.widget.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/widgets/widgets/suricata_alerts.widget.php
@@ -273,12 +273,8 @@ function suricata_widget_get_alerts() {
 		};
 	};
 
-	// Sort the alerts array
-	if (isset($config['syslog']['reverse'])) {
-		suricata_sksort($suricata_alerts, 'timestamp', false);
-	} else {
-		suricata_sksort($suricata_alerts, 'timestamp', true);
-	}
+	// Sort the alerts array by timestamp descending (newest first)
+	suricata_sksort($suricata_alerts, 'timestamp', false);
 
 	return $suricata_alerts;
 }


### PR DESCRIPTION
This update corrects a number of user-reported bugs in the GUI package.

**Bug Fixes**

1. The ALERTS, BLOCKS,  LOGS VIEW and SID MGMT tabs are missing some or all breadcrumbs in the header.
2. Rule suppression using "by address" icons on the ALERTS tab results in garbled HTML resulting in the tooltip text being incorrectly displayed instead the appropriate icon.
3. Disabling of rules by clicking the icon on the ALERTS tab not working and resulting in just a page reload.
4. Suppress List deletion is allowed for an assigned list, but it should be prevented and a warning message displayed instead.
5. Dashboard Widget not properly handling multiple interfaces (row sorting gets off).
6. Editing/saving of Custom Rules not working on RULES tab.
7. Pass Lists created on the PASS LIST tab are not available in the drop-down for selection on the INTERFACE SETTINGS tab for a Suricata instance.
8. Automatic log management does not default to "yes" on LOG MGMT tab.
9. Number of entries to display value on ALERTS tab not initialized in some instances.
10. Number of entries to display value on BLOCKS tab not initialized in some circumstances resulting in no blocked hosts being displayed even though blocks exist in the pf table.
11. Rules update process on UPDATES tab appears to not complete sometimes, and the lack of some visual feedback confuses users.
