### PR TITLE
Fixup RRD graphing enabled/disabled message

### DIFF
--- a/sysutils/pfSense-Status_Monitoring/Makefile
+++ b/sysutils/pfSense-Status_Monitoring/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-Status_Monitoring
 PORTVERSION=	1.6.0
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
@@ -66,14 +66,14 @@ function createSlug($string) {
 if($_POST['enable']) {
 	if(($_POST['enable'] === 'false')) {
 		unset($config['rrd']['enable']);
+		$savemsg = "RRD graphing has been disabled.";
 	} else {
 		$config['rrd']['enable'] = true;
+		$savemsg = "RRD graphing has been enabled.";
 	}
 	write_config();
 
-	$retval = 0;
-	$retval = enable_rrd_graphing();
-	$savemsg = get_std_save_message($retval);
+	enable_rrd_graphing();
 }
 
 if ($_POST['ResetRRD']) {


### PR DESCRIPTION
enable_rrd_graphing() does not actually return a status. It "just works".
Better to just give a specific message (enabled or disabled) rather than make an irrelevant attempt to use get_std_save_message()