### PR TITLE
Snort binary update to version 2.9.8.3 to sync with upstream.

### DIFF
--- a/security/snort/Makefile
+++ b/security/snort/Makefile
@@ -1,9 +1,8 @@
 # Created by: Dirk Froemberg <dirk@FreeBSD.org>
-# $FreeBSD$
+# $FreeBSD: head/security/snort/Makefile 417339 2016-06-23 01:56:42Z zi $
 
 PORTNAME=	snort
-PORTVERSION=	2.9.8.0
-PORTREVISION=	1
+PORTVERSION=	2.9.8.3
 CATEGORIES=	security
 MASTER_SITES=	https://snort.org/downloads/snort/ \
 		http://www.talosintel.com/downloads/ \

--- a/security/snort/distinfo
+++ b/security/snort/distinfo
@@ -1,2 +1,3 @@
-SHA256 (snort-2.9.8.0.tar.gz) = bddd5d01d10d20c182836fa0199cd3549239b7a9d0fd5bbb10226feb8b42d231
-SIZE (snort-2.9.8.0.tar.gz) = 6323095
+TIMESTAMP = 1466646606
+SHA256 (snort-2.9.8.3.tar.gz) = 856d02ccec49fa30c920a1e416c47c0d62dd224340a614959ba5c03239100e6a
+SIZE (snort-2.9.8.3.tar.gz) = 6244304

--- a/security/snort/files/snort.in
+++ b/security/snort/files/snort.in
@@ -1,5 +1,5 @@
 #!/bin/sh
-# $FreeBSD$
+# $FreeBSD: head/security/snort/files/snort.in 340872 2014-01-24 00:14:07Z mat $
 
 # PROVIDE: snort
 # REQUIRE: DAEMON

--- a/security/snort/pkg-descr
+++ b/security/snort/pkg-descr
@@ -1,8 +1,8 @@
-Snort is a libpcap-based packet sniffer/logger which can be used as a 
+Snort is a libpcap-based packet sniffer/logger which can be used as a
 lightweight network intrusion detection system. It features rules based logging
-and can perform content searching/matching in addition to being used to detect 
+and can perform content searching/matching in addition to being used to detect
 a variety of other attacks and probes, such as buffer overflows, stealth port
-scans, CGI attacks, SMB probes, and much more. Snort has a real-time alerting 
+scans, CGI attacks, SMB probes, and much more. Snort has a real-time alerting
 capability, with alerts being sent to syslog, a separate "alert" file, or even
 to a Windows computer via Samba.
 
@@ -11,11 +11,11 @@ based upon the IP address of the remote peer.  This allows Snort to be used as
 a sort of "poor man's intrusion detection system" if you specify what traffic
 you want to record and what to let through.
 
-For instance, I use it to record traffic of interest to the six computers in 
-my office at work while I'm away on travel or gone for the weekend.  It's 
-also nice for debugging network code since it shows you most of the Important 
+For instance, I use it to record traffic of interest to the six computers in
+my office at work while I'm away on travel or gone for the weekend.  It's
+also nice for debugging network code since it shows you most of the Important
 Stuff(TM) about your packets (as I see it anyway).  The code is pretty easy
-to modify to provide more complete packet decoding, so feel free to make 
+to modify to provide more complete packet decoding, so feel free to make
 suggestions.
 
 WWW: http://www.snort.org/

--- a/security/snort/pkg-plist
+++ b/security/snort/pkg-plist
@@ -4,36 +4,16 @@ bin/u2boat
 bin/u2spewfoo
 %%APPID%%bin/u2openappid
 %%APPID%%bin/u2streamer
-@unexec if cmp  -s %D/etc/snort/classification.config-sample %D/etc/snort/classification.config; then rm -f %D/etc/snort/classification.config; fi
-etc/snort/classification.config-sample
-@exec if [ ! -f %D/etc/snort/classification.config ] ; then cp -p %D/%F %B/classification.config; fi
-@unexec if cmp  -s %D/etc/snort/gen-msg.map-sample %D/etc/snort/gen-msg.map; then rm -f %D/etc/snort/gen-msg.map; fi
-etc/snort/gen-msg.map-sample
-@exec if [ ! -f %D/etc/snort/gen-msg.map ] ; then cp -p %D/%F %B/gen-msg.map; fi
-@unexec if cmp  -s %D/etc/snort/preproc_rules/decoder.rules %D/etc/snort/preproc_rules/decoder.rules; then rm -f %D/etc/snort/preproc_rules/decoder.rules;fi
-etc/snort/preproc_rules/decoder.rules-sample
-@exec if [ ! -f %D/etc/snort/preproc_rules/decoder.rules ] ; then cp -p %D/%F %B/decoder.rules; fi
-@unexec if cmp  -s %D/etc/snort/preproc_rules/preprocessor.rules %D/etc/snort/preproc_rules/preprocessor.rules; then rm -f %D/etc/snort/preproc_rules/preprocessor.rules;fi
-etc/snort/preproc_rules/preprocessor.rules-sample
-@exec if [ ! -f %D/etc/snort/preproc_rules/preprocessor.rules ] ; then cp -p %D/%F %B/preprocessor.rules; fi
-@unexec if cmp  -s %D/etc/snort/preproc_rules/sensitive-data.rules %D/etc/snort/preproc_rules/sensitive-data.rules; then rm -f %D/etc/snort/preproc_rules/sensitive-data.rules;fi
-etc/snort/preproc_rules/sensitive-data.rules-sample
-@exec if [ ! -f %D/etc/snort/preproc_rules/decoder.rules ] ; then cp -p %D/%F %B/; fi
-@unexec if cmp  -s %D/etc/snort/reference.config-sample %D/etc/snort/reference.config; then rm -f %D/etc/snort/reference.config; fi
-etc/snort/reference.config-sample
-@exec if [ ! -f %D/etc/snort/reference.config ] ; then cp -p %D/%F %B/reference.config; fi
-@unexec if cmp  -s %D/etc/snort/snort.conf-sample %D/etc/snort/snort.conf; then rm -f %D/etc/snort/snort.conf; fi
-etc/snort/snort.conf-sample
-@exec if [ ! -f %D/etc/snort/snort.conf ] ; then cp -p %D/%F %B/snort.conf; fi
-@unexec if cmp  -s %D/etc/snort/threshold.conf-sample %D/etc/snort/threshold.conf; then rm -f %D/etc/snort/threshold.conf; fi
-etc/snort/threshold.conf-sample
-@exec if [ ! -f %D/etc/snort/threshold.conf ] ; then cp -p %D/%F %B/threshold.conf; fi
-@unexec if cmp  -s %D/etc/snort/unicode.map-sample %D/etc/snort/unicode.map; then rm -f %D/etc/snort/unicode.map; fi
-etc/snort/unicode.map-sample
-@exec if [ ! -f %D/etc/snort/unicode.map ] ; then cp -p %D/%F %B/unicode.map; fi
-@unexec if cmp  -s %D/etc/snort/file_magic.conf-sample %D/etc/snort/file_magic.conf; then rm -f %D/etc/snort/file_magic.conf; fi
-etc/snort/file_magic.conf-sample
-@exec if [ ! -f %D/etc/snort/file_magic.conf ] ; then cp -p %D/%F %B/file_magic.conf; fi
+@sample etc/snort/classification.config-sample etc/snort/classification.config
+@sample etc/snort/gen-msg.map-sample etc/snort/gen-msg.map
+@sample etc/snort/preproc_rules/decoder.rules-sample etc/snort/preproc_rules/decoder.rules
+@sample etc/snort/preproc_rules/preprocessor.rules-sample etc/snort/preproc_rules/preprocessor.rules
+@sample etc/snort/preproc_rules/sensitive-data.rules-sample etc/snort/preproc_rules/sensitive-data.rules
+@sample etc/snort/reference.config-sample etc/snort/reference.config
+@sample etc/snort/snort.conf-sample etc/snort/snort.conf
+@sample etc/snort/threshold.conf-sample etc/snort/threshold.conf
+@sample etc/snort/unicode.map-sample etc/snort/unicode.map
+@sample etc/snort/file_magic.conf-sample etc/snort/file_magic.conf
 include/snort/dynamic_output/bitop.h
 include/snort/dynamic_output/ipv6_port.h
 include/snort/dynamic_output/obfuscation.h


### PR DESCRIPTION
This updates the Snort binary package to version 2.9.8.3.  The previous Snort 2.9.8.0 version is now officially EOL and VRT rule updates are no longer available.