### PR TITLE
pfBlockerNG - version 2.0.12

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-pfBlockerNG
-PORTVERSION=	2.0.11
+PORTVERSION=	2.0.12
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1514,7 +1514,7 @@ function pfb_firewall_rule($action, $pfb_alias, $vtype='', $pfb_log, $agateway_i
 			if ($pfb['config']['enable_log'] == 'on' || $pfb_log == 'enabled') {
 				$rule['log'] = '';
 			}
-			if ($agateway_out != 'default') {
+			if (!empty($agateway_out) && $agateway_out != 'default') {
 				$rule['gateway'] = "{$agateway_out}";
 				if ($pfb['float'] == 'on') {
 					$rule['direction'] = 'out';
@@ -1557,7 +1557,7 @@ function pfb_firewall_rule($action, $pfb_alias, $vtype='', $pfb_log, $agateway_i
 			if ($pfb['config']['enable_log'] == 'on' || $pfb_log == 'enabled') {
 				$rule['log'] = '';
 			}
-			if ($agateway_in != 'default') {
+			if (!empty($agateway_in) && $agateway_in != 'default') {
 				$rule['gateway'] = "{$agateway_in}";
 				if ($pfb['float'] == 'on') {
 					$rule['direction'] = 'in';
@@ -1599,7 +1599,7 @@ function pfb_firewall_rule($action, $pfb_alias, $vtype='', $pfb_log, $agateway_i
 			if ($pfb['config']['enable_log'] == 'on' || $pfb_log == 'enabled') {
 				$rule['log'] = '';
 			}
-			if ($agateway_out != 'default') {
+			if (!empty($agateway_out) && $agateway_out != 'default') {
 				$rule['gateway'] = "{$agateway_out}";
 				if ($pfb['float'] == 'on') {
 					$rule['direction'] = 'out';
@@ -1642,7 +1642,7 @@ function pfb_firewall_rule($action, $pfb_alias, $vtype='', $pfb_log, $agateway_i
 			if ($pfb['config']['enable_log'] == 'on' || $pfb_log == 'enabled') {
 				$rule['log'] = '';
 			}
-			if ($agateway_in != 'default') {
+			if (!empty($agateway_in) && $agateway_in != 'default') {
 				$rule['gateway'] = "{$agateway_in}";
 				if ($pfb['float'] == 'on') {
 					$rule['direction'] = 'in';
@@ -1682,7 +1682,7 @@ function pfb_firewall_rule($action, $pfb_alias, $vtype='', $pfb_log, $agateway_i
 			if ($pfb['config']['enable_log'] == 'on' || $pfb_log == 'enabled') {
 				$rule['log'] = '';
 			}
-			if ($agateway_out != 'default') {
+			if (!empty($agateway_out) && $agateway_out != 'default') {
 				$rule['gateway'] = "{$agateway_out}";
 				$rule['direction'] = 'out';
 			}
@@ -1721,7 +1721,7 @@ function pfb_firewall_rule($action, $pfb_alias, $vtype='', $pfb_log, $agateway_i
 			if ($pfb['config']['enable_log'] == 'on' || $pfb_log == 'enabled') {
 				$rule['log'] = '';
 			}
-			if ($agateway_in != 'default') {
+			if (!empty($agateway_in) && $agateway_in != 'default') {
 				$rule['gateway'] = "{$agateway_in}";
 				$rule['direction'] = 'in';
 			}

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -294,7 +294,7 @@ function pfb_log_mgmt() {
 function pfb_logger($log, $logtype) {
 	global $g, $pfb;
 
-	$now = date('m/d/y G:i:s', time());
+	$now = date('m/d/y H:i:s', time());
 
 	// Only log timestamp if new
 	if (strpos($log, 'NOW') !== FALSE) {
@@ -1875,7 +1875,7 @@ function pfb_livetail($logfile, $mode) {
 						$line = strstr($pfb_buffer, ' ) compare', TRUE);
 						$line = ltrim(strstr($line, '] ( ', FALSE), '] ( ');
 						if (!empty($line)) {
-							$log = "DNSBL Reject HTTPS," . date('M d G:i:s', time()) . ",{$line}\n";
+							$log = "DNSBL Reject HTTPS," . date('M d H:i:s', time()) . ",{$line}\n";
 							@file_put_contents($pfb['dnslog'], $log, FILE_APPEND | LOCK_EX);
 
 							// Query DNSBL Alias for Domain list.
@@ -3040,7 +3040,7 @@ function sync_package_pfblockerng($cron='') {
 						@fclose($pfb_output);
 
 	 					// Update domain alias statistics
-						$dns_now = date('M d G:i', time());
+						$dns_now = date('M d H:i:s', time());
 						$pfbfound = FALSE;
 						foreach ($dnsbl_info as $key => $line) {
 							// Update existing alias stats
@@ -3069,7 +3069,7 @@ function sync_package_pfblockerng($cron='') {
 						}
 					}
 					if (!$pfbfound) {
-						$dns_now = date('M d G:i', time());
+						$dns_now = date('M d H:i:s', time());
 						$dnsbl_info[] = explode(',', "{$alias},{$dns_now},disabled,0");
 					}
 				}

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -343,6 +343,8 @@ duplicate() {
 	echo '  ------------------------------'
 	printf "%-10s %-10s %-10s %-10s\n" "  ${counto}" "${countm}" "${countf}" " [ ${sanity} ]"
 	echo '  -----------------------------------------------------------------'
+
+	emptyfiles # Call emptyfiles function
 }
 
 

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng.php
@@ -341,6 +341,12 @@ function pfblockerng_sync_cron() {
 								continue;
 							}
 
+							// Attempt download, when a previous 'fail' file marker is found.
+							if (file_exists("{$pfbfolder}/{$header}.fail")) {
+								pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format']);
+								continue;
+							}
+
 							// Allow cURL SSL downgrade if user configured.
 							$pflex = FALSE;
 							if ($row['state'] == 'Flex') {

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -770,7 +770,7 @@ $group->add(new Form_Checkbox(
 	'hostlookup',
 	'Auto-Resolve',
 	NULL,
-	($hostookup == 'on' ? TRUE : FALSE),
+	($hostlookup == 'on' ? TRUE : FALSE),
 	'on'
 ))->setHelp('Auto-Resolve')->setAttribute('title', 'Select to \'Auto-Resolve\' Hosts.');
 

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -226,6 +226,7 @@ if ($pconfig['logFile'] && ($pconfig['download'] || $pconfig['clear'])) {
 			}
 			@fpassthru($fd);
 			@fclose($fd);
+			exit;
 		}
 	}
 } else {

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -87,7 +87,6 @@ function pfb_cron_update($type) {
 	exec('/bin/ps -wx', $result_cron);
 	if (preg_grep("/pfblockerng[.]php\s+?(cron|update|updatednsbl)/", $result_cron)) {
 		pfbupdate_status(gettext("Force {$type} Terminated - Failed due to Active Running Task. Click 'View' for running process"));
-		header('Location: /pfblockerng/pfblockerng_update.php');
 		exit;
 	}
 
@@ -198,7 +197,7 @@ if ($pfb['enable'] == 'on') {
 					$cron_hour_begin = $line;
 				}
 				if (($line * 3600) + ($pfb['min'] * 60) > $currentdaysec) {
-						$cron_hour_next = $line;
+					$cron_hour_next = $line;
 					break;
 				}
 			}
@@ -252,7 +251,7 @@ $options  = '<div class="infoblock"><dl class="dl-horizontal">';
 $options .= '	<dt>Update:</dt><dd>will download any new Alias/Lists.</dd>';
 $options .= '	<dt>Cron:</dt><dd>will download any Alias/Lists that are within the Frequency Setting (due for Update).</dd>';
 $options .= '	<dt>Reload:</dt><dd>will reload all Lists using the existing Downloaded files.<br />';
-$options .= '		This is useful when Lists are out of <q>sync</q> or Reputation changes were made.</dd>';
+$options .= '	This is useful when Lists are out of <q>sync</q> or Reputation changes were made.</dd>';
 $options .= '</dl></div>';
 
 // Create Form

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/www/index.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/www/index.php
@@ -14,7 +14,7 @@ header("Content-Type: image/gif");
 echo base64_decode('R0lGODlhAQABAJAAAP8AAAAAACH5BAUQAAAALAAAAAABAAEAAAICBAEAOw==');
 
 // Record DNSBL HTTP Alert to logfile
-$datereq = date('M d H:i:s', $_SERVER['REQUEST_TIME']);
+$datereq = date('M d H:i:s', time());
 $req_agent = str_replace(',', '', "{$_SERVER['HTTP_REFERER']} | {$_SERVER['REQUEST_URI']} | {$_SERVER['HTTP_USER_AGENT']}");
 $log = htmlspecialchars("DNSBL Reject,{$datereq},{$_SERVER['HTTP_HOST']},{$_SERVER['REMOTE_ADDR']},{$req_agent}\n");
 if (!empty($log)) {

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -386,18 +386,14 @@ $entries = count($results);
 	<div class="table-responsive">
 		<!-- Print failed downloads (if any) -->
 		<?php if (!empty($results)): ?>
-			<ol style="white-space: nowrap; text-overflow: ellipsis;"><small>
+			<ol style="white-space: nowrap; text-overflow: ellipsis;
+				max-height: <?=($pfb['maxfails'] * 1.37) + 0.1;?>em; overflow-y: scroll;"><small>
 <?
 			$counter = 1;
 			foreach ($results as $result) {
-				if ($counter > $pfb['maxfails'] && $entries > $pfb['maxfails']) {
-					// To many errors stop displaying
-					print (($entries - $pfb['maxfails']) . gettext(' more error(s)...'));
-					break;
-				}
 				if ($counter == 1) {
 					print ("<li>{$result}&emsp;<i class=\"fa fa-trash icon-pointer\" id=\"pfblockerngackicon\"
-							title=\"" . gettext("Clear Failed Downloads") . "\" ></i></li>");
+						title=\"" . gettext("Clear Failed Downloads") . "\" ></i></li>");
 				} else {
 					print ("<li>{$result}</li>");
 				}


### PR DESCRIPTION
* Floating Rule Generation - Check if XML tag is empty.
* Fix for https://redmine.pfsense.org/issues/6246
* Make timestamps consistent (DNSBL)
* When a failed download marker is found, bypass Cron Hour validation, and re-attempt download
* Alerts Tab - Fix typo in 'Auto-Resolve'
* Log Tab - While downloading a selected log file, exit on completion, otherwise HTML code will get appended to the downloaded log file.
* Update Tab - Fix issue with "headers already sent" PHP error
* Update Tab - Fix whitespace
* widget - Scroll failed downloads instead of previous Line limit defined by $pfb['maxfails'] variable.