### PR TITLE
pfBlockerNG - version 2.0.14

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-pfBlockerNG
-PORTVERSION=	2.0.13
+PORTVERSION=	2.0.14
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -187,10 +187,10 @@ function pfb_global() {
 	$pfb['supp']		= $pfb['config']['suppression'];		// Enable Suppression
 	$pfb['logmax']		= $pfb['config']['log_maxlines'];		// Max lines in pfblockerng.log file
 	$pfb['cc']		= $pfb['config']['database_cc'];		// Disable Country database CRON updates
-	$pfb['min']		= $pfb['config']['pfb_min'];			// User defined CRON start minute
-	$pfb['hour']		= $pfb['config']['pfb_hour'];			// Start hour of the scheduler
-	$pfb['interval']	= $pfb['config']['pfb_interval'];		// Hour cycle for scheduler
-	$pfb['24hour']		= $pfb['config']['pfb_dailystart'];		// Start hour of the 'Once a day' schedule
+	$pfb['min']		= $pfb['config']['pfb_min']		?: '0';	// User defined CRON start minute
+	$pfb['hour']		= $pfb['config']['pfb_hour']		?: '0';	// Start hour of the scheduler
+	$pfb['interval']	= $pfb['config']['pfb_interval']	?: '1';	// Hour cycle for scheduler
+	$pfb['24hour']		= $pfb['config']['pfb_dailystart']	?: '0';	// Start hour of the 'Once a day' schedule
 	$pfb['iplocal']		= $config['interfaces']['lan']['ipaddr'];	// Lan IP address
 	$pfb['dnsbl']		= $pfb['dnsblconfig']['pfb_dnsbl'];		// Enabled state of DNSBL
 	$pfb['dnsbl_port']	= $pfb['dnsblconfig']['pfb_dnsport'];		// Lighttpd web server http port setting
@@ -3158,11 +3158,6 @@ function sync_package_pfblockerng($cron='') {
 			@file_put_contents("{$pfb['aliasdir']}/pfB_DNSBLIP.txt", "1.1.1.1\n", LOCK_EX);
 		}
 	}
-	else {
-		// Remove 'DNSBLIP' aliastable and files
-		exec("{$pfb['pfctl']} -t pfB_DNSBLIP -T kill 2>&1", $result);
-		unlink_if_exists("{$pfb['aliasdir']}/pfB_DNSBLIP.txt");
-	}
 
 	#########################################
 	#	UPDATE Unbound DNS Database	#
@@ -3261,10 +3256,6 @@ function sync_package_pfblockerng($cron='') {
 
 			// Remove DNSBL NAT, VIP and lighttpd service
 			pfb_create_dnsbl('disable');
-
-			// Remove 'DNSBL_IPs' aliastable
-			exec("{$pfb['pfctl']} -t pfB_DNSBLIP -T kill 2>&1", $result);
-			unlink_if_exists("{$pfb['aliasdir']}/pfB_DNSBLIP.txt");
 		}
 
 
@@ -4367,6 +4358,11 @@ function sync_package_pfblockerng($cron='') {
 			}
 		}
 
+		// When DNSBL is disabled and not during an installation.
+		if ($pfb['dnsbl'] == '' && !$pfb['install']) {
+			unlink_if_exists("{$pfb['aliasdir']}/pfB_DNSBLIP.txt");
+		}
+
 		filter_configure();		// Load filter_configure which will create the pfctl tables
 		$pfb_filter_configure = TRUE;	// Flag to skip State removal function due to pf reloading
 
@@ -4676,10 +4672,7 @@ function sync_package_pfblockerng($cron='') {
 		} elseif ($pfb['interval'] == 24) {
 			$pfb_hour = $pfb['24hour'];
 		} else {
-			$pfb_cronbase_hour = pfb_cron_base_hour();
-			if (is_array($pfb_cronbase_hour)) {
-				$pfb_hour = implode(',', $pfb_cronbase_hour);
-			}
+			$pfb_hour = implode(',', pfb_cron_base_hour());
 		}
 
 		$pfb_mday	= '*';

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -184,7 +184,7 @@ if ($pfb['enable'] == 'on') {
 		}
 	}
 	elseif ($pfb['interval'] == 24) {
-		$cron_hour_next = $cron_hour_begin = !empty($pfb['24hour']) ?: '00';
+		$cron_hour_next = $cron_hour_begin = $pfb['24hour'] ?: '00';
 	}
 	else {
 		// Find next cron hour schedule


### PR DESCRIPTION
* Fix for #6229 - When $pfb['interval'] is not defined, default the variable to '1'. This variable was introduced over a year ago, but if the user does not hit "save" in the pfBlockerNG General Tab, this variable does not get created.  In 2.2.x, the error was never noticed; however, in 2.3, the PHP errors are more verbose. So when a user upgrades from 2.2.x to 2.3.x, this variable, when not defined, will cause issues.
* Fix for DNSBL. When disabled, it wasn't removing the pf table correctly.  "There were error(s) loading the rules: /tmp/rules.debug"