### PR TITLE
pfSense-pkg-suricata-3.1.2 - Update for bug fixes and new features

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	3.0
-PORTREVISION=	12
+PORTVERSION=	3.1.2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -1328,7 +1328,8 @@ function suricata_load_rules_map($rules_path) {
 	 *                   0 if not auto-managed 
 	 *   state_toggled = 1 if rule was toggled by SID MGMT process,
 	 *                   0 if not toggled
-	 *   modified      = 1 if rule action or content is modified by SID MGMT process,
+	 *   modified      = 1 if rule action or content is modified by SID MGMT or
+	 *                     IPS Poliocy process,
 	 *                   0 if not modified
 	 *   flowbits      = Array of applicable flowbits if rule contains 
 	 *                   flowbits options
@@ -1786,16 +1787,22 @@ function suricata_write_flowbit_rules_file($flowbit_rules, $rule_file) {
 	}
 }
 
-function suricata_load_vrt_policy($policy, $all_rules=null) {
+function suricata_load_vrt_policy($policy, $mode='alert', $all_rules=null) {
 
 	/************************************************/
 	/* This function returns an array of all rules  */
 	/* marked with the passed in $policy metadata.  */
 	/*                                              */
 	/*    $policy --> desired VRT security policy   */
-	/*                  1.  connectivity            */
-	/*                  2.  balanced                */
-	/*                  3.  security                */
+	/*                  1. connectivity             */
+	/*                  2. balanced                 */
+	/*                  3. security                 */
+	/*                                              */
+	/*      $mode --> determines rule action        */
+	/*                  1. alert = all rule alert   */
+	/*                  2. policy = rule action     */
+	/*                              set according   */
+	/*                              policy spec.    */
 	/*                                              */
 	/* $all_rules --> optional Rules Map array of   */
 	/*                rules to scan for policy.     */
@@ -1834,6 +1841,19 @@ function suricata_load_vrt_policy($policy, $all_rules=null) {
 					if ($arulem2['disabled'] == 1) {
 						$vrt_policy_rules[$k1][$k2]['rule'] = ltrim(substr($arulem2['rule'], strpos($arulem2['rule'], "#") + 1));
 						$vrt_policy_rules[$k1][$k2]['disabled'] = 0;
+					}
+
+					// If policy mode is enabled, grab the suggested action
+					// for this policy and set it as the rule action.
+					if ($mode == 'policy') {
+						$matches = array();
+						if (preg_match('/' . "policy {$policy}-ips" . '([^,|^;]*)/', $arulem2['rule'], $matches)) {
+							if ($tmp = preg_replace('/^\s*alert\s/', trim($matches[1]) . ' ', $vrt_policy_rules[$k1][$k2]['rule'], 1)) {
+								$vrt_policy_rules[$k1][$k2]['rule'] = $tmp;
+								$vrt_policy_rules[$k1][$k2]['action'] = $matches[1];
+								$vrt_policy_rules[$k1][$k2]['modified'] = 1;
+							}
+						}
 					}
 				}
 			}
@@ -2389,7 +2409,7 @@ function suricata_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results 
 					$modcount++;
 				}
 				elseif ($action == 'drop' && $rule_map[$k1][$k2]['action'] != 'drop') {
-					if ($tmp = preg_replace('/alert/', 'drop', $rule_map[$k1][$k2]['rule'], 1)) {
+					if ($tmp = preg_replace('/\s*alert\s*/', 'drop ', $rule_map[$k1][$k2]['rule'], 1)) {
 						$rule_map[$k1][$k2]['rule'] = $tmp;
 						$rule_map[$k1][$k2]['action'] = 'drop';
 						$rule_map[$k1][$k2]['managed'] = 1;
@@ -3009,8 +3029,8 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 
 		// Check if a pre-defined Snort VRT policy is selected. If so,
 		// add all the VRT policy rules to our enforcing rule set.
-		if (!empty($suricatacfg['ips_policy'])) {
-			$policy_rules = suricata_load_vrt_policy($suricatacfg['ips_policy'], $all_rules);
+		if ($suricatacfg['ips_policy_enable'] == 'on' && !empty($suricatacfg['ips_policy'])) {
+			$policy_rules = suricata_load_vrt_policy($suricatacfg['ips_policy'], $suricatacfg['ips_policy_mode'], $all_rules);
 			foreach ($policy_rules as $k1 => $policy) {
 				foreach ($policy as $k2 => $p) {
 					if (!is_array($enabled_rules[$k1])) {
@@ -3019,10 +3039,12 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 					if (!is_array($enabled_rules[$k1][$k2])) {
 						$enabled_rules[$k1][$k2] = array();
 					}
-					$enabled_rules[$k1][$k2]['rule'] = $p['rule'];
 					$enabled_rules[$k1][$k2]['category'] = $p['category'];
 					$enabled_rules[$k1][$k2]['disabled'] = $p['disabled'];
 					$enabled_rules[$k1][$k2]['flowbits'] = $p['flowbits'];
+					$enabled_rules[$k1][$k2]['rule'] = $p['rule'];
+					$enabled_rules[$k1][$k2]['action'] = $p['action'];
+					$enabled_rules[$k1][$k2]['modified'] = $p['modified'];
 				}
 			}
 			unset($policy_rules, $policy, $p);

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -838,6 +838,11 @@ function sync_suricata_package_config() {
 	$suricatadir = SURICATADIR;
 	$rcdir = RCFILEPREFIX;
 
+	/* Create required log and db directories in /var on each sync, in case /var is in RAM. */
+	safe_mkdir(SURICATALOGDIR);
+	safe_mkdir(SURICATA_IPREP_PATH);
+	safe_mkdir(SURICATA_SID_MODS_PATH);
+
 	// Do not start config build if there are no Suricata-configured interfaces
 	if (!is_array($config['installedpackages']['suricata']['rule']) || count($config['installedpackages']['suricata']['rule']) < 1) {
 		return;

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -1855,7 +1855,7 @@ function suricata_load_vrt_policy($policy, $mode='alert', $all_rules=null) {
 						if (preg_match('/' . "policy {$policy}-ips" . '([^,|^;]*)/', $arulem2['rule'], $matches)) {
 							if ($tmp = preg_replace('/^\s*alert\s/', trim($matches[1]) . ' ', $vrt_policy_rules[$k1][$k2]['rule'], 1)) {
 								$vrt_policy_rules[$k1][$k2]['rule'] = $tmp;
-								$vrt_policy_rules[$k1][$k2]['action'] = $matches[1];
+								$vrt_policy_rules[$k1][$k2]['action'] = trim($matches[1]);
 								$vrt_policy_rules[$k1][$k2]['modified'] = 1;
 							}
 						}
@@ -2924,6 +2924,67 @@ function suricata_modify_sids(&$rule_map, $suricatacfg) {
 	unset($enablesid, $disablesid);
 }
 
+function suricata_modify_sids_action(&$rule_map, $suricatacfg) {
+
+	/***********************************************/
+	/* This function modifies the rules in the     */
+	/* passed rules_map array based on values in   */
+	/* the alertsid/dropsid configuration          */
+	/* parameters for the interface.               */
+	/*                                             */
+	/*  $rule_map = array of current rules         */
+	/*  $suricatacfg = interface config settings   */
+	/***********************************************/
+
+	if (!isset($suricatacfg['rule_sid_force_alert']) && 
+	    !isset($suricatacfg['rule_sid_force_drop'])) {
+		return;
+	}
+
+	/* Load up our alertsid and dropsid arrays with manually changed SID actions */
+	$alertsid = suricata_load_sid_mods($suricatacfg['rule_sid_force_alert']);
+	$dropsid = suricata_load_sid_mods($suricatacfg['rule_sid_force_drop']);
+
+	/* Change action for any rules that need to be */
+	/* forced to "alert" with alertsid mods.       */
+	if (!empty($alertsid)) {
+		foreach ($rule_map as $k1 => $rulem) {
+			foreach ($rulem as $k2 => $v) {
+				if (isset($alertsid[$k1][$k2]) && $v['action'] != 'alert') {
+					$matches = array();
+					if (preg_match('/^\s*#*\s*(drop|pass|reject)/i', $v['rule'], $matches)) {
+						$txt_regx = '/^\s*' . "{$matches[1]}" . '\s/';
+						if ($tmp = preg_replace($txt_regx, 'alert ', $v['rule'], 1)) {
+							$rule_map[$k1][$k2]['rule'] = $tmp;
+							$rule_map[$k1][$k2]['action'] = 'alert';
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/* Change action for any rules that need to be */
+	/* forced to "drop" with dropsid mods.         */
+	if (!empty($dropsid)) {
+		foreach ($rule_map as $k1 => $rulem) {
+			foreach ($rulem as $k2 => $v) {
+				if (isset($dropsid[$k1][$k2]) && $v['action'] != 'drop') {
+					$matches = array();
+					if (preg_match('/^\s*#*\s*(alert|pass|reject)/i', $v['rule'], $matches)) {
+						$txt_regx = '/^\s*' . "{$matches[1]}" . '\s/';
+						if ($tmp = preg_replace($txt_regx, 'drop ', $v['rule'], 1)) {
+							$rule_map[$k1][$k2]['rule'] = $tmp;
+							$rule_map[$k1][$k2]['action'] = 'drop';
+						}
+					}
+				}
+			}
+		}
+	}
+	unset($alertsid, $dropsid);
+}
+
 function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 
 	/***********************************************************/
@@ -3055,10 +3116,11 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 			unset($policy_rules, $policy, $p);
 		}
 
-		// Process any enablesid or disablesid modifications for the selected rules.
+		// Process any enablesid, disablesid, alertsid or dropsid modifications for the selected rules.
 		// Do the auto-SID managment first, if enabled, then do any manual SID state changes.
 		suricata_auto_sid_mgmt($enabled_rules, $suricatacfg, TRUE);
 		suricata_modify_sids($enabled_rules, $suricatacfg);
+		suricata_modify_sids_action($enabled_rules, $suricatacfg);
 
 		// Write the enforcing rules file to the Suricata interface's "rules" directory.
 		suricata_write_enforcing_rules_file($enabled_rules, "{$suricatacfgdir}/rules/{$suricata_enforcing_rules_file}");
@@ -3086,9 +3148,11 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 
 		suricata_auto_sid_mgmt($enabled_rules, $suricatacfg, TRUE);
 		if (!empty($enabled_rules)) {
-			// Auto-SID management generated some rules, so use them
+			// Auto-SID management generated some rules, so use them but
+			// apply any user-specified overrides for state or action.
 			$no_rules_defined = false;
 			suricata_modify_sids($enabled_rules, $suricatacfg);
+			suricata_modify_sids_action($enabled_rules, $suricatacfg);
 
 			// Write the enforcing rules file to the Suricata interface's "rules" directory.
 			suricata_write_enforcing_rules_file($enabled_rules, "{$suricatacfgdir}/rules/{$suricata_enforcing_rules_file}");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -240,6 +240,11 @@ if ($suricatacfg['enable_tls_log'] == 'on')
 else
 	$tls_log_enabled = "no";
 
+if ($suricatacfg['enable_tls_store'] == 'on')
+	$tls_store_enabled = "yes";
+else
+	$tls_store_enabled = "no";
+
 if ($suricatacfg['tls_log_extended'] == 'on')
 	$tls_log_extended = "yes";
 else

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -74,6 +74,9 @@ outputs:
       enabled: {$tls_log_enabled}
       filename: tls.log
       extended: {$tls_log_extended}
+
+  - tls-store:
+      enabled: {$tls_store_enabled}
       certs-log-dir: certs
 
   - stats:

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -508,7 +508,7 @@ $group->add(new Form_Checkbox(
 	'arefresh',
 	null,
 	'Refresh',
-	($config['installedpackages']['suricata']['alertsblocks']['arefresh'] == "on"),
+	$pconfig['arefresh'] == 'on' ? true:false,
 	'on'
 ))->setHelp('Default is ON');
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -641,10 +641,10 @@ $group->add(new Form_Button(
 	'filterlogentries_clear',
 	'Clear',
 	null,
-	'fa-trash'
+	'fa-trash-o'
 ))->setHelp("Remove all filters")
   ->removeclass("btn-primary")
-  ->addClass("btn-danger");
+  ->addClass("btn-danger no-confirm");
 
 $section->add($group);
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -265,6 +265,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['enable_http_log'] == "on") { $natent['enable_http_log'] = 'on'; }else{ $natent['enable_http_log'] = 'off'; }
 		if ($_POST['append_http_log'] == "on") { $natent['append_http_log'] = 'on'; }else{ $natent['append_http_log'] = 'off'; }
 		if ($_POST['enable_tls_log'] == "on") { $natent['enable_tls_log'] = 'on'; }else{ $natent['enable_tls_log'] = 'off'; }
+		if ($_POST['enable_tls_store'] == "on") { $natent['enable_tls_store'] = 'on'; }else{ $natent['enable_tls_store'] = 'off'; }
 		if ($_POST['http_log_extended'] == "on") { $natent['http_log_extended'] = 'on'; }else{ $natent['http_log_extended'] = 'off'; }
 		if ($_POST['tls_log_extended'] == "on") { $natent['tls_log_extended'] = 'on'; }else{ $natent['tls_log_extended'] = 'off'; }
 		if ($_POST['enable_pcap_log'] == "on") { $natent['enable_pcap_log'] = 'on'; }else{ $natent['enable_pcap_log'] = 'off'; }
@@ -628,6 +629,13 @@ $section->addInput(new Form_Checkbox(
 	'Enable TLS Log',
 	'Suricata will log TLS handshake traffic for the interface. Default is Not Checked.',
 	$pconfig['enable_tls_log'] == 'on' ? true:false,
+	'on'
+));
+$section->addInput(new Form_Checkbox(
+	'enable_tls_store',
+	'Enable TLS Store',
+	'Suricata will log and store TLS certificates for the interface. Default is Not Checked.',
+	$pconfig['enable_tls_store'] == 'on' ? true:false,
 	'on'
 ));
 
@@ -1091,6 +1099,7 @@ events.push(function(){
 
 	function toggle_tls_log() {
 		var hide = ! $('#enable_tls_log').prop('checked');
+		hideCheckbox('enable_tls_store', hide);
 		hideCheckbox('tls_log_extended', hide);
 	}
 
@@ -1153,6 +1162,7 @@ events.push(function(){
 		disableInput('append_http_log', disable);
 		disableInput('http_log_extended', disable);
 		disableInput('enable_tls_log', disable);
+		disableInput('enable_tls_store', disable);
 		disableInput('tls_log_extended', disable);
 		disableInput('enable_json_file_log', disable);
 		disableInput('append_json_file_log', disable);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1063,7 +1063,6 @@ events.push(function(){
 		if ($('#ips_mode').val() == 'ips_mode_inline') {
 			hideCheckbox('blockoffenderskill', true);
 			hideSelect('blockoffendersip', true);
-			hideClass('passlist', true);
 		}
 	}
 
@@ -1262,7 +1261,6 @@ events.push(function(){
 		if ($('#ips_mode').val() == 'ips_mode_inline') {
 			hideCheckbox('blockoffenderskill', true);
 			hideSelect('blockoffendersip', true);
-			hideClass('passlist', true);
 		}
 		else {
 			hideCheckbox('blockoffenderskill', false);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_mgmt.php
@@ -33,7 +33,7 @@ $suricatadir = SURICATADIR;
 $pconfig = array();
 
 // Grab saved settings from configuration
-$pconfig['enable_log_mgmt'] = $config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 'on' ? 'on' : 'off';
+$pconfig['enable_log_mgmt'] = $config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 'off' ? 'off' : 'on';
 $pconfig['clearlogs'] = $config['installedpackages']['suricata']['config'][0]['clearlogs'] == 'on' ? 'on' : 'off';
 $pconfig['suricataloglimit'] = $config['installedpackages']['suricata']['config'][0]['suricataloglimit'] == 'on' ? 'on' : 'off';
 $pconfig['suricataloglimitsize'] = $config['installedpackages']['suricata']['config'][0]['suricataloglimitsize'];

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -140,15 +140,19 @@ $rulefile = "{$ruledir}/{$currentruleset}";
 if ($currentruleset != 'custom.rules') {
 	// Read the current rules file into our rules map array.
 	// If it is the auto-flowbits file, set the full path.
-	if ($currentruleset == "Auto-Flowbit Rules")
+	if ($currentruleset == "Auto-Flowbit Rules") {
 		$rulefile = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
+	}
 	// Test for the special case of an IPS Policy file.
-	if (substr($currentruleset, 0, 10) == "IPS Policy")
-		$rules_map = suricata_load_vrt_policy($a_rule[$id]['ips_policy']);
-	elseif (!file_exists($rulefile))
+	if (substr($currentruleset, 0, 10) == "IPS Policy") {
+		$rules_map = suricata_load_vrt_policy($a_rule[$id]['ips_policy'], $a_rule[$id]['ips_policy_mode']);
+	}
+	elseif (!file_exists($rulefile)) {
 		$input_errors[] = gettext("{$currentruleset} seems to be missing!!! Please verify rules files have been downloaded, then go to the Categories tab and save the rule set again.");
-	else
+	}
+	else {
 		$rules_map = suricata_load_rules_map($rulefile);
+	}
 }
 
 /* Process the current category rules through any auto SID MGMT changes if enabled */

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -144,7 +144,7 @@ if ($currentruleset != 'custom.rules') {
 		$rulefile = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
 	}
 	// Test for the special case of an IPS Policy file.
-	if (substr($currentruleset, 0, 10) == "IPS Policy") {
+	elseif (substr($currentruleset, 0, 10) == "IPS Policy") {
 		$rules_map = suricata_load_vrt_policy($a_rule[$id]['ips_policy'], $a_rule[$id]['ips_policy_mode']);
 	}
 	elseif (!file_exists($rulefile)) {
@@ -161,6 +161,12 @@ suricata_auto_sid_mgmt($rules_map, $a_rule[$id], FALSE);
 /* Load up our enablesid and disablesid arrays with manually enabled or disabled SIDs */
 $enablesid = suricata_load_sid_mods($a_rule[$id]['rule_sid_on']);
 $disablesid = suricata_load_sid_mods($a_rule[$id]['rule_sid_off']);
+suricata_modify_sids($rules_map, $a_rule[$id]);
+
+/* Load up our alertsid and dropsid arrays with manually changed SID actions */
+$alertsid = suricata_load_sid_mods($a_rule[$id]['rule_sid_force_alert']);
+$dropsid = suricata_load_sid_mods($a_rule[$id]['rule_sid_force_drop']);
+suricata_modify_sids_action($rules_map, $a_rule[$id]);
 
 /* Process AJAX request to view content of a specific rule */
 if ($_POST['action'] == 'loadRule') {
@@ -175,7 +181,7 @@ if ($_POST['action'] == 'loadRule') {
 	exit;
 }
 
-if (isset($_POST['toggle']) && is_numeric($_POST['sid']) && is_numeric($_POST['gid']) && !empty($rules_map)) {
+if (isset($_POST['toggle_state']) && is_numeric($_POST['sid']) && is_numeric($_POST['gid']) && !empty($rules_map)) {
 
 	// Get the GID:SID tags embedded in the clicked rule icon.
 	$gid = $_POST['gid'];
@@ -230,11 +236,76 @@ if (isset($_POST['toggle']) && is_numeric($_POST['sid']) && is_numeric($_POST['g
 	// We changed a rule state, remind user to apply the changes
 	mark_subsystem_dirty('suricata_rules');
 
+	// Update our in-memory rules map with the changes just saved
+	// to the Suricata configuration file.
+	suricata_modify_sids($rules_map, $a_rule[$id]);
+
+	// Set a scroll-to anchor location
+	$anchor = "rule_{$gid}_{$sid}";
+}
+elseif (isset($_POST['toggle_action']) && is_numeric($_POST['sid']) && is_numeric($_POST['gid']) && !empty($rules_map)) {
+
+	// Get the GID:SID tags embedded in the clicked rule icon.
+	$gid = $_POST['gid'];
+	$sid = $_POST['sid'];
+
+	// See if the target SID is in our list of modified SIDs,
+	// and toggle it to opposite action if present; otherwise,
+	// add it to the appropriate modified SID list.
+	if (isset($alertsid[$gid][$sid])) {
+		unset($alertsid[$gid][$sid]);
+		$dropsid[$gid][$sid] = "dropsid";
+	}
+	elseif (isset($dropsid[$gid][$sid])) {
+		unset($dropsid[$gid][$sid]);
+		$alertsid[$gid][$sid] = "alertsid";
+	}
+	else {
+		if ($rules_map[$gid][$sid]['action'] == 'drop')
+			$alertsid[$gid][$sid] = "alertsid";
+		else
+			$dropsid[$gid][$sid] = "dropsid";
+	}
+
+	// Write the updated alertsid and dropsid values to the config file.
+	$tmp = "";
+	foreach (array_keys($alertsid) as $k1) {
+		foreach (array_keys($alertsid[$k1]) as $k2)
+			$tmp .= "{$k1}:{$k2}||";
+	}
+	$tmp = rtrim($tmp, "||");
+
+	if (!empty($tmp))
+		$a_rule[$id]['rule_sid_force_alert'] = $tmp;
+	else
+		unset($a_rule[$id]['rule_sid_force_alert']);
+
+	$tmp = "";
+	foreach (array_keys($dropsid) as $k1) {
+		foreach (array_keys($dropsid[$k1]) as $k2)
+			$tmp .= "{$k1}:{$k2}||";
+	}
+	$tmp = rtrim($tmp, "||");
+
+	if (!empty($tmp))
+		$a_rule[$id]['rule_sid_force_drop'] = $tmp;
+	else
+		unset($a_rule[$id]['rule_sid_force_drop']);
+
+	/* Update the config.xml file. */
+	write_config("Suricata pkg: modified action for rule {$gid}:{$sid} on {$a_rule[$id]['interface']}.");
+
+	// We changed a rule action, remind user to apply the changes
+	mark_subsystem_dirty('suricata_rules');
+
+	// Update our in-memory rules map with the changes just saved
+	// to the Suricata configuration file.
+	suricata_modify_sids_action($rules_map, $a_rule[$id]);
+
 	// Set a scroll-to anchor location
 	$anchor = "rule_{$gid}_{$sid}";
 }
 elseif (isset($_POST['disable_all']) && !empty($rules_map)) {
-
 	// Mark all rules in the currently selected category "disabled".
 	foreach (array_keys($rules_map) as $k1) {
 		foreach (array_keys($rules_map[$k1]) as $k2) {
@@ -273,6 +344,10 @@ elseif (isset($_POST['disable_all']) && !empty($rules_map)) {
 	mark_subsystem_dirty('suricata_rules');
 
 	write_config("Suricata pkg: disabled all rules in category {$currentruleset} for {$a_rule[$id]['interface']}.");
+
+	// Update our in-memory rules map with the changes just saved
+	// to the Suricata configuration file.
+	suricata_modify_sids($rules_map, $a_rule[$id]);
 }
 elseif (isset($_POST['enable_all']) && !empty($rules_map)) {
 
@@ -313,6 +388,10 @@ elseif (isset($_POST['enable_all']) && !empty($rules_map)) {
 	mark_subsystem_dirty('suricata_rules');
 
 	write_config("Suricata pkg: enable all rules in category {$currentruleset} for {$a_rule[$id]['interface']}.");
+
+	// Update our in-memory rules map with the changes just saved
+	// to the Suricata configuration file.
+	suricata_modify_sids($rules_map, $a_rule[$id]);
 }
 elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 
@@ -323,6 +402,10 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 				unset($enablesid[$k1][$k2]);
 			if (isset($disablesid[$k1][$k2]))
 				unset($disablesid[$k1][$k2]);
+			if (isset($alertsid[$k1][$k2]))
+				unset($alertsid[$k1][$k2]);
+			if (isset($dropsid[$k1][$k2]))
+				unset($dropsid[$k1][$k2]);
 		}
 	}
 
@@ -351,22 +434,75 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 	else
 		unset($a_rule[$id]['rule_sid_off']);
 
-	// We changed a rule state, remind user to apply the changes
+	// Write the updated alertsid and dropsid values to the config file.
+	$tmp = "";
+	foreach (array_keys($alertsid) as $k1) {
+		foreach (array_keys($alertsid[$k1]) as $k2)
+			$tmp .= "{$k1}:{$k2}||";
+	}
+	$tmp = rtrim($tmp, "||");
+
+	if (!empty($tmp))
+		$a_rule[$id]['rule_sid_force_alert'] = $tmp;
+	else
+		unset($a_rule[$id]['rule_sid_force_alert']);
+
+	$tmp = "";
+	foreach (array_keys($dropsid) as $k1) {
+		foreach (array_keys($dropsid[$k1]) as $k2)
+			$tmp .= "{$k1}:{$k2}||";
+	}
+	$tmp = rtrim($tmp, "||");
+
+	if (!empty($tmp))
+		$a_rule[$id]['rule_sid_force_drop'] = $tmp;
+	else
+		unset($a_rule[$id]['rule_sid_force_drop']);
+
+	// We changed a rule state or action, remind user to apply the changes
 	mark_subsystem_dirty('suricata_rules');
 
-	write_config("Suricata pkg: remove enablesid/disablesid changes for category {$currentruleset} on {$a_rule[$id]['interface']}.");
+	write_config("Suricata pkg: remove rule state/action changes for category {$currentruleset} on {$a_rule[$id]['interface']}.");
+
+	// Reload the rules so we can accurately show content after
+	// resetting any user overrides.
+	if ($currentruleset == "Auto-Flowbit Rules") {
+		$rulefile = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
+	}
+	// Test for the special case of an IPS Policy file.
+	elseif (substr($currentruleset, 0, 10) == "IPS Policy") {
+		$rules_map = suricata_load_vrt_policy($a_rule[$id]['ips_policy'], $a_rule[$id]['ips_policy_mode']);
+	}
+	else {
+		$rules_map = suricata_load_rules_map($rulefile);
+	}
 }
 elseif (isset($_POST['resetall']) && !empty($rules_map)) {
 
 	// Remove all modified SIDs from config.xml and save the changes.
 	unset($a_rule[$id]['rule_sid_on']);
 	unset($a_rule[$id]['rule_sid_off']);
+	unset($a_rule[$id]['rule_sid_force_alert']);
+	unset($a_rule[$id]['rule_sid_force_drop']);
 
-	// We changed a rule state, remind user to apply the changes
+	// We changed a rule state or action, remind user to apply the changes
 	mark_subsystem_dirty('suricata_rules');
 
 	/* Update the config.xml file. */
-	write_config("Suricata pkg: remove all enablesid/disablesid changes for {$a_rule[$id]['interface']}.");
+	write_config("Suricata pkg: remove all rule state/action changes for {$a_rule[$id]['interface']}.");
+
+	// Reload the rules so we can accurately show content after
+	// resetting any user overrides.
+	if ($currentruleset == "Auto-Flowbit Rules") {
+		$rulefile = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
+	}
+	// Test for the special case of an IPS Policy file.
+	elseif (substr($currentruleset, 0, 10) == "IPS Policy") {
+		$rules_map = suricata_load_vrt_policy($a_rule[$id]['ips_policy'], $a_rule[$id]['ips_policy_mode']);
+	}
+	else {
+		$rules_map = suricata_load_rules_map($rulefile);
+	}
 }
 elseif (isset($_POST['clear'])) {
 	unset($a_rule[$id]['customrules']);
@@ -474,17 +610,9 @@ function build_cat_list() {
 $if_friendly = convert_friendly_interface_to_friendly_descr($pconfig['interface']);
 $pgtitle = array(gettext("Suricata"), gettext("Interface ") . $if_friendly, gettext("Rules: ") . $currentruleset);
 include_once("head.inc");
-?>
 
-<form action="/suricata/suricata_rules.php" method="post" enctype="multipart/form-data" class="form-horizontal" name="iform" id="iform">
-<input type='hidden' name='id' id='id' value='<?=$id;?>'/>
-<input type='hidden' name='openruleset' id='openruleset' value='<?=$currentruleset;?>'/>
-<input type='hidden' name='sid' id='sid' value=''/>
-<input type='hidden' name='gid' id='gid' value=''/>
-
-<?php
 if (is_subsystem_dirty('suricata_rules')) {
-	print_apply_box(gettext("A change has been made to a rule state.") . "<br/>" . gettext("Click APPLY when finished to send the changes to the running configuration."));
+	print_apply_box(gettext("A change has been made to a rule state or action.") . "<br/>" . gettext("Click APPLY when finished to send the changes to the running configuration."));
 }
 
 if ($input_errors) {
@@ -495,6 +623,15 @@ if ($savemsg) {
 	print_info_box($savemsg);
 }
 
+?>
+
+<form action="/suricata/suricata_rules.php" method="post" enctype="multipart/form-data" class="form-horizontal" name="iform" id="iform">
+<input type='hidden' name='id' id='id' value='<?=$id;?>'/>
+<input type='hidden' name='openruleset' id='openruleset' value='<?=$currentruleset;?>'/>
+<input type='hidden' name='sid' id='sid' value=''/>
+<input type='hidden' name='gid' id='gid' value=''/>
+
+<?php
 $tab_array = array();
 $tab_array[] = array(gettext("Interfaces"), true, "/suricata/suricata_interfaces.php");
 $tab_array[] = array(gettext("Global Settings"), false, "/suricata/suricata_global.php");
@@ -603,10 +740,10 @@ if ($currentruleset == 'Auto-Flowbit Rules') {
 	$msg = '<b>' . gettext('Note: ') . '</b>' . gettext('You should not disable flowbit rules!  Add Suppress List entries for them instead by ');
 	$msg .= '<a href="/suricata/suricata_rules_flowbits.php?id=' . $id . '" title="' . gettext('Add Suppress List entry for Flowbit Rule') . '">';
 	$msg .= gettext('clicking here.') . '</a>';
-	$group->setHelp('When finished, click APPLY to save and send any SID enable/disable changes made on this tab to Suricata.<br/>' . $msg);
+	$group->setHelp('When finished, click APPLY to save and send any SID state/action changes made on this tab to Suricata.<br/>' . $msg);
 }
 else {
-	$group->setHelp('When finished, click APPLY to save and send any SID enable/disable changes made on this tab to Suricata.');
+	$group->setHelp('When finished, click APPLY to save and send any SID state/action changes made on this tab to Suricata.');
 }
 $section->add($group);
 print($section);
@@ -667,6 +804,7 @@ print($section);
 						<td style="padding-left: 8px;"><i class="fa fa-check-circle-o text-success"></i></td><td style="padding-left: 4px;"><small><?=gettext('Default Enabled');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-check-circle text-success"></i></td><td style="padding-left: 4px;"><small><?=gettext('Enabled by user');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-adn text-success"></i></td><td style="padding-left: 4px;"><small><?=gettext('Auto-enabled by SID Mgmt');?></small></td>
+						<td style="padding-left: 8px;"><i class="fa fa-exclamation-triangle text-warning"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is alert');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-adn text-warning"></i></td><td style="padding-left: 4px;"><small><?=gettext('Action and/or content modified by SID Mgmt');?></small></td>
 					</tr>
 					<tr>
@@ -674,7 +812,8 @@ print($section);
 						<td style="padding-left: 8px;"><i class="fa fa-times-circle-o text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Default Disabled');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-times-circle text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Disabled by user');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-adn text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Auto-disabled by SID Mgmt');?></small></td>
-						<td></td>
+						<td style="padding-left: 8px;"><i class="fa fa-thumbs-down text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is drop');?></small></td>
+						<td></td><td></td>
 					</tr>
 				</tbody>
 			</table>
@@ -682,6 +821,7 @@ print($section);
 
 		<table  style="table-layout: fixed; width: 100%;" class="table table-striped table-hover table-condensed">
 			<colgroup>
+				<col width="5%">
 				<col width="5%">
 				<col width="4%">
 				<col width="9%">
@@ -695,6 +835,7 @@ print($section);
 			<thead>
 			   <tr>
 				<th><?=gettext("State");?></th>
+				<th><?=gettext("Action");?></th>
 				<th><?=gettext("GID");?></th>
 				<th><?=gettext("SID");?></th>
 				<th><?=gettext("Proto");?></th>
@@ -758,6 +899,7 @@ print($section);
 								$iconb_class = 'class="fa fa-check-circle text-success text-left"';
 								$title = gettext("Enabled by user. Click to toggle to disabled state");
 							}
+
 							// These last two checks handle normal cases of default-enabled or default disabled rules
 							// with no user overrides.
 							elseif (($v['disabled'] == 1) && ($v['state_toggled'] == 0) && (!isset($enablesid[$gid][$sid]))) {
@@ -772,6 +914,18 @@ print($section);
 								$enable_cnt++;
 								$iconb_class = 'class="fa fa-check-circle-o text-success text-left"';
 								$title = gettext("Enabled by default. Click to toggle to disabled state");
+							}
+
+							// Determine which icon to display in the second column for rule action
+							if ($v['action'] == 'drop') {
+								$textss = $textse = "";
+								$iconact_class = 'class="fa fa-thumbs-down text-danger text-center"';
+								$title_act = gettext("Rule will drop traffic when triggered.  Click to force alert action instead.");
+							}
+							else {
+								$textss = $textse = "";
+								$iconact_class = 'class="fa fa-exclamation-triangle text-warning text-center"';
+								$title_act = gettext("Rule will alert on traffic when triggered. Click to force drop action instead.");
 							}
 
 							// Pick off the first section of the rule (prior to the start of the MSG field),
@@ -803,6 +957,11 @@ print($section);
 								<i class="fa fa-adn text-warning text-left" title="<?=gettext('Action or content modified by settings on SID Mgmt tab'); ?>"></i><?=$textse; ?>
 				<?php endif; ?>
 								</td>
+
+							       <td><?=$textss; ?><a id="rule_<?=$gid; ?>_<?=$sid; ?>_action" href="#" onClick="toggleAction('<?=$sid; ?>', '<?=$gid; ?>');" 
+									<?=$iconact_class; ?> title="<?=$title_act; ?>"></a><?=$textse; ?>
+							       </td>
+
 							       <td ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
 									<?=$textss . $gid . $textse;?>
 							       </td>
@@ -882,7 +1041,15 @@ function toggleRule(sid, gid) {
 	$('#sid').val(sid);
 	$('#gid').val(gid);
 	$('#openruleset').val($('#selectbox').val());
-	$('<input name="toggle" value="1" />').appendTo($('#iform'));
+	$('<input name="toggle_state" value="1" />').appendTo($('#iform'));
+	$('#iform').submit();
+}
+
+function toggleAction(sid, gid) {
+	$('#sid').val(sid);
+	$('#gid').val(gid);
+	$('#openruleset').val($('#selectbox').val());
+	$('<input name="toggle_action" value="1" />').appendTo($('#iform'));
 	$('#iform').submit();
 }
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -31,6 +31,7 @@ global $g, $config, $rebuild_rules;
 $suricatadir = SURICATADIR;
 $rules_map = array();
 $pconfig = array();
+$filterrules = FALSE;
 
 if (!is_array($config['installedpackages']['suricata']['rule']))
 	$config['installedpackages']['suricata']['rule'] = array();
@@ -399,6 +400,17 @@ elseif (isset($_POST['save'])) {
 	// Sync to configured CARP slaves if any are enabled
 	suricata_sync_on_changes();
 }
+elseif ($_POST['filterrules_submit']) {
+	// Set flag for filtering rules
+	$filterrules = TRUE;
+	$filterfieldsarray = array();
+	$filterfieldsarray['show_enabled'] = $_POST['filterrules_enabled'] ? $_POST['filterrules_enabled'] : null;
+	$filterfieldsarray['show_disabled'] = $_POST['filterrules_disabled'] ? $_POST['filterrules_disabled'] : null;
+}
+elseif ($_POST['filterrules_clear']) {
+	$filterfieldsarray = array();
+	$filterrules = TRUE;
+}
 elseif (isset($_POST['apply'])) {
 
 	/* Save new configuration */
@@ -595,6 +607,48 @@ else {
 $section->add($group);
 print($section);
 
+// ========== Start Rule filter Panel =========================================
+if ($filterrules) {
+	$section = new Form_Section("Rules View Filter", "rulesfilter", COLLAPSIBLE|SEC_OPEN);
+}
+else {
+	$section = new Form_Section("Rules View Filter", "rulesfilter", COLLAPSIBLE|SEC_CLOSED);
+}
+$group = new Form_Group('');
+$group->add(new Form_Checkbox(
+	'filterrules_enabled',
+	'Show Enabled Rules',
+	'Show enabled rules',
+	$filterfieldsarray['show_enabled'] == 'on' ? true:false,
+	'on'
+));
+$group->add(new Form_Checkbox(
+	'filterrules_disabled',
+	'Show Disabled Rules',
+	'Show disabled rules',
+	$filterfieldsarray['show_disabled'] == 'on' ? true:false,
+	'on'
+));
+$group->add(new Form_Button(
+	'filterrules_submit',
+	'Filter',
+	null,
+	'fa-filter'
+))->setHelp("Apply filter")
+  ->removeClass("btn-primary")
+  ->addClass("btn-sm btn-success");
+$group->add(new Form_Button(
+	'filterrules_clear',
+	'Clear',
+	null,
+	'fa-trash-o'
+))->setHelp("Remove all filters")
+  ->removeclass("btn-primary")
+  ->addClass("btn-sm btn-danger no-confirm");
+$section->add($group);
+print($section);
+// ========== End Rule filter Panel ===========================================
+
 ?>
 
 <div class="panel panel-default">
@@ -656,6 +710,16 @@ print($section);
 							$gid = $k1;
 							$ruleset = $currentruleset;
 							$style = "";
+
+							// Apply rule state filters if filtering is enabled
+							if ($filterrules) {
+								if (isset($filterfieldsarray['show_disabled']) && $v['disabled'] == 0) {
+									continue;
+								}
+								elseif (isset($filterfieldsarray['show_enabled']) && $v['disabled'] == 1) {
+									continue;
+								}
+							}
 
 							// Determine which icons to display in the first column for rule state.
 							// See if the rule is auto-managed by the SID MGMT tab feature
@@ -867,6 +931,14 @@ events.push(function() {
 
 	$('#selectbox').on('change', function() {
 		go();
+	});
+
+	$('#filterrules_enabled').click(function() {
+		$('#filterrules_disabled').prop("checked", false);
+	});
+
+	$('#filterrules_disabled').click(function() {
+		$('#filterrules_enabled').prop("checked", false);
 	});
 
 	<?php if (!empty($anchor)): ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -52,6 +52,7 @@ if (isset($id) && $a_nat[$id]) {
 	$pconfig['autoflowbits'] = $a_nat[$id]['autoflowbitrules'];
 	$pconfig['ips_policy_enable'] = $a_nat[$id]['ips_policy_enable'];
 	$pconfig['ips_policy'] = $a_nat[$id]['ips_policy'];
+	$pconfig['ips_policy_mode'] = $a_nat[$id]['ips_policy_mode'];
 }
 
 $if_real = get_real_interface($a_nat[$id]['interface']);
@@ -109,10 +110,12 @@ if (isset($_POST["save"])) {
 	if ($_POST['ips_policy_enable'] == "on") {
 		$a_nat[$id]['ips_policy_enable'] = 'on';
 		$a_nat[$id]['ips_policy'] = $_POST['ips_policy'];
+		$a_nat[$id]['ips_policy_mode'] = $_POST['ips_policy_mode'];
 	}
 	else {
 		$a_nat[$id]['ips_policy_enable'] = 'off';
 		unset($a_nat[$id]['ips_policy']);
+		unset($a_nat[$id]['ips_policy_mode']);
 	}
 
 	// Always start with the default events and files rules
@@ -126,7 +129,6 @@ if (isset($_POST["save"])) {
 
 	if ($_POST['autoflowbits'] == "on") {
 		$a_nat[$id]['autoflowbitrules'] = 'on';
-		print("Autoflowbits is on");
 	}
 	else {
 		$a_nat[$id]['autoflowbitrules'] = 'off';
@@ -159,15 +161,18 @@ if (isset($_POST["save"])) {
 	if ($_POST['ips_policy_enable'] == "on") {
 		$a_nat[$id]['ips_policy_enable'] = 'on';
 		$a_nat[$id]['ips_policy'] = $_POST['ips_policy'];
+		$a_nat[$id]['ips_policy_mode'] = $_POST['ips_policy_mode'];
 	}
 	else {
 		$a_nat[$id]['ips_policy_enable'] = 'off';
 		unset($a_nat[$id]['ips_policy']);
+		unset($a_nat[$id]['ips_policy_mode']);
 	}
 
 	$pconfig['autoflowbits'] = $_POST['autoflowbits'];
 	$pconfig['ips_policy_enable'] = $_POST['ips_policy_enable'];
 	$pconfig['ips_policy'] = $_POST['ips_policy'];
+	$pconfig['ips_policy_mode'] = $_POST['ips_policy_mode'];
 
 	// Remove all but the default events and files rules
 	$enabled_rulesets_array = array();
@@ -182,15 +187,18 @@ if (isset($_POST["save"])) {
 	if ($_POST['ips_policy_enable'] == "on") {
 		$a_nat[$id]['ips_policy_enable'] = 'on';
 		$a_nat[$id]['ips_policy'] = $_POST['ips_policy'];
+		$a_nat[$id]['ips_policy_mode'] = $_POST['ips_policy_mode'];
 	}
 	else {
 		$a_nat[$id]['ips_policy_enable'] = 'off';
 		unset($a_nat[$id]['ips_policy']);
+		unset($a_nat[$id]['ips_policy_mode']);
 	}
 
 	$pconfig['autoflowbits'] = $_POST['autoflowbits'];
 	$pconfig['ips_policy_enable'] = $_POST['ips_policy_enable'];
 	$pconfig['ips_policy'] = $_POST['ips_policy'];
+	$pconfig['ips_policy_mode'] = $_POST['ips_policy_mode'];
 
 	// Start with the required default events and files rules
 	$enabled_rulesets_array = $default_rules;
@@ -301,7 +309,7 @@ else:
 		'fa-file-text-o'
 	);
 
-	$viewbtn->removeClass('btn-primary')->addClass('btn-success')
+	$viewbtn->removeClass('btn-primary')->addClass('btn-success btn-sm')
 	  ->setHelp('Click to view auto-enabled rules required to satisfy flowbit dependencies' . '<br /><br />' .
 	  			'<span class="text-danger"><strong>' . gettext('Note:  ') . '</strong></span>' .
 	  			gettext('Auto-enabled rules generating unwanted alerts should have their GID:SID added to the Suppression List for the interface.'));
@@ -327,10 +335,9 @@ else:
 
 	print($section);
 
-	if (true || $snortdownload == 'on') {
+	if ($snortdownload == 'on') {
 
 		$section = new Form_Section("Snort IPS Policy selection");
-
 		$chkips = new Form_Checkbox(
 			'ips_policy_enable',
 			'Use IPS Policy',
@@ -338,30 +345,32 @@ else:
 			($a_nat[$id]['ips_policy_enable'] == "on"),
 			'on'
 		);
-
 		$chkips->setHelp('<span class="text-danger"><strong>' . gettext("Note:  ") . '</strong></span>' . gettext('You must be using the Snort VRT rules to use this option.' . '<br />' .
 					'Selecting this option disables manual selection of Snort VRT categories in the list below, ' .
 						'although Emerging Threats categories may still be selected if enabled on the Global Settings tab.  ' .
 						'These will be added to the pre-defined Snort IPS policy rules from the Snort VRT.'));
-
-
-		if (($snortdownload != 'on') || ($a_nat[$id]['ips_policy_enable'] != 'on')) {
-			// $chkips->setDisabled();
-		}
-
 		$section->addInput($chkips);
-
 		$section->addInput(new Form_Select(
 			'ips_policy',
 			'IPS Policy Selection',
 			$pconfig['ips_policy'],
-			array(
-				'connected' => 'Conected',
+			array(	'connectivity' => 'Connectivity',
 				'balanced'  => 'Balanced',
-				'security'  => 'Security')
+				'security'  => 'Security',
+				'max-detect' => 'Maximum Detection')
 			))->setHelp('Connectivity blocks most major threats with few or no false positives. Balanced is a good starter policy. ' .
 						'It is speedy, has good base coverage level, and covers most threats of the day. It includes all rules in Connectivity. Security is a stringent policy. ' .
-						'It contains everything in the first two plus policy-type rules such as Flash in an Excel file.');
+						'It contains everything in the first two plus policy-type rules such as Flash in an Excel file.  Maximum Detection encompasses vulnerabilities from 2005 ' . 
+						'or later with a CVSS score of at least 7.5 along with critical malware and exploit kit rules.  The Maximum Detection policy favors detection over rated ' .
+						'throughput. In some situations this policy can and will cause significant throughput reductions.');
+		$section->addInput(new Form_Select(
+			'ips_policy_mode',
+			'IPS Policy Mode',
+			$pconfig['ips_policy_mode'],
+			array(  'alert' => 'Alert',
+				'policy'  => 'Policy')
+			))->setHelp('When Policy is selected, this will automatically change the action for rules in the selected IPS Policy from their default action of alert to the action specified ' . 
+					'in the policy metadata (typically drop, but may be alert for some policy rules).');
 
 		print($section);
 	}
@@ -635,6 +644,7 @@ events.push(function() {
 		var endis = !($('#ips_policy_enable').prop('checked'));
 
 		hideInput('ips_policy', endis);
+		hideInput('ips_policy_mode', endis);
 
 		$('input[type="checkbox"]').each(function() {
 			var str = $(this).val();


### PR DESCRIPTION
This update of the Suricata GUI package adds three new features, restores Pass List functionality when running with inline IPS mode enabled, and corrects four bugs.

**New Features**

1. The RULES tab has an action column with an icon to indicate if the rule action is alert or drop.  Clicking the icon allows toggling the rule action via a user override.  The GID:SID of the rule along with the user overriden action are both stored in the firewall config for Suricata and used to set the rule action when the enforcing rules file for the interface instance is written (the _suricata.rules_ file located in the _/rules_ directory of the interface).
2. The list of rules displayed on the RULES tab can now be filtered by state (enabled or disabled) to help with identifying enabled or disabled rules.
3. A new option has been added when operating with inline IPS mode enabled.  When the Snort VRT rules package is enabled and a Snort VRT IPS Policy is chosen on the CATEGORIES tab, a selection is available for automatically setting the rule action for the chosen policy rules.  This action is specified in the IPS policy metadata within the rule.  When using an IPS Policy, the default action for all the policy rules is alert.  But each of the policy rules also contains a suggested action for each policy category (Connectivity, Balanced, Security, etc.).  The suggested action may be to only alert on traffic, or it may instead suggest dropping the traffic.  The new IPS Policy Mode selector has two settings:  Alert or Policy.  When set to Alert, all IPS Policy rules will just alert no matter what the rule metadata specifies for the poplicy.  When set to Policy, the rule action will be changed to that specified by the IPS Policy metadata provided with each VRT rule.

**Restored Functionality**

1. When using inline IPS mode the Pass List function was not available due to changes in the blocking architecture from dependence on the _pf_ firewall to the use of Netmap.  The Pass List functionality has now been duplicated when inline IPS mode is enabled by automatically generating the required PASS rules in the Suricata rule set.  The rules will prevent traffic from hosts on the Pass List from being dropped.  You still create and assign Pass Lists the same as in Legacy Mode, but now they will also "just work" when using inline IPS Mode.

**Bug Fixes**

1. Auto Log Mgmt is not default checked on a fresh install.
2. REFRESH checkbox on ALERTS tab is not default checked on a fresh install.
3. Suricata error "[ERRCODE: SC_ERR_CONF_YAML_ERROR(242)] - Please use 'tls-store' in YAML to configure TLS storage" generated when TLS logging is enabled.
4. Make sure critical Suricata directories in _/var/log_ and _/var/db_ exist at each package sync in case these are on a RAM disk.