### PR TITLE
haproxy-devel, request syslogsocket in chroot environment, fix 'transparent-client-ip' function using ipfw on 2.4

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/Makefile
+++ b/net/pfSense-pkg-haproxy-devel/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-haproxy-devel
-PORTVERSION=	0.50
+PORTVERSION=	0.51
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -2089,22 +2089,27 @@ function load_ipfw_rules() {
 		$transparent_interfaces[$interface] = 1;
 	}
 	
-	if (haproxy_utils::$pf_version < 2.2) {
-		// pfSense 2.1 FreeBSD 8.3
-		mwexec("/usr/local/sbin/ipfw_context -a $ipfw_zone_haproxy", true);
-		
-		foreach($transparent_interfaces as $transparent_if => $value) {
-			mwexec("/usr/local/sbin/ipfw_context -a $ipfw_zone_haproxy -n $transparent_if", true);
+	if (haproxy_utils::$pf_version < 2.4) {
+		$rulenum = 64000; // why that high? captiveportal.inc also does it...
+		if (haproxy_utils::$pf_version < 2.2) {
+			// pfSense 2.1 FreeBSD 8.3
+			mwexec("/usr/local/sbin/ipfw_context -a $ipfw_zone_haproxy", true);
+
+			foreach($transparent_interfaces as $transparent_if => $value) {
+				mwexec("/usr/local/sbin/ipfw_context -a $ipfw_zone_haproxy -n $transparent_if", true);
+			}
+		} else {
+			// pfSense 2.2 FreeBSD 10
+			mwexec("/sbin/ipfw zone $ipfw_zone_haproxy create", true);
+			foreach($transparent_interfaces as $transparent_if => $value) {
+				mwexec("/sbin/ipfw zone $ipfw_zone_haproxy madd $transparent_if", true);
+			}
 		}
 	} else {
-		// pfSense 2.2 FreeBSD 10
-		mwexec("/sbin/ipfw zone $ipfw_zone_haproxy create", true);
-		foreach($transparent_interfaces as $transparent_if => $value) {
-			mwexec("/sbin/ipfw zone $ipfw_zone_haproxy madd $transparent_if", true);
-		}
+		// pfSense 2.4, captive portal rules start at 1000
+		$rulenum = 10;
 	}
 	
-	$rulenum = 64000; // why that high? captiveportal.inc also does it...
 	$rules = "flush\n";
 	foreach($transparent_backends as $transparent_be) {
 		if (is_ipaddrv4($transparent_be["address"])) {
@@ -2122,7 +2127,11 @@ function load_ipfw_rules() {
 	if (haproxy_utils::$pf_version < 2.2) {
 		mwexec("/usr/local/sbin/ipfw_context -s $ipfw_zone_haproxy", true);
 	}
-	mwexec("/sbin/ipfw -x $ipfw_zone_haproxy -q {$g['tmp_path']}/ipfw_{$ipfw_zone_haproxy}.haproxy.rules", true);
+	if (haproxy_utils::$pf_version < 2.4) {
+		mwexec("/sbin/ipfw -x $ipfw_zone_haproxy -q {$g['tmp_path']}/ipfw_{$ipfw_zone_haproxy}.haproxy.rules", true);
+	} else {
+		mwexec("/sbin/ipfw -q {$g['tmp_path']}/ipfw_{$ipfw_zone_haproxy}.haproxy.rules", true);
+	}
 }
 
 function haproxy_plugin_carp($pluginparams) {
@@ -2163,6 +2172,22 @@ function haproxy_plugin_certificates($pluginparams) {
 									$result['certificatelist'][$cert][] = $item;
 								}
 							}
+						}
+					}
+				}
+			}
+		}
+		
+		$a_backends = $config['installedpackages']['haproxy']['ha_pools']['item'];
+		if (is_array($a_backends)) {
+			foreach ($a_backends as &$backend) {
+				if (is_array($backend['ha_servers']['item'])) {
+					foreach($backend['ha_servers']['item'] as $srv) {
+						if ($srv['ssl-server-clientcert']) {
+							$item = array();
+							$cert = $srv['ssl-server-clientcert'];
+							$item['usedby'] = $backend['name']."/".$srv['name'];
+							$result['certificatelist'][$cert][] = $item;
 						}
 					}
 				}

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/share/pfSense-pkg-haproxy-devel/info.xml
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/share/pfSense-pkg-haproxy-devel/info.xml
@@ -9,5 +9,10 @@
 		<website>http://haproxy.1wt.eu/</website>
 		<version>%%PKGVERSION%%</version>
 		<configurationfile>haproxy.xml</configurationfile>
+		<logging>
+			<logsocket>/tmp/haproxy_chroot/var/run/log</logsocket>
+			<facilityname>haproxy</facilityname>
+			<logfilename>haproxy.log</logfilename>
+		</logging>
 	</package>
 </pfsensepkgs>


### PR DESCRIPTION
haproxy-devel, request syslogsocket in chroot environment, fix 'transparent-client-ip' function using ipfw on 2.4
