### PR TITLE
Squid - fix auth when LDAP/RADIUS server port is not explicitly set i…

### DIFF
--- a/www/pfSense-pkg-squid/Makefile
+++ b/www/pfSense-pkg-squid/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-squid
-PORTVERSION=	0.4.25
+PORTVERSION=	0.4.26
 CATEGORIES=	www
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
@@ -1845,12 +1845,12 @@ function squid_resync_auth() {
 				$conf .= 'auth_param basic program ' . SQUID_LOCALBASE . '/libexec/squid/basic_ncsa_auth ' . SQUID_PASSWD . "\n";
 				break;
 			case 'ldap':
-				$port = ((isset($settings['auth_server_port']) && !empty($setting['auth_server_port'])) ? ":{$settings['auth_server_port']}" : '');
+				$port = ((isset($settings['auth_server_port']) && !empty($settings['auth_server_port'])) ? ":{$settings['auth_server_port']}" : '');
 				$password = (isset($settings['ldap_pass']) ? "-w {$settings['ldap_pass']}" : '');
 				$conf .= "auth_param basic program " . SQUID_LOCALBASE . "/libexec/squid/basic_ldap_auth -v {$settings['ldap_version']} -b {$settings['ldap_basedomain']} -D {$settings['ldap_user']} $password -f \"{$settings['ldap_filter']}\" -u {$settings['ldap_userattribute']} -P {$settings['auth_server']}$port\n";
 				break;
 			case 'radius':
-				$port = ((isset($settings['auth_server_port']) && !empty($setting['auth_server_port'])) ? "-p {$settings['auth_server_port']}" : '');
+				$port = ((isset($settings['auth_server_port']) && !empty($settings['auth_server_port'])) ? "-p {$settings['auth_server_port']}" : '');
 				$conf .= "auth_param basic program ". SQUID_LOCALBASE . "/libexec/squid/basic_radius_auth -w {$settings['radius_secret']} -h {$settings['auth_server']} $port\n";
 				break;
 			case 'cp':

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
@@ -1845,12 +1845,12 @@ function squid_resync_auth() {
 				$conf .= 'auth_param basic program ' . SQUID_LOCALBASE . '/libexec/squid/basic_ncsa_auth ' . SQUID_PASSWD . "\n";
 				break;
 			case 'ldap':
-				$port = (isset($settings['auth_server_port']) ? ":{$settings['auth_server_port']}" : '');
+				$port = ((isset($settings['auth_server_port']) && !empty($setting['auth_server_port'])) ? ":{$settings['auth_server_port']}" : '');
 				$password = (isset($settings['ldap_pass']) ? "-w {$settings['ldap_pass']}" : '');
 				$conf .= "auth_param basic program " . SQUID_LOCALBASE . "/libexec/squid/basic_ldap_auth -v {$settings['ldap_version']} -b {$settings['ldap_basedomain']} -D {$settings['ldap_user']} $password -f \"{$settings['ldap_filter']}\" -u {$settings['ldap_userattribute']} -P {$settings['auth_server']}$port\n";
 				break;
 			case 'radius':
-				$port = (isset($settings['auth_server_port']) ? "-p {$settings['auth_server_port']}" : '');
+				$port = ((isset($settings['auth_server_port']) && !empty($setting['auth_server_port'])) ? "-p {$settings['auth_server_port']}" : '');
 				$conf .= "auth_param basic program ". SQUID_LOCALBASE . "/libexec/squid/basic_radius_auth -w {$settings['radius_secret']} -h {$settings['auth_server']} $port\n";
 				break;
 			case 'cp':


### PR DESCRIPTION
…n the GUI

As reported by a user @ https://forum.pfsense.org/index.php?topic=113667.msg632008#msg632008 - when the port is not explicitly set in the GUI but the tags still exist in config.xml, this adds a bogus trailing semicolon which breaks Squid auth.

RADIUS would be the same case, just with trailing -p without any port. Also broken.