### PR TITLE
pfSense-pkg-tftpd package improvements

### DIFF
--- a/ftp/pfSense-pkg-tftpd/Makefile
+++ b/ftp/pfSense-pkg-tftpd/Makefile
@@ -25,12 +25,15 @@ do-extract:
 
 do-install:
 	${MKDIR} ${STAGEDIR}${PREFIX}/pkg
+	${MKDIR} ${STAGEDIR}${PREFIX}/www
 	${MKDIR} ${STAGEDIR}/etc/inc/priv
 	${MKDIR} ${STAGEDIR}${DATADIR}
 	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/tftpd.xml \
 		${STAGEDIR}${PREFIX}/pkg
 	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/tftpd.inc \
 		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} -m 0755 ${FILESDIR}${PREFIX}/www/tftp_files.php \
+		${STAGEDIR}${PREFIX}/www
 	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/tftpd.priv.inc \
 		${STAGEDIR}/etc/inc/priv
 	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \

--- a/ftp/pfSense-pkg-tftpd/Makefile
+++ b/ftp/pfSense-pkg-tftpd/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-tftpd
-PORTVERSION=	0.1.2
+PORTVERSION=	0.1.3
 CATEGORIES=	ftp
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/ftp/pfSense-pkg-tftpd/files/etc/inc/priv/tftpd.priv.inc
+++ b/ftp/pfSense-pkg-tftpd/files/etc/inc/priv/tftpd.priv.inc
@@ -3,6 +3,7 @@
  * tftpd.priv.inc
  *
  * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2016 Stefan Seidel
  * All rights reserved.
  *
@@ -22,7 +23,7 @@
 global $priv_list;
 
 $priv_list['page-system-tftpd'] = array();
-$priv_list['page-system-tftpd']['name'] = "WebCfg - System: tftpd package";
+$priv_list['page-system-tftpd']['name'] = "WebCfg - Services: tftpd package";
 $priv_list['page-system-tftpd']['descr'] = "Allow access to tftpd package GUI";
 $priv_list['page-system-tftpd']['match'] = array();
 

--- a/ftp/pfSense-pkg-tftpd/files/etc/inc/priv/tftpd.priv.inc
+++ b/ftp/pfSense-pkg-tftpd/files/etc/inc/priv/tftpd.priv.inc
@@ -22,11 +22,12 @@
 
 global $priv_list;
 
-$priv_list['page-system-tftpd'] = array();
-$priv_list['page-system-tftpd']['name'] = "WebCfg - Services: tftpd package";
-$priv_list['page-system-tftpd']['descr'] = "Allow access to tftpd package GUI";
-$priv_list['page-system-tftpd']['match'] = array();
+$priv_list['page-services-tftpd'] = array();
+$priv_list['page-services-tftpd']['name'] = "WebCfg - Services: tftpd package";
+$priv_list['page-services-tftpd']['descr'] = "Allow access to tftpd package GUI";
+$priv_list['page-services-tftpd']['match'] = array();
 
-$priv_list['page-system-tftpd']['match'][] = "pkg_edit.php?xml=tftpd.xml*";
+$priv_list['page-services-tftpd']['match'][] = "pkg_edit.php?xml=tftpd.xml*";
+$priv_list['page-services-tftpd']['match'][] = "tftp_files.php*";
 
 ?>

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.inc
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.inc
@@ -3,6 +3,7 @@
  * tftpd.inc
  *
  * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2016 Stefan Seidel
  * All rights reserved.
  *
@@ -19,17 +20,14 @@
  * limitations under the License.
  */
 
-if (!function_exists("filter_configure")) {
-	require_once("filter.inc");
-}
 require_once("globals.inc");
-require_once("interfaces.inc");
 require_once("pfsense-utils.inc");
 require_once("service-utils.inc");
 require_once("util.inc");
 
 function install_package_tftpd() {
 	safe_mkdir("/tftpboot");
+	unlink_if_exists("/usr/local/etc/rc.d/tftpd");
 }
 
 function deinstall_package_tftpd() {
@@ -37,7 +35,7 @@ function deinstall_package_tftpd() {
 }
 
 function sync_package_tftpd() {
-	global $config;
+	global $g, $config;
 
 	conf_mount_rw();
 
@@ -56,17 +54,35 @@ function sync_package_tftpd() {
 		unlink_if_exists('/usr/local/etc/rc.d/tftpd.sh');
 		return;
 	}
-	
+
+	// Root directory
 	$datadir = $tftpd_conf['datadir'];
-	
-	if (!is_dir($datadir)) {
-		log_error("TFTP files directory {$datadir} does not exist.");
-		return;
-	} 
+
+	// TFTP Server Bind IP
+	if (!empty($tftpd_conf['tftpd_ip'])) {
+		$address = $tftpd_conf['tftpd_ip'];
+		if (is_ipaddrv6($address)) {
+			$address = "-a [{$address}]";
+		} else {
+			$address = "-a {$address}";
+		}
+	}
+
+	$pidfile = "{$g['varrun_path']}/tftpd-hpa.pid";
+
+	// IPv4 Only?
+	if ($tftpd_conf['tftpd_ipv4only'] == "on") {
+		$options = "-4";
+	}
+
+	// Max Block Size
+	if (!empty($tftpd_conf['tftpd_blocksize'])) {
+		$options .= " -B {$tftpd_conf['tftpd_blocksize']}";
+	}
 
 	write_rcfile(array(
 		"file" => "tftpd.sh",
-		"start" => "/usr/local/libexec/in.tftpd -l -s {$datadir}",
+		"start" => "/usr/local/libexec/in.tftpd -l -s {$datadir} {$address} -P {$pidfile} {$options}",
 		"stop" => "/usr/bin/killall in.tftpd"
 		)
 	);
@@ -82,13 +98,28 @@ function sync_package_tftpd() {
 	}
 
 	conf_mount_ro();
-
-	filter_configure();
 }
 
 function validate_form_tftpd($post, &$input_errors) {
 	if ($post['datadir'] && !is_dir($post['datadir'])) {
 		$input_errors[] = 'Directory for files does not exist!';
+	}
+
+	if ($post['tftpd_ip']) {
+		if ($post['tftpd_ipv4only'] && !is_ipaddrv4($post['tftpd_ip'])) {
+			$input_errors[] = 'TFTP Server Bind IP must be a valid IPv4 address!';
+		} elseif (!is_ipaddr($post['tftpd_ip'])) {
+			$input_errors[] = 'TFTP Server Bind IP must be a valid IP address!';
+		}
+		if (!is_ipaddr_configured($post['tftpd_ip'])) {
+			$input_errors[] = "{$post['tftpd_ip']} TFTP Server Bind IP must be a valid, locally configured IP address!";
+		}
+	}
+
+	if ($post['tftpd_blocksize']) {
+		if (!is_numericint($post['tftpd_blocksize']) || ($post['tftpd_blocksize'] < 512) || ($post['tftpd_blocksize'] > 65464)) {
+			$input_errors[] = 'Max Block Size must be an integer with a permitted range from 512 to 65464!';
+		}
 	}
 }
 

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.inc
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.inc
@@ -21,28 +21,25 @@
  */
 
 require_once("globals.inc");
+require_once("notices.inc");
 require_once("pfsense-utils.inc");
 require_once("service-utils.inc");
 require_once("util.inc");
 
-/* Helper function for files listing */
-function tftp_byte_convert($bytes) {
-	if ($bytes <= 0) {
-		return '0 Byte';
-	}
-	$convention = 1000;
-	$s = array('B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB');
-	$e = floor(log($bytes, $convention));
-	return round($bytes/pow($convention, $e), 2) . ' ' . $s[$e];
-}
+/* Define some locations */
+define('BACKUP_DIR', '/root/backup');
+define('BACKUP_FILENAME', 'tftp.bak.tgz');
+define('BACKUP_PATH', BACKUP_DIR . '/' . BACKUP_FILENAME);
+/* Change FILES_DIR below if you really need TFTP files directory elsewhere.
+ * Note: Such modifications are completely unsupported!
+ */
+define('FILES_DIR', '/tftpboot');
 
 /* Create backup of the TFTP server directory */
 function tftp_create_backup($trigger_download = false) {
-	global $backup_dir, $backup_path, $files_dir;
-
 	conf_mount_rw();
-	safe_mkdir("{$backup_dir}");
-	if (mwexec("/usr/bin/tar -czC / -f {$backup_path} {$files_dir}") || !file_exists("{$backup_path}")) {
+	safe_mkdir(BACKUP_DIR);
+	if (mwexec("/usr/bin/tar -czC / -f " . BACKUP_PATH . " " . FILES_DIR) || !file_exists(BACKUP_PATH)) {
 		header("Location: tftp_files.php?savemsg=Backup+failed.&result=alert-warning");
 	} elseif ($trigger_download == false) {
 		header("Location: tftp_files.php?savemsg=Backup+has+been+created");
@@ -50,26 +47,52 @@ function tftp_create_backup($trigger_download = false) {
 	conf_mount_ro();
 }
 
-function install_package_tftpd() {
-	if (is_array($config['installedpackages']['tftpd'])) {
-		$tftpd_conf = &$config['installedpackages']['tftpd']['config'][0];
+/* Restore backup of the TFTP server directory */
+function tftp_restore_backup() {
+	if (file_exists(BACKUP_PATH)) {
+		conf_mount_rw();
+		mwexec("/usr/bin/tar -xpzC / -f " . BACKUP_PATH);
+		header("Location: tftp_files.php?savemsg=Backup+has+been+restored.");
+		conf_mount_ro();
 	} else {
-		$tftpd_conf = array();
+		header("Location: tftp_files.php?savemsg=Restore+failed.+Backup+file+not+found.&result=alert-warning");
 	}
-	$datadir = ($tftpd_conf['datadir'] ?: '/tftpboot');
-	safe_mkdir("{$datadir}");
+}
+
+/* Only allow to download files under the FILES_DIR */
+function tftp_filesdir_bounds_check($filename, $error_msg) {
+	$basedirlength = strlen(FILES_DIR);
+	if (substr($filename, 0, $basedirlength) !== FILES_DIR) {
+		log_error("[tftpd] {$error_msg}");
+		file_notice("tftpd", "{$error_msg}", "Packages");
+		return false;
+	} else {
+		return true;
+	}
+}
+
+function install_package_tftpd() {
+	safe_mkdir(FILES_DIR);
 	unlink_if_exists("/usr/local/etc/rc.d/tftpd");
+	upgrade_config_tftpd();
 }
 
 function deinstall_package_tftpd() {
+	// Will only get removed when empty
+	@rmdir(FILES_DIR);
+}
+
+function upgrade_config_tftpd() {
+	// FILES_DIR is not configurable any more
 	if (is_array($config['installedpackages']['tftpd'])) {
 		$tftpd_conf = &$config['installedpackages']['tftpd']['config'][0];
 	} else {
 		$tftpd_conf = array();
 	}
-	$datadir = ($tftpd_conf['datadir'] ?: '/tftpboot');
-	// Will only get removed when empty
-	@rmdir("{$datadir}");
+	if (!empty($tftpd_conf['datadir']) && $tftpd_conf['datadir'] !== FILES_DIR) {
+		file_notice("tftpd", "Please, move your TFTP server files from {$tftpd_conf['datadir']} to /tftpboot", "Packages");
+		unset($config['installedpackages']['tftpd']['config'][0]['datadir']);
+	}
 }
 
 function sync_package_tftpd() {
@@ -94,15 +117,17 @@ function sync_package_tftpd() {
 	}
 
 	// Root directory
-	$datadir = $tftpd_conf['datadir'];
+	$datadir = FILES_DIR;
 
 	// TFTP Server Bind IP
 	if (!empty($tftpd_conf['tftpd_ip'])) {
 		$address = $tftpd_conf['tftpd_ip'];
 		if (is_ipaddrv6($address)) {
 			$address = "-a [{$address}]";
-		} else {
+		} elseif (is_ipaddrv4($address)) {
 			$address = "-a {$address}";
+		} else {
+			$address = "";
 		}
 	}
 
@@ -115,7 +140,7 @@ function sync_package_tftpd() {
 
 	// Max Block Size
 	if (!empty($tftpd_conf['tftpd_blocksize'])) {
-		$options .= " -B {$tftpd_conf['tftpd_blocksize']}";
+		$options .= " -B " . escapeshellarg($tftpd_conf['tftpd_blocksize']);
 	}
 
 	write_rcfile(array(
@@ -139,14 +164,6 @@ function sync_package_tftpd() {
 }
 
 function validate_form_tftpd($post, &$input_errors) {
-	if ($post['datadir'] && !is_dir($post['datadir'])) {
-		$input_errors[] = 'Directory for files does not exist!';
-	}
-
-	if ($post['datadir'] == '/') {
-		$input_errors[] = 'Setting "/" as directory for files is not allowed!';
-	}
-
 	if ($post['tftpd_ip']) {
 		if ($post['tftpd_ipv4only'] && !is_ipaddrv4($post['tftpd_ip'])) {
 			$input_errors[] = 'TFTP Server Bind IP must be a valid IPv4 address!';

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.inc
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.inc
@@ -143,6 +143,10 @@ function validate_form_tftpd($post, &$input_errors) {
 		$input_errors[] = 'Directory for files does not exist!';
 	}
 
+	if ($post['datadir'] == '/') {
+		$input_errors[] = 'Setting "/" as directory for files is not allowed!';
+	}
+
 	if ($post['tftpd_ip']) {
 		if ($post['tftpd_ipv4only'] && !is_ipaddrv4($post['tftpd_ip'])) {
 			$input_errors[] = 'TFTP Server Bind IP must be a valid IPv4 address!';

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.inc
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.inc
@@ -25,13 +25,51 @@ require_once("pfsense-utils.inc");
 require_once("service-utils.inc");
 require_once("util.inc");
 
+/* Helper function for files listing */
+function tftp_byte_convert($bytes) {
+	if ($bytes <= 0) {
+		return '0 Byte';
+	}
+	$convention = 1000;
+	$s = array('B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB');
+	$e = floor(log($bytes, $convention));
+	return round($bytes/pow($convention, $e), 2) . ' ' . $s[$e];
+}
+
+/* Create backup of the TFTP server directory */
+function tftp_create_backup($trigger_download = false) {
+	global $backup_dir, $backup_path, $files_dir;
+
+	conf_mount_rw();
+	safe_mkdir("{$backup_dir}");
+	if (mwexec("/usr/bin/tar -czC / -f {$backup_path} {$files_dir}") || !file_exists("{$backup_path}")) {
+		header("Location: tftp_files.php?savemsg=Backup+failed.&result=alert-warning");
+	} elseif ($trigger_download == false) {
+		header("Location: tftp_files.php?savemsg=Backup+has+been+created");
+	}
+	conf_mount_ro();
+}
+
 function install_package_tftpd() {
-	safe_mkdir("/tftpboot");
+	if (is_array($config['installedpackages']['tftpd'])) {
+		$tftpd_conf = &$config['installedpackages']['tftpd']['config'][0];
+	} else {
+		$tftpd_conf = array();
+	}
+	$datadir = ($tftpd_conf['datadir'] ?: '/tftpboot');
+	safe_mkdir("{$datadir}");
 	unlink_if_exists("/usr/local/etc/rc.d/tftpd");
 }
 
 function deinstall_package_tftpd() {
-	@rmdir("/tftpboot");
+	if (is_array($config['installedpackages']['tftpd'])) {
+		$tftpd_conf = &$config['installedpackages']['tftpd']['config'][0];
+	} else {
+		$tftpd_conf = array();
+	}
+	$datadir = ($tftpd_conf['datadir'] ?: '/tftpboot');
+	// Will only get removed when empty
+	@rmdir("{$datadir}");
 }
 
 function sync_package_tftpd() {

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.xml
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.xml
@@ -41,6 +41,17 @@
 		<executable>in.tftpd</executable>
 		<description>TFTP daemon</description>
 	</service>
+	<tabs>
+		<tab>
+			<text>Settings</text>
+			<url>/pkg_edit.php?xml=tftpd.xml</url>
+			<active/>
+		</tab>
+		<tab>
+			<text>Files</text>
+			<url>/tftp_files.php</url>
+		</tab>
+	</tabs>
 	<fields>
 		<field>
 			<fielddescr>Enable TFTP service</fielddescr>

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.xml
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.xml
@@ -31,7 +31,7 @@
 	<include_file>/usr/local/pkg/tftpd.inc</include_file>
 	<aftersaveredirect>/pkg_edit.php?xml=tftpd.xml</aftersaveredirect>
 	<menu>
-		<name>tftpd</name>
+		<name>TFTP Server</name>
 		<section>Services</section>
 		<url>/pkg_edit.php?xml=tftpd.xml</url>
 	</menu>

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.xml
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.xml
@@ -60,19 +60,6 @@
 			<type>checkbox</type>
 		</field>
 		<field>
-			<fielddescr>Directory for Files</fielddescr>
-			<fieldname>datadir</fieldname>
-			<description>
-				<![CDATA[
-				Enter the directory path to the files that the TFTP server should serve. The directory must exist.
-				<span class="text-info">Default: /tftpboot</span>
-				]]>
-			</description>
-			<type>input</type>
-			<default_value>/tftpboot</default_value>
-			<required/>
-		</field>
-		<field>
 			<fielddescr>TFTP Server Bind IP</fielddescr>
 			<fieldname>tftpd_ip</fieldname>
 			<description>

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.xml
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/pkg/tftpd.xml
@@ -8,6 +8,7 @@
  * tftpd.xml
  *
  * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2016 Stefan Seidel
  * All rights reserved.
  *
@@ -44,15 +45,56 @@
 		<field>
 			<fielddescr>Enable TFTP service</fielddescr>
 			<fieldname>tftpd_enable</fieldname>
-			<description>Enable the TFTP service?</description>
+			<description>Check to enable the TFTP service.</description>
 			<type>checkbox</type>
 		</field>
 		<field>
-			<fielddescr>Directory for files</fielddescr>
+			<fielddescr>Directory for Files</fielddescr>
 			<fieldname>datadir</fieldname>
-			<description>Enter the directory path to the files that the TFTP server should serve. The directory must exist. Default: /tftpboot</description>
+			<description>
+				<![CDATA[
+				Enter the directory path to the files that the TFTP server should serve. The directory must exist.
+				<span class="text-info">Default: /tftpboot</span>
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>/tftpboot</default_value>
+			<required/>
+		</field>
+		<field>
+			<fielddescr>TFTP Server Bind IP</fielddescr>
+			<fieldname>tftpd_ip</fieldname>
+			<description>
+				<![CDATA[
+				By default, TFTP server will listen on all local addresses. If this is not desired,
+				you can restrict this to a specific local address.<br/>
+				<span class="text-danger">This must be a valid, locally configured IP address.</span>
+				]]>
+			</description>
+			<type>input</type>
+		</field>
+		<field>
+			<fielddescr>IPv4 Only</fielddescr>
+			<fieldname>tftpd_ipv4only</fieldname>
+			<description>Check to allow clients to connect with IPv4 only.</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Max Block Size</fielddescr>
+			<fieldname>tftpd_blocksize</fieldname>
+			<description>
+				<![CDATA[
+				Specifies the maximum permitted block size. <span class="text-info">The permitted range is from 512 to 65464.</span>
+				<div class="infoblock">
+				Some embedded clients request large block sizes	and yet	do not handle fragmented packets
+				correctly; for these clients, it is recommended to set this value to the smallest MTU
+				on your network minus 32 bytes (20 bytes for IP, 8 for UDP, and 4 for TFTP; less if you
+				use IP options on your network.)<br/>
+				For example, on a standard Ethernet (MTU 1500) a value of 1468 is reasonable.
+				</div>
+				]]>
+			</description>
+			<type>input</type>
 		</field>
 	</fields>
 	<custom_php_install_command>
@@ -61,9 +103,6 @@
 	<custom_php_deinstall_command>
 		deinstall_package_tftpd();
 	</custom_php_deinstall_command>
-	<custom_add_php_command>
-		sync_package_tftpd();
-	</custom_add_php_command>
 	<custom_php_resync_config_command>
 		sync_package_tftpd();
 	</custom_php_resync_config_command>

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/www/tftp_files.php
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/www/tftp_files.php
@@ -173,6 +173,7 @@ display_top_tabs($tab_array);
 				</tr>
 			<?php endif; ?>
 			<?php endforeach; ?>
+			</tbody>
 			</table>
 		</td></tr></tbody>
 		</table>
@@ -206,7 +207,7 @@ display_top_tabs($tab_array);
 			<i class="fa fa-upload icon-embed-btn"></i>
 			<?=gettext("Upload")?>
 		</button>
-		<a name="tftpd_dnload_all" id="tftpd_dnload_all" type="button" class="btn btn-info btn-sm"" title="<?=gettext('Download all files in a single gzip archive');?>"
+		<a name="tftpd_dnload_all" id="tftpd_dnload_all" type="button" class="btn btn-info btn-sm" title="<?=gettext('Download all files in a single gzip archive');?>"
 			href="tftp_files.php?a=download&amp;t=backup" text="download all files">
 			<i class="fa fa-download icon-embed-btn"></i>
 			<?=gettext('Download');?>

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/www/tftp_files.php
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/www/tftp_files.php
@@ -51,20 +51,6 @@ if ($_GET['a'] == "download") {
 			$desc = $filename;
 			$filename = basename($filename);
 		}
-		/*
-		$basedirlength = strlen(FILES_DIR);
-		$filename = htmlspecialchars($_GET['filename']);
-		if (substr($filename, 0, $basedirlength) !== FILES_DIR) {
-			$error_msg = "Attempt to download files outside of TFTP server directory rejected!";
-			log_error("[tftpd] {$error_msg}");
-			file_notice("tftpd", "{$error_msg}", "Packages");
-			header("Location: tftp_files.php");
-			return;
-		} else {
-			$desc = $filename;
-			$filename = basename($filename);
-		}
-		*/
 	}
 
 	session_cache_limiter('public');
@@ -115,22 +101,6 @@ if ($_GET['act'] == "del") {
 			header("Location: tftp_files.php");
 			exit;
 		}
-		/*
-		// Only delete files under the FILES_DIR!
-		$basedirlength = strlen(FILES_DIR);
-		if (substr($filename, 0, $basedirlength) !== FILES_DIR) {
-			$error_msg = "Attempt to delete files outside of TFTP server directory rejected!";
-			log_error("[tftpd] {$error_msg}");
-			file_notice("tftpd", $error_msg, "Packages");
-			header("Location: tftp_files.php");
-			return;
-		} else {
-			unlink_if_exists("{$filename}");
-			conf_mount_ro();
-			header("Location: tftp_files.php");
-			exit;
-		}
-		*/
 	}
 }
 

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/www/tftp_files.php
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/www/tftp_files.php
@@ -1,0 +1,229 @@
+<?php
+/*
+ * tftp_files.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2011-2017 Rubicon Communications, LLC (Netgate)
+ * Copyright (C) 2008 Mark J Crane
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once("config.inc");
+require_once("guiconfig.inc");
+require_once("notices.inc");
+require_once("util.inc");
+require_once("/usr/local/pkg/tftpd.inc");
+
+/* Define some locations */
+$backup_dir = "/root/backup";
+$backup_filename = "tftp.bak.tgz";
+$backup_path = "{$backup_dir}/{$backup_filename}";
+$files_dir = $config['installedpackages']['tftpd']['config'][0]['datadir'];
+$filename = htmlspecialchars($_GET['filename']);
+$download_dir = $files_dir;
+
+/* Trigger full backup creation */
+if ($_GET['a'] == "other" && $_GET['t'] == "backup") {
+	tftp_create_backup();
+}
+
+/* Download full backup or individual files */
+if ($_GET['a'] == "download") {
+	if ($_GET['t'] == "backup") {
+		// Create backup first if it does not exist yet
+		if (!file_exists("{$backup_path}")) {
+			tftp_create_backup(true);
+		}
+		// Download full TFTP server backup from $backup_dir
+		$desc = $backup_path;
+		$filename = $backup_filename;
+	} else {
+		// Download a single file from $files_dir
+		// Only allow to download files under the $files_dir!
+		$basedirlength = strlen($files_dir);
+		if (substr($filename, 0, $basedirlength) !== "{$files_dir}") {
+			$error_msg = "Attempt to download files outside of TFTP server directory rejected!";
+			log_error("[tftpd] {$error_msg}");
+			file_notice("tftpd", $error_msg, "Packages");
+			header("Location: tftp_files.php");
+			return;
+		} else {
+			$desc = $filename;
+			$filename = basename($filename);
+		}
+	}
+
+	session_cache_limiter('public');
+	$fd = fopen("{$desc}", "rb");
+	header("Content-Type: application/force-download");
+	header("Content-Type: application/octet-stream");
+	header("Content-Type: application/download");
+	header("Content-Description: File Transfer");
+	header("Content-Disposition: attachment; filename=\"{$filename}\"");
+	header("Cache-Control: no-cache, must-revalidate");
+	header("Expires: Sat, 26 Jul 1997 05:00:00 GMT");
+	header("Content-Length: " . filesize("{$desc}"));
+	fpassthru($fd);
+	exit;
+}
+
+/* Restore TFTP server backup */
+if ($_GET['a'] == "other" && $_GET['t'] == "restore") {
+		if (file_exists($backup_path)) {
+			conf_mount_rw();
+			mwexec("/usr/bin/tar -xpzC / -f {$backup_path}");
+			header("Location: tftp_files.php?savemsg=Backup+has+been+restored.");
+			conf_mount_ro();
+		} else {
+			header("Location: tftp_files.php?savemsg=Restore+failed.+Backup+file+not+found.&result=alert-warning");
+		}
+		exit;
+}
+
+/* Upload files to TFTP server */
+if ($_POST['upload'] == "Upload" && $_FILES["tftpd_fileup"]["error"] == UPLOAD_ERR_OK) {
+	if (is_uploaded_file($_FILES['tftpd_fileup']['tmp_name'])) {
+		conf_mount_rw();
+		$tmp_name = $_FILES["tftpd_fileup"]["tmp_name"];
+		$name = basename($_FILES["tftpd_fileup"]["name"]);
+		move_uploaded_file($tmp_name, "{$files_dir}/{$name}");
+		conf_mount_ro();
+	} else {
+		$input_errors[] = gettext("Failed to upload file {$_FILES["tftpd_fileup"]["name"]}");
+	}
+}
+
+/* Delete a file from TFTP server */
+if ($_GET['act'] == "del") {
+	if ($_GET['type'] == 'tftp') {
+		conf_mount_rw();
+		$filename = htmlspecialchars($_GET['filename']);
+		// Only delete files under the $files_dir!
+		$basedirlength = strlen($files_dir);
+		if (substr($filename, 0, $basedirlength) !== "{$files_dir}") {
+			$error_msg = "Attempt to delete files outside of TFTP server directory rejected!";
+			log_error("[tftpd] {$error_msg}");
+			file_notice("tftpd", $error_msg, "Packages");
+			header("Location: tftp_files.php");
+			return;
+		} else {
+			unlink_if_exists("{$filename}");
+			conf_mount_ro();
+			header("Location: tftp_files.php");
+			exit;
+		}
+	}
+}
+
+$pgtitle = array("Package", "TFTP server", "Files");
+require_once("head.inc");
+$savemsg = htmlspecialchars($_GET["savemsg"]);
+$result = htmlspecialchars($_GET["result"]) ?: 'success';
+if ($savemsg) {
+	print_info_box($savemsg, $result);
+}
+$tab_array = array();
+$tab_array[] = array("Settings", false, "/pkg_edit.php?xml=tftpd.xml&amp;id=0");
+$tab_array[] = array("Files", true, "/tftp_files.php");
+display_top_tabs($tab_array);
+?>
+
+<div class="panel panel-default">
+        <div class="panel-heading"><h2 class="panel-title"><?=gettext("TFTP Server Files Management")?></h2></div>
+        <div class="panel-body table-responsive">
+                <table class="table table-striped table-hover table-condensed">
+		<tbody><tr><td>
+			<table class="table table-striped table-hover table-condensed">
+			<thead>
+				<th>File Name</th>
+				<th>Last Modified</th>
+				<th>Size</th>
+				<th>Actions</th>
+			</thead>
+			<tbody>
+			<?php $tftpdfiles = new RecursiveDirectoryIterator("{$files_dir}"); ?>
+			<?php foreach (new RecursiveIteratorIterator($tftpdfiles) as $filename => $file): ?>
+			<?php if (is_file($file)): ?>
+				<tr>
+					<td><?=gettext($file); ?></td>
+					<td><?=date('M-d Y g:i a', filemtime("{$file}")); ?></td>
+					<td><?=tftp_byte_convert(filesize("{$file}")); ?> </td>
+						<td>
+						<a name="tftpd_deleteX[]" id="tftpd_deleteX[]" type="button" title="<?=gettext('Delete this file');?>"
+							href='?type=tftp&amp;act=del&amp;filename=<?=$file;?>' style="cursor: pointer;" text="delete this">
+							<i class="fa fa-trash" title="<?=gettext('Delete this file');?>"></i>
+						</a>
+						<a name="tftpd_dnloadX[]" id="tftpd_dnloadX[]" type="button" title="<?=gettext('Download this file');?>"
+							href='tftp_files.php?a=download&amp;filename=<?=$file;?>' style="cursor: pointer;">
+							<i class="fa fa-download" title="<?=gettext('Download this file');?>"></i>
+						</a>
+					</td>
+				</tr>
+			<?php endif; ?>
+			<?php endforeach; ?>
+			</table>
+		</td></tr></tbody>
+		</table>
+	</div>
+	<!-- Modal file upload window -->
+	<div class="modal fade" role="dialog" id="uploader" name="uploader">
+		<div class="modal-dialog">
+			<div class="modal-content">
+				<div class="modal-header">
+					<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+						<span aria-hidden="true">&times;</span>
+					</button>
+
+					<h3 class="modal-title" id="myModalLabel"><?=gettext("File Upload")?></h3>
+				</div>
+
+				<div class="modal-body">
+					<?=gettext("Select a file to upload, and then click 'Upload'.  Click 'Close' to quit."); ?><br /><br />
+					<form action="tftp_files.php" method="post" enctype="multipart/form-data" name="iform" id="iform">
+					<input type="hidden" name="MAX_FILE_SIZE" value="100000000" />
+					<input type="file" class="btn btn-info" name="tftpd_fileup" id="tftpd_fileup" class="formfld file" size="50" /><br />
+					<input type="submit" class="btn btn-sm btn-primary" name="upload" id="upload" value="<?=gettext("Upload");?>" title="<?=gettext("Upload selected files");?>"/>&nbsp;&nbsp;
+					<input type="button" class="btn btn-sm btn-default" value="<?=gettext("Close");?>" data-dismiss="modal"/><br/>
+					</form>
+				</div>
+			</div>
+		</div>
+	</div>
+	<nav class="action-buttons">
+		<button data-toggle="modal" data-target="#uploader" role="button" aria-expanded="false" type="button" name="tftpd_upload" id="tftpd_upload" class="btn btn-info btn-sm" title="<?=gettext('Upload files');?>">
+			<i class="fa fa-upload icon-embed-btn"></i>
+			<?=gettext("Upload")?>
+		</button>
+		<a name="tftpd_dnload_all" id="tftpd_dnload_all" type="button" class="btn btn-info btn-sm"" title="<?=gettext('Download all files in a single gzip archive');?>"
+			href="tftp_files.php?a=download&amp;t=backup" text="download all files">
+			<i class="fa fa-download icon-embed-btn"></i>
+			<?=gettext('Download');?>
+		</a>
+		<a name="tftpd_backup" id="tftpd_backup" type="button" class="btn btn-success btn-sm" title="<?=sprintf(gettext('Backup all files to %s'), $backup_path);?>"
+			href="tftp_files.php?a=other&amp;t=backup" text="backup files">
+			<i class="fa fa-save icon-embed-btn"></i>
+			<?=gettext('Backup');?>
+		</a>
+		<?php if (file_exists($backup_path)): ?>
+		<a name="tftpd_restore" id="tftpd_restore" type="button" class="btn btn-danger btn-sm" title="<?=sprintf(gettext('Restore all files from %s'), $backup_path);?>"
+			href="tftp_files.php?a=other&amp;t=restore" text="restore backup">
+			<i class="fa fa-undo icon-embed-btn"></i>
+			<?=gettext('Restore');?>
+		</a>
+		<?php endif; ?>
+	</nav>
+</div>
+
+<?php require_once("foot.inc"); ?>

--- a/ftp/pfSense-pkg-tftpd/files/usr/local/www/tftp_files.php
+++ b/ftp/pfSense-pkg-tftpd/files/usr/local/www/tftp_files.php
@@ -141,9 +141,9 @@ display_top_tabs($tab_array);
 ?>
 
 <div class="panel panel-default">
-        <div class="panel-heading"><h2 class="panel-title"><?=gettext("TFTP Server Files Management")?></h2></div>
-        <div class="panel-body table-responsive">
-                <table class="table table-striped table-hover table-condensed">
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext("TFTP Server Files Management")?></h2></div>
+	<div class="panel-body table-responsive">
+		<table class="table table-striped table-hover table-condensed">
 		<tbody><tr><td>
 			<table class="table table-striped table-hover table-condensed">
 			<thead>
@@ -190,7 +190,7 @@ display_top_tabs($tab_array);
 				</div>
 
 				<div class="modal-body">
-					<?=gettext("Select a file to upload, and then click 'Upload'.  Click 'Close' to quit."); ?><br /><br />
+					<?=gettext("Select a file to upload, and then click 'Upload'. Click 'Close' to quit."); ?><br /><br />
 					<form action="tftp_files.php" method="post" enctype="multipart/form-data" name="iform" id="iform">
 					<input type="hidden" name="MAX_FILE_SIZE" value="100000000" />
 					<input type="file" class="btn btn-info" name="tftpd_fileup" id="tftpd_fileup" class="formfld file" size="50" /><br />

--- a/ftp/pfSense-pkg-tftpd/pkg-plist
+++ b/ftp/pfSense-pkg-tftpd/pkg-plist
@@ -1,6 +1,7 @@
 /etc/inc/priv/tftpd.priv.inc
 pkg/tftpd.inc
 pkg/tftpd.xml
+www/tftp_files.php
 %%DATADIR%%/info.xml
 @dir /etc/inc/priv
 @dir /etc/inc


### PR DESCRIPTION
- Add option to bind to a single IP
- Add option to force IPv4 only
- Add option to specify the maximum permitted block size
- Re-add backup/restore/upload/delete functionality
- Remove useless custom_add_php_command
- Remove unneeded includes
- Use a PID file for the service
- Remove useless filter_configure() call
- Nuke the shipped startup script on install
- Fix custom_php_{install,deinstall}_command