### PR TITLE
Quagga_OSPF - Attempt to work around Bug #6305

### DIFF
--- a/net/pfSense-pkg-Quagga_OSPF/Makefile
+++ b/net/pfSense-pkg-Quagga_OSPF/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-Quagga_OSPF
-PORTVERSION=	0.6.16
+PORTVERSION=	0.6.17
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd.inc
+++ b/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd.inc
@@ -303,11 +303,15 @@ EOF;
 	// Create rc.d file
 	$rc_file_stop = <<<EOF
 if [ -e /var/run/quagga/zebra.pid ]; then
-	/bin/kill -9 `/bin/cat /var/run/quagga/zebra.pid`
+	# XXX: See Bug #6305 - Quagga 1.x does not like SIGKILL
+	#/bin/kill -9 `/bin/cat /var/run/quagga/zebra.pid`
+	/bin/kill `/bin/cat /var/run/quagga/zebra.pid`
 	/bin/rm -f /var/run/quagga/zebra.pid
 fi
 if [ -e /var/run/quagga/ospfd.pid ]; then
-	/bin/kill -9 `/bin/cat /var/run/quagga/ospfd.pid`
+	# XXX: See Bug #6305 - Quagga 1.x does not like SIGKILL
+	#/bin/kill -9 `/bin/cat /var/run/quagga/ospfd.pid`
+	/bin/kill `/bin/cat /var/run/quagga/ospfd.pid`
 	/bin/rm -f /var/run/quagga/ospfd.pid
 fi
 EOF;
@@ -321,9 +325,22 @@ EOF;
 /usr/sbin/chown -R quagga:quagga /var/run/quagga
 /usr/sbin/chown -R quagga:quagga /var/log/quagga
 # Ensure no other copies of the daemons are running or it breaks.
-/usr/bin/killall -9 zebra 2>/dev/null
-/usr/bin/killall -9 ospfd 2>/dev/null
+# XXX: See Bug #6305 - Quagga 1.x does not like SIGKILL
+#/usr/bin/killall -9 zebra 2>/dev/null
+#/usr/bin/killall -9 ospfd 2>/dev/null
 sleep 1
+pidnum="$(/bin/pgrep zebra)"
+if [ ! -z "\${pidnum}" ]; then
+	/usr/bin/killall zebra
+	sleep 1
+	/usr/bin/killall -9 zebra 2>/dev/null
+fi
+pidnum="$(/bin/pgrep ospfd)"
+if [ ! -z "\${pidnum}" ]; then
+	/usr/bin/killall ospfd
+	sleep 1
+	/usr/bin/killall -9 ospfd 2>/dev/null
+fi
 {$carp_ip_status_check}
 /usr/local/sbin/zebra -d -f {$quagga_config_base}/zebra.conf
 /usr/local/sbin/ospfd -d -f {$quagga_config_base}/ospfd.conf

--- a/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd.inc
+++ b/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd.inc
@@ -304,12 +304,12 @@ EOF;
 	$rc_file_stop = <<<EOF
 if [ -e /var/run/quagga/zebra.pid ]; then
 	# XXX: See Bug #6305 - Quagga 1.x does not like SIGKILL
-	/bin/pkill -F `/bin/cat /var/run/quagga/zebra.pid`
+	/bin/pkill -F /var/run/quagga/zebra.pid
 	/bin/rm -f /var/run/quagga/zebra.pid
 fi
 if [ -e /var/run/quagga/ospfd.pid ]; then
 	# XXX: See Bug #6305 - Quagga 1.x does not like SIGKILL
-	/bin/pkill -F `/bin/cat /var/run/quagga/ospfd.pid`
+	/bin/pkill -F /var/run/quagga/ospfd.pid
 	/bin/rm -f /var/run/quagga/ospfd.pid
 fi
 EOF;

--- a/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd.inc
+++ b/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd.inc
@@ -304,14 +304,12 @@ EOF;
 	$rc_file_stop = <<<EOF
 if [ -e /var/run/quagga/zebra.pid ]; then
 	# XXX: See Bug #6305 - Quagga 1.x does not like SIGKILL
-	#/bin/kill -9 `/bin/cat /var/run/quagga/zebra.pid`
-	/bin/kill `/bin/cat /var/run/quagga/zebra.pid`
+	/bin/pkill -F `/bin/cat /var/run/quagga/zebra.pid`
 	/bin/rm -f /var/run/quagga/zebra.pid
 fi
 if [ -e /var/run/quagga/ospfd.pid ]; then
 	# XXX: See Bug #6305 - Quagga 1.x does not like SIGKILL
-	#/bin/kill -9 `/bin/cat /var/run/quagga/ospfd.pid`
-	/bin/kill `/bin/cat /var/run/quagga/ospfd.pid`
+	/bin/pkill -F `/bin/cat /var/run/quagga/ospfd.pid`
 	/bin/rm -f /var/run/quagga/ospfd.pid
 fi
 EOF;
@@ -325,18 +323,13 @@ EOF;
 /usr/sbin/chown -R quagga:quagga /var/run/quagga
 /usr/sbin/chown -R quagga:quagga /var/log/quagga
 # Ensure no other copies of the daemons are running or it breaks.
-# XXX: See Bug #6305 - Quagga 1.x does not like SIGKILL
-#/usr/bin/killall -9 zebra 2>/dev/null
-#/usr/bin/killall -9 ospfd 2>/dev/null
 sleep 1
-pidnum="$(/bin/pgrep zebra)"
-if [ ! -z "\${pidnum}" ]; then
+if /bin/pgrep -q zebra; then
 	/usr/bin/killall zebra
 	sleep 1
 	/usr/bin/killall -9 zebra 2>/dev/null
 fi
-pidnum="$(/bin/pgrep ospfd)"
-if [ ! -z "\${pidnum}" ]; then
+if /bin/pgrep -q ospfd; then
 	/usr/bin/killall ospfd
 	sleep 1
 	/usr/bin/killall -9 ospfd 2>/dev/null


### PR DESCRIPTION
Quagga 1.x does not like to be killed with SIGKILL. Try to kill it more gracefully. If everything fails, eventually force a SIGKILL on (re)start because otherwise things breaks completely.