### PR TITLE
Adding support for Google Authenticator

### DIFF
--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -99,7 +99,7 @@ function freeradius_install_command() {
 	// Install Google Authenticator scripts
 	if (!file_exists(FREERADIUS_ETC . "/raddb/scripts/googleauth.py")) { 
 		copy(FREERADIUS_BASE . "/pkg/googleauth.py", FREERADIUS_ETC . "/raddb/scripts/"); 
-		exec("chmod +x " . FREERADIUS_ETC . "/raddb/scripts/googleauth.py");
+		chmod(REERADIUS_ETC . "/raddb/scripts/googleauth.py",0755);
 	}
 	if (!file_exists(FREERADIUS_ETC . "/raddb/modules/googleauth")) { copy(FREERADIUS_BASE . "/pkg/googleauth", FREERADIUS_ETC . "/raddb/modules/");}
 	  

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -101,7 +101,9 @@ function freeradius_install_command() {
 		copy(FREERADIUS_BASE . "/pkg/googleauth.py", FREERADIUS_ETC . "/raddb/scripts/"); 
 		chmod(REERADIUS_ETC . "/raddb/scripts/googleauth.py",0755);
 	}
-	if (!file_exists(FREERADIUS_ETC . "/raddb/modules/googleauth")) { copy(FREERADIUS_BASE . "/pkg/googleauth", FREERADIUS_ETC . "/raddb/modules/");}
+	if (!file_exists(FREERADIUS_ETC . "/raddb/modules/googleauth")) { 
+		copy(FREERADIUS_BASE . "/pkg/googleauth", FREERADIUS_ETC . "/raddb/modules/");
+	}
 	  
 	// Disable virtual-server we do not need by default
 	if (file_exists(FREERADIUS_ETC . "/raddb/sites-enabled/control-socket")) { unlink(FREERADIUS_ETC . "/raddb/sites-enabled/control-socket"); }

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -95,7 +95,14 @@ function freeradius_install_command() {
 		log_error("FreeRADIUS: Creating backup of the original file to " . FREERADIUS_ETC . "/raddb/files.backup");
 		copy(FREERADIUS_ETC . "/raddb/modules/files", FREERADIUS_ETC . "/raddb/files.backup");
 	}
-
+	
+	// Install Google Authenticator scripts
+	if (!file_exists(FREERADIUS_ETC . "/raddb/scripts/googleauth.py")) { 
+		copy(FREERADIUS_BASE . "/pkg/googleauth.py", FREERADIUS_ETC . "/raddb/scripts/"); 
+		exec("chmod +x " . FREERADIUS_ETC . "/raddb/scripts/googleauth.py");
+	}
+	if (!file_exists(FREERADIUS_ETC . "/raddb/modules/googleauth")) { copy(FREERADIUS_BASE . "/pkg/googleauth", FREERADIUS_ETC . "/raddb/modules/");}
+	  
 	// Disable virtual-server we do not need by default
 	if (file_exists(FREERADIUS_ETC . "/raddb/sites-enabled/control-socket")) { unlink(FREERADIUS_ETC . "/raddb/sites-enabled/control-socket"); }
 	if (file_exists(FREERADIUS_ETC . "/raddb/sites-enabled/inner-tunnel")) { unlink(FREERADIUS_ETC . "/raddb/sites-enabled/inner-tunnel"); }
@@ -439,7 +446,8 @@ if (is_array($arrusers) && !empty($arrusers)) {
 				$varuserspassword = $users['varuserspassword'];
 		}
 	
-		
+	
+	$varusersauthmethod = $users['varusersauthmethod'];  	
 	$varusersmotpinitsecret = $users['varusersmotpinitsecret'];
 	$varusersmotppin = $users['varusersmotppin'];
 	$varusersmotpoffset = ($users['varusersmotpoffset']?$users['varusersmotpoffset']:'0');
@@ -1782,6 +1790,12 @@ authenticate {
 	#  Mobile-One-Time-Password (MOTP) authentication.
 	Auth-Type MOTP {
 		motp
+	}
+	
+	#
+	# Google-Authenticator authentication.
+	Auth-Type GOOGLEAUTH {
+		googleauth
 	}
 	
 	#

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.xml
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.xml
@@ -198,6 +198,21 @@
 			<enablefields>varusersmotpinitsecret,varusersmotppin,varusersmotpoffset</enablefields>
 		</field>
 		<field>
+			<fielddescr>Authentication Method</fielddescr>
+			<fieldname>varusersauthmethod</fieldname>
+			<description>
+				<![CDATA[
+				Select the authentication method for this user. Default: motp
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>motp</default_value>
+			<options>
+				<option><name>Use mOTP</name><value>motp</value></option>
+				<option><name>Use Google-Authenticator</name><value>googleauth</value></option>
+			</options>
+		</field>
+		<field>
 			<fielddescr>Init-Secret</fielddescr>
 			<fieldname>varusersmotpinitsecret</fieldname>
 			<description>

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/googleauth
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/googleauth
@@ -1,0 +1,4 @@
+exec googleauth {
+      wait = yes
+      program = " /usr/local/etc/raddb/scripts/googleauth.py %{request:User-Name} %{reply:MOTP-Init-Secret} %{reply:MOTP-PIN} %{request:User-Password}"
+}

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/googleauth.py
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/googleauth.py
@@ -1,4 +1,7 @@
 #!/usr/local/bin/python2.7
+# Copyright: www.brool.com (http://www.brool.com/post/using-google-authenticator-for-your-website/)
+# License: CC0 1.0 Universal License
+
 import sys
 import time
 import struct

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/googleauth.py
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/googleauth.py
@@ -1,0 +1,57 @@
+#!/usr/local/bin/python2.7
+import sys
+import time
+import struct
+import hmac
+import hashlib
+import base64
+import syslog
+ 
+def authenticate(username, secretkey, pin, code_attempt):
+
+    if code_attempt.startswith(pin,0, len(pin)) == False:
+         syslog.syslog(syslog.LOG_ERR, "freeRADIUS: Google Authenticator - Authentication failed. User: " + username + ", Reason: wrong PIN")
+         return False
+
+    code_attempt = code_attempt[len(pin):]
+    tm = int(time.time() / 30)
+ 
+    secretkey = base64.b32decode(secretkey)
+ 
+    # try 30 seconds behind and ahead as well
+    for ix in [-1, 0, 1]:
+        # convert timestamp to raw bytes
+        b = struct.pack(">q", tm + ix)
+ 
+        # generate HMAC-SHA1 from timestamp based on secret key
+        hm = hmac.HMAC(secretkey, b, hashlib.sha1).digest()
+ 
+        # extract 4 bytes from digest based on LSB
+        offset = ord(hm[-1]) & 0x0F
+        truncatedHash = hm[offset:offset+4]
+ 
+        # get the code from it
+        code = struct.unpack(">L", truncatedHash)[0]
+        code &= 0x7FFFFFFF;
+        code %= 1000000;
+ 
+        if ("%06d" % code) == str(code_attempt):
+            syslog.syslog(syslog.LOG_NOTICE, "freeRADIUS: Google Authenticator - Authentication successful for user: " + username)
+            return True
+
+    syslog.syslog(syslog.LOG_ERR, "freeRADIUS: Google Authenticator - Authentication failed. User: " + username + ", Reason: wrong tokencode")
+    return False
+
+
+# Check the length of the parameters
+if len(sys.argv) != 5:
+        syslog.syslog(syslog.LOG_ERR, "freeRADIUS: Google Authenticator - wrong syntax - USAGE: googleauth.py Username, Secret-Key, PIN, Auth-Attempt")
+        exit(1)
+
+
+auth = authenticate(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+
+if auth == True:
+   exit(0)
+
+exit(1)


### PR DESCRIPTION
Gives the possibility for a user to choose between mOTP and Google Authenticator in Freeradius, when using one-time-passwords.
