### PR TITLE
Update Suricata binary to 3.1.1 to match upstream.

### DIFF
--- a/security/suricata/Makefile
+++ b/security/suricata/Makefile
@@ -1,9 +1,9 @@
 # Created by: Patrick Tracanelli <eksffa@freebsdbrasil.com.br>
-# $FreeBSD$
+# $FreeBSD: head/security/suricata/Makefile 421635 2016-09-09 19:42:46Z amdmi3 $
 
 PORTNAME=	suricata
-PORTVERSION=	3.0
-PORTREVISION=	2
+PORTVERSION=	3.1.1
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	http://www.openinfosecfoundation.org/download/
 
@@ -20,20 +20,22 @@ LIB_DEPENDS=	libpcre.so:devel/pcre \
 USES=		autoreconf cpe gmake libtool pathfix pkgconfig
 USE_LDCONFIG=	yes
 USE_RC_SUBR=	${PORTNAME}
+
 GNU_CONFIGURE=	yes
 
 CPE_VENDOR=	openinfosecfoundation
 
 INSTALL_TARGET=		install-strip
+TEST_TARGET=		check
+
 PATHFIX_MAKEFILEIN=	Makefile.am
 
 OPTIONS_DEFINE=		GEOIP HTP_PORT IPFW JSON NETMAP NSS PORTS_PCAP PRELUDE SC TESTS
 OPTIONS_DEFAULT=	HTP_PORT IPFW JSON NETMAP PRELUDE
+OPTIONS_SUB=		yes
 
 OPTIONS_RADIO=		SCRIPTS
 OPTIONS_RADIO_SCRIPTS=	LUA LUAJIT
-
-OPTIONS_SUB=		yes
 
 SCRIPTS_DESC=		Scripting
 
@@ -53,6 +55,7 @@ TESTS_DESC=		Unit tests in suricata binary
 GEOIP_LIB_DEPENDS=		libGeoIP.so:net/GeoIP
 GEOIP_CONFIGURE_ON=		--enable-geoip
 
+HTP_PORT_BUILD_DEPENDS=		libhtp>=0.5.20:devel/libhtp
 HTP_PORT_LIB_DEPENDS=		libhtp.so:devel/libhtp
 HTP_PORT_CONFIGURE_ON=		--enable-non-bundled-htp
 HTP_PORT_CONFIGURE_OFF=		--enable-bundled-htp
@@ -82,7 +85,7 @@ NSS_CONFIGURE_ON=		--with-libnss-includes=${LOCALBASE}/include/nss/nss \
 
 NETMAP_CONFIGURE_ENABLE=	netmap
 
-PORTS_PCAP_LIB_DEPENDS=		libpcap.so:net/libpcap
+PORTS_PCAP_LIB_DEPENDS=		libpcap.so.1:net/libpcap
 PORTS_PCAP_CONFIGURE_ON=	--with-libpcap-includes=${LOCALBASE}/include \
 				--with-libpcap-libraries=${LOCALBASE}/lib
 PORTS_PCAP_CONFIGURE_OFF=	--with-libpcap-includes=/usr/include \
@@ -101,7 +104,6 @@ TESTS_CONFIGURE_ENABLE=		unittests
 SUB_FILES=	pkg-message
 
 CONFIGURE_ARGS+=--enable-gccprotect \
-		--disable-silent-rules \
 		--with-libpcre-includes=${LOCALBASE}/include \
 		--with-libpcre-libraries=${LOCALBASE}/lib \
 		--with-libyaml-includes=${LOCALBASE}/include \
@@ -143,7 +145,5 @@ post-install:
 	&& ${PYTHON_CMD} ${PYTHON_LIBDIR}/compileall.py \
 	-d ${PYTHONPREFIX_SITELIBDIR} -f ${PYTHONPREFIX_SITELIBDIR:S;${PREFIX}/;;})
 .endif
-
-TEST_TARGET=	check
 
 .include <bsd.port.post.mk>

--- a/security/suricata/distinfo
+++ b/security/suricata/distinfo
@@ -1,2 +1,3 @@
-SHA256 (suricata-3.0.tar.gz) = 4b8feb398a0800c955fe24aa31ca446c539e79492155717e826473f902c8e65a
-SIZE (suricata-3.0.tar.gz) = 3293102
+TIMESTAMP = 1469968754
+SHA256 (suricata-3.1.1.tar.gz) = b8f5711f4c24627b056a3889b296b29ec515b34bc2287ad20d13ca20da777ff7
+SIZE (suricata-3.1.1.tar.gz) = 3332129

--- a/security/suricata/files/patch-alert-pf.diff
+++ b/security/suricata/files/patch-alert-pf.diff
@@ -1203,10 +1203,10 @@ diff -ruN ../suricata-3.0.orig/src/suricata.c ./src/suricata.c
 diff -ruN ../suricata-3.0.orig/src/tm-modules.c ./src/tm-modules.c
 --- ../suricata-3.0.orig/src/tm-modules.c	2016-03-04 08:12:34.000000000 -0500
 +++ ./src/tm-modules.c	2016-01-06 19:52:55.000000000 -0500
-@@ -221,6 +221,9 @@
+@@ -219,6 +219,9 @@
+         CASE_CODE (TMM_ALERTDEBUGLOG);
+         CASE_CODE (TMM_ALERTSYSLOG);
          CASE_CODE (TMM_LOGDROPLOG);
-         CASE_CODE (TMM_ALERTSYSLOG4);
-         CASE_CODE (TMM_ALERTSYSLOG6);
 +        CASE_CODE (TMM_ALERTPF);
 +        CASE_CODE (TMM_ALERTPF4);
 +        CASE_CODE (TMM_ALERTPF6);

--- a/security/suricata/files/suricata.in
+++ b/security/suricata/files/suricata.in
@@ -1,5 +1,5 @@
 #!/bin/sh
-# $FreeBSD$
+# $FreeBSD: head/security/suricata/files/suricata.in 402907 2015-12-04 05:42:17Z koobs $
 
 # PROVIDE: suricata
 # REQUIRE: DAEMON

--- a/security/suricata/pkg-plist
+++ b/security/suricata/pkg-plist
@@ -45,8 +45,8 @@ bin/suricata
 %%NO_HTP_PORT%%include/htp/htp_urlencoded.h
 %%NO_HTP_PORT%%include/htp/htp_utf8_decoder.h
 %%NO_HTP_PORT%%include/htp/htp_version.h
-%%NO_HTP_PORT%%lib/libhtp-0.5.18.so.1
-%%NO_HTP_PORT%%lib/libhtp-0.5.18.so.1.0.0
+%%NO_HTP_PORT%%lib/libhtp-0.5.21.so.1
+%%NO_HTP_PORT%%lib/libhtp-0.5.21.so.1.0.0
 %%NO_HTP_PORT%%lib/libhtp.a
 %%NO_HTP_PORT%%lib/libhtp.so
 %%NO_HTP_PORT%%libdata/pkgconfig/htp.pc
@@ -72,5 +72,5 @@ bin/suricata
 @dir etc/suricata/rules
 @dir etc/suricata
 @dir(root,wheel,0700) /var/log/suricata
-@unexec if [ -d %D/%%ETCDIR%% ]; then echo "==> If you are permanently removing this port, run ``rm -rf ${PKG_PREFIX}/etc/suricata`` to remove configuration files."; fi
+@postunexec if [ -d %D/%%ETCDIR%% ]; then echo "==> If you are permanently removing this port, run ``rm -rf ${PKG_PREFIX}/etc/suricata`` to remove configuration files."; fi
 @dir %%DOCSDIR%%


### PR DESCRIPTION
## Suricata 3.1.1##
This updates the Suricata binary to version 3.1.1 to match upstream FreeBSD ports.  This version contains several fixes for Netmap and other issues identified and patched by upstream.