### PR TITLE
Add breadcrumb links for system_patches_edit

### DIFF
--- a/sysutils/pfSense-pkg-System_Patches/Makefile
+++ b/sysutils/pfSense-pkg-System_Patches/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-System_Patches
 PORTVERSION=	1.1.5
+PORTREVISION=	1
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-System_Patches/files/usr/local/www/system_patches_edit.php
+++ b/sysutils/pfSense-pkg-System_Patches/files/usr/local/www/system_patches_edit.php
@@ -142,6 +142,7 @@ if ($_POST) {
 
 $closehead = false;
 $pgtitle = array(gettext("System"),gettext("Patches"), gettext("Edit"));
+$pglinks = array("", "system_patches.php", "@self");
 include("head.inc");
 
 if ($input_errors) {


### PR DESCRIPTION
Note: this code is happily backward-compatible with pfSense base versions that do not have breadcrumb links code - $pglinks is never used in those versions, so will sit and happily do nothing.