### PR TITLE
openvpn-client-export, fix showing certs/users when no defaults have been saved before

### DIFF
--- a/security/pfSense-pkg-openvpn-client-export/Makefile
+++ b/security/pfSense-pkg-openvpn-client-export/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-openvpn-client-export
-PORTVERSION=	1.3.12
+PORTVERSION=	1.3.13
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-openvpn-client-export/files/usr/local/www/vpn_openvpn_export.php
+++ b/security/pfSense-pkg-openvpn-client-export/files/usr/local/www/vpn_openvpn_export.php
@@ -169,11 +169,11 @@ if (isset($_POST['save'])) {
 		write_config("Save openvpn client export defaults");
 	}
 }
-//$cfg['advancedoptions'] = base64_decode($cfg['advancedoptions']);
+
 for($i = 0; $i < count($ovpnserverdefaults); $i++) {
 	$ovpnserverdefaults[$i]['advancedoptions'] = base64_decode($ovpnserverdefaults[$i]['advancedoptions']);
 }
-//print_r($ovpnserverdefaults);
+
 if (!empty($act)) {
 
 	$srvid = $_GET['srvid'];

--- a/security/pfSense-pkg-openvpn-client-export/files/usr/local/www/vpn_openvpn_export.php
+++ b/security/pfSense-pkg-openvpn-client-export/files/usr/local/www/vpn_openvpn_export.php
@@ -131,7 +131,9 @@ $simplefields = array('server','useaddr','useaddr_hostname','verifyservercn','bl
 $openvpnexportcfg = &$config['installedpackages']['vpn_openvpn_export'];
 $ovpnserverdefaults = &$openvpnexportcfg['serverconfig']['item'];
 $cfg = &$config['installedpackages']['vpn_openvpn_export']['defaultsettings'];
-
+if (!is_array($ovpnserverdefaults)) {
+	$ovpnserverdefaults = array();
+}
 
 if (isset($_POST['save'])) {
 	$vpnid = $_POST['server'];


### PR DESCRIPTION
openvpn-client-export, fix showing certs/users when no defaults have been saved before