### PR TITLE
pfSense-pkg-suricata-3.1.2 0 -- Pass List implementation fix

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	3.1.2
+PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -295,7 +295,23 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 	$home_net = array();
 
 	if (!$externallist && ($listname == 'default' || empty($listname))) {
-		$localnet = 'yes'; $wanip = 'yes'; $wangw = 'yes'; $wandns = 'yes'; $vips = 'yes'; $vpns = 'yes';
+		// When using inline IPS mode, do not include
+		// locally-attached network segments or the WAN IP in
+		// the default Pass List as this will kill all alerts
+		// and allow all traffic to pass!  We do include
+		// locally-attached networks and the WAN IP when
+		// building only the HOME_NET variable.
+		if ($suricatacfg['ips_mode'] == 'ips_mode_inline' && $passlist == TRUE) {
+			$localnet = 'no';
+			$wanip = 'no';
+		}
+		else {
+			$localnet = 'yes';
+			$wanip = 'yes';
+		}
+
+		// Default the remaining Pass List/HOME_NET items to 'yes'.
+		$wangw = 'yes'; $wandns = 'yes'; $vips = 'yes'; $vpns = 'yes';
 	}
 	else {
 		$list = suricata_find_list($listname);
@@ -345,7 +361,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 		}
 	}
 	elseif (!$externallist && $localnet != 'yes') {
-		if (is_ipaddrv4($suricataip)) {
+		if (is_ipaddrv4($suricataip) && $suricatacfg['interface'] <> "wan") {
 			if (!in_array($suricataip . "/32", $home_net)) {
 				$home_net[] = $suricataip . "/32";
 			}
@@ -371,7 +387,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 		}
 	}
 	elseif (!$externallist && $localnet != 'yes') {
-		if (is_ipaddrv6($suricataip)) {
+		if (is_ipaddrv6($suricataip) && $suricatacfg['interface'] <> "wan") {
 			if (!in_array($suricataip . "/128", $home_net)) {
 				$home_net[] = $suricataip . "/128";
 			}
@@ -390,7 +406,9 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 		}
 	}
 
-	if (($$externallist && $localnet == 'yes') || (!$externallist && (!$passlist || $localnet == 'yes' || empty($localnet)))) {		
+	// Now find all the locally-attached network subnets and add them to the
+	// list if user chose to include Local Networks.
+	if (($externallist && $localnet == 'yes') || (!$externallist && (!$passlist || $localnet == 'yes' || empty($localnet)))) {		
 		/*************************************************************************/
 		/*  Iterate through the interface list and write out pass list items and */
 		/*  also compile a HOME_NET list of all local interfaces for suricata.   */
@@ -440,6 +458,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 		}
 	}
 
+	// If user chose to include the WAN IP, then do so.
 	if ($wanip == 'yes') {
 		$ip = get_interface_ip("wan");
 		if (is_ipaddrv4($ip)) {
@@ -470,6 +489,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 		}
 	}
 
+	// If the user chose to include WAN gateways, then do so.
 	if ($wangw == 'yes') {
 		// Grab the default gateway if set
 		$default_gw = exec("/sbin/route -n get default |grep 'gateway:' | /usr/bin/awk '{ print $2 }'");
@@ -495,6 +515,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 		}
 	}
 
+	// If the user chose to include WAN DNS servers, then do so.
 	if ($wandns == 'yes') {
 		// Add DNS server for WAN interface to Pass List
 		$dns_servers = get_dns_servers();
@@ -510,6 +531,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 		}
 	}
 
+	// If the user chose to include Virtual IPs, then do so.
 	if($vips == 'yes') {
 		// iterate all vips and add to passlist
 		if (is_array($config['virtualip']) && is_array($config['virtualip']['vip'])) {
@@ -523,7 +545,9 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 		}
 	}
 
-	// Grab a list of vpns enabled - these come back as CIDR mask networks
+	// If the user chose to include VPNs, then grab a list of 
+	// vpns enabled and include them.  These come back as CIDR
+	// mask networks.
 	if ($vpns == 'yes') {
 		$vpns_list = filter_get_vpns_list();
 		if (!empty($vpns_list)) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -759,7 +759,7 @@ if ($suricatacfg['enable_iprep'] == "on") {
 if (!empty($suricatacfg['host_memcap']))
 	$host_memcap = $suricatacfg['host_memcap'];
 else
-	$host_memcap = "16777216";
+	$host_memcap = "33554432";
 if (!empty($suricatacfg['host_hash_size']))
 	$host_hash_size = $suricatacfg['host_hash_size'];
 else

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -66,7 +66,7 @@ $suri_passlist = "{$suricatacfgdir}/passlist";
 
 // If using inline IPS mode, generate PASS rules to substitute for the PASS LIST
 @file_put_contents("{$suricatacfgdir}/rules/passlist.rules", '');
-if ($suricatacfg['ips_mode'] == 'ips_mode_inline' && $suricatacfg['blockoffenders'] == 'on') {
+if ($suricatacfg['ips_mode'] == 'ips_mode_inline' && $suricatacfg['blockoffenders'] == 'on' && $suricatacfg['passlistname'] <> 'none') {
 	$sid_tmp = 1000001;
 	foreach ($plist as $ip_tmp) {
 		$line = "pass ip {$ip_tmp} any <> any any (msg:\"Pass List Entry - allow all traffic from/to {$ip_tmp}\"; sid:{$sid_tmp};)\n";

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -403,7 +403,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$natent['msn_parser'] = "detection-only";
 
 			$natent['enable_iprep'] = "off";
-			$natent['host_memcap'] = "16777216";
+			$natent['host_memcap'] = "33554432";
 			$natent['host_hash_size'] = "4096";
 			$natent['host_prealloc'] = "1000";
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -932,13 +932,14 @@ $section->add($group);
 $group = new Form_Group('Pass List');
 
 $group->addClass('passlist');
-
+$list = suricata_get_config_lists('passlist');
+$list['none'] = 'none';
 $group->add(new Form_Select(
 	'passlistname',
 	'Pass List',
 	$pconfig['passlistname'],
-	suricata_get_config_lists('passlist')
-))->setHelp('Choose the Pass List you want this interface to use. Addresses in a Pass List are never blocked. ');
+	$list
+))->setHelp('Choose the Pass List you want this interface to use. Addresses in a Pass List are never blocked. Select "none" to prevent use of a Pass List.');
 
 $group->add(new Form_Button(
 	'btnPasslist',
@@ -947,8 +948,9 @@ $group->add(new Form_Button(
 	'fa-file-text-o'
 ))->removeClass('btn-primary')->addClass('btn-info')->addClass('btn-sm')->setAttribute('data-target', '#passlist')->setAttribute('data-toggle', 'modal');
 
-$group->setHelp('The default Pass List adds local networks, WAN IPs, Gateways, VPNs and VIPs.  Create an Alias to customize.' . '<br />' .
-				'This option will only be used when block offenders is on.');
+$group->setHelp('The default Pass List adds local networks, WAN IPs, Gateways, VPNs and VIPs.  Create an Alias to customize.' . 
+				'This option will only be used when block offenders is on.  Choosing "none" will disable Pass List generation ' . 
+				'and is the recommended choice when using Inline IPS Mode.');
 
 $section->add($group);
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
@@ -224,7 +224,7 @@ $section->addInput(new Form_Input(
 	'number',
 	$pconfig['host_memcap'],
 	['min' => '1048576']
-))->setHelp('Host table memory cap in bytes. Default is 16777216 (16 MB). Min value is 1048576 (1 MB)');
+))->setHelp('Host table memory cap in bytes. Default is 33554432 (32 MB). Min value is 1048576 (1 MB)');
 
 $section->addInput(new Form_Input(
 	'host_hash_size',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
@@ -236,6 +236,13 @@ $section->addInput(new Form_Checkbox(
 	'yes'
 ));
 $section->addInput(new Form_Checkbox(
+	'wanips',
+	'WAN IP',
+	'Add WAN interface IP to the list.',
+	$pconfig['wanips'] == 'yes' ? true:false,
+	'yes'
+));
+$section->addInput(new Form_Checkbox(
 	'wangateips',
 	'WAN Gateways',
 	'Add WAN Gateways to the list.',


### PR DESCRIPTION
This update to the Suricata GUI package corrects issues with implementation of default Pass Lists when running Suricata with inline IPS Mode enabled.  A couple of other minor bugs are also fixed.

**Bug Fixes**

1. Remove automatic inclusion of all locally-attached networks in the default Pass List when using IPS mode.  This had the unintended side-effect of essentially whitelisting all traffic to and from local hosts.

2. Added the capability to completely disable use of the default Pass List when running with inline IPS Mode.  Formerly, the default Pass List would be used when no custom list was specified.

3. Remove automatic inclusion of the WAN interface IP address in the default Pass List when using IPS mode.  This had the unintended side-effect of essentially whitelist all inbound NAT traffic because the destination IP would be the WAN IP.

4. Increase default value of Host Memcap on IP REPUTATION tab to 32 MB as most IP lists today are quite large.  This is effective only for newly created interfaces.

5. The checkbox for including/excluding the WAN IP from a custom Pass List was inadvertently removed during the Bootstrap conversion of the GUI code.  This checkbox is now restored.