### PR TITLE
Spelling Error

### DIFF
--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
@@ -244,7 +244,7 @@ $group->add(new Form_Checkbox(
 	'Refresh',
 	(($config['installedpackages']['suricata']['alertsblocks']['brefresh']=="on") || ($config['installedpackages']['suricata']['alertsblocks']['brefresh']=='')),
 	'on'
-))->setHelp('Deault is ON');
+))->setHelp('Default is ON');
 
 $group->add(new Form_Input(
 	'blertnumber',


### PR DESCRIPTION
Appeared in latest development build (2.3.1.a.20160416.1107) in Snort's snort_block.php in the "Blocked Hosts and Log View Settings"