### PR TITLE
Created no-release '-n' option and extra logging - 2nd commit only

### DIFF
--- a/net/dhcp6/files/patch-common.h
+++ b/net/dhcp6/files/patch-common.h
@@ -1,10 +1,20 @@
 --- common.h.orig	2007-03-21 09:52:57 UTC
 +++ common.h
-@@ -179,6 +179,7 @@ extern void duidfree __P((struct duid *)
+@@ -155,7 +155,7 @@ extern char *in6addr2str __P((struct in6
+ extern int in6_addrscopebyif __P((struct in6_addr *, char *));
+ extern int in6_scope __P((struct in6_addr *));
+ extern void setloglevel __P((int));
+-extern void dprintf __P((int, const char *, const char *, ...));
++extern void d_printf __P((int, const char *, const char *, ...));
+ extern int get_duid __P((char *, struct duid *));
+ extern void dhcp6_init_options __P((struct dhcp6_optinfo *));
+ extern void dhcp6_clear_options __P((struct dhcp6_optinfo *));
+@@ -179,7 +179,7 @@ extern void duidfree __P((struct duid *)
  extern int ifaddrconf __P((ifaddrconf_cmd_t, char *, struct sockaddr_in6 *,
  			   int, int, int));
  extern int safefile __P((const char *));
+-
 +extern int opt_norelease;
- 
  /* missing */
  #ifndef HAVE_STRLCAT
+ extern size_t strlcat __P((char *, const char *, size_t));

--- a/net/dhcp6/files/patch-common.h
+++ b/net/dhcp6/files/patch-common.h
@@ -1,11 +1,10 @@
 --- common.h.orig	2007-03-21 09:52:57 UTC
 +++ common.h
-@@ -155,7 +155,7 @@ extern char *in6addr2str __P((struct in6
- extern int in6_addrscopebyif __P((struct in6_addr *, char *));
- extern int in6_scope __P((struct in6_addr *));
- extern void setloglevel __P((int));
--extern void dprintf __P((int, const char *, const char *, ...));
-+extern void d_printf __P((int, const char *, const char *, ...));
- extern int get_duid __P((char *, struct duid *));
- extern void dhcp6_init_options __P((struct dhcp6_optinfo *));
- extern void dhcp6_clear_options __P((struct dhcp6_optinfo *));
+@@ -179,6 +179,7 @@ extern void duidfree __P((struct duid *)
+ extern int ifaddrconf __P((ifaddrconf_cmd_t, char *, struct sockaddr_in6 *,
+ 			   int, int, int));
+ extern int safefile __P((const char *));
++extern int opt_norelease;
+ 
+ /* missing */
+ #ifndef HAVE_STRLCAT

--- a/net/dhcp6/files/patch-dhcp6c.c
+++ b/net/dhcp6/files/patch-dhcp6c.c
@@ -1,34 +1,30 @@
 --- dhcp6c.c.orig	2008-06-15 07:48:41 UTC
 +++ dhcp6c.c
-@@ -55,6 +55,8 @@
- #include <netinet6/in6_var.h>
- #endif
+@@ -67,6 +67,7 @@
+ #include <string.h>
+ #include <err.h>
+ #include <ifaddrs.h>
++#include <fcntl.h>
  
-+#define __PFSENSE__ 1
-+
- #include <arpa/inet.h>
- #include <netdb.h>
+ #include <dhcp6.h>
+ #include <config.h>
+@@ -88,7 +89,6 @@ static sig_atomic_t sig_flags = 0;
+ const dhcp6_mode_t dhcp6_mode = DHCP6_MODE_CLIENT;
  
-@@ -74,7 +76,9 @@
- #include <timer.h>
- #include <dhcp6c.h>
- #include <control.h>
-+#ifndef __PFSENSE__
- #include <dhcp6_ctl.h>
-+#endif
- #include <dhcp6c_ia.h>
- #include <prefixconf.h>
- #include <auth.h>
-@@ -150,6 +154,8 @@ extern int client6_script __P((char *, i
+ int sock;	/* inbound/outbound udp port */
+-int rtsock;	/* routing socket */
+ int ctlsock = -1;		/* control TCP port */
+ char *ctladdr = DEFAULT_CLIENT_CONTROL_ADDR;
+ char *ctlport = DEFAULT_CLIENT_CONTROL_PORT;
+@@ -147,6 +147,7 @@ int client6_start __P((struct dhcp6_if *
+ static void info_printf __P((const char *, ...));
+ 
+ extern int client6_script __P((char *, int, struct dhcp6_optinfo *));
++int opt_norelease;
  
  #define MAX_ELAPSED_TIME 0xffff
  
-+int opt_norelease = 0;
-+
- int
- main(argc, argv)
- 	int argc;
-@@ -169,7 +175,7 @@ main(argc, argv)
+@@ -169,7 +170,7 @@ main(argc, argv)
  	else
  		progname++;
  
@@ -37,7 +33,7 @@
  		switch (ch) {
  		case 'c':
  			conffile = optarg;
-@@ -192,6 +198,9 @@ main(argc, argv)
+@@ -192,6 +193,9 @@ main(argc, argv)
  		case 'p':
  			pid_file = optarg;
  			break;
@@ -47,7 +43,7 @@
  		default:
  			usage();
  			exit(0);
-@@ -246,7 +255,7 @@ static void
+@@ -246,7 +250,7 @@ static void
  usage()
  {
  
@@ -56,149 +52,179 @@
  	    "[-p pid-file] interface [interfaces...]\n");
  }
  
-@@ -264,13 +273,16 @@ client6_init()
- 		dprintf(LOG_ERR, FNAME, "failed to get a DUID");
+@@ -257,7 +261,7 @@ client6_init()
+ {
+ 	struct addrinfo hints, *res;
+ 	static struct sockaddr_in6 sa6_allagent_storage;
+-	int error, on = 1;
++	int error, on = 0;
+ 
+ 	/* get our DUID */
+ 	if (get_duid(DUID_FILE, &client_duid)) {
+@@ -287,6 +291,20 @@ client6_init()
+ 		dprintf(LOG_ERR, FNAME, "socket");
  		exit(1);
  	}
--
-+	else {
-+	    dprintf(LOG_ERR, FNAME, "loaded DUID from %s",DUID_FILE);
++
++	if ((on = fcntl(sock, F_GETFL, 0)) == -1) {
++		dprintf(LOG_ERR, FNAME, "fctnl getflags");
++		exit(1);
 +	}
-+#ifndef __PFSENSE__
- 	if (dhcp6_ctl_authinit(ctlkeyfile, &ctlkey, &ctldigestlen) != 0) {
- 		dprintf(LOG_NOTICE, FNAME,
- 		    "failed initialize control message authentication");
- 		/* run the server anyway */
++
++	on |= FD_CLOEXEC;
++
++	if ((on = fcntl(sock, F_SETFL, on)) == -1) {
++		dprintf(LOG_ERR, FNAME, "fctnl setflags");
++		exit(1);
++	}
++
++	on = 1;
+ 	if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT,
+ 		       &on, sizeof(on)) < 0) {
+ 		dprintf(LOG_ERR, FNAME,
+@@ -337,13 +355,6 @@ client6_init()
  	}
+ 	freeaddrinfo(res);
+ 
+-	/* open a routing socket to watch the routing table */
+-	if ((rtsock = socket(PF_ROUTE, SOCK_RAW, 0)) < 0) {
+-		dprintf(LOG_ERR, FNAME, "open a routing socket: %s",
+-		    strerror(errno));
+-		exit(1);
+-	}
 -
-+#endif
  	memset(&hints, 0, sizeof(hints));
  	hints.ai_family = PF_INET6;
  	hints.ai_socktype = SOCK_DGRAM;
-@@ -357,7 +369,7 @@ client6_init()
- 	memcpy(&sa6_allagent_storage, res->ai_addr, res->ai_addrlen);
- 	sa6_allagent = (const struct sockaddr_in6 *)&sa6_allagent_storage;
- 	freeaddrinfo(res);
--
-+#ifndef __PFSENSE__
- 	/* set up control socket */
- 	if (ctlkey == NULL)
- 		dprintf(LOG_NOTICE, FNAME, "skip opening control port");
-@@ -367,7 +379,7 @@ client6_init()
- 		    "failed to initialize control channel");
- 		exit(1);
- 	}
--
-+#endif
- 	if (signal(SIGHUP, client6_signal) == SIG_ERR) {
- 		dprintf(LOG_WARNING, FNAME, "failed to set signal: %s",
- 		    strerror(errno));
-@@ -523,12 +535,13 @@ client6_mainloop()
- 		FD_ZERO(&r);
- 		FD_SET(sock, &r);
- 		maxsock = sock;
-+#ifndef __PFSENSE__
- 		if (ctlsock >= 0) {
- 			FD_SET(ctlsock, &r);
- 			maxsock = (sock > ctlsock) ? sock : ctlsock;
- 			(void)dhcp6_ctl_setreadfds(&r, &maxsock);
+@@ -596,7 +607,7 @@ get_ifname(bpp, lenp, ifbuf, ifbuflen)
+ 	if (*lenp < ifnamelen || ifnamelen > ifbuflen)
+ 		return (-1);
+ 
+-	memset(ifbuf, 0, sizeof(ifbuf));
++	memset(ifbuf, 0, ifbuflen);
+ 	memcpy(ifbuf, *bpp, ifnamelen);
+ 	if (ifbuf[ifbuflen - 1] != '\0')
+ 		return (-1);	/* not null terminated */
+@@ -763,6 +774,15 @@ client6_ifctl(ifname, command)
+ 
+ 	switch(command) {
+ 	case DHCP6CTL_COMMAND_START:
++		/*
++		 * The ifid might have changed, so reset it before releasing the
++		 * lease.
++		 */
++		if (ifreset(ifp)) {
++			dprintf(LOG_NOTICE, FNAME, "failed to reset %s",
++			    ifname);
++			return (-1);
++		}
+ 		free_resources(ifp);
+ 		if (client6_start(ifp)) {
+ 			dprintf(LOG_NOTICE, FNAME, "failed to restart %s",
+@@ -929,7 +949,7 @@ construct_confdata(ifp, ev)
+ 			    "failed to create a new event data");
+ 			goto fail;
  		}
--
-+#endif
- 		ret = select(maxsock + 1, &r, NULL, NULL, w);
+-		memset(evd, 0, sizeof(evd));
++		memset(evd, 0, sizeof(*evd));
  
- 		switch (ret) {
-@@ -545,7 +558,8 @@ client6_mainloop()
- 			break;
- 		}
- 		if (FD_ISSET(sock, &r))
--			client6_recv();
-+			client6_recv();		
-+#ifndef __PFSENSE__			
- 		if (ctlsock >= 0) {
- 			if (FD_ISSET(ctlsock, &r)) {
- 				(void)dhcp6_ctl_acceptcommand(ctlsock,
-@@ -553,6 +567,7 @@ client6_mainloop()
- 			}
- 			(void)dhcp6_ctl_readcommand(&r);
- 		}
-+#endif		
- 	}
- }
- 
-@@ -606,7 +621,7 @@ get_ifname(bpp, lenp, ifbuf, ifbuflen)
- 
- 	return (0);
- }
--
-+#ifndef __PFSENSE__
- static int
- client6_do_ctlcommand(buf, len)
- 	char *buf;
-@@ -728,7 +743,7 @@ client6_do_ctlcommand(buf, len)
- 
-   	return (DHCP6CTL_R_DONE);
- }
--
-+#endif
- static void
- client6_reload()
- {
-@@ -743,7 +758,7 @@ client6_reload()
- 
- 	return;
- }
--
-+#ifndef __PFSENSE__
- static int
- client6_ifctl(ifname, command)
- 	char *ifname;
-@@ -785,7 +800,7 @@ client6_ifctl(ifname, command)
- 
- 	return (0);
- }
--
-+#endif
- static struct dhcp6_timer *
- client6_expire_refreshtime(arg)
- 	void *arg;
-@@ -1459,6 +1474,7 @@ client6_recv()
- 	switch(dh6->dh6_msgtype) {
- 	case DH6_ADVERTISE:
- 		(void)client6_recvadvert(ifp, dh6, len, &optinfo);
-+		dprintf(LOG_INFO, FNAME, "dhcp6c Received ADVERTISE");
+ 		memset(&iaparam, 0, sizeof(iaparam));
+ 		iaparam.iaid = iac->iaid;
+@@ -1163,27 +1183,33 @@ client6_send(ev)
+ 	switch(ev->state) {
+ 	case DHCP6S_SOLICIT:
+ 		dh6->dh6_msgtype = DH6_SOLICIT;
++		d_printf(LOG_INFO, FNAME, "Sending Solicit");
  		break;
- 	case DH6_REPLY:
- 		(void)client6_recvreply(ifp, dh6, len, &optinfo);
-@@ -1721,6 +1737,31 @@ client6_recvreply(ifp, dh6, len, optinfo
+ 	case DHCP6S_REQUEST:
+ 		dh6->dh6_msgtype = DH6_REQUEST;
++		d_printf(LOG_INFO, FNAME, "Sending Request");
+ 		break;
+ 	case DHCP6S_RENEW:
+ 		dh6->dh6_msgtype = DH6_RENEW;
++		d_printf(LOG_INFO, FNAME, "Sending Renew");
+ 		break;
+ 	case DHCP6S_REBIND:
+ 		dh6->dh6_msgtype = DH6_REBIND;
++		d_printf(LOG_INFO, FNAME, "Sending Rebind");
+ 		break;
+ 	case DHCP6S_RELEASE:
+ 		dh6->dh6_msgtype = DH6_RELEASE;
++		d_printf(LOG_INFO, FNAME, "Sending Release");
+ 		break;
+ 	case DHCP6S_INFOREQ:
+ 		dh6->dh6_msgtype = DH6_INFORM_REQ;
++		d_printf(LOG_INFO, FNAME, "Sending Information Request");
+ 		break;
+ 	default:
+ 		dprintf(LOG_ERR, FNAME, "unexpected state");
+ 		exit(1);	/* XXX */
+ 	}
+-
++	
+ 	if (ev->timeouts == 0) {
+ 		/*
+ 		 * A client SHOULD generate a random number that cannot easily
+@@ -1721,7 +1747,29 @@ client6_recvreply(ifp, dh6, len, optinfo
  		dprintf(LOG_INFO, FNAME, "unexpected reply");
  		return (-1);
  	}
-+	// Log_received_reply
+-
 +	
 +	switch(state)
 +	{
-+	  
 +	  case DHCP6S_INFOREQ:
-+	  dprintf(LOG_INFO, FNAME, "dhcp6c Received INFOREQ");
-+	  break;
-+	  
++	    d_printf(LOG_INFO, FNAME, "dhcp6c Received INFOREQ");
++	  break;  
 +	  case DHCP6S_REQUEST:
-+	    dprintf(LOG_INFO, FNAME, "dhcp6c Received REQUEST");
++	    d_printf(LOG_INFO, FNAME, "dhcp6c Received REQUEST");
 +	  break;
 +	  case DHCP6S_RENEW:
-+	     dprintf(LOG_INFO, FNAME, "dhcp6c Received INFO");
++	     d_printf(LOG_INFO, FNAME, "dhcp6c Received INFO");
 +	  break;
 +	  case DHCP6S_REBIND:
-+	     dprintf(LOG_INFO, FNAME, "dhcp6c Received REBIND");
++	     d_printf(LOG_INFO, FNAME, "dhcp6c Received REBIND");
 +	  break;
 +	  case DHCP6S_RELEASE:
-+	     dprintf(LOG_INFO, FNAME, "dhcp6c Received RELEASE");
++	     d_printf(LOG_INFO, FNAME, "dhcp6c Received RELEASE");
 +	  break;
 +	  case DHCP6S_SOLICIT:
-+	     dprintf(LOG_INFO, FNAME, "dhcp6c Received SOLICIT");
-+	  break;
++	     d_printf(LOG_INFO, FNAME, "dhcp6c Received SOLICIT");
++	  break;	  
 +	}
- 
++	
  	/* A Reply message must contain a Server ID option */
  	if (optinfo->serverID.duid_len == 0) {
+ 		dprintf(LOG_INFO, FNAME, "no server ID option");
+@@ -1828,15 +1876,6 @@ client6_recvreply(ifp, dh6, len, optinfo
+ 	}
+ 
+ 	/*
+-	 * Call the configuration script, if specified, to handle various
+-	 * configuration parameters.
+-	 */
+-	if (ifp->scriptpath != NULL && strlen(ifp->scriptpath) != 0) {
+-		dprintf(LOG_DEBUG, FNAME, "executes %s", ifp->scriptpath);
+-		client6_script(ifp->scriptpath, state, optinfo);
+-	}
+-
+-	/*
+ 	 * Set refresh timer for configuration information specified in
+ 	 * information-request.  If the timer value is specified by the server
+ 	 * in an information refresh time option, use it; use the protocol
+@@ -1888,6 +1927,15 @@ client6_recvreply(ifp, dh6, len, optinfo
+ 		    &optinfo->serverID, ev->authparam);
+ 	}
+ 
++	/*
++	 * Call the configuration script, if specified, to handle various
++	 * configuration parameters.
++	 */
++	if (ifp->scriptpath != NULL && strlen(ifp->scriptpath) != 0) {
++		dprintf(LOG_DEBUG, FNAME, "executes %s", ifp->scriptpath);
++		client6_script(ifp->scriptpath, state, optinfo);
++	}
++
+ 	dhcp6_remove_event(ev);
+ 
+ 	if (state == DHCP6S_RELEASE) {

--- a/net/dhcp6/files/patch-dhcp6c.c
+++ b/net/dhcp6/files/patch-dhcp6c.c
@@ -1,128 +1,204 @@
 --- dhcp6c.c.orig	2008-06-15 07:48:41 UTC
 +++ dhcp6c.c
-@@ -67,6 +67,7 @@
- #include <string.h>
- #include <err.h>
- #include <ifaddrs.h>
-+#include <fcntl.h>
+@@ -55,6 +55,8 @@
+ #include <netinet6/in6_var.h>
+ #endif
  
- #include <dhcp6.h>
- #include <config.h>
-@@ -88,7 +89,6 @@ static sig_atomic_t sig_flags = 0;
- const dhcp6_mode_t dhcp6_mode = DHCP6_MODE_CLIENT;
++#define __PFSENSE__ 1
++
+ #include <arpa/inet.h>
+ #include <netdb.h>
  
- int sock;	/* inbound/outbound udp port */
--int rtsock;	/* routing socket */
- int ctlsock = -1;		/* control TCP port */
- char *ctladdr = DEFAULT_CLIENT_CONTROL_ADDR;
- char *ctlport = DEFAULT_CLIENT_CONTROL_PORT;
-@@ -257,7 +257,7 @@ client6_init()
+@@ -74,7 +76,9 @@
+ #include <timer.h>
+ #include <dhcp6c.h>
+ #include <control.h>
++#ifndef __PFSENSE__
+ #include <dhcp6_ctl.h>
++#endif
+ #include <dhcp6c_ia.h>
+ #include <prefixconf.h>
+ #include <auth.h>
+@@ -150,6 +154,8 @@ extern int client6_script __P((char *, i
+ 
+ #define MAX_ELAPSED_TIME 0xffff
+ 
++int opt_norelease = 0;
++
+ int
+ main(argc, argv)
+ 	int argc;
+@@ -169,7 +175,7 @@ main(argc, argv)
+ 	else
+ 		progname++;
+ 
+-	while ((ch = getopt(argc, argv, "c:dDfik:p:")) != -1) {
++	while ((ch = getopt(argc, argv, "c:ndDfik:p:")) != -1) {
+ 		switch (ch) {
+ 		case 'c':
+ 			conffile = optarg;
+@@ -192,6 +198,9 @@ main(argc, argv)
+ 		case 'p':
+ 			pid_file = optarg;
+ 			break;
++		case 'n':
++			opt_norelease = 1;
++			break;
+ 		default:
+ 			usage();
+ 			exit(0);
+@@ -246,7 +255,7 @@ static void
+ usage()
  {
- 	struct addrinfo hints, *res;
- 	static struct sockaddr_in6 sa6_allagent_storage;
--	int error, on = 1;
-+	int error, on = 0;
  
- 	/* get our DUID */
- 	if (get_duid(DUID_FILE, &client_duid)) {
-@@ -287,6 +287,20 @@ client6_init()
- 		dprintf(LOG_ERR, FNAME, "socket");
+-	fprintf(stderr, "usage: dhcp6c [-c configfile] [-dDfi] "
++	fprintf(stderr, "usage: dhcp6c [-c configfile] [-ndDfi] "
+ 	    "[-p pid-file] interface [interfaces...]\n");
+ }
+ 
+@@ -264,13 +273,16 @@ client6_init()
+ 		dprintf(LOG_ERR, FNAME, "failed to get a DUID");
  		exit(1);
  	}
-+
-+	if ((on = fcntl(sock, F_GETFL, 0)) == -1) {
-+		dprintf(LOG_ERR, FNAME, "fctnl getflags");
-+		exit(1);
-+	}
-+
-+	on |= FD_CLOEXEC;
-+
-+	if ((on = fcntl(sock, F_SETFL, on)) == -1) {
-+		dprintf(LOG_ERR, FNAME, "fctnl setflags");
-+		exit(1);
-+	}
-+
-+	on = 1;
- 	if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT,
- 		       &on, sizeof(on)) < 0) {
- 		dprintf(LOG_ERR, FNAME,
-@@ -337,13 +351,6 @@ client6_init()
- 	}
- 	freeaddrinfo(res);
- 
--	/* open a routing socket to watch the routing table */
--	if ((rtsock = socket(PF_ROUTE, SOCK_RAW, 0)) < 0) {
--		dprintf(LOG_ERR, FNAME, "open a routing socket: %s",
--		    strerror(errno));
--		exit(1);
--	}
 -
++	else {
++	    dprintf(LOG_ERR, FNAME, "loaded DUID from %s",DUID_FILE);
++	}
++#ifndef __PFSENSE__
+ 	if (dhcp6_ctl_authinit(ctlkeyfile, &ctlkey, &ctldigestlen) != 0) {
+ 		dprintf(LOG_NOTICE, FNAME,
+ 		    "failed initialize control message authentication");
+ 		/* run the server anyway */
+ 	}
+-
++#endif
  	memset(&hints, 0, sizeof(hints));
  	hints.ai_family = PF_INET6;
  	hints.ai_socktype = SOCK_DGRAM;
-@@ -596,7 +603,7 @@ get_ifname(bpp, lenp, ifbuf, ifbuflen)
- 	if (*lenp < ifnamelen || ifnamelen > ifbuflen)
- 		return (-1);
- 
--	memset(ifbuf, 0, sizeof(ifbuf));
-+	memset(ifbuf, 0, ifbuflen);
- 	memcpy(ifbuf, *bpp, ifnamelen);
- 	if (ifbuf[ifbuflen - 1] != '\0')
- 		return (-1);	/* not null terminated */
-@@ -763,6 +770,15 @@ client6_ifctl(ifname, command)
- 
- 	switch(command) {
- 	case DHCP6CTL_COMMAND_START:
-+		/*
-+		 * The ifid might have changed, so reset it before releasing the
-+		 * lease.
-+		 */
-+		if (ifreset(ifp)) {
-+			dprintf(LOG_NOTICE, FNAME, "failed to reset %s",
-+			    ifname);
-+			return (-1);
-+		}
- 		free_resources(ifp);
- 		if (client6_start(ifp)) {
- 			dprintf(LOG_NOTICE, FNAME, "failed to restart %s",
-@@ -929,7 +945,7 @@ construct_confdata(ifp, ev)
- 			    "failed to create a new event data");
- 			goto fail;
- 		}
--		memset(evd, 0, sizeof(evd));
-+		memset(evd, 0, sizeof(*evd));
- 
- 		memset(&iaparam, 0, sizeof(iaparam));
- 		iaparam.iaid = iac->iaid;
-@@ -1828,15 +1844,6 @@ client6_recvreply(ifp, dh6, len, optinfo
- 	}
- 
- 	/*
--	 * Call the configuration script, if specified, to handle various
--	 * configuration parameters.
--	 */
--	if (ifp->scriptpath != NULL && strlen(ifp->scriptpath) != 0) {
--		dprintf(LOG_DEBUG, FNAME, "executes %s", ifp->scriptpath);
--		client6_script(ifp->scriptpath, state, optinfo);
--	}
+@@ -357,7 +369,7 @@ client6_init()
+ 	memcpy(&sa6_allagent_storage, res->ai_addr, res->ai_addrlen);
+ 	sa6_allagent = (const struct sockaddr_in6 *)&sa6_allagent_storage;
+ 	freeaddrinfo(res);
 -
--	/*
- 	 * Set refresh timer for configuration information specified in
- 	 * information-request.  If the timer value is specified by the server
- 	 * in an information refresh time option, use it; use the protocol
-@@ -1888,6 +1895,15 @@ client6_recvreply(ifp, dh6, len, optinfo
- 		    &optinfo->serverID, ev->authparam);
++#ifndef __PFSENSE__
+ 	/* set up control socket */
+ 	if (ctlkey == NULL)
+ 		dprintf(LOG_NOTICE, FNAME, "skip opening control port");
+@@ -367,7 +379,7 @@ client6_init()
+ 		    "failed to initialize control channel");
+ 		exit(1);
  	}
+-
++#endif
+ 	if (signal(SIGHUP, client6_signal) == SIG_ERR) {
+ 		dprintf(LOG_WARNING, FNAME, "failed to set signal: %s",
+ 		    strerror(errno));
+@@ -523,12 +535,13 @@ client6_mainloop()
+ 		FD_ZERO(&r);
+ 		FD_SET(sock, &r);
+ 		maxsock = sock;
++#ifndef __PFSENSE__
+ 		if (ctlsock >= 0) {
+ 			FD_SET(ctlsock, &r);
+ 			maxsock = (sock > ctlsock) ? sock : ctlsock;
+ 			(void)dhcp6_ctl_setreadfds(&r, &maxsock);
+ 		}
+-
++#endif
+ 		ret = select(maxsock + 1, &r, NULL, NULL, w);
  
-+	/*
-+	 * Call the configuration script, if specified, to handle various
-+	 * configuration parameters.
-+	 */
-+	if (ifp->scriptpath != NULL && strlen(ifp->scriptpath) != 0) {
-+		dprintf(LOG_DEBUG, FNAME, "executes %s", ifp->scriptpath);
-+		client6_script(ifp->scriptpath, state, optinfo);
+ 		switch (ret) {
+@@ -545,7 +558,8 @@ client6_mainloop()
+ 			break;
+ 		}
+ 		if (FD_ISSET(sock, &r))
+-			client6_recv();
++			client6_recv();		
++#ifndef __PFSENSE__			
+ 		if (ctlsock >= 0) {
+ 			if (FD_ISSET(ctlsock, &r)) {
+ 				(void)dhcp6_ctl_acceptcommand(ctlsock,
+@@ -553,6 +567,7 @@ client6_mainloop()
+ 			}
+ 			(void)dhcp6_ctl_readcommand(&r);
+ 		}
++#endif		
+ 	}
+ }
+ 
+@@ -606,7 +621,7 @@ get_ifname(bpp, lenp, ifbuf, ifbuflen)
+ 
+ 	return (0);
+ }
+-
++#ifndef __PFSENSE__
+ static int
+ client6_do_ctlcommand(buf, len)
+ 	char *buf;
+@@ -728,7 +743,7 @@ client6_do_ctlcommand(buf, len)
+ 
+   	return (DHCP6CTL_R_DONE);
+ }
+-
++#endif
+ static void
+ client6_reload()
+ {
+@@ -743,7 +758,7 @@ client6_reload()
+ 
+ 	return;
+ }
+-
++#ifndef __PFSENSE__
+ static int
+ client6_ifctl(ifname, command)
+ 	char *ifname;
+@@ -785,7 +800,7 @@ client6_ifctl(ifname, command)
+ 
+ 	return (0);
+ }
+-
++#endif
+ static struct dhcp6_timer *
+ client6_expire_refreshtime(arg)
+ 	void *arg;
+@@ -1459,6 +1474,7 @@ client6_recv()
+ 	switch(dh6->dh6_msgtype) {
+ 	case DH6_ADVERTISE:
+ 		(void)client6_recvadvert(ifp, dh6, len, &optinfo);
++		dprintf(LOG_INFO, FNAME, "dhcp6c Received ADVERTISE");
+ 		break;
+ 	case DH6_REPLY:
+ 		(void)client6_recvreply(ifp, dh6, len, &optinfo);
+@@ -1721,6 +1737,31 @@ client6_recvreply(ifp, dh6, len, optinfo
+ 		dprintf(LOG_INFO, FNAME, "unexpected reply");
+ 		return (-1);
+ 	}
++	// Log_received_reply
++	
++	switch(state)
++	{
++	  
++	  case DHCP6S_INFOREQ:
++	  dprintf(LOG_INFO, FNAME, "dhcp6c Received INFOREQ");
++	  break;
++	  
++	  case DHCP6S_REQUEST:
++	    dprintf(LOG_INFO, FNAME, "dhcp6c Received REQUEST");
++	  break;
++	  case DHCP6S_RENEW:
++	     dprintf(LOG_INFO, FNAME, "dhcp6c Received INFO");
++	  break;
++	  case DHCP6S_REBIND:
++	     dprintf(LOG_INFO, FNAME, "dhcp6c Received REBIND");
++	  break;
++	  case DHCP6S_RELEASE:
++	     dprintf(LOG_INFO, FNAME, "dhcp6c Received RELEASE");
++	  break;
++	  case DHCP6S_SOLICIT:
++	     dprintf(LOG_INFO, FNAME, "dhcp6c Received SOLICIT");
++	  break;
 +	}
-+
- 	dhcp6_remove_event(ev);
  
- 	if (state == DHCP6S_RELEASE) {
+ 	/* A Reply message must contain a Server ID option */
+ 	if (optinfo->serverID.duid_len == 0) {

--- a/net/dhcp6/files/patch-dhcp6c__ia.c
+++ b/net/dhcp6/files/patch-dhcp6c__ia.c
@@ -1,0 +1,16 @@
+--- dhcp6c_ia.c.orig	2007-03-21 09:52:55 UTC
++++ dhcp6c_ia.c
+@@ -420,7 +420,12 @@ release_all_ia(ifp)
+ 		for (ia = TAILQ_FIRST(&iac->iadata); ia; ia = ia_next) {
+ 			ia_next = TAILQ_NEXT(ia, link);
+ 
+-			(void)release_ia(ia);
++			if(opt_norelease != 1){
++			  d_printf(LOG_INFO, FNAME,"Start address release");
++			  (void)release_ia(ia);
++			} else {
++			  d_printf(LOG_INFO,FNAME,"Bypassing address release");
++			}
+ 
+ 			/*
+ 			 * The client MUST stop using all of the addresses

--- a/net/dhcp6/files/patch-dhcp6c_ia.c
+++ b/net/dhcp6/files/patch-dhcp6c_ia.c
@@ -1,0 +1,16 @@
+--- dhcp6c_ia.c.orig	2007-03-21 09:52:55 UTC
++++ dhcp6c_ia.c
+@@ -420,7 +420,12 @@ release_all_ia(ifp)
+ 		for (ia = TAILQ_FIRST(&iac->iadata); ia; ia = ia_next) {
+ 			ia_next = TAILQ_NEXT(ia, link);
+ 
+-			(void)release_ia(ia);
++			if(opt_norelease != 1){
++			  dprintf(LOG_INFO, FNAME,"Start address release");
++			  (void)release_ia(ia);
++			} else {
++			  dprintf(LOG_NOTICE,FNAME,"Bypassing address release");
++			}
+ 
+ 			/*
+ 			 * The client MUST stop using all of the addresses

--- a/net/dhcp6/files/patch-prefixconf.c
+++ b/net/dhcp6/files/patch-prefixconf.c
@@ -5,7 +5,7 @@
  	sp->prefix.pltime = pinfo->pltime;
  	sp->prefix.vltime = pinfo->vltime;
 -	dprintf(LOG_DEBUG, FNAME, "%s a prefix %s/%d pltime=%lu, vltime=%lu",
-+	dprintf(LOG_INFO, FNAME, "%s a prefix %s/%d pltime=%lu, vltime=%lu",
++	d_printf(LOG_INFO, FNAME, "%s a prefix %s/%d pltime=%lu, vltime=%lu",
  	    spcreate ? "create" : "update",
  	    in6addr2str(&pinfo->addr, 0), pinfo->plen,
  	    pinfo->pltime, pinfo->vltime);

--- a/net/dhcp6/files/patch-prefixconf.c
+++ b/net/dhcp6/files/patch-prefixconf.c
@@ -1,0 +1,11 @@
+--- prefixconf.c.orig	2007-03-21 09:52:55 UTC
++++ prefixconf.c
+@@ -192,7 +192,7 @@ update_prefix(ia, pinfo, pifc, dhcpifp, 
+ 	/* update the prefix according to pinfo */
+ 	sp->prefix.pltime = pinfo->pltime;
+ 	sp->prefix.vltime = pinfo->vltime;
+-	dprintf(LOG_DEBUG, FNAME, "%s a prefix %s/%d pltime=%lu, vltime=%lu",
++	dprintf(LOG_INFO, FNAME, "%s a prefix %s/%d pltime=%lu, vltime=%lu",
+ 	    spcreate ? "create" : "update",
+ 	    in6addr2str(&pinfo->addr, 0), pinfo->plen,
+ 	    pinfo->pltime, pinfo->vltime);


### PR DESCRIPTION
no-release option added to prevent a release signal being sent to the ISP. Some ISP's will release the given allocation and issue a new allocation on next connect, regardless of the DUID. As this is a default state for dhcp6c whenever it terminates it has to be prevented. The -n option prevents the signal from ever being sent.

Some LOG_DEBUG info has been changed to LOG_INFO and some extra logging added also.

The original sync of these files included the last commit, I patched this in before commencing my changes. 

Everything appears to work fine but I am unsure as to whether I should or should not have patched them in first.

I will PR the changes required to interfaces.php and interfaces.inc with a link to this PR