### PR TITLE
Fixed password length for squid local user Bug #5940

### DIFF
--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
@@ -1930,7 +1930,7 @@ function squid_resync_users() {
 	$contents = '';
 	if (is_array($users)) {
 		foreach ($users as $user) {
-			$contents .= $user['username'] . ':' . crypt($user['password'], base64_encode($user['password'])) . "\n";
+			$contents .= $user['username'] . ':' . crypt($user['password'], "$1$" . base64_encode($user['password'])) . "\n";
 		}
 	}
 	file_put_contents(SQUID_PASSWD, $contents);


### PR DESCRIPTION
The basic_ncsa_auth authentication helper with DES only accecpt passwords with 8 characters or less.
By default the crypt function of PHP uses DES, it will change the squid_resync_users function to save the password with MD5-based hashing