### PR TITLE
syslog-ng - multiple fixes

### DIFF
--- a/sysutils/pfSense-pkg-syslog-ng/Makefile
+++ b/sysutils/pfSense-pkg-syslog-ng/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-syslog-ng
 PORTVERSION=	1.1.2
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
@@ -247,7 +247,7 @@ function syslogng_build_logrotate_conf($settings, $objects) {
 	if ($compress_archives == 'on') {
 		$conf .= "\tcompress\n";
 		if ($compress_type == 'bz2') {
-			$conf .= "\tcompresscmd bzip2\n";
+			$conf .= "\tcompresscmd /usr/bin/bzip2\n";
 		}
 	}
 

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
@@ -248,6 +248,7 @@ function syslogng_build_logrotate_conf($settings, $objects) {
 		$conf .= "\tcompress\n";
 		if ($compress_type == 'bz2') {
 			$conf .= "\tcompresscmd /usr/bin/bzip2\n";
+			$conf .= "\tcompressext .bz2\n";
 		}
 	}
 

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
@@ -56,6 +56,22 @@ function syslogng_deinstall_command() {
 	filter_configure();
 }
 
+function syslogng_upgrade_config() {
+	global $config;
+	
+	// _DEFAULT was renamed to zzzDEFAULT to allow overriding the default values (Feature #4548)
+	$oldobjects = $config['installedpackages']['syslogngadvanced']['config'];
+	if (is_array($oldobjects)) {
+		foreach ($oldobjects as $i => $oldobject) {
+			if ($oldobjects[$i]['objectname'] == '_DEFAULT') {
+				unset($config['installedpackages']['syslogngadvanced']['config'][$i]);
+			}
+		}
+	write_config();
+	}
+}
+
+
 function syslogng_validate_general($post, &$input_errors) {
 	global $config;
 
@@ -104,8 +120,8 @@ function syslogng_validate_advanced($post, &$input_errors) {
 
 	$objects = $config['installedpackages']['syslogngadvanced']['config'];
 
-	if ($post['objectname'] == '_DEFAULT') {
-		$input_errors[] = 'Creation or modification of \'_DEFAULT\' objects not permitted. Change default settings under \'General\' tab.';
+	if ($post['objectname'] == 'zzzDEFAULT') {
+		$input_errors[] = 'Creation or modification of \'zzzDEFAULT\' objects not permitted. Change default settings under \'General\' tab.';
 	}
 
 	$post['objectparameters'] = base64_encode($post['objectparameters']);
@@ -131,7 +147,7 @@ function syslogng_build_default_objects($settings) {
 	$default_logdir = $settings['default_logdir'];
 	$default_logfile = $settings['default_logfile'];
 
-	$default_objects[0] = array("objecttype"=>"source", "objectname"=>"_DEFAULT", "objectparameters"=>"{ internal(); syslog(transport($default_protocol) port($default_port)");
+	$default_objects[0] = array("objecttype"=>"source", "objectname"=>"zzzDEFAULT", "objectparameters"=>"{ internal(); syslog(transport($default_protocol) port($default_port)");
 	foreach (explode(",", $interfaces) as $interface) {
 		$interface_address = syslogng_get_real_interface_address($interface);
 		if ($interface_address[0]) {
@@ -140,9 +156,9 @@ function syslogng_build_default_objects($settings) {
 	}
 	$default_objects[0]['objectparameters'] .= "); };";
 	$default_objects[0]['objectparameters'] = base64_encode($default_objects[0]['objectparameters']);
-	$default_objects[1] = array("objecttype"=>"destination", "objectname"=>"_DEFAULT", "objectparameters"=>"{ file(\"$default_logdir/$default_logfile\"); };");
+	$default_objects[1] = array("objecttype"=>"destination", "objectname"=>"zzzDEFAULT", "objectparameters"=>"{ file(\"$default_logdir/$default_logfile\"); };");
 	$default_objects[1]['objectparameters'] = base64_encode($default_objects[1]['objectparameters']);
-	$default_objects[2] = array("objecttype"=>"log", "objectname"=>"_DEFAULT", "objectparameters"=>"{ source(_DEFAULT); destination(_DEFAULT); };");
+	$default_objects[2] = array("objecttype"=>"log", "objectname"=>"zzzDEFAULT", "objectparameters"=>"{ source(zzzDEFAULT); destination(zzzDEFAULT); };");
 	$default_objects[2]['objectparameters'] = base64_encode($default_objects[2]['objectparameters']);
 
 	return $default_objects;

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.xml
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.xml
@@ -153,6 +153,7 @@
 	</custom_php_resync_config_command>
 	<custom_php_install_command>
 		syslogng_install_command();
+		syslogng_upgrade_config();
 	</custom_php_install_command>
 	<custom_php_deinstall_command>
 		syslogng_deinstall_command();

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.xml
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.xml
@@ -48,7 +48,7 @@
 		</tab>
 		<tab>
 			<text>Advanced</text>
-			<url>/pkg_edit.php?xml=syslog-ng_advanced.xml</url>
+			<url>/pkg.php?xml=syslog-ng_advanced.xml</url>
 		</tab>
 		<tab>
 			<text>Log Viewer</text>

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.xml
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.xml
@@ -152,8 +152,8 @@
 		syslogng_resync();
 	</custom_php_resync_config_command>
 	<custom_php_install_command>
-		syslogng_install_command();
 		syslogng_upgrade_config();
+		syslogng_install_command();
 	</custom_php_install_command>
 	<custom_php_deinstall_command>
 		syslogng_deinstall_command();

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng_advanced.xml
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng_advanced.xml
@@ -43,7 +43,7 @@
 		</tab>
 		<tab>
 			<text>Advanced</text>
-			<url>/pkg_edit.php?xml=syslog-ng_advanced.xml</url>
+			<url>/pkg.php?xml=syslog-ng_advanced.xml</url>
 			<active/>
 		</tab>
 		<tab>

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/www/syslog-ng_log_viewer.php
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/www/syslog-ng_log_viewer.php
@@ -37,7 +37,7 @@ if ($_POST['logfile']) {
 if ($_POST['limit']) {
 	$limit = intval($_POST['limit']);
 } else {
-	$limit = "10";
+	$limit = "50";
 }
 
 if ($_POST['archives']) {
@@ -132,7 +132,7 @@ include("head.inc");
 				</select></td></tr>
 				<tr><td class="border-bottom" width="22%">Limit</td><td class="border-bottom" width="78%"><select name="limit">
 				<?php
-				$limit_options = array("10", "20", "50");
+				$limit_options = array("10", "20", "50", "100", "250", "500");
 				foreach($limit_options as $limit_option) {
 					if($limit_option == $limit) {
 						echo "<option value=\"$limit_option\" selected=\"selected\">$limit_option</option>\n";
@@ -143,6 +143,9 @@ include("head.inc");
 				?>
 				</select></td></tr>
 				<tr><td class="border-bottom" width="22%">Include Archives</td><td class="border-bottom" width="78%"><input type="checkbox" name="archives" <?php if($archives) echo " CHECKED"; ?> /></td></tr>
+				<tr><td class="border-bottom" width="22%">Filter</td><td class="border-bottom" width="78%"><input name="filter" value="<?=$filter?>" /></td></tr>
+				<tr><td class="border-bottom" width="22%">Inverse Filter (NOT)</td><td class="border-bottom" width="78%"><input type="checkbox" name="not" <?php if($not) echo " CHECKED"; ?> /></td></tr>
+				<tr><td class="border-bottom" colspan="2"><input type="submit" value="Refresh" /></td></tr>
 				<tr><td class="border-bottom" colspan="2">
 				<table class="tabcont" width="100%" border="0" cellspacing="0" cellpadding="0">
 				<?php
@@ -157,9 +160,6 @@ include("head.inc");
 				?>
 				</table>
 				</td></tr>
-				<tr><td class="border-bottom" width="22%">Filter</td><td class="border-bottom" width="78%"><input name="filter" value="<?=$filter?>" /></td></tr>
-				<tr><td class="border-bottom" width="22%">Inverse Filter (NOT)</td><td class="border-bottom" width="78%"><input type="checkbox" name="not" <?php if($not) echo " CHECKED"; ?> /></td></tr>
-				<tr><td class="border-bottom" colspan="2"><input type="submit" value="Refresh" /></td></tr>
 			</table>
 
 			</td></tr>

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/www/syslog-ng_log_viewer.php
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/www/syslog-ng_log_viewer.php
@@ -106,7 +106,7 @@ include("head.inc");
 <?php
 	$tab_array = array();
 	$tab_array[] = array("General", false, "/pkg_edit.php?xml=syslog-ng.xml&amp;id=0");
-	$tab_array[] = array("Advanced", false, "/pkg_edit.php?xml=syslog-ng_advanced.xml");
+	$tab_array[] = array("Advanced", false, "/pkg.php?xml=syslog-ng_advanced.xml");
 	$tab_array[] = array("Log Viewer", true, "/syslog-ng_log_viewer.php");
 	display_top_tabs($tab_array);
 ?>


### PR DESCRIPTION
- Prevent opening edit mode on the _DEFAULT entry when clicking the "Advanced" tab; makes it impossible to do anything without modifying the URL manually in the browser.
- Allow overriding default values (Feature #4548)
- Better defaults/options for log viewer (Bug #6547)
- Fix log rotation with bzip2