### PR TITLE
Add stunnel package for pfSense 2.3

### DIFF
--- a/security/pfSense-pkg-stunnel/Makefile
+++ b/security/pfSense-pkg-stunnel/Makefile
@@ -1,0 +1,45 @@
+# $FreeBSD$
+
+PORTNAME=	pfSense-pkg-stunnel
+PORTVERSION=	5.37
+CATEGORIES=	security
+MASTER_SITES=	# empty
+DISTFILES=	# empty
+EXTRACT_ONLY=	# empty
+
+MAINTAINER=	coreteam@pfsense.org
+COMMENT=	pfSense package stunnel
+
+LICENSE=	APACHE20
+
+RUN_DEPENDS=	${LOCALBASE}/bin/stunnel:security/stunnel
+
+NO_BUILD=	yes
+NO_MTREE=	yes
+
+SUB_FILES=	pkg-install pkg-deinstall
+SUB_LIST=	PORTNAME=${PORTNAME}
+
+do-extract:
+	${MKDIR} ${WRKSRC}
+
+do-install:
+	${MKDIR} ${STAGEDIR}${PREFIX}/pkg
+	${MKDIR} ${STAGEDIR}/etc/inc/priv
+	${MKDIR} ${STAGEDIR}${PREFIX}/www/shortcuts
+	${MKDIR} ${STAGEDIR}${DATADIR}
+	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/stunnel.xml \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/stunnel.inc \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/stunnel.priv.inc \
+		${STAGEDIR}/etc/inc/priv
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/shortcuts/pkg_stunnel.inc \
+		${STAGEDIR}${PREFIX}/www/shortcuts
+	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \
+		${STAGEDIR}${DATADIR}
+	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
+		${STAGEDIR}${DATADIR}/info.xml \
+		${STAGEDIR}${PREFIX}/pkg/stunnel.xml
+
+.include <bsd.port.mk>

--- a/security/pfSense-pkg-stunnel/files/etc/inc/priv/stunnel.priv.inc
+++ b/security/pfSense-pkg-stunnel/files/etc/inc/priv/stunnel.priv.inc
@@ -1,0 +1,31 @@
+<?php
+/*
+ * stunnel.priv.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2015-2016 Rubicon Communications, LLC (Netgate)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+global $priv_list;
+
+$priv_list['page-system-stunnel'] = array();
+$priv_list['page-system-stunnel']['name'] = "WebCfg - System: stunnel package";
+$priv_list['page-system-stunnel']['descr'] = "Allow access to stunnel package GUI";
+$priv_list['page-system-stunnel']['match'] = array();
+$priv_list['page-system-stunnel']['match'][] = "pkg_edit.php?xml=stunnel.xml*";
+$priv_list['page-services-stunnel']['match'][] = "shortcuts/pkg_stunnel.inc*";
+
+?>

--- a/security/pfSense-pkg-stunnel/files/pkg-deinstall.in
+++ b/security/pfSense-pkg-stunnel/files/pkg-deinstall.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/local/bin/php -f /etc/rc.packages %%PORTNAME%% ${2}

--- a/security/pfSense-pkg-stunnel/files/pkg-install.in
+++ b/security/pfSense-pkg-stunnel/files/pkg-install.in
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "${2}" != "POST-INSTALL" ]; then
+	exit 0
+fi
+
+/usr/local/bin/php -f /etc/rc.packages %%PORTNAME%% ${2}

--- a/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.inc
+++ b/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.inc
@@ -1,0 +1,130 @@
+<?php
+/*
+ * stunnel.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2015-2016 Rubicon Communications, LLC (Netgate)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once("certs.inc");
+require_once("config.inc");
+require_once("pfsense-utils.inc");
+require_once("util.inc");
+require_once('services.inc');
+require_once('service-utils.inc');
+
+define('STUNNEL_LOCALBASE', '/usr/local');
+define('STUNNEL_ETCDIR', STUNNEL_LOCALBASE . "/etc/stunnel");
+
+function stunnel_save() {
+	global $config;
+	conf_mount_rw();
+	safe_mkdir(STUNNEL_ETCDIR, 0755);
+	$fout = fopen(STUNNEL_ETCDIR . "/stunnel.conf", "w");
+	fwrite($fout, "cert = " . STUNNEL_ETCDIR . "/stunnel.pem \n");
+	fwrite($fout, "chroot = /var/tmp/stunnel \n");
+	fwrite($fout, "setuid = stunnel \n");
+	fwrite($fout, "setgid = stunnel \n");
+	if (!is_array($config['installedpackages']['stunnel']['config'])) {
+		$config['installedpackages']['stunnel']['config'] = array();
+	}
+
+	// Keep array of in-use certificates so we can clean up after ourselves.
+	$in_use_certs = array();
+	$in_use_certs[] = 'stunnel.pem';
+
+	foreach ($config['installedpackages']['stunnel']['config'] as $pkgconfig) {
+		fwrite($fout, "\n[" . $pkgconfig['description'] . "]\n");
+		if ($pkgconfig['client']) {
+			fwrite($fout, "client = yes" . "\n");
+		}
+		if ($pkgconfig['certificate'] && $pkgconfig['certificate'] != 'default') {
+			$cert = lookup_cert($pkgconfig['certificate']);
+			if ($cert != false) {
+				file_put_contents(STUNNEL_ETCDIR . "/{$pkgconfig['certificate']}.pem", 
+					base64_decode($cert['prv']) . base64_decode($cert['crt']) . ca_chain($cert));
+				fwrite($fout, "cert = " . STUNNEL_ETCDIR . "/{$pkgconfig['certificate']}.pem\n");
+				$in_use_certs[] = "{$pkgconfig['certificate']}.pem";
+			}
+		}
+		if ($pkgconfig['sourceip']) {
+			fwrite($fout, "local = " . $pkgconfig['sourceip'] . "\n");
+		}
+		fwrite($fout, "accept = " . ($pkgconfig['localip'] ? $pkgconfig['localip'] . ":" : "")  . $pkgconfig['localport'] . "\n");
+		fwrite($fout, "connect = " . $pkgconfig['redirectip'] . ":" . $pkgconfig['redirectport'] . "\n");
+		fwrite($fout, "TIMEOUTclose = 0\n\n");
+	}
+	fclose($fout);
+
+	// Clean up certs that are no longer in use.
+	foreach (glob(STUNNEL_ETCDIR . "/*.pem") as $file) {
+		if (!in_array(basename($file), $in_use_certs)) {
+			unlink($file);
+		}
+	}
+
+	conf_mount_ro();
+
+	restart_service("stunnel");
+}
+
+function stunnel_install() {
+	global $config;
+	safe_mkdir(STUNNEL_ETCDIR);
+
+	// Generate a self-signed default certificate if one does not already exist.
+	$stunnel_pem_filename = STUNNEL_ETCDIR . "/stunnel.pem";
+	if (!file_exists($stunnel_pem_filename)) {
+		$cert = array();
+		$cert['refid'] = uniqid();
+		$cert['descr'] = sprintf(gettext("stunnel default (%s)"), $cert['refid']);
+
+		$dn = array(
+			'countryName' => "US",
+			'stateOrProvinceName' => "State",
+			'localityName' => "Locality",
+			'organizationName' => "{$g['product_name']} stunnel Self-Signed Certificate",
+			'emailAddress' => "admin@{$config['system']['hostname']}.{$config['system']['domain']}",
+			'commonName' => "{$config['system']['hostname']}-{$cert['refid']}");
+		$old_err_level = error_reporting(0); /* otherwise openssl_ functions throw warnings directly to a page screwing menu tab */
+		if (!cert_create($cert, null, 2048, 365, $dn, "self-signed", "sha256")) {
+			while ($ssl_err = openssl_error_string()) {
+				log_error(sprintf(gettext("Error creating stunnel certificate: openssl library returns: %s"), $ssl_err));
+			}
+			error_reporting($old_err_level);
+			return null;
+		}
+		error_reporting($old_err_level);
+
+		// Write the .pem file to the expected default location for stunnel and set up required permissions.
+		file_put_contents(STUNNEL_ETCDIR . "/stunnel.pem", base64_decode($cert['prv']) . base64_decode($cert['crt']));
+		chmod(STUNNEL_ETCDIR . "/stunnel.pem", 0600);
+	}
+
+	@mkdir("/var/tmp/stunnel/var/tmp/run/stunnel", 0755, true);
+	system("/usr/sbin/chown -R stunnel:stunnel /var/tmp/stunnel");
+	$_rcfile['file'] = 'stunnel.sh';
+	$_rcfile['start'] = STUNNEL_LOCALBASE . "/bin/stunnel " . STUNNEL_ETCDIR . "/stunnel.conf \n\t";
+	$_rcfile['stop'] = "/usr/bin/killall stunnel \n\t";
+	write_rcfile($_rcfile);
+	unlink_if_exists("/usr/local/etc/rc.d/stunnel");
+}
+
+function stunnel_deinstall() {
+	rmdir_recursive("/var/tmp/stunnel");
+	rmdir_recursive(STUNNEL_ETCDIR);
+}
+?>

--- a/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.xml
+++ b/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
+<packagegui>
+	<copyright>
+<![CDATA[
+/*
+ * stunnel.xml
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2015-2016 Rubicon Communications, LLC (Netgate)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+	]]>
+	</copyright>
+	<name>stunnel</name>
+	<version>%%PKGVERSION%%</version>
+	<title>Services: Secure Tunnel</title>
+	<menu>
+		<name>STunnel</name>
+		<section>Services</section>
+		<configfile>stunnel.xml</configfile>
+	</menu>
+	<include_file>/usr/local/pkg/stunnel.inc</include_file>	
+	<tabs>
+		<tab>
+			<text>Tunnels</text>
+			<url>/pkg.php?xml=stunnel.xml</url>
+			<active/>
+		</tab>
+	</tabs>
+	<service>
+		<name>stunnel</name>
+		<rcfile>stunnel.sh</rcfile>
+		<executable>stunnel</executable>
+	</service>	
+	<adddeleteeditpagefields>
+		<columnitem>
+			<fielddescr>Description</fielddescr>
+			<fieldname>description</fieldname>
+		</columnitem>
+		<columnitem>
+			<fielddescr>Listen on IP</fielddescr>
+			<fieldname>localip</fieldname>
+		</columnitem>
+		<columnitem>
+			<fielddescr>Listen on Port</fielddescr>
+			<fieldname>localport</fieldname>
+		</columnitem>
+		<columnitem>
+			<fielddescr>Certificate</fielddescr>
+			<fieldname>certificatelink</fieldname>
+		</columnitem>
+		<columnitem>
+			<fielddescr>Redirects to IP</fielddescr>
+			<fieldname>redirectip</fieldname>
+		</columnitem>
+		<columnitem>
+			<fielddescr>Redirects to Port</fielddescr>
+			<fieldname>redirectport</fieldname>
+		</columnitem>
+	</adddeleteeditpagefields>
+	<fields>
+		<field>
+			<fielddescr>Description</fielddescr>
+			<fieldname>description</fieldname>
+			<description>Enter a description for this redirection.</description>
+			<type>input</type>
+		</field>
+		<field>
+			<fielddescr>Client Mode</fielddescr>
+			<fieldname>client</fieldname>
+			<description>Use client mode for this tunnel (i.e. connect to an SSL server, do not act as an SSL server).</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Listen on IP</fielddescr>
+			<fieldname>localip</fieldname>
+			<description>Enter the local IP address to bind this redirection to.</description>
+			<type>input</type>
+		</field>
+		<field>
+			<fielddescr>Listen on Port</fielddescr>
+			<fieldname>localport</fieldname>
+			<description>Enter the local port to bind this redirection to.</description>
+			<type>input</type>
+		</field>
+		<field>
+			<fielddescr>Certificate</fielddescr>
+			<fieldname>certificate</fieldname>
+			<description>Select server certificate to use for this tunnel.</description>
+			<type>select_source</type>
+			<source><![CDATA[$config['cert']]]></source>
+			<source_name>descr</source_name>
+			<source_value>refid</source_value>
+			<show_disable_value>default</show_disable_value>
+			<default_value>default</default_value>
+		</field>
+		<field>
+			<fielddescr>Redirects to IP</fielddescr>
+			<fieldname>redirectip</fieldname>
+			<description>Enter the IP address to redirect this to.</description>
+			<type>input</type>
+		</field>
+		<field>
+			<fielddescr>Redirects to Port</fielddescr>
+			<fieldname>redirectport</fieldname>
+			<description>Enter the port to redirect to.</description>
+			<type>input</type>
+		</field>
+		<field>
+			<fielddescr>Outgoing Source IP</fielddescr>
+			<fieldname>sourceip</fieldname>
+			<description>Enter the source IP address for outgoing connections.</description>
+			<type>input</type>
+		</field>
+	</fields>
+	<custom_add_php_command_late>
+		stunnel_save();
+	</custom_add_php_command_late>
+	<custom_delete_php_command>
+		stunnel_save();
+	</custom_delete_php_command>
+	<custom_php_install_command>
+		stunnel_install();
+	</custom_php_install_command>
+	<custom_php_deinstall_command>
+		stunnel_deinstall();
+	</custom_php_deinstall_command>
+	<custom_php_resync_config_command>
+		stunnel_save();
+	</custom_php_resync_config_command>
+</packagegui>

--- a/security/pfSense-pkg-stunnel/files/usr/local/share/pfSense-pkg-stunnel/info.xml
+++ b/security/pfSense-pkg-stunnel/files/usr/local/share/pfSense-pkg-stunnel/info.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<pfsensepkgs>
+	<package>
+		<name>stunnel</name>
+		<pkginfolink>https://doc.pfsense.org/index.php/Sudo_Package</pkginfolink>
+		<descr><![CDATA[SSL encryption wrapper between remote client and local or remote servers.]]></descr>
+		<website>http://www.stunnel.org/</website>
+		<version>%%PKGVERSION%%</version>
+		<configurationfile>stunnel.xml</configurationfile>
+	</package>
+</pfsensepkgs>

--- a/security/pfSense-pkg-stunnel/files/usr/local/www/shortcuts/pkg_stunnel.inc
+++ b/security/pfSense-pkg-stunnel/files/usr/local/www/shortcuts/pkg_stunnel.inc
@@ -1,0 +1,10 @@
+<?php
+
+global $shortcuts;
+
+$shortcuts['stunnel'] = array();
+$shortcuts['stunnel']['main'] = "pkg.php?xml=stunnel.xml";
+$shortcuts['stunnel']['service'] = "stunnel";
+
+?>
+

--- a/security/pfSense-pkg-stunnel/pkg-descr
+++ b/security/pfSense-pkg-stunnel/pkg-descr
@@ -1,0 +1,3 @@
+SSL encryption wrapper between remote client and local or remote servers.
+
+WWW: https://doc.pfsense.org/index.php/Stunnel_package

--- a/security/pfSense-pkg-stunnel/pkg-plist
+++ b/security/pfSense-pkg-stunnel/pkg-plist
@@ -1,0 +1,7 @@
+pkg/stunnel.xml
+pkg/stunnel.inc
+www/shortcuts/pkg_stunnel.inc
+/etc/inc/priv/stunnel.priv.inc
+%%DATADIR%%/info.xml
+@dir /etc/inc
+@dir /etc/inc/priv


### PR DESCRIPTION
Mostly straight copies of the files from the 2.2 package with the new 2.3 package metadata files.

No attempt has been made to clean up the existing code, notably in security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.inc:
- There is code checking for pfsense versions < 2.3 which can probably be deleted
- The gui attempts to render colored text, but since it gets escaped simply renders text like &lt;font color="#AABBCC"&gt;blahblah&lt;/font&gt;.  I couldn't figure out how to get colored text in the status page tables.

I am willing to work on those issues, but since this doesn't seem to have any major issues perhaps it is OK as a first approximation to get the stunnel package working again.  If the pull can't be accepted as is, any pointers on how to fix the above issues would be greatly appreciated.  I couldn't find anything promising in the convert to bootstrap docs.
