### PR TITLE
Squid - dashboard widget bootstrap facelift + fixes

### DIFF
--- a/www/pfSense-pkg-squid/Makefile
+++ b/www/pfSense-pkg-squid/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-squid
 PORTVERSION=	0.4.35
+PORTREVISION=	1
 CATEGORIES=	www
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/www/pfSense-pkg-squid/files/etc/inc/priv/squid.priv.inc
+++ b/www/pfSense-pkg-squid/files/etc/inc/priv/squid.priv.inc
@@ -3,7 +3,7 @@
  * squid.priv.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,8 +22,8 @@
 global $priv_list;
 
 $priv_list['page-services-squid3'] = array();
-$priv_list['page-services-squid3']['name'] = "WebCfg - Services: Squid3 package";
-$priv_list['page-services-squid3']['descr'] = "Allow access to Squid3 package GUI";
+$priv_list['page-services-squid3']['name'] = "WebCfg - Services: Squid package";
+$priv_list['page-services-squid3']['descr'] = "Allow access to Squid package GUI";
 $priv_list['page-services-squid3']['match'] = array();
 
 $priv_list['page-services-squid3']['match'][] = "pkg.php?xml=squid_reverse_peer.xml*";

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.xml
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.xml
@@ -729,7 +729,7 @@
 			<description>
 				<![CDATA[
 				Put your own custom options here, one per line. They'll be added to the configuration in place of the default SSL/MITM configuration.<br/>
-				<span class="text-info">Click Info for details.</span> 
+				<span class="text-info"><strong>Ignored unless 'SSL/MITM Mode' is set to 'Custom'.</strong> Click Info for details.</span>
 				<div class="infoblock">
 				Some predefined ACLs for step values are available here: <strong><span class="text-info">step1, step2, step3</span></strong>.<br/>
 				These can be used there for custom configuration and are applied at the corresponding ssl_bump evaluation moments:<br/><br/>

--- a/www/pfSense-pkg-squid/files/usr/local/www/squid_clwarn.php
+++ b/www/pfSense-pkg-squid/files/usr/local/www/squid_clwarn.php
@@ -54,8 +54,11 @@ error_log(date("Y-m-d H:i:s") . " | VIRUS FOUND | "
 	. str_replace('|', '', $user) . "\n", 3, "/var/log/c-icap/virus.log");
 
 ?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
 <style type="text/css">
-	.visu {
+.visu {
 	border:1px solid #C0C0C0;
 	color:#FFFFFF;
 	position: relative;
@@ -66,27 +69,34 @@ error_log(date("Y-m-d H:i:s") . " | VIRUS FOUND | "
 	border-radius: 10px;
 	padding: 3em;
 	-moz-padding-start: 30px;
-	background-color: #8b0000;
+	background-color: #8B0000;
 }
 .visu h2, .visu h3, .visu h4 {
-	font-size:130%;
-	font-family:"times new roman", times, serif;
-	font-style:normal;
-	font-weight:bolder;
+	font-size: 130%;
+	font-family: "times new roman", times, serif;
+	font-style: normal;
+	font-weight: bolder;
+
+}
+a:link, a:visited {
+	color: #FFFFFF;
+	text-decoration: underline;
 }
 </style>
+<title><?=$TITLE_VIRUS?></title>
+</head>
+<body>
 <div class="visu">
 	<h2><?=$TITLE_VIRUS?></h2>
 	<hr />
 	<p>
 	The requested URL <?=$url?> <?=$urlerror?><br/>
 	<?=$subtitle?>: <?=$virus?>
-	</p><p>
-	<?=$errorreturn?>
-	</p><p>
-	Origin: <?=$source?> / <?=$user?>
-	</p><p>
-	<hr />
-	<font color="blue"> Powered by <a href="http://squidclamav.darold.net/">SquidClamav <?=$VERSION?></a>.</font>
 	</p>
+	<p><?=$errorreturn?></p>
+	<p>Origin: <?=$source?> / <?=$user?></p>
+	<hr />
+	<p><small>Powered by <a href="http://squidclamav.darold.net/">SquidClamav <?=$VERSION?></a></small></p>
 </div>
+</body>
+</html>

--- a/www/pfSense-pkg-squid/files/usr/local/www/squid_clwarn.php
+++ b/www/pfSense-pkg-squid/files/usr/local/www/squid_clwarn.php
@@ -3,7 +3,7 @@
  * squid_clwarn.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2015 Marcello Coutinho
  * All rights reserved.
  *
@@ -19,7 +19,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-$VERSION = '6.10';
+require_once("pkg-utils.inc");
+pkg_exec("query '%v' squidclamav", $version, $err);
+$VERSION = "{$version}";
 $url = htmlspecialchars($_REQUEST['url']);
 $virus = ($_REQUEST['virus'] ? $_REQUEST['virus'] : $_REQUEST['malware']);
 

--- a/www/pfSense-pkg-squid/files/usr/local/www/squid_clwarn.php
+++ b/www/pfSense-pkg-squid/files/usr/local/www/squid_clwarn.php
@@ -20,8 +20,12 @@
  * limitations under the License.
  */
 require_once("pkg-utils.inc");
-pkg_exec("query '%v' squidclamav", $version, $err);
-$VERSION = "{$version}";
+$rc = pkg_exec("query '%v' squidclamav", $version, $err);
+if ($rc != 0) {
+	$VERSION = "N/A";
+} else {
+	$VERSION = "{$version}";
+}
 $url = htmlspecialchars($_REQUEST['url']);
 $virus = ($_REQUEST['virus'] ? $_REQUEST['virus'] : $_REQUEST['malware']);
 

--- a/www/pfSense-pkg-squid/files/usr/local/www/widgets/widgets/squid_antivirus_status.widget.php
+++ b/www/pfSense-pkg-squid/files/usr/local/www/widgets/widgets/squid_antivirus_status.widget.php
@@ -3,7 +3,7 @@
  * squid_antivirus_status.widget.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (C) 2010 Serg Dvoriancev <dv_serg@mail.ru>
  * All rights reserved.
  *
@@ -20,25 +20,25 @@
  * limitations under the License.
  */
 
+require_once("functions.inc");
 require_once("guiconfig.inc");
 require_once("pfsense-utils.inc");
-require_once("functions.inc");
 require_once("pkg-utils.inc");
+require_once("service-utils.inc");
 if (file_exists("/usr/local/pkg/squid.inc")) {
 	require_once("/usr/local/pkg/squid.inc");
 } else {
-	echo "No squid.inc found. You must have Squid3 package installed to use this widget.";
+	echo "No squid.inc found. You must have Squid package installed to use this widget.";
 }
 
 define('PATH_CLAMDB', '/var/db/clamav');
 define('PATH_SQUID', SQUID_BASE . '/bin/squid');
 define('PATH_AVLOG', '/var/log/c-icap/virus.log');
-global $clamd_path, $cicap_cfg_path, $img;
+global $clamd_path, $img;
 $clamd_path = SQUID_BASE . "/sbin/clamd";
-$cicap_cfg_path = SQUID_LOCALBASE . "/bin/c-icap-config";
 $img = array();
-$img['up'] = "<img src='data:image/gif;base64,R0lGODlhCwALAIABACPcMP///yH+FUNyZWF0ZWQgd2l0aCBUaGUgR0lNUAAh+QQBCgABACwAAAAACwALAAACFYwNpwi50eKK9NA722Puyf15GjgaBQA7' title='Service running' alt='' />";
-$img['down'] = "<img src='data:image/gif;base64,R0lGODlhCwALAIABANwjI////yH+FUNyZWF0ZWQgd2l0aCBUaGUgR0lNUAAh+QQBCgABACwAAAAACwALAAACFowDeYvKlsCD7sXZ5Iq89kpdFshoRwEAOw==' title='Service not running' alt='' />";
+$img['up'] = '<i class="fa fa-level-up text-success" title="Service running"></i>';
+$img['down'] = '<i class="fa fa-level-down text-danger" title="Service not running"></i>';
 
 function squid_avdb_info($filename) {
 	$stl = "style='padding-top: 0px; padding-bottom: 0px; padding-left: 4px; padding-right: 4px; border-left: 1px solid #999999;'";
@@ -49,11 +49,11 @@ function squid_avdb_info($filename) {
 		if ($handle = fopen($path, "r")) {
 			$s = fread($handle, 1024);
 			$s = explode(':', $s);
-			# datetime
+			// datetime
 			$dt = explode(" ", $s[1]);
 			$s[1] = strftime("%Y.%m.%d", strtotime("{$dt[0]} {$dt[1]} {$dt[2]}"));
 			if ($s[0] == 'ClamAV-VDB') {
-				$r .= "<tr class='listr'><td>{$filename}</td><td {$stl}>{$s[1]}</td><td {$stl}>{$s[2]}</td><td $stl>{$s[7]}</td></tr>";
+				$r .= "<tr><td>{$filename}</td><td {$stl}>{$s[1]}</td><td {$stl}>{$s[2]}</td><td $stl>{$s[7]}</td></tr>";
 			}
 			fclose($handle);
 		}
@@ -62,8 +62,8 @@ function squid_avdb_info($filename) {
 }
 
 function squid_antivirus_bases_info() {
-	$db = '<table width="100%" border="0" cellspacing="0" cellpadding="1"><tbody>';
-	$db .= '<tr class="vncellt" ><td>Database</td><td>Date</td><td>Version</td><td>Builder</td></tr>';
+	$db = '<table class="table table-striped table-hover table-condensed"><tbody>';
+	$db .= '<tr><th>Database</th><th>Date</th><th>Version</th><th>Builder</th></tr>';
 	$avdbs = array("daily.cvd", "daily.cld", "bytecode.cvd", "bytecode.cld", "main.cvd", "main.cld", "safebrowsing.cvd", "safebrowsing.cld");
 	foreach ($avdbs as $avdb) {
 		$db .= squid_avdb_info($avdb);
@@ -73,27 +73,19 @@ function squid_antivirus_bases_info() {
 }
 
 function squid_clamav_version() {
-	global $clamd_path, $cicap_cfg_path, $img;
-	if (is_executable($clamd_path)) {
-		$s = (is_service_running("clamd") ? $img['up'] : $img['down']);
-		$version = preg_split("@/@", shell_exec("{$clamd_path} -V"));
-		$s .= "&nbsp;&nbsp;{$version[0]}";
-	} else {
-		$s .= "&nbsp;&nbsp;ClamAV: N/A";
-	}
-	if (is_executable($cicap_cfg_path)) {
-		$s .= "&nbsp;&nbsp;";
-		$s .= (is_service_running("c-icap") ? $img['up'] : $img['down']);
-		$s .= "&nbsp;&nbsp;C-ICAP " . shell_exec("{$cicap_cfg_path} --version");
-	} else {
-		$s .= "&nbsp;&nbsp;C-ICAP: N/A";
-	}
-	if (file_exists("/usr/local/www/squid_clwarn.php")) {
-		preg_match("@(VERSION.*).(\d{1}).(\d{2})@", file_get_contents("/usr/local/www/squid_clwarn.php"), $squidclamav_version);
-		$s .= "+&nbsp;&nbsp;SquidClamav " . str_replace("'", "", strstr($squidclamav_version[0], "'"));
-	} else {
-		$s .= "+&nbsp;&nbsp;SquidClamav: N/A";
-	}
+	global $img;
+	// ClamAV status and version
+	$s = (is_service_running("clamd") ? $img['up'] : $img['down']);
+	pkg_exec("query '%v' clamav", $version, $err);
+	$s .= "&nbsp;&nbsp;ClamAV {$version}";
+	$s .= "&nbsp;&nbsp;";
+	// C-ICAP status and version
+	$s .= (is_service_running("c-icap") ? $img['up'] : $img['down']);
+	pkg_exec("query '%v' c-icap", $version, $err);
+	$s .= "&nbsp;&nbsp;C-ICAP {$version}";
+	// SquidClamav version
+	pkg_exec("query '%v' squidclamav", $version, $err);
+	$s .= "+&nbsp;&nbsp;SquidClamav {$version}";
 	return $s;
 }
 
@@ -119,11 +111,12 @@ function squid_antivirus_statistics() {
 
 ?>
 
-<table width="100%" border="0" cellspacing="0" cellpadding="0">
+<div class="table-responsive">
+	<table class="table table-striped table-hover table-condensed">
 	<tbody>
 		<tr>
-			<td class="vncellt">Squid Version</td>
-			<td class="listr" width="75%">
+			<th>Squid Version</th>
+			<td width="75%">
 			<?php
 				$updown = (is_service_running("squid") ? $img['up'] : $img['down']);
 				pkg_exec("query '%v' squid", $version, $err);
@@ -132,28 +125,29 @@ function squid_antivirus_statistics() {
 			</td>
 		</tr>
 		<tr>
-			<td class="vncellt">Antivirus Scanner</td>
-			<td class="listr" width="75%">
+			<th>Antivirus Scanner</th>
+			<td width="75%">
 				<?php echo squid_clamav_version(); ?>
 			</td>
 		</tr>
 		<tr>
-			<td class="vncellt">Antivirus Bases</td>
-			<td class="listr" width="75%">
+			<th style="vertical-align:middle;">Antivirus Bases</th>
+			<td width="75%">
 				<?php echo squid_antivirus_bases_info(); ?>
 			</td>
 		</tr>
 		<tr>
-			<td class="vncellt">Last Update</td>
-			<td class="listr" width="75%">
+			<th>Last Update</th>
+			<td width="75%">
 				<?php echo squid_avupdate_status(); ?>
 			</td>
 		</tr>
 		<tr>
-			<td class="vncellt">Statistics</td>
-			<td class="listr" width="75%">
+			<th>Statistics</th>
+			<td width="75%">
 				<?php echo squid_antivirus_statistics(); ?>
 			</td>
 		</tr>
 	</tbody>
-</table>
+	</table>
+</div>

--- a/www/pfSense-pkg-squid/files/usr/local/www/widgets/widgets/squid_antivirus_status.widget.php
+++ b/www/pfSense-pkg-squid/files/usr/local/www/widgets/widgets/squid_antivirus_status.widget.php
@@ -76,15 +76,18 @@ function squid_clamav_version() {
 	global $img;
 	// ClamAV status and version
 	$s = (is_service_running("clamd") ? $img['up'] : $img['down']);
-	pkg_exec("query '%v' clamav", $version, $err);
+	$rc = pkg_exec("query '%v' clamav", $version, $err);
+	$version = (($rc != 0) ? "N/A" : $version);
 	$s .= "&nbsp;&nbsp;ClamAV {$version}";
 	$s .= "&nbsp;&nbsp;";
 	// C-ICAP status and version
 	$s .= (is_service_running("c-icap") ? $img['up'] : $img['down']);
-	pkg_exec("query '%v' c-icap", $version, $err);
+	$rc = pkg_exec("query '%v' c-icap", $version, $err);
+	$version = (($rc != 0) ? "N/A" : $version);
 	$s .= "&nbsp;&nbsp;C-ICAP {$version}";
 	// SquidClamav version
-	pkg_exec("query '%v' squidclamav", $version, $err);
+	$rc = pkg_exec("query '%v' squidclamav", $version, $err);
+	$version = (($rc != 0) ? "N/A" : $version);
 	$s .= "+&nbsp;&nbsp;SquidClamav {$version}";
 	return $s;
 }
@@ -119,7 +122,8 @@ function squid_antivirus_statistics() {
 			<td width="75%">
 			<?php
 				$updown = (is_service_running("squid") ? $img['up'] : $img['down']);
-				pkg_exec("query '%v' squid", $version, $err);
+				$rc = pkg_exec("query '%v' squid", $version, $err);
+				$version = (($rc != 0) ? "N/A" : $version);
 				echo "{$updown}&nbsp;&nbsp;${version}";
 			?>
 			</td>


### PR DESCRIPTION
- replace inline base64 images with bootstrap icons
- tidy up tables and remove old styling
- fix squiclamav version detection and use pkg_exec() to get packages' versions in general
- fix version and HTML on squid_clwarn.php page