### PR TITLE
Disable Auto Config Backup feature (Feature #6951), add some tweaks for savemsg (Bug #6950)

### DIFF
--- a/sysutils/pfSense-pkg-AutoConfigBackup/Makefile
+++ b/sysutils/pfSense-pkg-AutoConfigBackup/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-AutoConfigBackup
-PORTVERSION=	1.45
+PORTVERSION=	1.46
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/pkg/autoconfigbackup.inc
+++ b/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/pkg/autoconfigbackup.inc
@@ -3,7 +3,7 @@
  * autoconfigbackup.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2008-2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2008-2016 Rubicon Communications, LLC (Netgate)
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -123,13 +123,7 @@ function test_connection($post) {
 	global $savemsg, $config, $g;
 
 	// Do nothing when booting or when not enabled
-	if (function_exists("platform_booting")) {
-		if (platform_booting()) {
-			return;
-		}
-	} elseif ($g['booting']) {
-		return;
-	} elseif (!acb_enabled()) {
+	if (platform_booting() || !acb_enabled()) {
 		return;
 	}
 
@@ -179,13 +173,7 @@ function upload_config($reasonm = "") {
 	global $config, $g, $input_errors;
 
 	// Do nothing when booting or when not enabled
-	if (function_exists("platform_booting")) {
-		if (platform_booting()) {
-			return;
-		}
-	} elseif ($g['booting']) {
-		return;
-	} elseif (!acb_enabled()) {
+	if (platform_booting() || !acb_enabled()) {
 		return;
 	}
 

--- a/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/pkg/autoconfigbackup.inc
+++ b/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/pkg/autoconfigbackup.inc
@@ -32,7 +32,7 @@ function acb_enabled() {
 	$acb_enabled = false;
 
 	if (is_array($config['installedpackages']['autoconfigbackup']['config'])) {
-		if ($config['installedpackages']['autoconfigbackup']['config'][0]['enable_acb'] == "on") {
+		if ($config['installedpackages']['autoconfigbackup']['config'][0]['enable_acb'] != "disabled") {
 			$acb_enabled = true;
 		}
 	}

--- a/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/pkg/autoconfigbackup.inc
+++ b/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/pkg/autoconfigbackup.inc
@@ -26,9 +26,30 @@ require_once("notices.inc");
 unlink_if_exists("/usr/local/pkg/parse_config/parse_config_upload.inc");
 unlink_if_exists("/usr/local/pkg/parse_config/parse_config_upload.php");
 
+/* Check whether ACB is enabled */
+function acb_enabled() {
+	global $config;
+	$acb_enabled = false;
+
+	if (is_array($config['installedpackages']['autoconfigbackup']['config'])) {
+		if ($config['installedpackages']['autoconfigbackup']['config'][0]['enable_acb'] == "on") {
+			$acb_enabled = true;
+		}
+	}
+	return $acb_enabled;
+}
+
 // Ensures patches match
 function acb_custom_php_validation_command($post, &$input_errors) {
 	global $_POST, $savemsg, $config;
+
+	// Do nothing when ACB is disabled in configuration
+	// This also makes it possible to delete the credentials from config.xml
+	if (!acb_enabled()) {
+		// We do not need to store this value.
+		unset($_POST['testconnection']);
+		return;
+	}
 
 	if (!$post['username']) {
 		$input_errors[] = "Username is required.";
@@ -62,6 +83,11 @@ function acb_custom_php_validation_command($post, &$input_errors) {
 }
 
 function acb_custom_php_resync_config_command() {
+	// Do nothing when ACB is disabled in configuration
+	if (!acb_enabled()) {
+		return;
+	}
+
 	if (is_file("/cf/conf/lastpfSbackup.txt")) {
 		conf_mount_rw();
 		unlink("/cf/conf/lastpfSbackup.txt");
@@ -96,12 +122,14 @@ function configure_proxy() {
 function test_connection($post) {
 	global $savemsg, $config, $g;
 
-	// Do nothing when booting
+	// Do nothing when booting or when not enabled
 	if (function_exists("platform_booting")) {
 		if (platform_booting()) {
 			return;
 		}
 	} elseif ($g['booting']) {
+		return;
+	} elseif (!acb_enabled()) {
 		return;
 	}
 
@@ -150,12 +178,14 @@ function test_connection($post) {
 function upload_config($reasonm = "") {
 	global $config, $g, $input_errors;
 
-	// Do nothing when booting
+	// Do nothing when booting or when not enabled
 	if (function_exists("platform_booting")) {
 		if (platform_booting()) {
 			return;
 		}
 	} elseif ($g['booting']) {
+		return;
+	} elseif (!acb_enabled()) {
 		return;
 	}
 
@@ -284,4 +314,3 @@ function upload_config($reasonm = "") {
 		}
 	}
 }
-

--- a/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/pkg/autoconfigbackup.xml
+++ b/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/pkg/autoconfigbackup.xml
@@ -60,8 +60,13 @@
 		<field>
 			<fielddescr>Enable AutoConfigBackup</fielddescr>
 			<fieldname>enable_acb</fieldname>
-			<description>Check this to enable configuration backups to portal.pfsense.org</description>
-			<type>checkbox</type>
+			<description>Enable/disable configuration backups to portal.pfsense.org</description>
+			<type>select</type>
+			<default_value>enabled</default_value>
+			<options>
+				<option><value>enabled</value><name>Enabled</name></option>
+				<option><value>disabled</value><name>Disabled</name></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Subscription Username</fielddescr>

--- a/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/pkg/autoconfigbackup.xml
+++ b/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/pkg/autoconfigbackup.xml
@@ -8,7 +8,7 @@
  * autoconfigbackup.xml
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2008-2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2008-2016 Rubicon Communications, LLC (Netgate)
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,6 +57,12 @@
 		</tab>
 	</tabs>
 	<fields>
+		<field>
+			<fielddescr>Enable AutoConfigBackup</fielddescr>
+			<fieldname>enable_acb</fieldname>
+			<description>Check this to enable configuration backups to portal.pfsense.org</description>
+			<type>checkbox</type>
+		</field>
 		<field>
 			<fielddescr>Subscription Username</fielddescr>
 			<fieldname>username</fieldname>

--- a/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/www/autoconfigbackup_backup.php
+++ b/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/www/autoconfigbackup_backup.php
@@ -32,9 +32,13 @@ if ($_POST) {
 		touch("/tmp/acb_nooverwrite");
 	}
 	if ($_REQUEST['reason']) {
-		write_config($_REQUEST['reason']);
+		if (write_config($_REQUEST['reason'])) {
+			$savemsg = "Backup completed successfully.";
+		}
+	} elseif (write_config("Backup invoked via Auto Config Backup.")) {
+			$savemsg = "Backup completed successfully.";
 	} else {
-		write_config("Backup invoked via Auto Config Backup.");
+		$savemsg = "Backup not completed - write_config() failed.";
 	}
 	$config = parse_config(true);
 	conf_mount_rw();
@@ -55,6 +59,9 @@ include("head.inc");
 
 if ($input_errors) {
 	print_input_errors($input_errors);
+}
+if ($savemsg) {
+	print_info_box($savemsg, 'success');
 }
 
 $tab_array = array();

--- a/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/www/autoconfigbackup_backup.php
+++ b/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/www/autoconfigbackup_backup.php
@@ -47,7 +47,6 @@ if ($_POST) {
 	 */
 	//upload_config($_REQUEST['reason']);
 
-	$savemsg = "Backup completed successfully.";
 	$donotshowheader = true;
 }
 
@@ -56,9 +55,6 @@ include("head.inc");
 
 if ($input_errors) {
 	print_input_errors($input_errors);
-}
-if ($savemsg) {
-	print_info_box($savemsg, 'success');
 }
 
 $tab_array = array();


### PR DESCRIPTION
Make it possible to disable the package without uninstalling (e.g. to prevent timeout delays when there's no WAN connection). Also, it is now possible to delete the stored credentials from config.xml. 

Some tweaks to avoid completely bogus "success" message for Bug #6950 while here. Now it should at least report failure when the write_config() failed due to the user having user-config-readonly privilege, instead of always claiming it worked.