### PR TITLE
pfSense-pkg-suricata-3.0_7 -- Bug fix update

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	3.0
-PORTREVISION=	6
+PORTREVISION=	7
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -782,7 +782,7 @@ else
 	$suricata_use_syslog_facility = "local1";
 
 // Configure IPS operational mode
-if ($suricatacfg['ips_mode'] == 'ips_mode_inline') {
+if ($suricatacfg['ips_mode'] == 'ips_mode_inline' && $suricatacfg['blockoffenders'] == 'on') {
 	// Note -- Netmap promiscuous mode logic is backwards from pcap
 	$netmap_intf_promisc_mode = $intf_promisc_mode == 'yes' ? 'no' : 'yes';
 	$suricata_ips_mode = <<<EOD

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -248,7 +248,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 
 	// Restore the Dashboard Widget if it was previously enabled and saved
 	if (!empty($config['installedpackages']['suricata']['config'][0]['dashboard_widget']) && !empty($config['widgets']['sequence'])) {
-		if (strpos($config['widgets']['sequence'], "suricata_alerts-container") === FALSE)
+		if (strpos($config['widgets']['sequence'], "suricata_alerts") === FALSE)
 			$config['widgets']['sequence'] .= "," . $config['installedpackages']['suricata']['config'][0]['dashboard_widget'];
 	}
 	if (!empty($config['installedpackages']['suricata']['config'][0]['dashboard_widget_rows']) && !empty($config['widgets'])) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
@@ -106,11 +106,10 @@ unlink_if_exists("{$suricatadir}gen-msg.map");
 unlink_if_exists("{$suricatadir}unicode.map");
 unlink_if_exists("{$suricatadir}classification.config");
 unlink_if_exists("{$suricatadir}reference.config");
+unlink_if_exists("{$suricatadir}rules/*.txt");
 unlink_if_exists("{$suricatadir}rules/" . VRT_FILE_PREFIX . "*.rules");
 unlink_if_exists("{$suricatadir}rules/" . ET_OPEN_FILE_PREFIX . "*.rules");
-unlink_if_exists("{$suricatadir}rules/" . ET_OPEN_FILE_PREFIX . "*.txt");
 unlink_if_exists("{$suricatadir}rules/" . ET_PRO_FILE_PREFIX . "*.rules");
-unlink_if_exists("{$suricatadir}rules/" . ET_PRO_FILE_PREFIX . "*.txt");
 unlink_if_exists("{$suricatadir}rules/" . GPL_FILE_PREFIX . "*.rules");
 if (is_array($config['installedpackages']['suricata']['rule'])) {
 	foreach ($config['installedpackages']['suricata']['rule'] as $suricatacfg) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
@@ -125,7 +125,7 @@ $widgets = $config['widgets']['sequence'];
 if (!empty($widgets)) {
 	$widgetlist = explode(",", $widgets);
 	foreach ($widgetlist as $key => $widget) {
-		if (strstr($widget, "suricata_alerts-container")) {
+		if (strstr($widget, "suricata_alerts")) {
 			if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] == 'on') {
 				$config['installedpackages']['suricata']['config'][0]['dashboard_widget'] = $widget;
 				if ($config['widgets']['widget_suricata_display_lines']) {
@@ -137,6 +137,7 @@ if (!empty($widgets)) {
 		}
 	}
 	$config['widgets']['sequence'] = implode(",", $widgetlist);
+	write_config("Suricata pkg removed Dashboard Alerts widget.");
 }
 
 /*******************************************************/

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -911,7 +911,7 @@ $group->add(new Form_Select(
 	'homelistname',
 	'Home Net',
 	$pconfig['homelistname'],
-	suricata_get_config_lists('whitelist')
+	suricata_get_config_lists('passlist')
 ))->setHelp('Choose the Home Net you want this interface to use.');
 
 $group->add(new Form_Button(
@@ -932,7 +932,7 @@ $group->add(new Form_Select(
 	'externallistname',
 	'External Net',
 	$pconfig['externallistname'],
-	suricata_get_config_lists('whitelist')
+	suricata_get_config_lists('passlist')
 ))->setHelp('Choose the External Net you want this interface to use.');
 
 $group->add(new Form_Button(
@@ -1147,9 +1147,17 @@ events.push(function(){
 		disableInput('alertsystemlog_facility', disable);
 		disableInput('alertsystemlog_priority', disable);
 		disableInput('blockoffenders', disable);
+		disableInput('ips_mode', disable);
 		disableInput('blockoffenderskill', disable);
 		disableInput('blockoffendersip', disable);
 		disableInput('performance', disable);
+		disableInput('max_pending_packets', disable);
+		disableInput('detect_eng_profile', disable);
+		disableInput('inspect_recursion_limit', disable);
+		disableInput('mpm_algo', disable);
+		disableInput('sgh_mpm_context', disable);
+		disableInput('delayed_detect', disable);
+		disableInput('intf_promisc_mode', disable);
 		disableInput('fpm_split_any_any', disable);
 		disableInput('fpm_search_optimize', disable);
 		disableInput('fpm_no_stream_inserts', disable);
@@ -1160,8 +1168,8 @@ events.push(function(){
 		disableInput('btnHomeNet', disable);
 		disableInput('btnExternalNet', disable);
 		disableInput('btnSuppressList', disable);
-		disableInput('whitelistname', disable);
-		disableInput('btnWhitelist', disable);
+		disableInput('passlistname', disable);
+		disableInput('btnPasslist', disable);
 		disableInput('configpassthru', disable);
 		disableInput('enable_dns_log', disable);
 		disableInput('append_dns_log', disable);


### PR DESCRIPTION
This update for the Suricata GUI package addresses the following reported bugs.

**Bug Fixes**

1. Typo in list name parameter results in an inability to see and select custom IP lists for the HOME_NET or EXTERNAL_NET settings on the INTERFACE SETTINGS tab.
2. Dashboard Suricata Alerts widget not always properly restored following a package reinstall.
3. An extra text file is leftover in the rules directory following removal of the package.
