### PR TITLE
add pfSense tftp package for tftp-hpa daemon

### DIFF
--- a/ftp/pfSense-pkg-tftpd/Makefile
+++ b/ftp/pfSense-pkg-tftpd/Makefile
@@ -2,7 +2,6 @@
 
 PORTNAME=	pfSense-pkg-tftpd
 PORTVERSION=	0.1.2
-PORTREVISION=	1
 CATEGORIES=	ftp
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -11,7 +10,7 @@ EXTRACT_ONLY=	# empty
 MAINTAINER=	pfsense@stefanseidel.info
 COMMENT=	pfSense package for tftp server
 
-LICENSE=	GPLv3
+LICENSE=	APACHE20
 
 RUN_DEPENDS=	${LOCALBASE}/libexec/in.tftpd:ftp/tftp-hpa
 

--- a/ftp/pfSense-pkg-tftpd/Makefile
+++ b/ftp/pfSense-pkg-tftpd/Makefile
@@ -1,0 +1,42 @@
+# $FreeBSD$
+
+PORTNAME=	pfSense-pkg-tftpd
+PORTVERSION=	0.1.2
+PORTREVISION=	1
+CATEGORIES=	ftp
+MASTER_SITES=	# empty
+DISTFILES=	# empty
+EXTRACT_ONLY=	# empty
+
+MAINTAINER=	pfsense@stefanseidel.info
+COMMENT=	pfSense package for tftp server
+
+LICENSE=	GPLv3
+
+RUN_DEPENDS=	${LOCALBASE}/libexec/in.tftpd:ftp/tftp-hpa
+
+NO_BUILD=	yes
+NO_MTREE=	yes
+
+SUB_FILES=	pkg-install pkg-deinstall
+SUB_LIST=	PORTNAME=${PORTNAME}
+
+do-extract:
+	${MKDIR} ${WRKSRC}
+
+do-install:
+	${MKDIR} ${STAGEDIR}${PREFIX}/pkg
+	${MKDIR} ${STAGEDIR}/etc/inc/priv
+	${MKDIR} ${STAGEDIR}${DATADIR}
+	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/tftpd.xml \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/tftpd.inc \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/tftpd.priv.inc \
+		${STAGEDIR}/etc/inc/priv
+	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \
+		${STAGEDIR}${DATADIR}
+	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
+		${STAGEDIR}${DATADIR}/info.xml
+
+.include <bsd.port.mk>

--- a/ftp/pfSense-pkg-tftpd/files/etc/inc/priv/tftpd.priv.inc
+++ b/ftp/pfSense-pkg-tftpd/files/etc/inc/priv/tftpd.priv.inc
@@ -1,30 +1,22 @@
 <?php
 /*
-	tftpd.priv.inc
-	Copyright (C) 2016 Stefan Seidel
-	All rights reserved.
+ * tftpd.priv.inc
+ * Copyright (C) 2016 Stefan Seidel
+ * All rights reserved.
 
-	Redistribution and use in source and binary forms, with or without
-	modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-	1. Redistributions of source code must retain the above copyright notice,
-	   this list of conditions and the following disclaimer.
-
-	2. Redistributions in binary form must reproduce the above copyright
-	   notice, this list of conditions and the following disclaimer in the
-	   documentation and/or other materials provided with the distribution.
-
-	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-	POSSIBILITY OF SUCH DAMAGE.
-*/
 global $priv_list;
 
 $priv_list['page-system-tftpd'] = array();

--- a/ftp/pfSense-pkg-tftpd/files/etc/inc/priv/tftpd.priv.inc
+++ b/ftp/pfSense-pkg-tftpd/files/etc/inc/priv/tftpd.priv.inc
@@ -1,0 +1,37 @@
+<?php
+/*
+	tftpd.priv.inc
+	Copyright (C) 2016 Stefan Seidel
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+global $priv_list;
+
+$priv_list['page-system-tftpd'] = array();
+$priv_list['page-system-tftpd']['name'] = "WebCfg - System: tftpd package";
+$priv_list['page-system-tftpd']['descr'] = "Allow access to tftpd package GUI";
+$priv_list['page-system-tftpd']['match'] = array();
+
+$priv_list['page-system-tftpd']['match'][] = "pkg_edit.php?xml=tftpd.xml*";
+
+?>

--- a/ftp/pfSense-pkg-tftpd/files/pkg-deinstall.in
+++ b/ftp/pfSense-pkg-tftpd/files/pkg-deinstall.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/local/bin/php -f /etc/rc.packages %%PORTNAME%% ${2}

--- a/ftp/pfSense-pkg-tftpd/files/pkg-install.in
+++ b/ftp/pfSense-pkg-tftpd/files/pkg-install.in
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "${2}" != "POST-INSTALL" ]; then
+	exit 0
+fi
+
+/usr/local/bin/php -f /etc/rc.packages %%PORTNAME%% ${2}

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.inc
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.inc
@@ -1,0 +1,100 @@
+<?php
+/*
+	tftpd.inc
+	Copyright (C) 2016 Stefan Seidel
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+if (!function_exists("filter_configure")) {
+	require_once("filter.inc");
+}
+require_once("globals.inc");
+require_once("interfaces.inc");
+require_once("pfsense-utils.inc");
+require_once("service-utils.inc");
+require_once("util.inc");
+
+function install_package_tftpd() {
+	safe_mkdir("/tftpboot");
+}
+
+function deinstall_package_tftpd() {
+	rmdir("/tftpboot");
+}
+
+function sync_package_tftpd() {
+	global $config;
+
+	conf_mount_rw();
+
+	if (is_array($config['installedpackages']['tftpd'])) {
+		$tftpd_conf = &$config['installedpackages']['tftpd']['config'][0];
+	} else {
+		$tftpd_conf = array();
+	}
+
+	/* if turned off in package settings, stop service, remove rc script and do nothing else */
+	if ($tftpd_conf['tftpd_enable'] != "on") {
+		if (is_service_running('tftpd')) {
+			stop_service("tftpd");
+			sleep(3);
+		}
+		unlink_if_exists('/usr/local/etc/rc.d/tftpd.sh');
+		return;
+	}
+	
+	$datadir = $tftpd_conf['datadir'];
+	
+	if (!is_dir($datadir)) {
+		log_error("TFTP files directory {$datadir} does not exist.");
+		return;
+	} 
+
+	write_rcfile(array(
+		"file" => "tftpd.sh",
+		"start" => "/usr/local/libexec/in.tftpd -l -s {$datadir}",
+		"stop" => "/usr/bin/killall in.tftpd"
+		)
+	);
+
+	if (is_service_running('tftpd')) {
+		stop_service("tftpd");
+		sleep(3);
+	}
+	/* Only (re)start the service when it is enabled */
+	if ($tftpd_conf['tftpd_enable'] == "on") {
+		start_service("tftpd");
+		sleep(3);
+	}
+	filter_configure();
+
+	conf_mount_ro();
+}
+
+function validate_form_tftpd($post, &$input_errors) {
+	if ($post['datadir'] && !is_dir($post['datadir'])) {
+		$input_errors[] = 'Directory for files does not exist!';
+	}
+}
+
+?>

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.inc
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.inc
@@ -1,30 +1,22 @@
 <?php
 /*
-	tftpd.inc
-	Copyright (C) 2016 Stefan Seidel
-	All rights reserved.
+ * tftpd.inc
+ * Copyright (C) 2016 Stefan Seidel
+ * All rights reserved.
 
-	Redistribution and use in source and binary forms, with or without
-	modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-	1. Redistributions of source code must retain the above copyright notice,
-	   this list of conditions and the following disclaimer.
-
-	2. Redistributions in binary form must reproduce the above copyright
-	   notice, this list of conditions and the following disclaimer in the
-	   documentation and/or other materials provided with the distribution.
-
-	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-	POSSIBILITY OF SUCH DAMAGE.
-*/
 if (!function_exists("filter_configure")) {
 	require_once("filter.inc");
 }
@@ -44,8 +36,6 @@ function deinstall_package_tftpd() {
 
 function sync_package_tftpd() {
 	global $config;
-
-	conf_mount_rw();
 
 	if (is_array($config['installedpackages']['tftpd'])) {
 		$tftpd_conf = &$config['installedpackages']['tftpd']['config'][0];
@@ -87,8 +77,6 @@ function sync_package_tftpd() {
 		sleep(3);
 	}
 	filter_configure();
-
-	conf_mount_ro();
 }
 
 function validate_form_tftpd($post, &$input_errors) {

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.xml
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
+<packagegui>
+	<copyright>
+	<![CDATA[
+/* $Id$ */
+/* ====================================================================================== */
+/*
+	tftpd.xml
+	Copyright (C) 2016 Stefan Seidel
+	All rights reserved.
+*/
+/* ====================================================================================== */
+/*
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
+	<name>tftpd</name>
+	<title>TFTP server</title>
+	<include_file>/usr/local/pkg/tftpd.inc</include_file>
+	<aftersaveredirect>/pkg_edit.php?xml=tftpd.xml</aftersaveredirect>
+	<menu>
+		<name>tftpd</name>
+		<section>Services</section>
+		<url>/pkg_edit.php?xml=tftpd.xml</url>
+	</menu>
+	<service>
+		<name>tftpd</name>
+		<rcfile>tftpd.sh</rcfile>
+		<executable>in.tftpd</executable>
+		<description>TFTP daemon</description>
+	</service>
+	<fields>
+		<field>
+			<fielddescr>Enable TFTP service</fielddescr>
+			<fieldname>tftpd_enable</fieldname>
+			<description>Enable the TFTP service?</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Directory for files</fielddescr>
+			<fieldname>datadir</fieldname>
+			<description>Enter the directory path to the files that the TFTP server should serve. The directory must exist. Default: /tftpboot</description>
+			<type>input</type>
+			<default_value>/tftpboot</default_value>
+		</field>
+	</fields>
+	<custom_php_install_command>
+		install_package_tftpd();
+	</custom_php_install_command>
+	<custom_php_deinstall_command>
+		deinstall_package_tftpd();
+	</custom_php_deinstall_command>
+	<custom_add_php_command>
+		sync_package_tftpd();
+	</custom_add_php_command>
+	<custom_php_resync_config_command>
+		sync_package_tftpd();
+	</custom_php_resync_config_command>
+	<custom_php_validation_command>
+		validate_form_tftpd($_POST, $input_errors);
+	</custom_php_validation_command>
+</packagegui>

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.xml
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.xml
@@ -13,28 +13,17 @@
 */
 /* ====================================================================================== */
 /*
-	Redistribution and use in source and binary forms, with or without
-	modification, are permitted provided that the following conditions are met:
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
+	http://www.apache.org/licenses/LICENSE-2.0
 
-	1. Redistributions of source code must retain the above copyright notice,
-	   this list of conditions and the following disclaimer.
-
-	2. Redistributions in binary form must reproduce the above copyright
-	   notice, this list of conditions and the following disclaimer in the
-	   documentation and/or other materials provided with the distribution.
-
-
-	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-	POSSIBILITY OF SUCH DAMAGE.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 */
 /* ====================================================================================== */
 	]]>

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/share/pfSense-pkg-tftpd/info.xml
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/share/pfSense-pkg-tftpd/info.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<pfsensepkgs>
+	<package>
+		<name>tftpd</name>
+		<pkginfolink>https://forum.pfsense.org/</pkginfolink>
+		<descr><![CDATA[Installs a TFTP server, used for thin client booting and more.]]></descr>
+		<website>http://freecode.com/projects/tftp-hpa/</website>
+		<version>%%PKGVERSION%%</version>
+		<configurationfile>tftpd.xml</configurationfile>
+	</package>
+</pfsensepkgs>

--- a/ftp/pfSense-pkg-tftpd/pkg-descr
+++ b/ftp/pfSense-pkg-tftpd/pkg-descr
@@ -1,0 +1,1 @@
+tftpd installs and runs a TFTP server. We use the versatile tftp-hpa server.

--- a/ftp/pfSense-pkg-tftpd/pkg-plist
+++ b/ftp/pfSense-pkg-tftpd/pkg-plist
@@ -1,0 +1,5 @@
+pkg/tftpd.xml
+pkg/tftpd.inc
+/etc/inc/priv/tftpd.priv.inc
+%%DATADIR%%/info.xml
+@dir /etc/inc/priv


### PR DESCRIPTION
Rather than porting the old tftp package, I created a new package for the much more versatile and fast tftp-hpa daemon. This is my first attempt at packaging, so please advise about any problems with the code. The package did compile, install and work correctly on a fresh pfSense 2.3.2 install.
