### PR TITLE
Bind9 Error on ipv4 and ipv6 enabled restart the running daemon is not recognized

### DIFF
--- a/dns/pfSense-pkg-bind9/Makefile
+++ b/dns/pfSense-pkg-bind9/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-bind
 PORTVERSION=	9.10
-PORTREVISION=	8
+PORTREVISION=	9
 CATEGORIES=	dns net ipv6
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.inc
+++ b/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.inc
@@ -847,7 +847,7 @@ function bind_write_rcfile() {
 	$rc['file'] = 'named.sh';
 	// Curly braces in the following <<<EOD are PHP {$variable}, not named.conf text { value; }
 	$rc['start'] = <<<EOD
-		if [ -z "`/bin/ps auxw | /usr/bin/grep "[n]amed {$ip_version} -c /etc/namedb/named.conf" | /usr/bin/awk '{print $2}'`" ]; then
+		if [ -z "`/bin/ps auxw | /usr/bin/grep "[n]amed" | /usr/bin/awk '{print $2}'`" ]; then
 			{$BIND_LOCALBASE}/sbin/named {$ip_version} -c /etc/namedb/named.conf -u bind -t /cf/named/
 		fi
 EOD;
@@ -857,7 +857,7 @@ EOD;
 EOD;
 	// curly braces in the following <<<EOD are PHP {$variable}, not named.conf text { value; }
 	$rc['restart'] = <<<EOD
-		if [ -z "`/bin/ps auxw | /usr/bin/grep "[n]amed {$ip_version} -c /etc/namedb/named.conf" | /usr/bin/awk '{print $2}'`" ]; then
+		if [ -z "`/bin/ps auxw | /usr/bin/grep "[n]amed" | /usr/bin/awk '{print $2}'`" ]; then
 			{$BIND_LOCALBASE}/sbin/named {$ip_version} -c /etc/namedb/named.conf -u bind -t /cf/named/
 		else
 			/usr/bin/killall -9 named 2>/dev/null

--- a/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.xml
+++ b/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.xml
@@ -336,6 +336,7 @@
 			<description>
 				<![CDATA[
 				Enter IPs of DNS servers to use for recursion. Separate by semi-colons (;).<br />
+				Please also add a semi-colon (;) behind the last entry<br />
 				Applies only if Enable Forwarding is chosen.
 				]]>
 			</description>


### PR DESCRIPTION
Hi,

this commit fixes the bug that the daemon is not recognized if IPv4 and IPv6 are both enabled.

Best
Sven