### PR TITLE
Status Monitoring - Default Resolution

### DIFF
--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
@@ -717,6 +717,10 @@ events.push(function() {
 		$( "#start-time" ).prop( "disabled", true );
 		$( "#end-time" ).prop( "disabled", true );
 
+		if (page_loading) {	// Save resolution of page load "applySettings".
+			resolution = $( "#resolution" ).val();
+		}
+
 		switch(this.value) {
 			case "-3m":
 			case "-1y":
@@ -779,7 +783,10 @@ events.push(function() {
 				$("#resolution").append('<option value="60">1 Minute</option>');
 				break;
 			}
-			
+
+			if (page_loading) {	// Restore resolution of page load "applySettings".
+				($( "#resolution" ).val(resolution));
+			}
 	});
 
 	function convertToEpoch(datestring) {
@@ -962,6 +969,8 @@ events.push(function() {
 		}, this);
 
 	}
+
+	var page_loading = true;
 
 	applySettings("<?php echo $pconfig['category']; ?>");
 

--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
@@ -1354,6 +1354,8 @@ events.push(function() {
 
 	}
 
+	page_loading = false;	// Page has finished loading now.
+
 });
 //]]>
 </script>


### PR DESCRIPTION
Use the resolution of the applied settings on page load instead of the time period default resolution.
Fixes bug 6402