### PR TITLE
pfSense-pkg-suricata-3.0_12 - bug fixes

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	3.0
-PORTREVISION=	11
+PORTREVISION=	12
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -87,6 +87,9 @@ function suricata_stop($suricatacfg, $if_real) {
 			killbypid("{$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid");
 		}
 	}
+	// Make sure the PID file is actually deleted so Suricata will restart without error
+	unlink_if_exists("{$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid");
+
 	// Stop Barnyard2 on the interface if running
 	suricata_barnyard_stop($suricatacfg, $if_real);
 }

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -236,7 +236,7 @@ $section->addInput(new Form_Input(
 	'Snort VRT Rules Filename',
 	'text',
 	$pconfig['snort_rules_file']
-))->setHelp('Enter the rules tarball filename (filename only, do not include the URL.)<br />Example: snortrules-snapshot-2980.tar.gz');
+))->setHelp('Enter the rules tarball filename (filename only, do not include the URL.)<br />Example: snortrules-snapshot-2990.tar.gz');
 $section->addInput(new Form_Input(
 	'oinkcode',
 	'Snort VRT Oinkmaster Code',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -50,7 +50,7 @@ else {
 	$pconfig['forcekeepsettings'] = $config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] == "on" ? 'on' : 'off';
 	$pconfig['snortcommunityrules'] = $config['installedpackages']['suricata']['config'][0]['snortcommunityrules'] == "on" ? 'on' : 'off';
 	$pconfig['snort_rules_file'] = $config['installedpackages']['suricata']['config'][0]['snort_rules_file'];
-	$pconfig['autogeoipupdate'] = $config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] == "on" ? 'on' : 'off';
+	$pconfig['autogeoipupdate'] = $config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] == "off" ? 'off' : 'on';
 	$pconfig['hide_deprecated_rules'] = $config['installedpackages']['suricata']['config'][0]['hide_deprecated_rules'] == "on" ? 'on' : 'off';
 }
 


### PR DESCRIPTION
This update corrects a couple of minor bugs noticed with the Suricata package on pfSense 2.4-BETA. These fixes are compatible with the Suricata package on pfSense 2.3.x as well.

**Bug Fixes:**

1.  The auto-update of the GeoIP database should default to enabled on the GLOBAL SETTINGS tab. On a fresh install when the underlying parameter is empty (non-existent) in the _config.xml_ file, the checkbox on this tab remains unchecked (or off) when it should show checked (or on).

2.  When restarting Suricata using the icon on the INTERFACES tab, Suricata will stop but may fail to restart due to the presence of a PID file in _/var/run_. When stopping Suricata, ensure the PID file for the interface is removed if it still exists in _/var/run_ after Suricata is stopped.