### PR TITLE
Squid - Correct conf creation for reverse IPs

### DIFF
--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid_reverse.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid_reverse.inc
@@ -189,7 +189,10 @@ function squid_resync_reverse() {
 			}
 			//HTTPS
 			if (!empty($settings['reverse_https'])) {
-				$conf .= "https_port {$reip}:{$https_port} accel cert={$reverse_crt} key={$reverse_key} {$sslflags_https_port_reverse} {$dhparams} {$ciphers} {$options} defaultsite={$https_defsite} vhost\n";
+				// Squid will fail when the line length exceeds 1024 characters, this can happen because of the long ciphersuite so break the line
+				$conf .= "https_port {$reip}:{$https_port} accel cert={$reverse_crt} key={$reverse_key} {$sslflags_https_port_reverse} {$dhparams} {$ciphers} \\\n";
+				$conf .= " {$options} defaultsite={$https_defsite} vhost\n";
+				$conf .= "\n";
 			}
 		}
 	}


### PR DESCRIPTION
Properly break out $reverse_ip config onto two lines in order to avoid the Squid configuration limit of 1024 characters per line.
