### PR TITLE
Squid - improve ClamAV DB updates cronjob handling

### DIFF
--- a/www/pfSense-pkg-squid/Makefile
+++ b/www/pfSense-pkg-squid/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-squid
-PORTVERSION=	0.4.32
+PORTVERSION=	0.4.33
 CATEGORIES=	www
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid_antivirus.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid_antivirus.inc
@@ -77,8 +77,10 @@ function squid_install_freshclam_cron($should_install) {
 		}
 		if ($antivirus_config['clamav_update'] != "") {
 			log_error("[squid] Adding freshclam cronjob.");
+			// Randomize minutes to mitigate mirrors overload issues
+			$minutes = rand(0,59);
 			$hours = $antivirus_config['clamav_update'];
-			install_cron_job("{$freshclam_cmd}", true, "*", "*/{$hours}", "*", "*", "*", "clamav");
+			install_cron_job("{$freshclam_cmd}", true, "{$minutes}", "*/{$hours}", "*", "*", "*", "clamav");
 		} else {
 			log_error("[squid] Removing freshclam cronjob.");
 			install_cron_job("{$freshclam_cmd}", false);

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid_antivirus.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid_antivirus.inc
@@ -77,8 +77,8 @@ function squid_install_freshclam_cron($should_install) {
 		}
 		if ($antivirus_config['clamav_update'] != "") {
 			log_error("[squid] Adding freshclam cronjob.");
-			$minutes = ($antivirus_config['clamav_update'] * 60);
-			install_cron_job("{$freshclam_cmd}", true, "*/{$minutes}", "*", "*", "*", "*", "clamav");
+			$hours = $antivirus_config['clamav_update'];
+			install_cron_job("{$freshclam_cmd}", true, "*", "*/{$hours}", "*", "*", "*", "clamav");
 		} else {
 			log_error("[squid] Removing freshclam cronjob.");
 			install_cron_job("{$freshclam_cmd}", false);


### PR DESCRIPTION
Make the minutes random (avoids some mirrors overload issues) and the update frequency more obvious.