### PR TITLE
Allow quagga ospf stub, not so stub and totally stub areas (Feature #3303)

### DIFF
--- a/net/pfSense-pkg-Quagga_OSPF/Makefile
+++ b/net/pfSense-pkg-Quagga_OSPF/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-Quagga_OSPF
-PORTVERSION=	0.6.15
+PORTVERSION=	0.6.16
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-Quagga_OSPF/files/etc/inc/priv/quagga_ospfd.priv.inc
+++ b/net/pfSense-pkg-Quagga_OSPF/files/etc/inc/priv/quagga_ospfd.priv.inc
@@ -3,7 +3,7 @@
  * quagga_ospfd.priv.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2016 Rubicon Communications, LLC (Netgate)
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,14 +29,10 @@ $priv_list['page-services-quagga']['match'] = array();
 $priv_list['page-services-quagga']['match'][] = "pkg.php?xml=quagga_ospfd.xml*";
 $priv_list['page-services-quagga']['match'][] = "pkg.php?xml=quagga_ospfd_interfaces.xml*";
 $priv_list['page-services-quagga']['match'][] = "pkg.php?xml=quagga_ospfd_raw.xml*";
-$priv_list['page-services-quagga']['match'][] = "pkg.php?xml=bind_views.xml*";
-$priv_list['page-services-quagga']['match'][] = "pkg.php?xml=bind_zones.xml*";
 
 $priv_list['page-services-quagga']['match'][] = "pkg_edit.php?xml=quagga_ospfd.xml*";
 $priv_list['page-services-quagga']['match'][] = "pkg_edit.php?xml=quagga_ospfd_interfaces.xml*";
 $priv_list['page-services-quagga']['match'][] = "pkg_edit.php?xml=quagga_ospfd_raw.xml*";
-$priv_list['page-services-quagga']['match'][] = "pkg_edit.php?xml=bind_views.xml*";
-$priv_list['page-services-quagga']['match'][] = "pkg_edit.php?xml=bind_zones.xml*";
 
 $priv_list['page-services-quagga']['match'][] = "status_ospfd.php*";
 

--- a/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd.inc
+++ b/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd.inc
@@ -181,8 +181,17 @@ function quagga_ospfd_install_conf() {
 		if ($ospfd_conf['routerid']) {
 			$conffile .= "  ospf router-id {$ospfd_conf['routerid']}\n";
 		}
-		if ($ospfd_conf['updatefib']) {
+		/* In package versions <=0.6.15, this used to a checkbox handling stub areas only
+		 * Leave the first check here
+		 */
+		if ($ospfd_conf['updatefib'] == "on" ) {
 			$conffile .= "  area {$ospfd_conf['area']} stub\n";
+		} elseif ($ospfd_conf['updatefib'] == "stub") {
+			$conffile .= "  area {$ospfd_conf['area']} stub\n";
+		} elseif ($ospfd_conf['updatefib'] == "nosum") {
+			$conffile .= "  area {$ospfd_conf['area']} stub no-summary\n";
+		} elseif ($ospfd_conf['updatefib'] == "nssa") {
+			$conffile .= "  area {$ospfd_conf['area']} nssa\n";
 		}
 		if ($ospfd_conf['logging'] && $ospfd_conf['adjacencylog']) {
 			$conffile .= "  log-adjacency-changes detail\n";

--- a/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd.xml
+++ b/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd.xml
@@ -117,8 +117,15 @@
 		<field>
 			<fielddescr>Disable FIB updates (Routing table)</fielddescr>
 			<fieldname>updatefib</fieldname>
-			<description>Disables the updating of the host routing table(turns into stub router).</description>
-			<type>checkbox</type>
+			<description>Disables the updating of the host routing table (turns into stub router).</description>
+			<type>select</type>
+			<default_value>none</default_value>
+			<options>
+				<option><name>None (FIB updates enabled) (default)</name><value>none</value></option>
+				<option><name>Stub Area (stub)</name><value>stub</value></option>
+				<option><name>Totally Stub (no-summary)</name><value>stub no-summary</value></option>
+				<option><name>Not so Stub Area (nssa)</name><value>nssa</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Redistribute connected subnets</fielddescr>

--- a/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd.xml
+++ b/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd.xml
@@ -123,7 +123,7 @@
 			<options>
 				<option><name>None (FIB updates enabled) (default)</name><value>none</value></option>
 				<option><name>Stub Area (stub)</name><value>stub</value></option>
-				<option><name>Totally Stub (no-summary)</name><value>stub no-summary</value></option>
+				<option><name>Totally Stub (no-summary)</name><value>nosum</value></option>
 				<option><name>Not so Stub Area (nssa)</name><value>nssa</value></option>
 			</options>
 		</field>

--- a/net/pfSense-pkg-Quagga_OSPF/files/usr/local/share/pfSense-pkg-Quagga_OSPF/info.xml
+++ b/net/pfSense-pkg-Quagga_OSPF/files/usr/local/share/pfSense-pkg-Quagga_OSPF/info.xml
@@ -4,7 +4,7 @@
 		<name>Quagga OSPF</name>
 		<internal_name>Quagga_OSPF</internal_name>
 		<descr><![CDATA[OSPF routing protocol using Quagga.&lt;br /&gt;
-			&lt;strong&gt;WARNING! Installs files to the same place as OpenBGPD. Installing both will break things.&lt;/strong&gt;]]></descr>
+			&lt;strong&gt;Conflicts with OpenBGPD; both packages cannot be installed at the same time.&lt;/strong&gt;]]></descr>
 		<version>%%PKGVERSION%%</version>
 		<configurationfile>quagga_ospfd.xml</configurationfile>
 	</package>

--- a/net/pfSense-pkg-Quagga_OSPF/pkg-descr
+++ b/net/pfSense-pkg-Quagga_OSPF/pkg-descr
@@ -1,3 +1,2 @@
-OSPF routing protocol using Quagga.<br />
-			<strong>WARNING! Installs files to the same place as
-			OpenBGPD. Installing both will break things.</strong>
+OSPF routing protocol using Quagga.
+Conflicts with OpenBGPD; both packages cannot be installed at the same time.


### PR DESCRIPTION
Slightly modified patch from https://redmine.pfsense.org/issues/3303 to handle the checkbox-based configuration in old versions of the package. (I'd rather avoid renaming the badly chosen config variable name and upgrading the config on upgrade.)

While here, also tweaked the package description (conflicts should be handled by pkg now) and removed some copy-paste junk from privs.