### PR TITLE
Status / Monitoring - Last Sample Zero

### DIFF
--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/rrd_fetch_json.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/rrd_fetch_json.php
@@ -85,6 +85,9 @@ if ($timePeriod === "custom") {
 	$resolution = 60; //defaults to lowest resolution possible
 	$start = floor($start/$resolution) * $resolution;
 	$end = floor($end/$resolution) * $resolution;
+}
+
+if ($start && $end) {
 	$rrd_options = array( 'AVERAGE', '-r', $resolution, '-s', $start, '-e', $end );
 } else {
 	$rrd_options = array( 'AVERAGE', '-r', $resolution, '-s', $timePeriod );

--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
@@ -812,8 +812,9 @@ events.push(function() {
 		var resolution = $( "#resolution" ).val();
 		var graphtype = $( "#graph-type" ).val();
 		var invert = $( "#invert" ).val();
-		var start = '';
-		var end = '';
+
+		var end = '-1min';				// Ensure RRD will have a data point for the end time so the graph, last, and minimum, doesn't end with zero (0) value.
+		var start = timePeriod + end;	// Maintain the time period duration.
 
 		//convert dates to epoch and validate
 		if(timePeriod === "custom" && startDate && endDate) { //TODO check if both are valid dates

--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
@@ -814,7 +814,7 @@ events.push(function() {
 		var invert = $( "#invert" ).val();
 
 		var end = '-1min';				// Ensure RRD will have a data point for the end time so the graph, last, and minimum, doesn't end with zero (0) value.
-		var start = timePeriod + end;	// Maintain the time period duration.
+		var start = 'end' + timePeriod;	// Maintain the time period duration.
 
 		//convert dates to epoch and validate
 		if(timePeriod === "custom" && startDate && endDate) { //TODO check if both are valid dates


### PR DESCRIPTION
Monitoring graphs last sample being zero

If there is no RRD data sample for the current minute then the graph and last and minimum data value will be zero in certain circumstances.  Such as resolution 1 minute and graph loaded prior to the current minute RRD sample being made.  Similar for the first minute of other resolutions.

This PR corrects this situation by never requesting RRD data for the uncompleted current minute to ensure that there is a data point for the last/end time.