### PR TITLE
apcupsd - prevents apcupsd of being started two times

### DIFF
--- a/sysutils/pfSense-pkg-apcupsd/Makefile
+++ b/sysutils/pfSense-pkg-apcupsd/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-apcupsd
 PORTVERSION=	0.3.9
+PORTREVISION=	1
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-apcupsd/files/usr/local/pkg/apcupsd.inc
+++ b/sysutils/pfSense-pkg-apcupsd/files/usr/local/pkg/apcupsd.inc
@@ -44,15 +44,8 @@ function php_deinstall_apcupsd() {
 
 	unlink_if_exists(APCUPSD_BASE . "/etc/rc.d/apcupsd.sh");
 	unlink_if_exists(APCUPSD_BASE . "/etc/apcupsd/apcupsd.conf");
-	unlink_if_exists("/var/log/apcupsd/apcupsd.log");
-	unlink_if_exists("/var/run/apcupsd/apcupsd.pid");
-
-	if (is_dir("/var/log/apcupsd")) {
-		exec("/bin/rm -rf /var/log/apcupsd/");
-	}
-	if (is_dir("/var/run/apcupsd")) {
-		exec("/bin/rm -rf /var/run/apcupsd/");
-	}
+	unlink_if_exists("/var/log/apcupsd.events");
+	unlink_if_exists("/var/run/apcupsd.pid");
 
 }
 
@@ -131,6 +124,11 @@ function sync_package_apcupsd() {
 
 	conf_mount_rw();
 
+	if (is_service_running('apcupsd') && !file_exists("{$g['tmp_path']}/.rc.start_packages.running")) {
+		log_error("Stopping service apcupsd");
+		stop_service('apcupsd');
+	}
+
 	define('APCUPSD_BASE', '/usr/local');
 
 	// check apcupsd settings
@@ -189,14 +187,14 @@ function sync_package_apcupsd() {
 			)
 		);
 
-		restart_service("apcupsd");
+		apccontrol_scripts_install($emailnotification);
 
-	} else {
-		stop_service("apcupsd");
-		unlink_if_exists($apcupsd_rcfile);
+		if (!file_exists("{$g['tmp_path']}/.rc.start_packages.running")) {
+			log_error("Starting service apcupsd");
+			start_service("apcupsd");
+		}
 	}
 
-	apccontrol_scripts_install($emailnotification);
 	conf_mount_ro();
 }
 

--- a/sysutils/pfSense-pkg-apcupsd/files/usr/local/pkg/apcupsd.inc
+++ b/sysutils/pfSense-pkg-apcupsd/files/usr/local/pkg/apcupsd.inc
@@ -165,6 +165,10 @@ function sync_package_apcupsd() {
 	if (is_array($apcupsd_config) && $apcupsd_config['apcupsdenabled']=="on") {
 
 		$apcupsd_start = "echo \"Starting APC UPS Daemon...\"\n";
+		$apcupsd_start .= "	if [ -f /var/run/apcupsd.pid ]; then \n";
+		$apcupsd_start .= "		echo \"Already running\" \n";
+		$apcupsd_start .= "		exit 1 \n";
+		$apcupsd_start .= "	fi \n";
 		$apcupsd_start .= "	if [ ! -d {$lockfile} ]; then \n";
 		$apcupsd_start .= "		/bin/mkdir -p {$lockfile} \n";
 		$apcupsd_start .= "	fi \n";


### PR DESCRIPTION
There are two calls on rc.start_packages, sync_package() and start_service(), 
and on the sync of apcupsd the package is restarted.
This PR prevents apcupsd of being started two times on booting.

Problem reported on:
https://forum.pfsense.org/index.php?topic=70830.msg646565#msg646565
Those logs just showed up when using pcnet protocol. 

Also:

- Fix php_deinstall_apcupsd()
- Bump version