### PR TITLE
Small cosmetic patch to System Patches list view

### DIFF
--- a/sysutils/pfSense-pkg-System_Patches/files/usr/local/www/system_patches.php
+++ b/sysutils/pfSense-pkg-System_Patches/files/usr/local/www/system_patches.php
@@ -180,8 +180,7 @@ if ($savemsg) {
 				<thead>
 					<tr>
 						<th width="5%">&nbsp;</th>
-						<th width="5%"><?=gettext("Description")?></th>
-						<th width="60%"><?=gettext("URL/ID")?></th>
+						<th width="65%"><?=gettext("Description")?></th>
 						<th width="5%"><?=gettext("Fetch")?></th>
 						<th width="5%"><?=gettext("Test")?></th>
 						<th width="5%"><?=gettext("Apply")?></th>
@@ -211,15 +210,6 @@ foreach ($a_patches as $thispatch):
 
 		<td id="frd<?=$i?>" onclick="fr_toggle(<?=$i?>)">
 			<?=$thispatch['descr']?>
-		</td>
-		<td id="frd<?=$i?>">
-			<?php
-			if (!empty($thispatch['location'])) {
-				echo $thispatch['location'];
-			} elseif (!empty($thispatch['patch'])) {
-				echo gettext("Saved Patch");
-			}
-			?>
 		</td>
 		<td id="frd<?=$i?>" onclick="fr_toggle(<?=$i?>)">
 		<?php if (empty($thispatch['patch'])): ?>


### PR DESCRIPTION
When viewing installed patch list on 2.3+ the GitHub commit URLs are quite long and cause the main table to extend beyond the screen boundary. This looks weird and forces you to scroll to access the action buttons.

Seeing the commit URL on the list doesn't add much as far as usability (and it can be seen anyway if needed on the edit page). This patch makes the page display properly.