### PR TITLE
pfBlockerNG - version 2.0.11

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-pfBlockerNG
-PORTVERSION=	2.0.10
+PORTVERSION=	2.0.11
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng.xml
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng.xml
@@ -466,11 +466,11 @@
 		include_once('/usr/local/pkg/pfblockerng/pfblockerng_install.inc');
 		]]>
 	</custom_php_install_command>
-	<custom_php_deinstall_command>
+	<custom_php_pre_deinstall_command>
 		<![CDATA[
-		pfblockerng_php_deinstall_command();
+		pfblockerng_php_pre_deinstall_command();
 		]]>
-	</custom_php_deinstall_command>
+	</custom_php_pre_deinstall_command>
 	<custom_php_validation_command>
 		<![CDATA[
 		pfblockerng_validate_input($_POST, $input_errors);

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -44,7 +44,9 @@ require_once('services.inc');
 require_once('service-utils.inc');
 require_once('xmlrpc.inc');
 require_once('xmlrpc_client.inc');
-require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');	// 'include functions' not yet merged into pfSense
+if (file_exists('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc')) {
+	require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');	// 'include functions' not yet merged into pfSense
+}
 
 global $g, $config, $pfb;
 
@@ -4456,10 +4458,12 @@ function sync_package_pfblockerng($cron='') {
 					if (isset($config['filter']['rule'])) {
 						foreach ($config['filter']['rule'] as $rule) {
 							if ($alias['name'] === $rule['source']['address'] || $alias['name'] === $rule['destination']['address']) {
-								if (isset($rule['source']['address'])) {
-									$tablesin[] = $rule['source']['address'];
-								} else {
-									$tablesout[] = $rule['destination']['address'];
+								if ($rule['type'] == 'block' || $rule['type'] == 'reject') {
+									if (isset($rule['source']['address']) && !isset($rule['source']['not'])) {
+										$tablesin[] = $rule['source']['address'];
+									} elseif (isset($rule['destination']['address']) && !isset($rule['destination']['not'])) {
+										$tablesout[] = $rule['destination']['address'];
+									}
 								}
 							}
 						}
@@ -4780,24 +4784,19 @@ function pfblockerng_validate_input($post, &$input_errors) {
 
 
 // Function to De-Install pfBlockerNG
-function pfblockerng_php_deinstall_command() {
+function pfblockerng_php_pre_deinstall_command() {
 	require_once('config.inc');
-	global $config, $pfb, $static_output;
+	global $config, $pfb;
 
 	// Set these two variables to disable pfBlockerNG on de-install
-	$pfb['save'] = TRUE;
-	$pfb['install'] = TRUE;
+	$pfb['save'] = $pfb['install'] = TRUE;
 
+	update_status("Removing pfBlockerNG...");
 	sync_package_pfblockerng();
-	rmdir_recursive('/usr/local/pkg/pfblockerng');
-	rmdir_recursive('/usr/local/www/pfblockerng');
-
-	// Clear any existing pfBlockerNG CRON jobs
-	install_cron_job('pfblockerng.php cron', false);
-	install_cron_job('pfblockerng.php dc', false);
 
 	// Maintain pfBlockerNG settings and database files if $pfb['keep'] is ON.
 	if ($pfb['keep'] != 'on') {
+		update_status(" Removing all customizations/data...");
 		// Remove pfBlockerNG log and DB folder
 		rmdir_recursive("{$pfb['dbdir']}");
 		rmdir_recursive("{$pfb['logdir']}");
@@ -4855,6 +4854,9 @@ function pfblockerng_php_deinstall_command() {
 		unlink_if_exists("{$pfb['dnsbl_info']}");
 		unlink_if_exists("{$pfb['aliasarchive']}");
 	}
+	else {
+		update_status(" All customizations/data will be retained...");
+	}
 
 	// Remove widget (code from Snort deinstall)
 	$pfb['widgets'] = $config['widgets']['sequence'];
@@ -4869,8 +4871,7 @@ function pfblockerng_php_deinstall_command() {
 		write_config('pfBlockerNG: Remove widget');
 	}
 
-	$static_output .= 'pfBlockerNG has been uninstalled.';
-	update_output_window($static_output);
+	update_status(" done.\n");
 }
 
 

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -963,8 +963,8 @@ function pfblockerng_alexa() {
 				if (substr($aline[1], 0, 4) == 'www.') {
 					$aline[1] = substr($aline[1], 4);
 				}
-				fwrite($pfb_output, "local-data: \"www." . $aline[1] . " 60 IN A {$pfb['dnsbl_vip']}\"\n");
-				fwrite($pfb_output, "local-data: \"" . $aline[1] . " 60 IN A {$pfb['dnsbl_vip']}\"\n");
+				@fwrite($pfb_output, "local-data: \"www." . $aline[1] . " 60 IN A {$pfb['dnsbl_vip']}\"\n");
+				@fwrite($pfb_output, "local-data: \"" . $aline[1] . " 60 IN A {$pfb['dnsbl_vip']}\"\n");
 			}
 			else {
 				// Re-Increment $i count
@@ -1802,7 +1802,7 @@ function pfb_livetail($logfile, $mode) {
 
 	// Start at EOF
 	$lastpos_old = '';
-	$len = filesize("{$logfile}");
+	$len = @filesize("{$logfile}");
 
 	if ($mode == 'view') {
 		// Start at EOF ( - 15000)
@@ -1819,7 +1819,7 @@ function pfb_livetail($logfile, $mode) {
 	while (true) {
 		usleep(300000); //0.3s
 		clearstatcache(false, "{$logfile}");
-		$len = filesize("{$logfile}");
+		$len = @filesize("{$logfile}");
 		if ($len < $lastpos) {
 			//file deleted or reset
 			$lastpos = $len;
@@ -1828,12 +1828,12 @@ function pfb_livetail($logfile, $mode) {
 			if ($f === false) {
 				break;
 			}
-			fseek($f, $lastpos);
+			@fseek($f, $lastpos);
 
 			// 'Force Update/Cron/Reload'
 			if ($mode == 'force' || $mode == 'view') {
 				while (!feof($f)) {
-					$pfb_buffer = fread($f, 2048);
+					$pfb_buffer = @fread($f, 2048);
 					$pfb_output .= str_replace( array ("\r", "\")"), '', $pfb_buffer);
 					// Refresh on new lines only. This allows Scrolling.
 					if ($lastpos != $lastpos_old) {
@@ -1844,14 +1844,14 @@ function pfb_livetail($logfile, $mode) {
 					flush();
 
 				}
-				$lastpos = ftell($f);
+				$lastpos = @ftell($f);
 				@fclose($f);
 
 				// Capture remaining output
 				if ($mode != 'view' && strpos($pfb_output, 'UPDATE PROCESS ENDED') !== FALSE) {
 					$f = @fopen($pfb['log'], 'rb');
-					fseek($f, $lastpos);
-					$pfb_buffer = fread($f, 2048);
+					@fseek($f, $lastpos);
+					$pfb_buffer = @fread($f, 2048);
 					$pfb_output .= str_replace( "\r", '', $pfb_buffer);
 					pfbupdate_output($pfb_output);
 					clearstatcache(false, $pfb['log']);
@@ -1866,7 +1866,7 @@ function pfb_livetail($logfile, $mode) {
 			}
 			else {
 				// DNSBL Lighttpd 'dnsbl_error.log' conditional log parser
-				while (($pfb_buffer = fgets($f, 1024)) !== FALSE) {
+				while (($pfb_buffer = @fgets($f, 1024)) !== FALSE) {
 					if (strpos($pfb_buffer, 'HTTPhost') !== FALSE) {
 						$checkpos = 0;
 					}
@@ -1886,16 +1886,16 @@ function pfb_livetail($logfile, $mode) {
 							if (!empty($pfb_query)) {
 								// Increment DNSBL Alias counter
 								if (($handle = @fopen("{$pfb['dnsbl_info']}", 'r')) !== FALSE) {
-									flock($handle, LOCK_EX);
+									@flock($handle, LOCK_EX);
 									$pfb_output = @fopen("{$pfb['dnsbl_info']}.bk", 'w');
-									flock($pfb_output, LOCK_EX);
+									@flock($pfb_output, LOCK_EX);
 
 									// Find line with corresponding DNSBL Aliasname
 									while (($line = @fgetcsv($handle)) !== FALSE) {
 										if ($line[0] == $pfb_query) {
 											$line[3] += 1;
 										}
-										fputcsv($pfb_output, $line);
+										@fputcsv($pfb_output, $line);
 									}
 
 									@fclose($pfb_output);
@@ -1912,10 +1912,10 @@ function pfb_livetail($logfile, $mode) {
 
 				// Delete parsed logfile contents
 				clearstatcache(false, "{$logfile}");
-				$tlen = filesize("{$logfile}");
+				$tlen = @filesize("{$logfile}");
 				if ($tlen > $lastpos) {
 					$tlen = $tlen - $lastpos;
-					ftruncate($f, $tlen);
+					@ftruncate($f, $tlen);
 					@fclose($f);
 					$lastpos = $tlen;
 				}
@@ -3032,7 +3032,7 @@ function sync_package_pfblockerng($cron='') {
 						foreach ($lists_dnsbl_current as $clist) {
 							if (($handle = @fopen("{$pfbfolder}/{$clist}.txt", 'r')) !== FALSE) {
 								while (($line = @fgets($handle, 3072)) !== FALSE) {
-									fwrite($pfb_output, $line);
+									@fwrite($pfb_output, $line);
 								}
 							}
 							@fclose($handle);
@@ -3089,11 +3089,11 @@ function sync_package_pfblockerng($cron='') {
 
 		// Save alias statistics to file (Remove any feeds that are not referenced)
 		$handle = @fopen("{$pfb['dnsbl_info']}", 'w');
-		fwrite($handle, "# Keeping this file open in a file editor will interrupt DNSBL!\n");
+		@fwrite($handle, "# Keeping this file open in a file editor will interrupt DNSBL!\n");
 		if (!empty($dnsbl_info)) {
 			foreach ($dnsbl_info as $alias) {
 				if (in_array($alias[0], $alias_dnsbl_all)) {
-					fputcsv($handle, $alias);
+					@fputcsv($handle, $alias);
 				}
 			}
 		}
@@ -3129,7 +3129,7 @@ function sync_package_pfblockerng($cron='') {
 				foreach ($dnsbl_ip as $d_ip) {
 					if (($handle = @fopen("{$d_ip}", 'r')) !== FALSE) {
 						while (($line = @fgets($handle, 1024)) !== FALSE) {
-							fwrite($pfb_ips, $line);
+							@fwrite($pfb_ips, $line);
 						}
 					}
 					@fclose($handle);
@@ -3175,7 +3175,7 @@ function sync_package_pfblockerng($cron='') {
 			foreach ($lists_dnsbl_all as $current_list) {
 				if (($handle = @fopen("{$pfb['dnsdir']}/{$current_list}.txt", 'r')) !== FALSE) {
 					while (($line = @fgets($handle, 3072)) !== FALSE) {
-						fwrite($pfb_output, $line);
+						@fwrite($pfb_output, $line);
 					}
 				}
 				@fclose($handle);
@@ -3196,7 +3196,7 @@ function sync_package_pfblockerng($cron='') {
 			pfb_logger("\nClearing all DNSBL Feeds... ", 1);
 			$pfb['domain_clear'] = TRUE;
 			$pfb_output = @fopen("{$pfb['dnsbl_file']}.conf", 'w');
-			fwrite($pfb_output, '');
+			@fwrite($pfb_output, '');
 			@fclose($pfb_output);
 		}
 	}

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_dnsbl.xml
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_dnsbl.xml
@@ -660,7 +660,7 @@
 			<multiple/>
 		</field>
 		<field>
-			<name>Custom Domain Suppression (Whitelist)</name>
+			<name>Custom Domain Whitelist</name>
 			<type>listtopic</type>
 			<collapse>closed</collapse>
 		</field>

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_dnsbl.xml
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_dnsbl.xml
@@ -660,7 +660,7 @@
 			<multiple/>
 		</field>
 		<field>
-			<name>Custom Domain Suppression</name>
+			<name>Custom Domain Suppression (Whitelist)</name>
 			<type>listtopic</type>
 			<collapse>closed</collapse>
 		</field>


### PR DESCRIPTION
* Fix package de-install function
* Fix 'States Removal' - only parse 'Deny|Reject' types, and exclude any "!" Not Rules.