### PR TITLE
Support https

### DIFF
--- a/net/pfSense-pkg-ntopng/Makefile
+++ b/net/pfSense-pkg-ntopng/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-ntopng
 PORTVERSION=	0.8.4
+PORTREVISION=	1
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -32,12 +33,15 @@ do-extract:
 
 do-install:
 	${MKDIR} ${STAGEDIR}${PREFIX}/pkg
+	${MKDIR} ${STAGEDIR}${PREFIX}/www
 	${MKDIR} ${STAGEDIR}/etc/inc/priv
 	${MKDIR} ${STAGEDIR}${DATADIR}
 	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/ntopng.xml \
 		${STAGEDIR}${PREFIX}/pkg
 	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/ntopng.inc \
 		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/ntopng_redirect.php \
+		${STAGEDIR}${PREFIX}/www
 	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/ntopng.priv.inc \
 		${STAGEDIR}/etc/inc/priv
 	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \

--- a/net/pfSense-pkg-ntopng/files/usr/local/pkg/ntopng.inc
+++ b/net/pfSense-pkg-ntopng/files/usr/local/pkg/ntopng.inc
@@ -32,6 +32,7 @@ require_once("interfaces.inc");
 require_once("pkg-utils.inc");
 require_once("service-utils.inc");
 require_once("util.inc");
+require_once("certs.inc");
 
 global $redis_path;
 $redis_path = "/usr/local/bin";
@@ -62,6 +63,19 @@ function ntopng_php_deinstall_command() {
 	}
 }
 
+function ntopng_write_cert_file($file, $cert) {
+	$fd = fopen($file, "w");
+	if (!$fd) {
+		log_error("ERROR: Could not open {$file} for writing");
+		return;
+	}
+	chmod($file, 0600);
+	fwrite($fd, base64_decode($cert['crt']));
+	fwrite($fd, base64_decode($cert['prv']));
+	fclose($fd);
+}
+
+
 function ntopng_sync_package() {
 	global $config, $ntopng_config, $redis_path;
 	/* These are done via ntopng_validate_input(), just return */
@@ -79,6 +93,7 @@ function ntopng_sync_package() {
 	if ($ntopng_config['enable'] != "on") {
 		ntopng_services_stop();
 		unlink_if_exists("/usr/local/etc/rc.d/ntopng.sh");
+		unlink_if_exists("/usr/local/share/ntopng/httpdocs/ssl/ntopng-cert.pem");
 		return;
 	}
 
@@ -128,6 +143,15 @@ function ntopng_sync_package() {
 		$disable_alerts = "-H";
 	}
 
+	if ($config['system']['webgui']['protocol'] == "https") {
+		$cert =& lookup_cert($config['system']['webgui']['ssl-certref']);
+		ntopng_write_cert_file("/usr/local/share/ntopng/httpdocs/ssl/ntopng-cert.pem", $cert);
+		$http_args = "-w 0 -W 3000\n";
+	} else {
+		unlink_if_exists("/usr/local/share/ntopng/httpdocs/ssl/ntopng-cert.pem");
+		$http_args = "-w 3000\n";
+	}
+
 	/* Create rc script */
 	$start = "";
 	$stop = "";
@@ -136,7 +160,7 @@ function ntopng_sync_package() {
 	// Add support for --data-dir /somewhere, --httpdocs-dir /somewhereelse,
 	// --dump-timeline (on/off) --http-port, --https-port
 
-	$start .= "\t/usr/local/bin/ntopng -d /var/db/ntopng -G /var/run/ntopng.pid -s -e {$disable_alerts} {$dump_flows} {$ifaces} {$dns_mode} {$aggregations} {$local_networks} &\n";
+	$start .= "\t/usr/local/bin/ntopng -d /var/db/ntopng -G /var/run/ntopng.pid -s -e $http_args {$disable_alerts} {$dump_flows} {$ifaces} {$dns_mode} {$aggregations} {$local_networks} &\n";
 	$stop .= "/usr/bin/killall ntopng redis-cli redis-server\n";
 	write_rcfile(array("file" => "ntopng.sh", "start" => $start, "stop" => $stop));
 

--- a/net/pfSense-pkg-ntopng/files/usr/local/pkg/ntopng.xml
+++ b/net/pfSense-pkg-ntopng/files/usr/local/pkg/ntopng.xml
@@ -52,7 +52,7 @@
 		<name>ntopng</name>
 		<tooltiptext>Access ntopng</tooltiptext>
 		<section>Diagnostics</section>
-		<url>http://$myurl:3000</url>
+		<url>/ntopng_redirect.php</url>
 	</menu>
 	<service>
 		<name>ntopng</name>
@@ -68,7 +68,7 @@
 		</tab>
 		<tab>
 			<text>Access ntopng</text>
-			<url>http://$myurl:3000</url>
+			<url>/ntopng_redirect.php</url>
 		</tab>
 	</tabs>
 	<fields>

--- a/net/pfSense-pkg-ntopng/files/usr/local/www/ntopng_redirect.php
+++ b/net/pfSense-pkg-ntopng/files/usr/local/www/ntopng_redirect.php
@@ -1,0 +1,23 @@
+<?php
+
+require_once("config.inc");
+
+global $config;
+
+$proto = $config['system']['webgui']['protocol'];
+
+$httphost = getenv("HTTP_HOST");
+$colonpos = strpos($httphost, ":");
+if ($colonpos) {
+	$baseurl = substr($httphost, 0, $colonpos);
+} else {
+	$baseurl = $httphost;
+}
+
+/* Change if port becomes configurable */
+$port=3000;
+
+$url = "$proto://$baseurl:$port";
+header("Location: $url");
+
+?>

--- a/net/pfSense-pkg-ntopng/pkg-plist
+++ b/net/pfSense-pkg-ntopng/pkg-plist
@@ -1,5 +1,6 @@
 pkg/ntopng.xml
 pkg/ntopng.inc
+www/ntopng_redirect.php
 /etc/inc/priv/ntopng.priv.inc
 %%DATADIR%%/info.xml
 @dir /etc/inc/priv


### PR DESCRIPTION
Ntopng now uses the same http(s) configuration as the webgui. Necessary following the introduction of HSTS.