### PR TITLE
squid - Remove NT Domain auth (Bug #7017), allow some configuration for DH and cipher suites (Feature #6593), fix EDH and EECDH cipher suites (Bug #6592), some cosmetics

### DIFF
--- a/www/pfSense-pkg-squid/Makefile
+++ b/www/pfSense-pkg-squid/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-squid
-PORTVERSION=	0.4.28
+PORTVERSION=	0.4.29
 CATEGORIES=	www
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
@@ -639,6 +639,14 @@ function squid_upgrade_config() {
 		$settingsauth['no_auth_hosts'] = base64_encode(implode("\n", explode(",", $settingsauth['no_auth_hosts'])));
 		$config['installedpackages']['squidauth']['config'][0]['no_auth_hosts'] = $settingsauth['no_auth_hosts'];
 	}
+	/* NT Domain authentication has been removed - Bug #7017 */
+	if (!empty($settingsauth['auth_method'])) {
+		if (preg_match("/msnt/i", $settingsauth['auth_method'])) {
+			$msnt_msg = "NT Domain authentication has been removed - see Bug #7017! Use LDAP for AD authentication.";
+			file_notice("squid", $msnt_msg, "Packages", "");
+			log_error("[squid] {$msnt_msg}");
+		}
+	}
 
 	/* migrate cache settings */
 	if (!empty($settingscache['donotcache']) && strstr($settingscache['donotcache'], ",")) {

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
@@ -1152,19 +1152,41 @@ function squid_resync_general() {
 				}
 				// force squid user permission on /var/squid/lib/ssl_db/
 				squid_chown_recursive(SQUID_SSL_DB, SQUID_UID, SQUID_GID);
-				// cert, key, version, cipher, options, clientca, cafile, capath, crlfile, dhparams, sslflags, sslcontext
+				// cert, key, version, cipher, options, clientca, cafile, capath, crlfile, tls-dh, sslflags, sslcontext
 				$crt_pk = SQUID_CONFBASE . "/serverkey.pem";
 				$crt_capath = SQUID_LOCALBASE . "/share/certs/";
-				/* XXX: Bug #4453
-				 * http://wiki.squid-cache.org/ConfigExamples/Intercept/SslBumpExplicit#Modern_DH.2Fciphers_usage
+				$sslproxy_options = "NO_SSLv2,NO_SSLv3";
+				/* XXX: Bug #4453, Bug #6592, Feature #6593
+				 * http://wiki.squid-cache.org/ConfigExamples/Intercept/SslBumpExplicit#Modern_DH.2FEDH_ciphers_usage
 				 */
-				//$sslproxy_cipher = "EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH:EDH+aRSA:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS";
-				$sslproxy_cipher = "EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH:EDH+aRSA:HIGH:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS";
-				$sslproxy_dhparams = "/etc/dh-parameters.2048";
-				$sslproxy_options = "NO_SSLv2,NO_SSLv3,SINGLE_DH_USE";
+				if (!empty($settings['sslproxy_compatibility_mode']) && ($settings['sslproxy_compatibility_mode'] == 'modern')) {
+					// Modern cipher suites
+					$sslproxy_cipher = "EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH:EDH+aRSA:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS";
+					$sslproxy_options .= ",NO_TLSv1";
+				} else {
+					// Use intermediate cipher suites by default to match port versions <0.4.29 behavior on upgrade
+					$sslproxy_cipher = "EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH:EDH+aRSA:HIGH:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS";
+				}
+				if (!empty($settings["dhparams_size"])) {
+					if ($settings['dhparams_size'] == '4096') {
+						$sslproxy_dhparams = "tls-dh=prime256v1:/etc/dh-parameters.4096";
+					} elseif ($settings['dhparams_size'] == '2048') {
+						$sslproxy_dhparams = "tls-dh=prime256v1:/etc/dh-parameters.2048";
+					} elseif ($settings['dhparams_size'] == '1024') {
+						$sslproxy_dhparams = "tls-dh=prime256v1:/etc/dh-parameters.1024";
+					}
+					$sslproxy_options .= ",SINGLE_DH_USE,SINGLE_ECDH_USE";
+				} elseif (file_exists("/etc/dh-parameters.2048")) {
+					// Fallback options for defaults on install
+					$sslproxy_dhparams = "tls-dh=prime256v1:/etc/dh-parameters.2048";
+					$sslproxy_options .= ",SINGLE_DH_USE,SINGLE_ECDH_USE";
+				} else {
+					// Should never get here
+					$sslproxy_dhparams = "";
+				}
 				file_put_contents($crt_pk, base64_decode($srv_cert['prv']) . base64_decode($srv_cert['crt']));
 				$sslcrtd_children = ($settings['sslcrtd_children'] ? $settings['sslcrtd_children'] : 5);
-				$ssl_interception .= "ssl-bump generate-host-certificates=on dynamic_cert_mem_cache_size=" . ($sslcrtd_children*2) . "MB cert={$crt_pk} capath={$crt_capath} cipher={$sslproxy_cipher} dhparams={$sslproxy_dhparams} options={$sslproxy_options}\n";
+				$ssl_interception .= "ssl-bump generate-host-certificates=on dynamic_cert_mem_cache_size=" . ($sslcrtd_children*2) . "MB cert={$crt_pk} capath={$crt_capath} cipher={$sslproxy_cipher} {$sslproxy_dhparams} options={$sslproxy_options}\n";
 				$interception_checks = "sslcrtd_program " . SQUID_LOCALBASE . "/libexec/squid/ssl_crtd -s " . SQUID_SSL_DB . " -M 4MB -b 2048\n";
 				$interception_checks .= "sslcrtd_children {$sslcrtd_children}\n";
 				$interception_checks .= "sslproxy_capath {$crt_capath}\n";

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
@@ -503,6 +503,9 @@ function squid_install_command() {
 	install_cron_job("/usr/local/pkg/swapstate_check.php clean;", false);
 	install_cron_job("/bin/rm /var/squid/cache/swap.state;", false);
 
+	/* NT Domain authentication has been removed */
+	unlink_if_exists(SQUID_CONFBASE . '/msntauth.conf');
+
 }
 
 function squid_deinstall_command() {
@@ -1099,13 +1102,6 @@ function squid_validate_auth($post, &$input_errors) {
 				$secret = trim($post['radius_secret']);
 				if (empty($secret)) {
 					$input_errors[] = "'RADIUS secret' is required.";
-				}
-				break;
-			case 'msnt':
-				foreach (explode(",", trim($post['msnt_secondary'])) as $server) {
-					if (!empty($server) && !is_ipaddr($server) && !is_domain($server)) {
-						$input_errors[] = "The host '$server' is not a valid IP address or domain name";
-					}
 				}
 				break;
 		}
@@ -1858,10 +1854,6 @@ function squid_resync_auth() {
 				$conf .= "external_acl_type check_cp {$helpers_num} ttl={$auth_ttl} %SRC " . SQUID_BASE . "/bin/check_ip.php\n";
 				$conf .= "acl password external check_cp\n";
 				break;
-			case 'msnt':
-				$conf .= "auth_param basic program " . SQUID_LOCALBASE . "/libexec/squid/basic_msnt_auth\n";
-				squid_resync_msnt();
-				break;
 		}
 		if ($auth_method != 'cp') {
 		$conf .= <<< EOD
@@ -1929,24 +1921,6 @@ function squid_resync_users() {
 	file_put_contents(SQUID_PASSWD, $contents);
 	chown(SQUID_PASSWD, SQUID_UID);
 	chmod(SQUID_PASSWD, 0600);
-}
-
-/* Proxy server: NT Domain configuration handler */
-function squid_resync_msnt() {
-	global $config;
-
-	if (is_array($config['installedpackages']['squidauth'])) {
-		$settings = $config['installedpackages']['squidauth']['config'][0];
-	} else {
-		$settings = array();
-	}
-	$pdcserver = $settings['auth_server'];
-	$bdcserver = str_replace(',', ' ', $settings['msnt_secondary']);
-	$ntdomain = $settings['auth_ntdomain'];
-
-	file_put_contents(SQUID_CONFBASE . "/msntauth.conf", "server {$pdcserver} {$bdcserver} {$ntdomain}");
-	chown(SQUID_CONFBASE . "/msntauth.conf", SQUID_UID);
-	chmod(SQUID_CONFBASE . "/msntauth.conf", 0600);
 }
 
 /* Wrapper function to sync whole Squid configuration */

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.xml
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.xml
@@ -8,7 +8,7 @@
  * squid.xml
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2012-2014 Marcello Coutinho
  * All rights reserved.
  *
@@ -194,9 +194,7 @@
 			<fielddescr>Patch Captive Portal</fielddescr>
 			<description>
 				<![CDATA[
-				<strong><span class="errmsg">This feature was removed</span></strong> - see <a href="https://redmine.pfsense.org/issues/5594">Bug #5594</a> for details!<br/>
-				If you were using this feature, double-check '/etc/inc/captiveportal.inc' content for sanity.<br/>
-				Get a <a href="https://github.com/pfsense/pfsense/blob/master/src/etc/inc/captiveportal.inc">sane copy of the file from pfSense GitHub repository</a> if needed.
+				<strong><span class="errmsg">This feature was removed</span></strong> - see <a href="https://redmine.pfsense.org/issues/5594">Bug #5594</a> for details!
 				]]>
 			</description>
 			<type>info</type>

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.xml
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.xml
@@ -102,14 +102,6 @@
 			<url>/pkg_edit.php?xml=squid_sync.xml</url>
 		</tab>
 	</tabs>
-	<!-- START INC files -->
-	<!-- END INC files -->
-	<!-- START XML files -->
-	<!-- END XML files -->
-	<!-- START additional PHP files -->
-	<!-- END additional PHP files -->
-	<!-- START executable CLI scripts -->
-	<!-- END executable CLI scripts -->
 	<advanced_options>enabled</advanced_options>
 	<fields>
 		<field>
@@ -336,6 +328,43 @@
 			<type>input</type>
 			<size>5</size>
 			<default_value>3129</default_value>
+		</field>
+		<field>
+			<fielddescr>SSL Proxy Compatibility Mode</fielddescr>
+			<fieldname>sslproxy_compatibility_mode</fieldname>
+			<description>
+				<![CDATA[
+				The compatibility mode determines which cipher suites and TLS versions are supported.<br/>
+				Modern is the default, intended for modern clients only (post FF 27, Chrome 22, IE 11 etc.) and also disables HIGH ciphers and TLS v1.0.<br/>
+				If you need to support older clients, use the Intermediate setting.<br/><br/>
+				<strong><span class="errmsg">Warning: </span>Clients like IE 6 and Java 6 are not supported anymore!</strong>
+				]]>
+			</description>
+			<type>select</type>
+			<options>
+				<option><name>Modern</name><value>modern</value></option>
+				<option><name>Intermediate</name><value>intermediate</value>
+				</option>
+			</options>
+			<size>1</size>
+			<default_value>modern</default_value>
+		</field>
+		<field>
+			<fielddescr>DHParams Key Size</fielddescr>
+			<fieldname>dhparams_size</fieldname>
+			<description>
+				<![CDATA[
+				DH parameters are used for temporary/ephemeral DH key exchanges. They improve security by enabling the use of DHE ciphers.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<options>
+				<option><name>1024 (not recommended)</name><value>1024</value></option>
+				<option><name>2048 (default)</name><value>2048</value></option>
+				<option><name>4096 (very secure)</name><value>4096</value></option>
+			</options>
+			<size>1</size>
+			<default_value>2048</default_value>
 		</field>
 		<field>
 			<fielddescr>CA</fielddescr>

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid_auth.xml
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid_auth.xml
@@ -89,7 +89,6 @@
 				<option><name>LDAP</name><value>ldap</value></option>
 				<option><name>RADIUS</name><value>radius</value></option>
 				<option><name>Captive Portal</name><value>cp</value></option>
-				<option><name>NT Domain</name><value>msnt</value></option>
 			</options>
 			<onchange>on_auth_method_changed()</onchange>
 		</field>
@@ -217,24 +216,6 @@
 			<default_value>(&amp;(objectClass=person)(uid=%s))</default_value>
 		</field>
 		<field>
-			<name>Squid Authentication NT Domain Settings</name>
-			<type>listtopic</type>
-		</field>
-		<field>
-			<fielddescr>NT Domain</fielddescr>
-			<fieldname>auth_ntdomain</fieldname>
-			<description>Enter the NT domain here.</description>
-			<type>input</type>
-			<size>60</size>
-		</field>
-		<field>
-			<fielddescr>Secondary NT Servers</fielddescr>
-			<fieldname>msnt_secondary</fieldname>
-			<description>Enter comma-separated list of secondary servers to be used for NT domain authentication here.</description>
-			<type>input</type>
-			<size>60</size>
-		</field>
-		<field>
 			<name>Squid Authentication RADIUS Settings</name>
 			<type>listtopic</type>
 		</field>
@@ -261,7 +242,7 @@
 	<custom_php_after_head_command>
 		<![CDATA[
 		$transparent_proxy = ($config['installedpackages']['squid']['config'][0]['transparent_proxy'] == 'on');
-		if ($transparent_proxy and preg_match("/(local|ldap|radius|msnt|ntlm)/", $config['installedpackages']['squidauth']['config'][0]['auth_method'])) {
+		if ($transparent_proxy and preg_match("/(local|ldap|radius|ntlm)/", $config['installedpackages']['squidauth']['config'][0]['auth_method'])) {
 			$input_errors[] = "Authentication cannot be enabled while transparent proxy mode is enabled";
 		}
 		squid_print_javascript_auth();

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid_js.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid_js.inc
@@ -242,7 +242,7 @@ function on_antivirus_advanced_config_changed() {
 
 	}
 
-	if (! $('enable').prop("checked")) {
+	if ($('#enable').prop('checked') == false) {
 		$('#update_av').prop("disabled", true);
 	} else {
 		$('#update_av').prop("disabled", false);

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid_js.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid_js.inc
@@ -44,14 +44,13 @@ function squid_print_javascript_auth() {
 	$auth_method = $settingsauth['auth_method'];
 
 	// No authentication for transparent proxy
-	if ($transparent_proxy and preg_match("/(local|ldap|radius|msnt|ntlm)/", $auth_method)) {
+	if ($transparent_proxy and preg_match("/(local|ldap|radius|ntlm)/", $auth_method)) {
 		$javascript = <<< EOD
 <script type="text/javascript">
 //<![CDATA[
 function on_auth_method_changed() {
 	$('#auth_method').prop("disabled", true);
 	$('#auth_server').prop("disabled", true);
-	$('#auth_ntdomain').prop("disabled", true);
 	$('#auth_server_port').prop("disabled", true);
 	$('#ldap_user').prop("disabled", true);
 	$('#ldap_version').prop("disabled", true);
@@ -60,7 +59,6 @@ function on_auth_method_changed() {
 	$('#ldap_pass').prop("disabled", true);
 	$('#ldap_basedomain').prop("disabled", true);
 	$('#radius_secret').prop("disabled", true);
-	$('#msnt_secondary').prop("disabled", true);
 	$('#auth_prompt').prop("disabled", true);
 	$('#auth_processes').prop("disabled", true);
 	$('#auth_ttl').prop("disabled", true);
@@ -83,7 +81,6 @@ function on_auth_method_changed() {
 	if (auth_method == 'none') {
 		$('#auth_server').prop("disabled", true);
 		$('#auth_server_port').prop("disabled", true);
-		$('#auth_ntdomain').prop("disabled", true);
 		$('#ldap_user').prop("disabled", true);
 		$('#ldap_version').prop("disabled", true);
 		$('#ldap_userattribute').prop("disabled", true);
@@ -91,7 +88,6 @@ function on_auth_method_changed() {
 		$('#ldap_pass').prop("disabled", true);
 		$('#ldap_basedomain').prop("disabled", true);
 		$('#radius_secret').prop("disabled", true);
-		$('#msnt_secondary').prop("disabled", true);
 		$('#auth_prompt').prop("disabled", true);
 		$('#auth_processes').prop("disabled", true);
 		$('#auth_ttl').prop("disabled", true);
@@ -109,7 +105,6 @@ function on_auth_method_changed() {
 	case 'local':
 		$('#auth_server').prop("disabled", true);
 		$('#auth_server_port').prop("disabled", true);
-		$('#auth_ntdomain').prop("disabled", true);
 		$('#ldap_user').prop("disabled", true);
 		$('#ldap_pass').prop("disabled", true);
 		$('#ldap_version').prop("disabled", true);
@@ -117,7 +112,6 @@ function on_auth_method_changed() {
 		$('#ldap_filter').prop("disabled", true);
 		$('#ldap_basedomain').prop("disabled", true);
 		$('#radius_secret').prop("disabled", true);
-		$('#msnt_secondary').prop("disabled", true);
 		break;
 	case 'ldap':
 		$('#auth_server').prop("disabled", false);
@@ -129,8 +123,6 @@ function on_auth_method_changed() {
 		$('#ldap_filter').prop("disabled", false);
 		$('#ldap_basedomain').prop("disabled", false);
 		$('#radius_secret').prop("disabled", true);
-		$('#msnt_secondary').prop("disabled", true);
-		$('#auth_ntdomain').prop("disabled", true);
 		break;
 	case 'radius':
 		$('#auth_server').prop("disabled", false);
@@ -142,26 +134,10 @@ function on_auth_method_changed() {
 		$('#ldap_filter').prop("disabled", true);
 		$('#ldap_basedomain').prop("disabled", true);
 		$('#radius_secret').prop("disabled", false);
-		$('#msnt_secondary').prop("disabled", true);
-		$('#auth_ntdomain').prop("disabled", true);
-		break;
-	case 'msnt':
-		$('#auth_server').prop("disabled", false);
-		$('#auth_server_port').prop("disabled", true);
-		$('#auth_ntdomain').prop("disabled", false);
-		$('#ldap_user').prop("disabled", true);
-		$('#ldap_pass').prop("disabled", true);
-		$('#ldap_version').prop("disabled", true);
-		$('#ldap_userattribute').prop("disabled", true);
-		$('#ldap_filter').prop("disabled", true);
-		$('#ldap_basedomain').prop("disabled", true);
-		$('#radius_secret').prop("disabled", true);
-		$('#msnt_secondary').prop("disabled", false);
 		break;
 	case 'cp':
 		$('#auth_server').prop("disabled", true);
 		$('#auth_server_port').prop("disabled", true);
-		$('#auth_ntdomain').prop("disabled", true);
 		$('#ldap_user').prop("disabled", true);
 		$('#ldap_version').prop("disabled", true);
 		$('#ldap_userattribute').prop("disabled", true);
@@ -169,7 +145,6 @@ function on_auth_method_changed() {
 		$('#ldap_pass').prop("disabled", true);
 		$('#ldap_basedomain').prop("disabled", true);
 		$('#radius_secret').prop("disabled", true);
-		$('#msnt_secondary').prop("disabled", true);
 		$('#auth_prompt').prop("disabled", true);
 		$('#auth_processes').prop("disabled", false);
 		$('#auth_ttl').prop("disabled", false);

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid_reverse.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid_reverse.inc
@@ -3,7 +3,7 @@
  * squid_reverse.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2012 Martin Fuchs
  * Copyright (c) 2012-2014 Marcello Coutinho
  * Copyright (c) 2013-2015 Gekkenhuis
@@ -176,6 +176,10 @@ function squid_resync_reverse() {
 	if (!empty($settings['reverse_ip'])) {
 		$reverse_ip = explode(";", ($settings['reverse_ip']));
 		foreach ($reverse_ip as $reip) {
+			//Take care of IPv6 IP(s) configured in User Defined Reverse Proxy IPs
+			if (is_ipaddrv6($reip)) {
+				$reip = "[{$reip}]";
+			}
 			//HTTP
 			if ((!empty($settings['reverse_http'])) || ($settings['reverse_owa_autodiscover'] == 'on')) {
 				$conf .= "http_port {$reip}:{$http_port} accel defaultsite={$http_defsite} vhost\n";

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid_reverse.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid_reverse.inc
@@ -116,28 +116,30 @@ function squid_resync_reverse() {
 	$sslflags_cache_peer = ($settings['reverse_ignore_ssl_valid'] == "on" ? "sslflags=DONT_VERIFY_PEER" : "");
 
 	// Reverse Proxy HTTPS security settings
-	if (isset($settings["dhparams_size"])) {
-		if ($settings['dhparams_size'] == '2048' && file_exists("/etc/dh-parameters.2048")) {
-			$dhparams = "dhparams=/etc/dh-parameters.2048";
-		} else if ($settings['dhparams_size'] == '4096' && file_exists("/etc/dh-parameters.4096")) {
-			$dhparams = "dhparams=/etc/dh-parameters.4096";
-		}
-	} else if (file_exists("/etc/dh-parameters.2048")) {
-		// Fallback dhparams option
-		$dhparams = "dhparams=/etc/dh-parameters.2048";
+	$options = "NO_SSLv2,NO_SSLv3,CIPHER_SERVER_PREFERENCE";
+	if (!empty($settings['reverse_compatibility_mode']) && ($settings['reverse_compatibility_mode'] == 'modern')) {
+		// Modern
+		$ciphers = "cipher=ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK";
+		$options .= ",NO_TLSv1";
+	} else {
+		// Intermediate
+		$ciphers = "cipher=ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA";
 	}
 
-	// Without DHParams file and settings below squid will not work correct
-	if (isset($dhparams) && !empty($dhparams)) {
-		if ($settings['reverse_compatibility_mode'] == 'modern') {
-			// Modern
-			$ciphers = "cipher=ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK";
-			$options = "options=NO_SSLv2,NO_SSLv3,NO_TLSv1,SINGLE_DH_USE,CIPHER_SERVER_PREFERENCE";
-		} else if ($settings['reverse_compatibility_mode'] == 'intermediate') {
-			// Intermediate
-			$ciphers = "cipher=ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA";
-			$options = "options=NO_SSLv2,NO_SSLv3,SINGLE_DH_USE,CIPHER_SERVER_PREFERENCE";
+	if (!empty($settings['dhparams_size'])) {
+		if ($settings['dhparams_size'] == '4096') {
+			$dhparams = "tls-dh=prime256v1:/etc/dh-parameters.4096";
+		} elseif ($settings['dhparams_size'] == '2048') {
+			$dhparams = "tls-dh=prime256v1:/dh-parameters.2048";
 		}
+		$options .= ",SINGLE_DH_USE,SINGLE_ECDH_USE";
+	} elseif (file_exists("/etc/dh-parameters.2048")) {
+		// Fallback dhparams option
+		$dhparams = "tls-dh=prime256v1:/etc/dh-parameters.2048";
+		$options .= ",SINGLE_DH_USE,SINGLE_ECDH_USE";
+	} else {
+		// Should never get here
+		$dhparams = "";
 	}
 
 	if (!empty($settings['disable_session_reuse'])) {
@@ -147,7 +149,7 @@ function squid_resync_reverse() {
 	
 		// Check or the sslflags for the interface https_port
 		// are already set by reverse_ssl_clientcrl setting
-		if(!empty($sslflags_https_port_iface)) {
+		if (!empty($sslflags_https_port_iface)) {
 			// Append the sslflags
 			$sslflags_https_port_iface .= ",NO_SESSION_REUSE";
 		} else {
@@ -167,7 +169,7 @@ function squid_resync_reverse() {
 			if (!empty($settings['reverse_https'])) {
 				// Squid will fail when the line length exceeds 1024 characters, this can happen because of the long ciphersuite so break the line
 				$conf .= "https_port {$real_ifaces[$i][0]}:{$https_port} accel cert={$reverse_crt} key={$reverse_key} {$clientca_opts} {$sslflags_https_port_iface} {$dhparams} {$ciphers} \\\n";
-				$conf .= " {$options} defaultsite={$https_defsite} vhost\n";
+				$conf .= " options={$options} defaultsite={$https_defsite} vhost\n";
 				$conf .= "\n";
 			}
 		}
@@ -188,7 +190,7 @@ function squid_resync_reverse() {
 			if (!empty($settings['reverse_https'])) {
 				// Squid will fail when the line length exceeds 1024 characters, this can happen because of the long ciphersuite so break the line
 				$conf .= "https_port {$reip}:{$https_port} accel cert={$reverse_crt} key={$reverse_key} {$sslflags_https_port_reverse} {$dhparams} {$ciphers} \\\n";
-				$conf .= " {$options} defaultsite={$https_defsite} vhost\n";
+				$conf .= " options={$options} defaultsite={$https_defsite} vhost\n";
 				$conf .= "\n";
 			}
 		}

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid_reverse_general.xml
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid_reverse_general.xml
@@ -8,7 +8,7 @@
  * squid_reverse_general.xml
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2012-2014 Marcello Coutinho
  * Copyright (c) 2015 Gekkenhuis
  * All rights reserved.
@@ -83,7 +83,8 @@
 			<fieldname>reverse_ip</fieldname>
 			<description>
 				<![CDATA[
-				Squid will additionally bind to these user-defined IPs for reverse proxy operation. Useful for virtual IPs such as CARP.<br/>
+				Squid will additionally bind to these user-defined IPs for reverse proxy operation.<br/>
+				Useful for virtual IPs such as CARP, or for binding to IPv6 configured on an above-selected interface.<br/>
 				Note: Separate entries by semi-colons (;)<br/><br/>
 				<strong><span class="errmsg">Important:</span> Any entry here must be a valid, locally configured IP address.</strong>
 				]]>


### PR DESCRIPTION
1. Remove NT Domain authentication. Dead deprecated junk. This has been broken ever since 2.3 release (https://redmine.pfsense.org/issues/7017) without anyone noticing. Just use LDAP for AD authentication.

2. Added Modern and Intermediate options for cipher suites 

- settings per http://wiki.squid-cache.org/ConfigExamples/Intercept/SslBumpExplicit#Modern_DH.2FEDH_ciphers_usage docs
- modern disables TLS v1.0 as well (matching the behavior of reverse proxy)
- intermediate enables the HIGH cipher suites for compatibility
- add DH key size selection (defaults to 2048 for security)

3. Fixed EDH and EECDH cipher suites usage (Bug #6592)

4. Cosmetics
- Fix "Update AV" button handling
- Remove confusing note about CP patch
- Handle IPv6 IPs in "User Defined Reverse Proxy IPs" properly - requested and tested by a user @ https://forum.pfsense.org/index.php?topic=123077.0 
- Nuked some comments cruft remaining from bootstrap conversion while here.