### PR TITLE
pfBlockerNG - version 2.0.15

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-pfBlockerNG
-PORTVERSION=	2.0.14
+PORTVERSION=	2.0.15
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng.xml
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng.xml
@@ -275,7 +275,7 @@
 			<fielddescr>Global Logging</fielddescr>
 			<fieldname>enable_log</fieldname>
 			<type>checkbox</type>
-			<description><![CDATA[Firewall Rule logging - Enable Global logging to [ Status: System Logs: FIREWALL Log ]<br />
+			<description><![CDATA[Firewall Rule logging - Enable Global logging to [ Status: System Logs: FIREWALL Log ].<br />
 				This overrides any log settings in the Continent/IPv4/6 Alias tabs. (DNSBL not included)]]>
 			</description>
 		</field>

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng.xml
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng.xml
@@ -411,9 +411,10 @@
 			<type>select</type>
 			<options>
 				<option><name>| pfB_Block/Reject | All other Rules | (original format)</name><value>order_0</value></option>
-				<option><name>| pfSense Pass/Match | pfB_Pass/Match | pfB_Block/Reject |</name><value>order_1</value></option>
-				<option><name>| pfB_Pass/Match | pfSense Pass/Match | pfB_Block/Reject |</name><value>order_2</value></option>
-				<option><name>| pfB_Pass/Match | pfB_Block/Reject | pfSense Pass/Match |</name><value>order_3</value></option>
+				<option><name>| pfSense Pass/Match | pfB_Pass/Match | pfB_Block/Reject | pfSense Block/Reject |</name><value>order_1</value></option>
+				<option><name>| pfB_Pass/Match | pfSense Pass/Match | pfB_Block/Reject | pfSense Block/Reject |</name><value>order_2</value></option>
+				<option><name>| pfB_Pass/Match | pfB_Block/Reject | pfSense Pass/Match | pfSense Block/Reject |</name><value>order_3</value></option>
+				<option><name>| pfB_Pass/Match | pfB_Block/Reject | pfSense Block/Reject | pfSense Pass/Match |</name><value>order_4</value></option>
 			</options>
 			<default_value>order_0</default_value>
 		</field>

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4146,10 +4146,11 @@ function sync_package_pfblockerng($cron='') {
 
 			#################################################################################
 			#			PASS/MATCH RULES ORDER(p/m)				#
-			#  ORDER 0 - pfBlockerNG / All other Rules					#
-			#  ORDER 1 - pfSense (p/m) / pfBlockerNG (p/m) / pfBlockerNG Block/Reject	#
-			#  ORDER 2 - pfBlockerNG (p/m) / pfSense (p/m) / pfBlockerNG Block/Reject	#
-			#  ORDER 3 - pfBlockerNG (p/m) / pfBlockerNG Block/Reject / pfSense (p/m)	#
+			#  ORDER 0 |	pfB (all)	| All other	|				#
+			#  ORDER 1 |	pfSense (p/m)	| pfB (p/m)	| pfB (b/r) 	| pfSense (b/r)	#
+			#  ORDER 2 |	pfB (p/m)	| pfSense (p/m) | pfB (b/r)	| pfSense (b/r)	#
+			#  ORDER 3 |	pfB (p/m)	| pfB (b/r) 	| pfSense (p/m)	| pfSense (b/r)	#
+			#  ORDER 4 |	pfB (p/m)	| pfB (b/r)	| pfSense (b/r)	| pfSense (p/m)	#
 			#################################################################################
 
 			if ($pfb['float'] == '') {
@@ -4298,7 +4299,7 @@ function sync_package_pfblockerng($cron='') {
 				}
 			}
 
-			if ($pfb['float'] == 'on' && in_array($pfb['order'], array('order_0', 'order_3'))) {
+			if ($pfb['float'] == 'on' && in_array($pfb['order'], array('order_0', 'order_3', 'order_4'))) {
 				if ($pfb['order'] == 'order_0') {
 					$rule_order = array($fother_rules, $fpermit_rules, $fmatch_rules);
 				} else {
@@ -4317,12 +4318,22 @@ function sync_package_pfblockerng($cron='') {
 					$new_rules[] = $cb_rules;
 				}
 			}
+			if ($pfb['order'] == 'order_4' && !empty($other_rules)) {
+				foreach ($other_rules as $cb_rules) {
+					$new_rules[] = $cb_rules;
+				}
+			}
+			if ($pfb['order'] == 'order_4' && !empty($permit_rules)) {
+				foreach ($permit_rules as $cb_rules) {
+					$new_rules[] = $cb_rules;
+				}
+			}
 			if ($pfb['order'] == 'order_3' && !empty($permit_rules)) {
 				foreach ($permit_rules as $cb_rules) {
 					$new_rules[] = $cb_rules;
 				}
 			}
-			if (!empty($other_rules)) {
+			if ($pfb['order'] != 'order_4' && !empty($other_rules)) {
 				foreach ($other_rules as $cb_rules) {
 					$new_rules[] = $cb_rules;
 				}

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -255,7 +255,7 @@ function pfbng_text_area_decode($text, $mode=FALSE) {
 			if (substr(trim($line), 0, 1) != '#' && !empty($line)) {
 				if (strpos($line, '#') !== FALSE) {
 					if ($mode) {
-						$custom[] = preg_split('/\s+(?=#)/', trim($line));
+						$custom[] = array_map('trim', preg_split('/(?=#)/', $line));
 					} else {
 						$custom .= trim(strstr($line, '#', TRUE)) . "\n";
 					}
@@ -1072,12 +1072,12 @@ function find_reported_header($ip, $pfbfolder, $exclude=FALSE) {
 	$arr = $cidrs = array();
 
 	// Exclude MaxMind files for Alerts tab query; however include for Download failure queries.
-	$exclusion = "--exclude='pfB_*'";
 	if ($exclude) {
-		$exclusion = '';
+		exec("/usr/bin/find {$pfbfolder} ! -name 'pfB_*.txt' -type f | xargs grep '^{$query}\.'", $result);
+	} else {
+		exec("/usr/bin/grep '^{$query}\.' {$pfbfolder}", $result);
 	}
 
-	exec("/usr/bin/grep '^{$query}\.' {$exclusion} {$pfbfolder}", $result);
 	if (!empty($result)) {
 		foreach ($result as $line) {
 
@@ -1744,8 +1744,23 @@ function pfb_aliastables($mode) {
 		conf_mount_rw();
 		if ($mode == 'update') {
 			// Archive aliastable folder
-			exec("cd {$pfb['aliasdir']}; ls -A pfB_*.txt && /usr/bin/tar -jcvf {$pfb['aliasarchive']} pfB_*.txt >/dev/null 2>&1");
 			pfb_logger("\n\nArchiving Aliastable folder\n", 1);
+			$files_to_backup = '';
+			if (glob("{$pfb['aliasdir']}/pfB_*.txt")) {
+				$files_to_backup = "{$pfb['aliasdir']}/pfB_*.txt";
+			}
+
+			if ($pfb['dnsbl'] == 'on' && file_exists("{$pfb['dnsbl_file']}.conf")) {
+				$files_to_backup .= " {$pfb['dnsbl_file']}.conf";
+			}
+
+			// Archive IP Aliastables/Unbound DNSBL Database as required.
+			if (!empty($files_to_backup)) {
+				exec("/usr/bin/tar -jcvf {$pfb['aliasarchive']} {$files_to_backup} >/dev/null 2>&1");
+				pfb_logger("\n\nArchiving selected pfBlockerNG files.\n", 1);
+			} else {
+				pfb_logger("\n\nNo Files to archive.\n", 1);
+			}
 		}
 		elseif ($mode == 'conf') {
 
@@ -1937,7 +1952,9 @@ function sync_package_pfblockerng($cron='') {
 		if ($pfb['dnsbl'] == 'on') {
 			pfb_create_dnsbl('enable');
 		}
-		log_error('[pfBlockerNG] Sync terminated during boot process.');
+		$log = 'Sync terminated during boot process.';
+		pfb_logger("\n{$log}\nUPDATE PROCESS ENDED [ NOW ]\n", 1);
+		log_error("[pfBlockerNG] {$log}");
 		return;
 	}
 	syslog(LOG_NOTICE, '[pfBlockerNG] Starting cron process.');
@@ -2525,6 +2542,7 @@ function sync_package_pfblockerng($cron='') {
 
 			// Collect suppression list
 			$pfb_dnssupp = dnsbl_suppression();
+			$pfb_dnssupp[] = 'localhost.localdomain'; // Added due to SWC Feed
 
 			// Call Alexa whitelist process
 			if ($pfb['dnsbl_alexa'] == 'on') {
@@ -2704,7 +2722,7 @@ function sync_package_pfblockerng($cron='') {
 										// On 'category match', parse EasyList feed 
 										if (isset($easylist)) {
 											if (substr($line, 24, 19) == 'easylist_adservers.' ||
-											    substr($line, 27, 28) == 'easyprivacy_trackingservers.') {
+											    substr($line, 91, 28) == 'easyprivacy_trackingservers.') {
 												$e_found = TRUE;
 											}
 										}
@@ -2830,10 +2848,10 @@ function sync_package_pfblockerng($cron='') {
 											}
 
 											// Collect EasyPrivacy feed
-											elseif (substr($line, 27, 28) == 'easyprivacy_trackingservers.') {
+											elseif (substr($line, 91, 28) == 'easyprivacy_trackingservers.') {
 												if (in_array('epts', $easylist) ? $e_skip = FALSE : $e_skip = TRUE);
 											}
-											elseif (substr($line, 27, 42) == 'easyprivacy_trackingservers_international.') {
+											elseif (substr($line, 91, 42) == 'easyprivacy_trackingservers_international.') {
 												if (in_array('epti', $easylist) ? $e_skip = FALSE : $e_skip = TRUE);
 											}
 
@@ -4316,9 +4334,11 @@ function sync_package_pfblockerng($cron='') {
 			unset($cb_rules, $other_rules, $fother_rules, $permit_rules, $fpermit_rules, $match_rules, $fmatch_rules);
 
 			// Remove 'created' tag (New vs old rules array comparison)
-			foreach ($new_rules as $key => $rule) {
+			foreach ($new_rules as $rule) {
+				if (isset($rule['created'])) {
+					unset($rule['created']);
+				}
 				$new_rules_nocreated[] = $rule;
-				unset($new_rules_nocreated[$key]['created']);
 			}
 
 			// Update config.xml, if changes required

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -105,10 +105,15 @@ exitnow() {
 }
 
 
-# Function to restore aliasables from archive on reboot. ( NanoBSD and Ramdisk installations only )
+# Function to restore IP aliastables and DNSBL database from archive on reboot. ( NanoBSD and Ramdisk installations only )
 aliastables() {
 	if [ "${PLATFORM}" != 'pfSense' ] || [ ${USE_MFS_TMPVAR} -gt 0 ] || [ "${DISK_TYPE}" = 'md' ]; then
-		[ -f "${aliasarchive}" ] && cd "${pfsensealias}" && /usr/bin/tar -jxvf "${aliasarchive}"
+		if [ ! -d '/var/unbound' ]; then
+			mkdir '/var/unbound'
+			chown -f unbound:unbound /var/unbound
+			chgrp -f unbound /var/unbound
+		fi
+		[ -f "${aliasarchive}" ] && cd / && /usr/bin/tar -Pxvf "${aliasarchive}"
 	fi
 }
 

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -186,15 +186,23 @@ $rc = array();
 $rc['file'] = 'dnsbl.sh';
 $rc['start'] = <<<EOF
 
+	# Check if DNSBL is enabled
+	dnsblcheck="$(/usr/bin/grep '<pfb_dnsbl>' /conf/config.xml)"
+	if [ -z "${dnsblcheck}" ]; then
+		exit
+	fi
+
 	# Start DNSBL Lighttpd webserver
 	if [ -f /var/unbound/pfb_dnsbl_lighty.conf ]; then
 		/usr/local/sbin/lighttpd_pfb -f /var/unbound/pfb_dnsbl_lighty.conf
 	fi
 
 	# Terminate DNSBL HTTPS Daemon if found
-	pidnum="$(/bin/ps -wax | /usr/bin/grep '[p]fblockerng.inc dnsbl' | /usr/bin/awk '{print $1}')"
+	pidnum="$(/bin/ps -wax | /usr/bin/grep '[p]fblockerng.inc dnsbl' | /usr/bin/awk '{print \$1}')"
 	if [ ! -z "\${pidnum}" ]; then
-		/bin/kill -9 "\${pidnum}"
+		for i in \${pidnum}; do
+			/bin/kill -9 "\${i}"
+		done
 		/bin/sleep 2
 	fi
 
@@ -212,9 +220,11 @@ $rc['stop'] = <<<EOF
 	fi
 
 	# Terminate DNSBL HTTPS Daemon, if found.
-	pidnum="$(/bin/ps -wax | /usr/bin/grep '[p]fblockerng.inc dnsbl' | /usr/bin/awk '{print $1}')"
+	pidnum="$(/bin/ps -wax | /usr/bin/grep '[p]fblockerng.inc dnsbl' | /usr/bin/awk '{print \$1}')"
 	if [ ! -z "\${pidnum}" ]; then
-		/bin/kill -9 "\${pidnum}"
+		for i in \${pidnum}; do
+			/bin/kill -9 "\${i}"
+		done
 		/bin/sleep 2
 	fi
 

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_top20.xml
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng_top20.xml
@@ -184,7 +184,7 @@
 				<option><name>Spain-ES</name><value>ES</value></option>
 				<option><name>Vietnam-VN</name><value>VN</value></option>
 				<option><name>Argentina-AR</name><value>AR</value></option>
-				<option><name>Columbia-CO</name><value>CO</value></option>
+				<option><name>Colombia-CO</name><value>CO</value></option>
 				<option><name>Taiwan-TW</name><value>TW</value></option>
 				<option><name>Mexico-MX</name><value>MX</value></option>
 				<option><name>Chile-CL</name><value>CL</value></option>
@@ -214,10 +214,10 @@
 				<option><name>Spain-ES</name><value>ES</value></option>
 				<option><name>Vietnam-VN</name><value>VN</value></option>
 				<option><name>Argentina-AR</name><value>AR</value></option>
-				<option><name>Columbia-CO</name><value>CO</value></option>
+				<option><name>Colombia-CO</name><value>CO</value></option>
 				<option><name>Taiwan-TW</name><value>TW</value></option>
 				<option><name>Mexico-MX</name><value>MX</value></option>
-				<option><name>Chilie-CL</name><value>CL</value></option>
+				<option><name>Chile-CL</name><value>CL</value></option>
 			</options>
 			<size>20</size>
 			<multiple/>

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -91,7 +91,7 @@ if (isset($suppression)) {
 	foreach ($suppression as $dnssupp) {
 		// Create 1) array for the suppressed domains 2) A string with the domain and comment text
 		$dnssupp_ex[] = $dnssupp[0];
-		$dnssupp_dat .= "{$dnssupp[0]}{$dnssupp[1]}\r\n";
+		$dnssupp_dat .= "{$dnssupp[0]} {$dnssupp[1]}\r\n";
 	}
 }
 


### PR DESCRIPTION

* Fix Issue for RamDisk installation on Reboot - https://redmine.pfsense.org/issues/6116 and https://redmine.pfsense.org/issues/6380
* Fix typo - https://redmine.pfsense.org/issues/6368
* Improve DNSBL Suppression function for comment lines
* Improve find_reported_header() function for excluded files
* Write log message to the system log on Reboot
* Suppress 'localhost.localdomain' - added due to SWC Feed
* Fix potential unset() error
* Fix ADBlock EasyPrivacy parse code
* dnsbl.sh - Only start when DNSBL is enabled. Kill all DNSBL pids if multiple found.
* Fix typos in TOP20 Country List
* Add a new Rule Order option
