### PR TITLE
freeradius service handling fixes (Bug #6404), fix chown handling and various bugs

### DIFF
--- a/net/pfSense-pkg-freeradius2/Makefile
+++ b/net/pfSense-pkg-freeradius2/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-freeradius2
-PORTVERSION=	1.7.4
+PORTVERSION=	1.7.5
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -163,10 +163,9 @@ SERVICENAME="radiusd"
 EOD;
 	$rcfile['stop'] = FREERADIUS_ETC . '/rc.d/radiusd onestop';
 	write_rcfile($rcfile);
-	start_service("radiusd");
 }
 
-function freeradius_settings_resync() {
+function freeradius_settings_resync($restart_svc = true) {
 	global $config;
 	$conf = '';
 
@@ -410,6 +409,9 @@ EOD;
 	exec("ldconfig -m /usr/local/lib/mysql");
 	// Change owner of freeradius created files
 	exec("chown -R root:wheel /var/log");
+	if ($restart_svc) {
+		restart_service("radiusd");
+	}
 }
 
 function freeradius_users_resync() {

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -453,7 +453,7 @@ EOD;
 	}
 }
 
-function freeradius_users_resync($via_rpc = "no") {
+function freeradius_users_resync($via_rpc = false) {
 global $config;
 
 $conf = '';
@@ -676,13 +676,13 @@ EOD;
 	freeradius_sync_on_changes();
 	// Do not restart on boot
 	// Will get restarted later by freeradius_clients_resync() if called via XMLRPC sync
-	if ($via_rpc == "no" && !platform_booting()) {
+	if ($via_rpc === false && !platform_booting()) {
 		restart_service('radiusd');
 	}
 }
 
 
-function freeradius_authorizedmacs_resync($via_rpc = "no") {
+function freeradius_authorizedmacs_resync($via_rpc = false) {
 global $config;
 
 $conf = '';
@@ -872,7 +872,7 @@ EOD;
 	conf_mount_ro();
 	
 	freeradius_sync_on_changes();
-	if ($via_rpc == "no") {
+	if ($via_rpc === false) {
 		restart_service('radiusd');
 	}
 }
@@ -2804,9 +2804,9 @@ function freeradius_do_xmlrpc_sync($sync_to_ip, $username, $password, $varsyncpo
 // This function restarts all other needed functions after XMLRPC so that the content of .XML + .INC will be written in the files (clients.conf, users)
 // Adding more functions will increase the to sync
 function freeradius_all_after_XMLRPC_resync() {
-	// Only (re)start the service once by passing $via_rpc = 'yes' to the below function calls
-	freeradius_users_resync('yes');
-	freeradius_authorizedmacs_resync('yes');
+	// Only (re)start the service once by passing $via_rpc = true to the below function calls
+	freeradius_users_resync(true);
+	freeradius_authorizedmacs_resync(true);
 	freeradius_clients_resync();
 	
 	log_error("[FreeRADIUS]: Finished XMLRPC process. It should be OK. For more information look at the host which started sync.");

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -75,8 +75,11 @@ function freeradius_install_command() {
 	@mkdir("/var/log/radacct/timecounter", 0755, true);
 	@mkdir(FREERADIUS_ETC . "/raddb/scripts", 0755, true);
 
-	unlink_if_exists("/usr/local/etc/raddb");
-	@symlink(FREERADIUS_ETC . "/raddb", "/usr/local/etc/raddb");
+	// Previous package versions were creating a symlink targeting itself here
+	if (is_link(FREERADIUS_ETC . "/raddb")) {
+		unlink(FREERADIUS_ETC . "/raddb");
+	}
+	safe_mkdir(FREERADIUS_ETC . "/raddb");
 	if (!file_exists("/var/log/radutmp")) { exec("touch /var/log/radutmp");	}
 	if (!file_exists("/var/log/radwtmp")) {	exec("touch /var/log/radwtmp");	}
 	exec("chown -R root:wheel " . FREERADIUS_ETC . "/raddb /var/log/radacct");

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -176,12 +176,20 @@ function freeradius_settings_resync($restart_svc = true) {
 	$varFREERADIUS_BASE = FREERADIUS_BASE;
 
 	// We do some checks of some folders which will be deleted after reboot on nanobsd systems
-	if (!file_exists("/var/log/radacct/")) { exec("mkdir /var/log/radacct"); }
-	if (!file_exists("/var/log/radacct/datacounter/")) { exec("mkdir /var/log/radacct/datacounter && mkdir /var/log/radacct/datacounter/daily && mkdir /var/log/radacct/datacounter/weekly && mkdir /var/log/radacct/datacounter/monthly && mkdir /var/log/radacct/datacounter/forever"); }
-	if (!file_exists("/var/log/radacct/timecounter/")) { exec("mkdir /var/log/radacct/timecounter"); }
-	if (!file_exists("/var/log/radutmp")) { exec("touch /var/log/radutmp");	}
-	if (!file_exists("/var/log/radwtmp")) {	exec("touch /var/log/radwtmp");	}
-	if (!file_exists("/var/log/radacct/")) { exec("chown -R root:wheel /var/log/radacct"); }
+	safe_mkdir("/var/log/radacct/datacounter/daily");
+	safe_mkdir("/var/log/radacct/datacounter/weekly");
+	safe_mkdir("/var/log/radacct/datacounter/monthly");
+	safe_mkdir("/var/log/radacct/datacounter/forever");
+	safe_mkdir("/var/log/radacct/timecounter");
+	if (!file_exists("/var/log/radutmp")) {
+		touch("/var/log/radutmp");
+	}
+	if (!file_exists("/var/log/radwtmp")) {
+		touch("/var/log/radwtmp");
+	}
+	if (is_dir("/var/log/radacct/")) {
+		exec("chown -R root:wheel /var/log/radacct");
+	}
 
 	$varsettings = $config['installedpackages']['freeradiussettings']['config'][0];
 	

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -410,7 +410,6 @@ EOD;
 	exec("ldconfig -m /usr/local/lib/mysql");
 	// Change owner of freeradius created files
 	exec("chown -R root:wheel /var/log");
-	restart_service("radiusd");
 }
 
 function freeradius_users_resync() {

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -106,7 +106,7 @@ function freeradius_install_command() {
 
 	// Previous package versions were creating a symlink targeting itself here
 	if (is_link(FREERADIUS_ETC . "/raddb")) {
-		unlink(FREERADIUS_ETC . "/raddb");
+		@unlink(FREERADIUS_ETC . "/raddb");
 	}
 	safe_mkdir(FREERADIUS_ETC . "/raddb/scripts");
 	freeradius_chown_recursive(FREERADIUS_ETC . "/raddb");

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -39,16 +39,17 @@ define('FREERADIUS_LIB', FREERADIUS_BASE . '/lib');
 define('FREERADIUS_ETC', FREERADIUS_BASE . '/etc');
 
 // Check freeradius lib version
-	$frlib="";
-	if (file_exists(FREERADIUS_LIB)) {
+	$frlib = "";
+	if (is_dir(FREERADIUS_LIB)) {
 		$libfiles = scandir(FREERADIUS_LIB);
-		foreach ($libfiles as $libfile){
-			if (preg_match("/freeradius-/",$libfile))
-				$frlib=FREERADIUS_LIB . '/' . $libfile;
+		foreach ($libfiles as $libfile) {
+			if (preg_match("/freeradius-/", $libfile)) {
+				$frlib = FREERADIUS_LIB . '/' . $libfile;
+			}
 		}
 	}
-	if ($frlib == ""){
-		log_error("freeRADIUS - No freeradius lib found on ".FREERADIUS_LIB);
+	if ($frlib == "") {
+		log_error("freeRADIUS - No freeradius libs found on " . FREERADIUS_LIB);
 	}
 	
 function freeradius_deinstall_command() {
@@ -62,6 +63,29 @@ function freeradius_deinstall_command() {
 		$i++;
 	}
 	return;
+}
+
+function freeradius_chown_recursive($dir, $user = "root", $group = "wheel") {
+	if (empty($dir) || ($dir == '/') || ($dir == '/usr/local') || ($dir == '/usr/local/etc') || ($dir == '/usr/local/lib') || ($dir == '/var/log') || !is_dir($dir)) {
+		log_error(gettext("[freeradius] Attempted to recursively chown an invalid directory: '{$dir}'"));
+		return;
+	}
+	chown($dir, $user);
+	chgrp($dir, $group);
+	$handle = opendir($dir);
+	if ($handle) {
+		while (($item = readdir($handle)) !== false) {
+			if (!empty($item) && ($item != ".") && ($item != "..")) {
+				$path = "{$dir}/{$item}";
+				if (is_file($path)) {
+					chown($path, $user);
+					chgrp($path, $group);
+				}
+			}
+		}
+	} else {
+		log_error(gettext("[freedarius] freeradius_chown_recursive() call failed; permissions not set for directory: '{$dir}'"));
+	}
 }
 
 function freeradius_install_command() {
@@ -82,9 +106,10 @@ function freeradius_install_command() {
 	safe_mkdir(FREERADIUS_ETC . "/raddb");
 	if (!file_exists("/var/log/radutmp")) { exec("touch /var/log/radutmp");	}
 	if (!file_exists("/var/log/radwtmp")) {	exec("touch /var/log/radwtmp");	}
-	exec("chown -R root:wheel " . FREERADIUS_ETC . "/raddb /var/log/radacct");
-	if (file_exists($frlib)) {
-		exec("chown -R root:wheel {$frlib}");
+	freeradius_chown_recursive(FREERADIUS_ETC . "/raddb");
+	freeradius_chown_recursive("/var/log/radacct");
+	if (is_dir($frlib)) {
+		freeradius_chown_recursive($frlib);
 	}
 
 	// creating a backup file of the original policy.conf no matter if user checked this or not
@@ -186,9 +211,6 @@ function freeradius_settings_resync($restart_svc = true) {
 	}
 	if (!file_exists("/var/log/radwtmp")) {
 		touch("/var/log/radwtmp");
-	}
-	if (is_dir("/var/log/radacct/")) {
-		exec("chown -R root:wheel /var/log/radacct");
 	}
 
 	$varsettings = $config['installedpackages']['freeradiussettings']['config'][0];
@@ -418,6 +440,10 @@ EOD;
 	
 	// This is to fix the mysqlclient.so which gets lost after reboot
 	exec("ldconfig -m /usr/local/lib/mysql");
+	// Change owner of freeradius created files
+	if (is_dir("/var/log/radacct/")) {
+		freeradius_chown_recursive("/var/log/radacct");
+	}
 
 	if ($restart_svc) {
 		restart_service("radiusd");

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -92,20 +92,23 @@ function freeradius_install_command() {
 	global $config, $frlib;
 
 	// We create here different folders for different counters.
-	@mkdir("/var/log/radacct/datacounter/daily", 0755, true);
-	@mkdir("/var/log/radacct/datacounter/weekly", 0755, true);
-	@mkdir("/var/log/radacct/datacounter/monthly", 0755, true);
-	@mkdir("/var/log/radacct/datacounter/forever", 0755, true);
-	@mkdir("/var/log/radacct/timecounter", 0755, true);
-	@mkdir(FREERADIUS_ETC . "/raddb/scripts", 0755, true);
+	safe_mkdir("/var/log/radacct/datacounter/daily");
+	safe_mkdir("/var/log/radacct/datacounter/weekly");
+	safe_mkdir("/var/log/radacct/datacounter/monthly");
+	safe_mkdir("/var/log/radacct/datacounter/forever");
+	safe_mkdir("/var/log/radacct/timecounter");
+	if (!file_exists("/var/log/radutmp")) {
+		touch("/var/log/radutmp");
+	}
+	if (!file_exists("/var/log/radwtmp")) {
+		touch("/var/log/radwtmp");
+	}
 
 	// Previous package versions were creating a symlink targeting itself here
 	if (is_link(FREERADIUS_ETC . "/raddb")) {
 		unlink(FREERADIUS_ETC . "/raddb");
 	}
-	safe_mkdir(FREERADIUS_ETC . "/raddb");
-	if (!file_exists("/var/log/radutmp")) { exec("touch /var/log/radutmp");	}
-	if (!file_exists("/var/log/radwtmp")) {	exec("touch /var/log/radwtmp");	}
+	safe_mkdir(FREERADIUS_ETC . "/raddb/scripts");
 	freeradius_chown_recursive(FREERADIUS_ETC . "/raddb");
 	freeradius_chown_recursive("/var/log/radacct");
 	if (is_dir($frlib)) {

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -635,7 +635,9 @@ EOD;
 	conf_mount_ro();
 	
 	freeradius_sync_on_changes();
-	if ($via_rpc == "no") {
+	// Do not restart on boot
+	// Will get restarted later by freeradius_clients_resync() if called via XMLRPC sync
+	if ($via_rpc == "no" && !platform_booting()) {
 		restart_service('radiusd');
 	}
 }

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -414,7 +414,7 @@ EOD;
 	}
 }
 
-function freeradius_users_resync() {
+function freeradius_users_resync($via_rpc = "no") {
 global $config;
 
 $conf = '';
@@ -635,11 +635,13 @@ EOD;
 	conf_mount_ro();
 	
 	freeradius_sync_on_changes();
-	restart_service('radiusd');
+	if ($via_rpc == "no") {
+		restart_service('radiusd');
+	}
 }
 
 
-function freeradius_authorizedmacs_resync() {
+function freeradius_authorizedmacs_resync($via_rpc = "no") {
 global $config;
 
 $conf = '';
@@ -829,7 +831,9 @@ EOD;
 	conf_mount_ro();
 	
 	freeradius_sync_on_changes();
-	restart_service('radiusd');
+	if ($via_rpc == "no") {
+		restart_service('radiusd');
+	}
 }
 
 function freeradius_clients_resync() {
@@ -2759,14 +2763,12 @@ function freeradius_do_xmlrpc_sync($sync_to_ip, $username, $password, $varsyncpo
 // This function restarts all other needed functions after XMLRPC so that the content of .XML + .INC will be written in the files (clients.conf, users)
 // Adding more functions will increase the to sync
 function freeradius_all_after_XMLRPC_resync() {
-	
-	freeradius_users_resync();
-	freeradius_authorizedmacs_resync();
+	// Only (re)start the service once by passing $via_rpc = 'yes' to the below function calls
+	freeradius_users_resync('yes');
+	freeradius_authorizedmacs_resync('yes');
 	freeradius_clients_resync();
 	
 	log_error("[FreeRADIUS]: Finished XMLRPC process. It should be OK. For more information look at the host which started sync.");
-	
-	exec(FREERADIUS_ETC . "/rc.d/radiusd onerestart");
 }
 
 function freeradius_modulescounter_resync() {

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -407,8 +407,7 @@ EOD;
 	
 	// This is to fix the mysqlclient.so which gets lost after reboot
 	exec("ldconfig -m /usr/local/lib/mysql");
-	// Change owner of freeradius created files
-	exec("chown -R root:wheel /var/log");
+
 	if ($restart_svc) {
 		restart_service("radiusd");
 	}

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -38,6 +38,17 @@ $bash_path = FREERADIUS_BASE . "/bin/bash";
 define('FREERADIUS_LIB', FREERADIUS_BASE . '/lib');
 define('FREERADIUS_ETC', FREERADIUS_BASE . '/etc');
 
+/*
+ * List of functions that directly call restart_service('radiusd')
+ * (with optional parameters to be passed to avoid that behaviour)
+ * freeradius_settings_resync($restart_svc = true)
+ * freeradius_users_resync($via_rpc = false)
+ * freeradius_authorizedmacs_resync($restart_svc = true, $via_rpc = false)
+ * freeradius_clients_resync($restart_svc = true)
+ * freeradius_eapconf_resync($restart_svc = true)
+ * freeradius_modulesldap_resync($restart_svc = true)
+*/
+
 // Check freeradius lib version
 	$frlib = "";
 	if (is_dir(FREERADIUS_LIB)) {
@@ -132,7 +143,7 @@ function freeradius_install_command() {
 	if (file_exists(FREERADIUS_ETC . "/raddb/sites-enabled/inner-tunnel")) { unlink(FREERADIUS_ETC . "/raddb/sites-enabled/inner-tunnel"); }
 
 	// We run this here just to suppress some warnings on syslog if file doesn't exist
-	freeradius_authorizedmacs_resync();
+	freeradius_authorizedmacs_resync(false, false);
 
 	// These two functions create the module and the dictionary entry for Mobile-One-Time-Password
 	freeradius_dictionary_resync();
@@ -150,9 +161,9 @@ function freeradius_install_command() {
 
 	// Initialize some config files - the functions below call other functions
 	freeradius_sqlconf_resync();
-	freeradius_eapconf_resync();
-	freeradius_clients_resync();
-	freeradius_modulesldap_resync();
+	freeradius_eapconf_resync(false);
+	freeradius_clients_resync(false);
+	freeradius_modulesldap_resync(false);
 
 	$rcfile = array();
 	$rcfile['file'] = 'radiusd.sh';
@@ -682,7 +693,7 @@ EOD;
 }
 
 
-function freeradius_authorizedmacs_resync($via_rpc = false) {
+function freeradius_authorizedmacs_resync($restart_svc = true, $via_rpc = false) {
 global $config;
 
 $conf = '';
@@ -872,12 +883,12 @@ EOD;
 	conf_mount_ro();
 	
 	freeradius_sync_on_changes();
-	if ($via_rpc === false) {
+	if ($restart_svc === true && $via_rpc === false) {
 		restart_service('radiusd');
 	}
 }
 
-function freeradius_clients_resync() {
+function freeradius_clients_resync($restart_svc = true) {
 	global $config;
 
 	$conf = '';
@@ -947,7 +958,7 @@ EOD;
 
 
 
-function freeradius_eapconf_resync() {
+function freeradius_eapconf_resync($restart_svc = true) {
 	global $config;
 		// We make this write enabled here because embedded systems need to write certs in ../raddb/certs/ folder
 		conf_mount_rw();
@@ -1020,7 +1031,7 @@ function freeradius_eapconf_resync() {
 // This is for the pfsense cert manager
 // Depends on "freeradius_get_server_certs" and "freeradius_get_ca_certs"
 
-if ($eapconf['vareapconfchoosecertmanager'] == 'on') {
+	if ($eapconf['vareapconfchoosecertmanager'] == 'on') {
 		
 		$ca_cert = lookup_ca($eapconf["ssl_ca_cert"]);
 		if ($ca_cert != false) {
@@ -1194,7 +1205,9 @@ EOD;
 	chmod($filename, 0640);
 	conf_mount_ro();
 
-	restart_service('radiusd');
+	if ($restart_svc) {
+		restart_service('radiusd');
+	}
 }
 
 // Gets started from freeradiuseapconf.xml
@@ -2804,9 +2817,11 @@ function freeradius_do_xmlrpc_sync($sync_to_ip, $username, $password, $varsyncpo
 // This function restarts all other needed functions after XMLRPC so that the content of .XML + .INC will be written in the files (clients.conf, users)
 // Adding more functions will increase the to sync
 function freeradius_all_after_XMLRPC_resync() {
-	// Only (re)start the service once by passing $via_rpc = true to the below function calls
+	// Only (re)start the service once by passing $restart_svc = false 
+	// and/or $via_rpc = true to the below function calls
 	freeradius_users_resync(true);
-	freeradius_authorizedmacs_resync(true);
+	// Do not restart service
+	freeradius_authorizedmacs_resync(false, true);
 	freeradius_clients_resync();
 	
 	log_error("[FreeRADIUS]: Finished XMLRPC process. It should be OK. For more information look at the host which started sync.");
@@ -3079,7 +3094,7 @@ EOD;
 
 }
 
-function freeradius_modulesldap_resync() {
+function freeradius_modulesldap_resync($restart_svc = true) {
 	global $config;
 	$conf = '';
 	
@@ -3684,7 +3699,9 @@ EOD;
 	// We need to rebuild "freeradius_serverdefault_resync" before restart service
 	// "freeradius_serverdefault_resync" needs to restart other dependencies so we are pointing directly to "freeradius_settings_resync()"
 	freeradius_serverdefault_resync();
-	restart_service("radiusd");
+	if ($restart_svc) {
+		restart_service("radiusd");
+	}
 	
 }
 

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.xml
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.xml
@@ -497,7 +497,7 @@
 		freeradius_users_resync();
 	</custom_delete_php_command>
 	<custom_php_resync_config_command>
-		freeradius_settings_resync();
+		freeradius_settings_resync(false);
 		sleep(1);
 		freeradius_users_resync();
 	</custom_php_resync_config_command>


### PR DESCRIPTION
Service handling fixes:
- Remove unwanted freeradius restart on install/upgrade
This breaks things due to restarting the service multiple times - once here and more times when custom_php_resync_config_command is run on install, which in turn runs freeradius_settings_resync() which restarts the service, and then freeradius_users_resync() runs which restarts the service yet again.
- Add an argument to skip service restart to freeradius_settings_resync() function
- Do not restart service twice on resync
- Do not restart on boot
- Attempt to fix XMLRPC sync which was restarting the service four times for a good measure, WTF.

Other fixes:
- Remove an evil recursive chown call on /var/log screwing up logdir permissions for things like squid, clamav, redis... Same unwanted recursive chown would be run on entire /usr/local/lib if $frlib was empty for some reason. Create a function with sanity checks, use PHP's chown()/chgrp() functions instead of exec() and refuse to recursively chown invalid targets.
- Stop creating a symlink to itself instead of /usr/local/etc/raddb directory
- Use safe_mkdir() in buch of places and fix some wrong checks while here.

Note: Would be worth getting everywhere, incl. RELENG_2_3_2:
https://forum.pfsense.org/index.php?topic=119569.0
https://forum.pfsense.org/index.php?topic=87441.0