### PR TITLE
dhcp6c no release option & extra light info logging

### DIFF
--- a/net/dhcp6/files/patch-common.h
+++ b/net/dhcp6/files/patch-common.h
@@ -9,3 +9,12 @@
  extern int get_duid __P((char *, struct duid *));
  extern void dhcp6_init_options __P((struct dhcp6_optinfo *));
  extern void dhcp6_clear_options __P((struct dhcp6_optinfo *));
+@@ -179,7 +179,7 @@ extern void duidfree __P((struct duid *)
+ extern int ifaddrconf __P((ifaddrconf_cmd_t, char *, struct sockaddr_in6 *,
+ 			   int, int, int));
+ extern int safefile __P((const char *));
+-
++extern int opt_norelease;
+ /* missing */
+ #ifndef HAVE_STRLCAT
+ extern size_t strlcat __P((char *, const char *, size_t));

--- a/net/dhcp6/files/patch-dhcp6c__ia.c
+++ b/net/dhcp6/files/patch-dhcp6c__ia.c
@@ -1,0 +1,16 @@
+--- dhcp6c_ia.c.orig	2007-03-21 09:52:55 UTC
++++ dhcp6c_ia.c
+@@ -420,7 +420,12 @@ release_all_ia(ifp)
+ 		for (ia = TAILQ_FIRST(&iac->iadata); ia; ia = ia_next) {
+ 			ia_next = TAILQ_NEXT(ia, link);
+ 
+-			(void)release_ia(ia);
++			if(opt_norelease != 1){
++			  d_printf(LOG_INFO, FNAME,"Start address release");
++			  (void)release_ia(ia);
++			} else {
++			  d_printf(LOG_INFO,FNAME,"Bypassing address release");
++			}
+ 
+ 			/*
+ 			 * The client MUST stop using all of the addresses

--- a/net/dhcp6/files/patch-prefixconf.c
+++ b/net/dhcp6/files/patch-prefixconf.c
@@ -1,0 +1,11 @@
+--- prefixconf.c.orig	2007-03-21 09:52:55 UTC
++++ prefixconf.c
+@@ -192,7 +192,7 @@ update_prefix(ia, pinfo, pifc, dhcpifp, 
+ 	/* update the prefix according to pinfo */
+ 	sp->prefix.pltime = pinfo->pltime;
+ 	sp->prefix.vltime = pinfo->vltime;
+-	dprintf(LOG_DEBUG, FNAME, "%s a prefix %s/%d pltime=%lu, vltime=%lu",
++	d_printf(LOG_INFO, FNAME, "%s a prefix %s/%d pltime=%lu, vltime=%lu",
+ 	    spcreate ? "create" : "update",
+ 	    in6addr2str(&pinfo->addr, 0), pinfo->plen,
+ 	    pinfo->pltime, pinfo->vltime);


### PR DESCRIPTION
Add a no release option '-n'. This prevents a release signal from being sent to the ISP causing a new PD or address to be allocated.
Added some extra light INFO logging which is useful to see the communications between dhcp6c and the ISP