### PR TITLE
freeradius code style and other fixes

### DIFF
--- a/net/pfSense-pkg-freeradius2/Makefile
+++ b/net/pfSense-pkg-freeradius2/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-freeradius2
-PORTVERSION=	1.7.5
-PORTREVISION=	1
+PORTVERSION=	1.7.6
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -26,6 +26,7 @@ require_once("filter.inc");
 require_once("functions.inc");
 require_once("globals.inc");
 require_once("notices.inc");
+require_once("openvpn.inc");
 require_once("pkg-utils.inc");
 require_once("services.inc");
 require_once("service-utils.inc");
@@ -48,7 +49,7 @@ define('FREERADIUS_ETC', FREERADIUS_BASE . '/etc');
  * freeradius_eapconf_resync($restart_svc = true)
  * freeradius_modulesldap_resync($restart_svc = true)
  * freeradius_allcertcnf_resync($restart_svc = true)
-*/
+ */
 
 // Check freeradius lib version
 	$frlib = "";
@@ -61,7 +62,7 @@ define('FREERADIUS_ETC', FREERADIUS_BASE . '/etc');
 		}
 	}
 	if ($frlib == "") {
-		log_error("freeRADIUS - No freeradius libs found on " . FREERADIUS_LIB);
+		log_error("freeRADIUS: No freeradius libs found on " . FREERADIUS_LIB);
 	}
 
 function freeradius_deinstall_command() {
@@ -79,7 +80,7 @@ function freeradius_deinstall_command() {
 
 function freeradius_chown_recursive($dir, $user = "root", $group = "wheel") {
 	if (empty($dir) || ($dir == '/') || ($dir == '/usr/local') || ($dir == '/usr/local/etc') || ($dir == '/usr/local/lib') || ($dir == '/var/log') || !is_dir($dir)) {
-		log_error(gettext("[freeradius] Attempted to recursively chown an invalid directory: '{$dir}'"));
+		log_error(gettext("freeRADIUS: Attempted to recursively chown an invalid directory: '{$dir}'"));
 		return;
 	}
 	chown($dir, $user);
@@ -96,7 +97,7 @@ function freeradius_chown_recursive($dir, $user = "root", $group = "wheel") {
 			}
 		}
 	} else {
-		log_error(gettext("[freedarius] freeradius_chown_recursive() call failed; permissions not set for directory: '{$dir}'"));
+		log_error(gettext("freeRADIUS: freeradius_chown_recursive() call failed; permissions not set for directory: '{$dir}'"));
 	}
 }
 
@@ -140,8 +141,12 @@ function freeradius_install_command() {
 	}
 
 	// Disable virtual-server we do not need by default
-	if (file_exists(FREERADIUS_ETC . "/raddb/sites-enabled/control-socket")) { unlink(FREERADIUS_ETC . "/raddb/sites-enabled/control-socket"); }
-	if (file_exists(FREERADIUS_ETC . "/raddb/sites-enabled/inner-tunnel")) { unlink(FREERADIUS_ETC . "/raddb/sites-enabled/inner-tunnel"); }
+	if (file_exists(FREERADIUS_ETC . "/raddb/sites-enabled/control-socket")) {
+		unlink(FREERADIUS_ETC . "/raddb/sites-enabled/control-socket");
+	}
+	if (file_exists(FREERADIUS_ETC . "/raddb/sites-enabled/inner-tunnel")) {
+		unlink(FREERADIUS_ETC . "/raddb/sites-enabled/inner-tunnel");
+	}
 
 	// We run this here just to suppress some warnings on syslog if file doesn't exist
 	freeradius_authorizedmacs_resync(false, false);
@@ -264,28 +269,27 @@ function freeradius_settings_resync($restart_svc = true) {
 	$varsettingsmaxqueuesize = ($varsettings['varsettingsmaxqueuesize'] ?: '65536');
 	$varsettingsmaxrequestsperserver = ($varsettings['varsettingsmaxrequestsperserver'] ?: '0');
 
-	// For more details look at "freeradius_sqlconf_resync"
+	// For more details look at freeradius_sqlconf_resync()
 	if (is_array($config['installedpackages']['freeradiussqlconf']['config'][0])) {
 		$sqlconf = $config['installedpackages']['freeradiussqlconf']['config'][0];
 	} else {
 		$sqlconf = array();
 	}
 
-	// Dis-/Enable SQL in "instatiate" section in "freeradius_settings_resync" and radiusd.conf SQL SERVER 2
+	// Dis-/Enable SQL in "instatiate" section in freeradius_settings_resync() and radiusd.conf SQL SERVER 2
 	if ($sqlconf['varsqlconf2includeenable'] == 'on') {
 		$varsqlconf2instantiate = 'sql2';
-	}
-	else {
+	} else {
 		$varsqlconf2instantiate = '### sql2 DISABLED ###';
 	}
 
 	$varsqlconf2failover = ($varsettings['varsqlconf2failover'] ?: 'redundant');
 
-	// Dis-/Enable SQL in "instatiate" section in "freeradius_settings_resync" and radiusd.conf SQL SERVER 1
+	// Dis-/Enable SQL in "instatiate" section in freeradius_settings_resync() and radiusd.conf SQL SERVER 1
 	if ($sqlconf['varsqlconfincludeenable'] == 'on') {
 		$varsqlconfinclude = '$INCLUDE sql.conf';
 		$varsqlconfincludecounter = '$INCLUDE sql/mysql/counter.conf';
-		$varsqlconfinstantiate = "$varsqlconf2failover {" . "\n\t\tsql" . "\n\t\t$varsqlconf2instantiate" . "\n\t}";
+		$varsqlconfinstantiate = "{$varsqlconf2failover} {" . "\n\t\tsql" . "\n\t\t{$varsqlconf2instantiate}" . "\n\t}";
 	} else {
 		$varsqlconfinclude = '#$INCLUDE sql.conf';
 		$varsqlconfincludecounter = '#$INCLUDE sql/mysql/counter.conf';
@@ -334,7 +338,7 @@ extended_expressions = $varsettingsextendedexpressions
 EOD;
 
 	// Deletes virtual-server coa by default. Will be re-enabled if there is an interface-type "coa"
-	exec("rm -f " . FREERADIUS_ETC . "/raddb/sites-enabled/coa");
+	mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/sites-enabled/coa");
 
 	if (is_array($config['installedpackages']['freeradiusinterfaces']['config'])) {
 		$arrinterfaces = $config['installedpackages']['freeradiusinterfaces']['config'];
@@ -349,48 +353,48 @@ EOD;
 			$varinterfacetype = $item['varinterfacetype'];
 			$varinterfaceipversion = $item['varinterfaceipversion'];
 
-			// Begin "if" for interface-type = detail
+			// if interface-type = detail
 			if ($item['varinterfacetype'] == 'detail') {
 				$conf .= <<<EOD
 listen {
-		type = $varinterfacetype
-		$varinterfaceipversion = $varinterfaceip
-		port = $varinterfaceport
-		filename = \${radacctdir}/detail-%Y%m%d:%H
-		load_factor = 10
+	type = $varinterfacetype
+	$varinterfaceipversion = $varinterfaceip
+	port = $varinterfaceport
+	filename = \${radacctdir}/detail-%Y%m%d:%H
+	load_factor = 10
 }
 
 EOD;
-			} // End "if" for interface-type = detail
+			} // endif - interface-type = detail
 
-			// Begin "if" for interface-type = coa
+			// if interface-type = coa
 			if ($item['varinterfacetype'] == 'coa') {
 			// Enables virtual-server coa because interface-type is coa
 				symlink(FREERADIUS_ETC . "/raddb/sites-available/coa", FREERADIUS_ETC . "/raddb/sites-enabled/");
 				$conf .= <<<EOD
 listen {
-		type = $varinterfacetype
-		$varinterfaceipversion = $varinterfaceip
-		port = $varinterfaceport
-		server = coa
+	type = $varinterfacetype
+	$varinterfaceipversion = $varinterfaceip
+	port = $varinterfaceport
+	server = coa
 }
 
 EOD;
-			} // End "if" for interface-type = coa
+			} // endif interface-type = coa
 
-			// Begin "if" for interface-type = auth, acct, proxy, status
+			// if interface-type = auth, acct, proxy, status
 			if (($item['varinterfacetype'] == 'auth') || ($item['varinterfacetype'] == 'acct') || ($item['varinterfacetype'] == 'proxy') || ($item['varinterfacetype'] == 'status')) {
-			$conf .= <<<EOD
+				$conf .= <<<EOD
 listen {
-		type = $varinterfacetype
-		$varinterfaceipversion = $varinterfaceip
-		port = $varinterfaceport
+	type = $varinterfacetype
+	$varinterfaceipversion = $varinterfaceip
+	port = $varinterfaceport
 }
 
 EOD;
-			} // End "if" for interface-type = auth, acct, proxy, status
+			} // endif interface-type = auth, acct, proxy, status
 		} // endforeach
-	} // end if array
+	} // endif empty
 
 
 	$conf .= <<<EOD
@@ -468,7 +472,7 @@ EOD;
 
 	// This is to fix the mysqlclient.so which gets lost after reboot
 	// XXX: Probably some PBI leftover, remove?
-	exec("ldconfig -m /usr/local/lib/mysql");
+	mwexec("/sbin/ldconfig -m /usr/local/lib/mysql");
 	// Change owner of freeradius created files
 	if (is_dir("/var/log/radacct/")) {
 		freeradius_chown_recursive("/var/log/radacct");
@@ -687,10 +691,10 @@ function freeradius_users_resync($via_rpc = false) {
 			// create exec script
 			$varusersreplyitem .= "\n\tExec-Program-Wait = " . '"/bin/sh ' . FREERADIUS_ETC . '/raddb/scripts/datacounter_auth.sh ' . "$varusersusername $varusersmaxtotaloctetstimerange" . '"';
 			// create limit file - will be always overwritten so we can increase limit from GUI
-			exec("`echo $varusersmaxtotaloctets > /var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/max-octets-$varusersusername`");
+			file_put_contents("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/max-octets-$varusersusername", $varusersmaxtotaloctets, LOCK_EX);
 			// if used-octets file exist we do NOT overwrite this file!!!
 			if (!file_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername")) {
-				exec("echo 0 > /var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername");
+				file_put_contents("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername", "0", LOCK_EX);
 			}
 		} else {
 			// If an octet limit is NOT set we delete the files for the limit and the counter.
@@ -698,12 +702,12 @@ function freeradius_users_resync($via_rpc = false) {
 				unlink("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/max-octets-$varusersusername");
 			}
 			if (file_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername")) {
-				unlink("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername*");
+				mwexec("/bin/rm -f /var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername*");
 			}
 		}
 		if ($varusersadditionaloptionsreplyitems != '') {
 			if ($varusersreplyitem != '') {
-				$varusersreplyitem .=",";
+				$varusersreplyitem .= ",";
 			}
 			$varusersreplyitem .= "\n\t$varusersadditionaloptionsreplyitems";
 		}
@@ -913,10 +917,10 @@ function freeradius_authorizedmacs_resync($restart_svc = true, $via_rpc = false)
 			//create exec script
 			$varmacsreplyitem .= "\n\tExec-Program-Wait = " . '"/bin/sh ' . FREERADIUS_ETC . '/raddb/scripts/datacounter_auth.sh ' . "$varmacsaddress $varmacsmaxtotaloctetstimerange" . '"';
 			// create limit file - will be always overwritten so we can increase limit from GUI
-			exec("`echo $varmacsmaxtotaloctets > /var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/max-octets-$varmacsaddress`");
+			file_put_contents("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/max-octets-$varmacsaddress", $varmacsmaxtotaloctets, LOCK_EX);
 			// if used-octets file exist we do NOT overwrite this file!!!
 			if (!file_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress")) {
-				exec("echo 0 > /var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress");
+				file_put_contents("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress", "0", LOCK_EX);
 			}
 		} else {
 			// If an octet limit is NOT set we delete the files for the limit and the counter.
@@ -924,12 +928,12 @@ function freeradius_authorizedmacs_resync($restart_svc = true, $via_rpc = false)
 				unlink("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/max-octets-$varmacsaddress");
 			}
 			if (file_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress")) {
-				unlink("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress*");
+				mwexec("/bin/rm -f /var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress*");
 			}
 		}
 		if ($varmacsadditionaloptionsreplyitems != '') {
 			if ($varmacsreplyitem != '') {
-				$varmacsreplyitem .=",";
+				$varmacsreplyitem .= ",";
 			}
 			$varmacsreplyitem .= "\n\t$varmacsadditionaloptionsreplyitems";
 		}
@@ -1096,7 +1100,7 @@ function freeradius_eapconf_resync($restart_svc = true) {
 	} else {
 		$vareapconfpeapsoh = '### MS SoH Server is disabled ###';
 		if (file_exists(FREERADIUS_ETC . "/raddb/sites-enabled/soh")) {
-			exec("rm -f " . FREERADIUS_ETC . "/raddb/sites-enabled/soh");
+			mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/sites-enabled/soh");
 		}
 	}
 
@@ -1147,12 +1151,13 @@ function freeradius_eapconf_resync($restart_svc = true) {
 
 		// generate new DH and RANDOM file
 		// We create a single empty file just to check if there is really a change
-		// from one to another cert manager to avoid building ne DH and random files
+		// from one to another cert manager to avoid building new DH and random files
+		// use openvpn_create_dhparams() from openvpn.inc to generate DH params
 		if (!file_exists(FREERADIUS_ETC . "/raddb/certs/pfsense_cert_mgr")) {
 			log_error("freeRADIUS: Switched to pfSense Cert Manager. Creating new DH and random file in " . FREERADIUS_ETC . "/raddb/certs");
-			exec("cd " . FREERADIUS_ETC . "/raddb/certs && /usr/bin/openssl dhparam -out dh 1024");
-			exec("cd " . FREERADIUS_ETC . "/raddb/certs && /bin/dd if=/dev/urandom of=./random count=10");
-			exec("/usr/bin/touch " . FREERADIUS_ETC . "/raddb/certs/pfsense_cert_mgr");
+			file_put_contents(FREERADIUS_ETC . "/raddb/certs/dh", openvpn_create_dhparams('1024'), LOCK_EX);
+			mwexec("/bin/dd if=/dev/urandom of=" . FREERADIUS_ETC . "/raddb/certs/random count=10");
+			touch(FREERADIUS_ETC . "/raddb/certs/pfsense_cert_mgr");
 		}
 	} else {
 		// This is for freeradius cert manager
@@ -1659,7 +1664,7 @@ function freeradius_serverdefault_resync() {
 #  The order of the realm modules will determine the order that
 #  we try to find a matching realm.
 #
-#  Make *sure* that 'preprocess' comes before any realm if you 
+#  Make *sure* that 'preprocess' comes before any realm if you
 #  need to setup hints for the remote radius server
 authorize {
 	#
@@ -1927,7 +1932,7 @@ authenticate {
 	#
 #	Auth-Type eap {
 #		eap {
-#			handled = 1  
+#			handled = 1
 #		}
 #		if (handled && (Response-Packet-Type == Access-Challenge)) {
 #			attr_filter.access_challenge.post-auth
@@ -2065,7 +2070,7 @@ accounting {
 }
 
 
-#  Session database, used for checking Simultaneous-Use. Either the radutmp 
+#  Session database, used for checking Simultaneous-Use. Either the radutmp
 #  or rlm_sql module can handle this.
 #  The rlm_sql module is *much* faster
 session {
@@ -2174,7 +2179,7 @@ post-auth {
 	#  Access-Reject packets are sent through the REJECT sub-section of the
 	#  post-auth section.
 	#
-	#  Add the ldap module name (or instance) if you have set 
+	#  Add the ldap module name (or instance) if you have set
 	#  'edir_account_policy_check = yes' in the ldap module configuration
 	#
 	Post-Auth-Type REJECT {
@@ -2568,48 +2573,48 @@ function freeradius_allcertcnf_resync() {
 			if ($arrcerts['varcertscreateclient'] == 'yes') {
 				// delete all old certificates and keys
 				log_error("freeRADIUS: deleting all client.csr .crt .key .pem .tar in " . FREERADIUS_ETC . "/raddb/certs");
-				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.csr");
-				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.crt");
-				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.key");
-				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.pem");
-				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.tar");
+				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.csr");
+				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.crt");
+				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.key");
+				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.pem");
+				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.tar");
 
 				// run fuction to create ONLY new client.cnf files based on user input from freeradiuscert.xml
 				freeradius_clientcertcnf_resync();
 
 				// make bootstrap executable and run to create cert based on client.cnf files
-				exec("chmod 0770 " . FREERADIUS_ETC . "/raddb/certs/bootstrap");
-				exec(FREERADIUS_ETC . "/raddb/certs/bootstrap");
+				chmod(FREERADIUS_ETC . "/raddb/certs/bootstrap", 0770);
+				mwexec(FREERADIUS_ETC . "/raddb/certs/bootstrap");
 
-				// rename client generated XX.pem to client.pem 
+				// rename client generated XX.pem to client.pem
 				// use regex to replace spaces and so on.
 				$varserial = preg_replace("/\s/","",file_get_contents(FREERADIUS_ETC . '/raddb/certs/serial.old'));
-					if (file_exists(FREERADIUS_ETC . "/raddb/certs/$varserial.pem"))
-						rename(FREERADIUS_ETC . "/raddb/certs/$varserial.pem",FREERADIUS_ETC . "/raddb/certs/client.pem");
-
+					if (file_exists(FREERADIUS_ETC . "/raddb/certs/$varserial.pem")) {
+						rename(FREERADIUS_ETC . "/raddb/certs/$varserial.pem", FREERADIUS_ETC . "/raddb/certs/client.pem");
+					}
 
 				// tar client-cert files
-				exec("cd " . FREERADIUS_ETC . "/raddb/certs && tar -cf client.tar client.crt client.csr client.key ca.der client.pem");
+				mwexec("/usr/bin/tar -C " . FREERADIUS_ETC . "/raddb/certs -cf " . FREERADIUS_ETC . "/raddb/certs/client.tar client.crt client.csr client.key ca.der client.pem");
 
 				// Make all files in certs folder read/write only for root
-				exec("chmod -R 0600 " . FREERADIUS_ETC . "/raddb/certs/");
+				mwexec("/bin/chmod -R 0600 " . FREERADIUS_ETC . "/raddb/certs/");
 				log_error("freeRADIUS: Created new client.csr .crt .key .pem and added them together with ca.der in " . FREERADIUS_ETC . "/raddb/certs/client.tar");
 			}
 		} else {
 			if ($arrcerts['varcertsdeleteall'] == 'yes') {
 				// delete all old certificates and keys - deletes certs from pfsense cert-manager IN THIS FOLDER, too.
 				log_error("freeRADIUS: deleting all CA, Server and Client certs, DH, random and database files in " . FREERADIUS_ETC . "/raddb/certs");
-				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.pem && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.pem && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.pem");
-				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.der && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.der && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.der");
-				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.csr && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.csr && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.csr");
-				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.crt && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.crt && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.crt");
-				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.key && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.key && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.key");
-				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.p12 && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.p12 && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.p12");
-				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/serial*");
-				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/index*");
-				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/dh");
-				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/random");
-				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.tar");
+				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.pem && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/server.pem && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.pem");
+				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.der && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/server.der && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.der");
+				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.csr && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/server.csr && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.csr");
+				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.crt && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/server.crt && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.crt");
+				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.key && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/server.key && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.key");
+				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.p12 && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/server.p12 && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.p12");
+				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/serial*");
+				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/index*");
+				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/dh");
+				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/random");
+				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.tar");
 
 				// run fuctions to create new .cnf files based on user input from freeradiuscert.xml
 				freeradius_cacertcnf_resync();
@@ -2623,13 +2628,14 @@ function freeradius_allcertcnf_resync() {
 
 				// generate new DH and RANDOM file
 				log_error("freeRADIUS: Creating new DH and random file in " . FREERADIUS_ETC . "/raddb/certs");
-				exec("cd " . FREERADIUS_ETC . "/raddb/certs && openssl dhparam -out dh 1024");
-				exec("cd " . FREERADIUS_ETC . "/raddb/certs && dd if=/dev/urandom of=./random count=10");
+				// use openvpn_create_dhparams() from openvpn.inc to generate DH params
+				file_put_contents(FREERADIUS_ETC . "/raddb/certs/dh", openvpn_create_dhparams('1024'), LOCK_EX);
+				mwexec("/bin/dd if=/dev/urandom of=" . FREERADIUS_ETC . "/raddb/certs/random count=10");
 
 				log_error("freeRADIUS: Creating new CA, Server and Client certs in " . FREERADIUS_ETC . "/raddb/certs");
 				// make bootstrap executable and run to create certs based on .cnf files
-				exec("chmod 0770 " . FREERADIUS_ETC . "/raddb/certs/bootstrap");
-				exec(FREERADIUS_ETC . "/raddb/certs/bootstrap");
+				chmod(FREERADIUS_ETC . "/raddb/certs/bootstrap", 0770);
+				mwexec(FREERADIUS_ETC . "/raddb/certs/bootstrap");
 
 				// rename client generated 02.pem to client.pem
 				if (file_exists(FREERADIUS_ETC . "/raddb/certs/02.pem")) {
@@ -2637,8 +2643,8 @@ function freeradius_allcertcnf_resync() {
 				}
 
 				// tar client-cert files
-				exec("cd " . FREERADIUS_ETC . "/raddb/certs && tar -cf client.tar client.crt client.csr client.key ca.der client.pem");
-				exec("chmod -R 0600 " . FREERADIUS_ETC . "/raddb/certs/");
+				mwexec("/usr/bin/tar -C " . FREERADIUS_ETC . "/raddb/certs -cf " . FREERADIUS_ETC . "/raddb/certs/client.tar client.crt client.csr client.key ca.der client.pem");
+				mwexec("/bin/chmod -R 0600 " . FREERADIUS_ETC . "/raddb/certs/");
 				log_error("freeRADIUS: Added client.csr .crt .key .pem together with ca.der in " . FREERADIUS_ETC . "/raddb/certs/client.tar");
 
 				// If there were changes on the certificates we need to restart freeradius
@@ -2648,7 +2654,7 @@ function freeradius_allcertcnf_resync() {
 				}
 			}
 		}
-	//end choose pfSense cert-manager
+	// end choose pfSense cert-manager
 	} else {
 		return;
 	}
@@ -2746,7 +2752,7 @@ function freeradius_sync_on_changes() {
 	}
 }
 
-if(!function_exists('pf_version')) {
+if (!function_exists('pf_version')) {
 	function pf_version() {
 		return substr(trim(file_get_contents("/etc/version")), 0, 3);
 	}
@@ -2757,11 +2763,7 @@ function freeradius_do_xmlrpc_sync($sync_to_ip, $username, $password, $varsyncpo
 	global $config, $g;
 
 	/* Detect boot process, do nothing during boot. */
-	if (function_exists("platform_booting")) {
-		if (platform_booting()) {
-			return;
-		}
-	} elseif ($g['booting']) {
+	if (platform_booting()) {
 		return;
 	}
 
@@ -2780,7 +2782,7 @@ function freeradius_do_xmlrpc_sync($sync_to_ip, $username, $password, $varsyncpo
 	$execcmd .= "freeradius_all_after_XMLRPC_resync();";
 
 	if (pf_version() >= "2.4") {
-		// xmlrpc cannot encode NULL objects/arrays..
+		// xmlrpc cannot encode NULL objects/arrays
 		foreach($xml as $xmlkey => $xmlvalue) {
 			if (gettype($xmlvalue) == "NULL") {
 				$xml[$xmlkey] = array();
@@ -2858,7 +2860,7 @@ function freeradius_do_xmlrpc_sync($sync_to_ip, $username, $password, $varsyncpo
 	}
 }
 
-// This function restarts all other needed functions after XMLRPC 
+// This function restarts all other needed functions after XMLRPC
 // so that the content of .XML + .INC will be written in the files (clients.conf, users)
 // Adding more functions will increase the to sync
 function freeradius_all_after_XMLRPC_resync() {
@@ -3150,7 +3152,7 @@ function freeradius_modulesldap_resync($restart_svc = true) {
 		$arrmodulesldap = array();
 	}
 
-	// Enable and Disable LDAP for "authorize" and "authenticate" will be done in "freeradius_serverdefault_resync"
+	// Enable and Disable LDAP for "authorize" and "authenticate" will be done in freeradius_serverdefault_resync()
 	// redundatnt-load-balancing will there be done, too
 
 	// Variables for General Configuration ldap1
@@ -3183,7 +3185,7 @@ function freeradius_modulesldap_resync($restart_svc = true) {
 	$varmodulesldaprequirecert = ($arrmodulesldap['varmodulesldaprequirecert'] ?: 'never');
 
 	// if enabled then create the certs in ../raddb/certs/ and enable "Start_tls" in ldap1 module
-	if($arrmodulesldap['varmodulesldapenabletlssupport'] == 'on') {
+	if ($arrmodulesldap['varmodulesldapenabletlssupport'] == 'on') {
 
 		$ca_cert = lookup_ca($arrmodulesldap["ssl_ca_cert1"]);
 		if ($ca_cert != false) {
@@ -3219,7 +3221,7 @@ function freeradius_modulesldap_resync($restart_svc = true) {
 	$varmodulesldap2requirecert = ($arrmodulesldap['varmodulesldap2requirecert'] ?: 'never');
 
 	// if enabled then create the certs in ../raddb/certs/ and enable "Start_tls" in ldap2 module
-	if($arrmodulesldap['varmodulesldap2enabletlssupport'] == 'on') {
+	if ($arrmodulesldap['varmodulesldap2enabletlssupport'] == 'on') {
 
 		$ca_cert = lookup_ca($arrmodulesldap["ssl_ca_cert2"]);
 		if ($ca_cert != false) {
@@ -3714,8 +3716,8 @@ EOD;
 	chmod($filename, 0640);
 	conf_mount_ro();
 
-	// We need to rebuild "freeradius_serverdefault_resync" before restart service
-	// "freeradius_serverdefault_resync" needs to restart other dependencies so
+	// We need to rebuild freeradius_serverdefault_resync() before restart service
+	// freeradius_serverdefault_resync() needs to restart other dependencies so
 	// we are pointing directly to freeradius_settings_resync()
 	freeradius_serverdefault_resync();
 	if ($restart_svc === true) {
@@ -3757,7 +3759,7 @@ function freeradius_plainmacauth_resync() {
 		if (!file_exists(FREERADIUS_ETC . "/raddb/plain_macauth_enabled")) {
 			freeradius_modulesfiles_resync();
 			freeradius_policyconf_resync();
-			exec("cd " . FREERADIUS_ETC . "/raddb && touch " . FREERADIUS_ETC . "/raddb/plain_macauth_enabled");
+			touch(FREERADIUS_ETC . "/raddb/plain_macauth_enabled");
 			log_error("FreeRADIUS: Plain-MAC-Auth enabled. Modified {$filepolicyconf} and {$filemodulesfiles}");
 			freeradius_serverdefault_resync();
 		}

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -1036,56 +1036,59 @@ function freeradius_eapconf_resync($restart_svc = true) {
 	conf_mount_rw();
 	$conf = '';
 
-	$eapconf = $config['installedpackages']['freeradiuseapconf']['config'][0];
-	
+	if (is_array($config['installedpackages']['freeradiuseapconf']['config'][0])) {
+		$eapconf = $config['installedpackages']['freeradiuseapconf']['config'][0];
+	} else {
+		$eapconf = array();
+	}
+
 	// Disable weak EAP types like MD5, GTC, LEAP
 	if ($eapconf['vareapconfdisableweakeaptypes'] == '') {
 		$vareapconfweakeaptypes = "md5 {" . "\n\t\t}" . "\n\t\tleap {" . "\n\t\t}" . "\n\t\tgtc {" . "\n\t\t\t#challenge = " . '"Password: "' . "\n\t\t\tauth_type = PAP" . "\n\t\t}";
-	}
-	else {
+	} else {
 		$vareapconfweakeaptypes = '### DISABLED WEAK EAP TYPES MD5, GTC, LEAP ###';
 	}
-	
+
 	// Variables: EAP
-	$vareapconfdefaulteaptype = ($eapconf['vareapconfdefaulteaptype']?$eapconf['vareapconfdefaulteaptype']:'md5');
-	$vareapconftimerexpire = ($eapconf['vareapconftimerexpire']?$eapconf['vareapconftimerexpire']:'60');
-	$vareapconfignoreunknowneaptypes = ($eapconf['vareapconfignoreunknowneaptypes']?$eapconf['vareapconfignoreunknowneaptypes']:'no');
-	$vareapconfciscoaccountingusernamebug = ($eapconf['vareapconfciscoaccountingusernamebug']?$eapconf['vareapconfciscoaccountingusernamebug']:'no');
-	$vareapconfmaxsessions = ($eapconf['vareapconfmaxsessions']?$eapconf['vareapconfmaxsessions']:'4096');
-	
+	$vareapconfdefaulteaptype = ($eapconf['vareapconfdefaulteaptype'] ?: 'md5');
+	$vareapconftimerexpire = ($eapconf['vareapconftimerexpire'] ?: '60');
+	$vareapconfignoreunknowneaptypes = ($eapconf['vareapconfignoreunknowneaptypes'] ?: 'no');
+	$vareapconfciscoaccountingusernamebug = ($eapconf['vareapconfciscoaccountingusernamebug'] ?: 'no');
+	$vareapconfmaxsessions = ($eapconf['vareapconfmaxsessions'] ?: '4096');
+
 	// Variables: EAP-TLS
-	$vareapconfprivatekeypassword = ($eapconf['vareapconfprivatekeypassword']?$eapconf['vareapconfprivatekeypassword']:'whatever');
-	$vareapconffragmentsize = ($eapconf['vareapconffragmentsize']?$eapconf['vareapconffragmentsize']:'1024');
-	$vareapconfincludelength = ($eapconf['vareapconfincludelength']?$eapconf['vareapconfincludelength']:'yes');
-	$vareapconfcountry = ($eapconf['vareapconfcountry']?$eapconf['vareapconfcountry']:'US');
-	$vareapconfstate = ($eapconf['vareapconfstate']?$eapconf['vareapconfstate']:'Texas');
-	$vareapconfcity = ($eapconf['vareapconfcity']?$eapconf['vareapconfcity']:'Austin');
-	$vareapconforganization = ($eapconf['vareapconforganization']?$eapconf['vareapconforganization']:'My Company Ltd');
-	$vareapconfemail = ($eapconf['vareapconfemail']?$eapconf['vareapconfemail']:'admin@mycompany.com');
-	$vareapconfcommonname = ($eapconf['vareapconfcommonname']?$eapconf['vareapconfcommonname']:'internal-ca');
-		
+	$vareapconfprivatekeypassword = ($eapconf['vareapconfprivatekeypassword'] ?: 'whatever');
+	$vareapconffragmentsize = ($eapconf['vareapconffragmentsize'] ?: '1024');
+	$vareapconfincludelength = ($eapconf['vareapconfincludelength'] ?: 'yes');
+	$vareapconfcountry = ($eapconf['vareapconfcountry'] ?: 'US');
+	$vareapconfstate = ($eapconf['vareapconfstate'] ?: 'Texas');
+	$vareapconfcity = ($eapconf['vareapconfcity'] ?: 'Austin');
+	$vareapconforganization = ($eapconf['vareapconforganization'] ?: 'My Company Ltd');
+	$vareapconfemail = ($eapconf['vareapconfemail'] ?: 'admin@mycompany.com');
+	$vareapconfcommonname = ($eapconf['vareapconfcommonname'] ?: 'internal-ca');
+
 	// Variables: Cache
-	$vareapconfcacheenablecache = ($eapconf['vareapconfcacheenablecache']?$eapconf['vareapconfcacheenablecache']:'no');
-	$vareapconfcachelifetime = ($eapconf['vareapconfcachelifetime']?$eapconf['vareapconfcachelifetime']:'24');
-	$vareapconfcachemaxentries = ($eapconf['vareapconfcachemaxentries']?$eapconf['vareapconfcachemaxentries']:'255');
-	
-	// Variables OSCP	
-	$vareapconfocspenable = ($eapconf['vareapconfocspenable']?$eapconf['vareapconfocspenable']:'no');
-	$vareapconfocspoverridecerturl = ($eapconf['vareapconfocspoverridecerturl']?$eapconf['vareapconfocspoverridecerturl']:'no');
-	$vareapconfocspurl = ($eapconf['vareapconfocspurl']?$eapconf['vareapconfocspurl']:'http://127.0.0.1/ocsp/');
-	
+	$vareapconfcacheenablecache = ($eapconf['vareapconfcacheenablecache'] ?: 'no');
+	$vareapconfcachelifetime = ($eapconf['vareapconfcachelifetime'] ?: '24');
+	$vareapconfcachemaxentries = ($eapconf['vareapconfcachemaxentries'] ?: '255');
+
+	// Variables OSCP
+	$vareapconfocspenable = ($eapconf['vareapconfocspenable'] ?: 'no');
+	$vareapconfocspoverridecerturl = ($eapconf['vareapconfocspoverridecerturl'] ?: 'no');
+	$vareapconfocspurl = ($eapconf['vareapconfocspurl'] ?: 'http://127.0.0.1/ocsp/');
+
 	// Variables: EAP-TTLS
-	$vareapconfttlsdefaulteaptype = ($eapconf['vareapconfttlsdefaulteaptype']?$eapconf['vareapconfttlsdefaulteaptype']:'md5');
-	$vareapconfttlscopyrequesttotunnel = ($eapconf['vareapconfttlscopyrequesttotunnel']?$eapconf['vareapconfttlscopyrequesttotunnel']:'no');
-	$vareapconfttlsusetunneledreply = ($eapconf['vareapconfttlsusetunneledreply']?$eapconf['vareapconfttlsusetunneledreply']:'no');
-	$vareapconfttlsincludelength = ($eapconf['vareapconfttlsincludelength']?$eapconf['vareapconfttlsincludelength']:'yes');
-	
+	$vareapconfttlsdefaulteaptype = ($eapconf['vareapconfttlsdefaulteaptype'] ?: 'md5');
+	$vareapconfttlscopyrequesttotunnel = ($eapconf['vareapconfttlscopyrequesttotunnel'] ?: 'no');
+	$vareapconfttlsusetunneledreply = ($eapconf['vareapconfttlsusetunneledreply'] ?: 'no');
+	$vareapconfttlsincludelength = ($eapconf['vareapconfttlsincludelength'] ?: 'yes');
+
 	// Variables: EAP-PEAP with MSCHAPv2
-	$vareapconfpeapdefaulteaptype = ($eapconf['vareapconfpeapdefaulteaptype']?$eapconf['vareapconfpeapdefaulteaptype']:'mschapv2');
-	$vareapconfpeapcopyrequesttotunnel = ($eapconf['vareapconfpeapcopyrequesttotunnel']?$eapconf['vareapconfpeapcopyrequesttotunnel']:'no');
-	$vareapconfpeapusetunneledreply = ($eapconf['vareapconfpeapusetunneledreply']?$eapconf['vareapconfpeapusetunneledreply']:'no');
-	$vareapconfpeapsohenable = ($eapconf['vareapconfpeapsohenable']?$eapconf['vareapconfpeapsohenable']:'Disable');
-	
+	$vareapconfpeapdefaulteaptype = ($eapconf['vareapconfpeapdefaulteaptype'] ?: 'mschapv2');
+	$vareapconfpeapcopyrequesttotunnel = ($eapconf['vareapconfpeapcopyrequesttotunnel'] ?: 'no');
+	$vareapconfpeapusetunneledreply = ($eapconf['vareapconfpeapusetunneledreply'] ?: 'no');
+	$vareapconfpeapsohenable = ($eapconf['vareapconfpeapsohenable'] ?: 'Disable');
+
 	// This is for enable/disbable MS SoH in EAP-PEAP and the virtuial-server "soh-server"
 	if ($eapconf['vareapconfpeapsohenable'] == 'Enable') {
 		$vareapconfpeapsoh = 'soh = yes' . "\n\t\t\tsoh_virtual_server = " . '"' . "soh-server" . '"';
@@ -1096,112 +1099,81 @@ function freeradius_eapconf_resync($restart_svc = true) {
 			exec("rm -f " . FREERADIUS_ETC . "/raddb/sites-enabled/soh");
 		}
 	}
-		
 
-// The filenames of pfsense cert manager are different from freeradius cert manager so it is possible to store both in the same folder at any time.
-// This is for the pfsense cert manager
-// Depends on "freeradius_get_server_certs" and "freeradius_get_ca_certs"
+
+	// The filenames of pfsense cert manager are different from freeradius cert manager so it is possible
+	// to store both in the same folder at any time. This is for the pfsense cert manager
+	// Depends on freeradius_get_server_certs() and freeradius_get_ca_certs()
 
 	if ($eapconf['vareapconfchoosecertmanager'] == 'on') {
-		
+
 		$ca_cert = lookup_ca($eapconf["ssl_ca_cert"]);
 		if ($ca_cert != false) {
-			if(base64_decode($ca_cert['prv'])) {
-				file_put_contents(FREERADIUS_ETC . "/raddb/certs/ca_key.pem", 
-					base64_decode($ca_cert['prv']));
+			if (base64_decode($ca_cert['prv'])) {
+				file_put_contents(FREERADIUS_ETC . "/raddb/certs/ca_key.pem", base64_decode($ca_cert['prv']));
 				$conf['ssl_ca_key'] = FREERADIUS_ETC . '/raddb/certs/ca_key.pem';
 			}
 
-
-			if(base64_decode($ca_cert['crt'])) {
+			if (base64_decode($ca_cert['crt'])) {
 				$crl_cert = lookup_crl($eapconf["ssl_ca_crl"]);
-				if ($crl_cert != false){
-					$crl=base64_decode($crl_cert['text']);
-					$check_crl="check_crl = yes";
-				}
-				else{
+				if ($crl_cert != false) {
+					$crl = base64_decode($crl_cert['text']);
+					$check_crl = "check_crl = yes";
+				} else {
 					$check_crl="check_crl = no";
 				}
-				file_put_contents(FREERADIUS_ETC . "/raddb/certs/ca_cert.pem", 
-					base64_decode($ca_cert['crt']). $crl);
+				file_put_contents(FREERADIUS_ETC . "/raddb/certs/ca_cert.pem", base64_decode($ca_cert['crt']). $crl);
 				$conf['ssl_ca_cert'] = FREERADIUS_ETC . "/raddb/certs/ca_cert.pem";
 			}
+
 			$svr_cert = lookup_cert($eapconf["ssl_server_cert"]);
 			if ($svr_cert != false) {
-				if(base64_decode($svr_cert['prv'])) {
-					file_put_contents(FREERADIUS_ETC . "/raddb/certs/server_key.pem", 
-						base64_decode($svr_cert['prv']));
+				if (base64_decode($svr_cert['prv'])) {
+					file_put_contents(FREERADIUS_ETC . "/raddb/certs/server_key.pem", base64_decode($svr_cert['prv']));
 					$conf['ssl_key'] = FREERADIUS_ETC . '/raddb/certs/server_key.pem';
 				}
 			}
-
-
-			if(base64_decode($svr_cert['crt'])) {
-				file_put_contents(FREERADIUS_ETC . "/raddb/certs/server_cert.pem", 
-					base64_decode($svr_cert['crt']));
+			if (base64_decode($svr_cert['crt'])) {
+				file_put_contents(FREERADIUS_ETC . "/raddb/certs/server_cert.pem", base64_decode($svr_cert['crt']));
 				$conf['ssl_server_cert'] = FREERADIUS_ETC . "/raddb/certs/server_cert.pem";
 			}
-			
-			/* Not needed anymore because pfsense can do this by default
-			if ($eapconf['vareapconfenableclientp12'] == 'on') {
-				$svr_cert = lookup_cert($eapconf["ssl_client_cert"]);
-				if ($svr_cert != false) {
-					if(base64_decode($svr_cert['prv'])) {
-						file_put_contents(FREERADIUS_ETC . "/raddb/certs/client_key.pem", 
-							base64_decode($svr_cert['prv']));
-						$conf['ssl_key'] = FREERADIUS_ETC . '/raddb/certs/client_key.pem';
-					}
-				}
 
-
-				if(base64_decode($svr_cert['crt'])) {
-					file_put_contents(FREERADIUS_ETC . "/raddb/certs/client_cert.pem", 
-						base64_decode($svr_cert['crt']));
-					$conf['ssl_client_cert'] = FREERADIUS_ETC . "/raddb/certs/client_cert.pem";
-				}
-			
-			exec("openssl pkcs12 -export -in " . FREERADIUS_ETC . "/raddb/certs/client_cert.pem -inkey " . FREERADIUS_ETC . "/raddb/certs/client_key.pem -out " . FREERADIUS_ETC . "/raddb/certs/client_cert.p12 -passout pass\:");	
-			}
-			*/
 			$conf['ssl_cert_dir'] = FREERADIUS_ETC . '/raddb/certs';
 		}
 
-	$vareapconfprivatekeyfile = 'server_key.pem';
-	$vareapconfcertificatefile = 'server_cert.pem';
-	$vareapconfcafile = 'ca_cert.pem';
-	
-	// generate new DH and RANDOM file
-	// We create a single empty file just to check if there is really a change from one to another cert manager to avoid building ne DH and random files
-	if (!file_exists(FREERADIUS_ETC . "/raddb/certs/pfsense_cert_mgr")) {
-		log_error("freeRADIUS: Switched to pfSense Cert-Manager. Creating new DH and random file in " . FREERADIUS_ETC . "/raddb/certs");
-		exec("cd " . FREERADIUS_ETC . "/raddb/certs && openssl dhparam -out dh 1024");
-		exec("cd " . FREERADIUS_ETC . "/raddb/certs && dd if=/dev/urandom of=./random count=10");
-		exec("touch " . FREERADIUS_ETC . "/raddb/certs/pfsense_cert_mgr");
+		$vareapconfprivatekeyfile = 'server_key.pem';
+		$vareapconfcertificatefile = 'server_cert.pem';
+		$vareapconfcafile = 'ca_cert.pem';
+
+		// generate new DH and RANDOM file
+		// We create a single empty file just to check if there is really a change
+		// from one to another cert manager to avoid building ne DH and random files
+		if (!file_exists(FREERADIUS_ETC . "/raddb/certs/pfsense_cert_mgr")) {
+			log_error("freeRADIUS: Switched to pfSense Cert Manager. Creating new DH and random file in " . FREERADIUS_ETC . "/raddb/certs");
+			exec("cd " . FREERADIUS_ETC . "/raddb/certs && /usr/bin/openssl dhparam -out dh 1024");
+			exec("cd " . FREERADIUS_ETC . "/raddb/certs && /bin/dd if=/dev/urandom of=./random count=10");
+			exec("/usr/bin/touch " . FREERADIUS_ETC . "/raddb/certs/pfsense_cert_mgr");
+		}
+	} else {
+		// This is for freeradius cert manager
+		$vareapconfprivatekeyfile = 'server.pem';
+		$vareapconfcertificatefile = 'server.pem';
+		$vareapconfcafile = 'ca.pem';
 	}
-}
 
-// This is for freeradius cert manager
-else {
-	$vareapconfprivatekeyfile = 'server.pem';
-	$vareapconfcertificatefile = 'server.pem';
-	$vareapconfcafile = 'ca.pem';
-}
+	// check if the common name of the certificate must match the username
+	if ($eapconf['vareapconfenablecheckcertcn'] == 'on') {
+		$vareapconfcheckcertcn = 'check_cert_cn = %{User-Name}';
+	} else {
+		$vareapconfcheckcertcn = '### check_cert_cn = %{User-Name} ###';
+	}
 
-// check if the common name of the certificate must match the username
-if($eapconf['vareapconfenablecheckcertcn'] == 'on') {
-	$vareapconfcheckcertcn = 'check_cert_cn = %{User-Name}';
-}
-else {
-	$vareapconfcheckcertcn = '### check_cert_cn = %{User-Name} ###';
-}
-
-// check if cert issuer of CA and certs match
-if($eapconf['vareapconfenablecheckcertissuer'] == 'on') {
-	$vareapconfcheckcertissuer = "check_cert_issuer = " . '"' . "/C=$vareapconfcountry/ST=$vareapconfstate/L=$vareapconfcity/O=$vareapconforganization/emailAddress=$vareapconfemail/CN=$vareapconfcommonname" . '"';
-}
-else {
-	$vareapconfcheckcertissuer = '### check_cert_issuer = "/C=GB/ST=Berkshire/L=Newbury/O=My Company Ltd/emailAddress=test@mycomp.com/CN=myca" ###';
-}
+	// check if cert issuer of CA and certs match
+	if ($eapconf['vareapconfenablecheckcertissuer'] == 'on') {
+		$vareapconfcheckcertissuer = "check_cert_issuer = " . '"' . "/C=$vareapconfcountry/ST=$vareapconfstate/L=$vareapconfcity/O=$vareapconforganization/emailAddress=$vareapconfemail/CN=$vareapconfcommonname" . '"';
+	} else {
+		$vareapconfcheckcertissuer = '### check_cert_issuer = "/C=GB/ST=Berkshire/L=Newbury/O=My Company Ltd/emailAddress=test@mycomp.com/CN=myca" ###';
+	}
 
 	$conf .= <<<EOD
 	### EAP
@@ -1211,7 +1183,7 @@ else {
 		ignore_unknown_eap_types = $vareapconfignoreunknowneaptypes
 		cisco_accounting_username_bug = $vareapconfciscoaccountingusernamebug
 		max_sessions = $vareapconfmaxsessions
-		
+
 		$vareapconfweakeaptypes
 
 
@@ -1248,15 +1220,15 @@ else {
 			      url = "$vareapconfocspurl"
 			}
 		}
-	
+
 		### EAP-TTLS
 		ttls {
 			default_eap_type = $vareapconfttlsdefaulteaptype
 			copy_request_to_tunnel = $vareapconfttlscopyrequesttotunnel
 			use_tunneled_reply = $vareapconfttlsusetunneledreply
 			include_length = $vareapconfttlsincludelength
-		}	### end ttls	
-	
+		}	### end ttls
+
 		### EAP-PEAP
 		peap {
 			default_eap_type = $vareapconfpeapdefaulteaptype
@@ -1267,7 +1239,7 @@ else {
 		}
 		mschapv2 {
 		#	send_error = no
-		}	
+		}
 	}
 EOD;
 
@@ -1327,63 +1299,66 @@ function freeradius_sqlconf_resync() {
 	global $config;
 	$conf = '';
 
-	$sqlconf = $config['installedpackages']['freeradiussqlconf']['config'][0];
-	
+	if (is_array($config['installedpackages']['freeradiussqlconf']['config'][0])) {
+		$sqlconf = $config['installedpackages']['freeradiussqlconf']['config'][0];
+	} else {
+		$sqlconf = array();
+	}
+
 	// Variables: SQL DATABASE 1
-	$varsqlconfdatabase = ($sqlconf['varsqlconfdatabase']?$sqlconf['varsqlconfdatabase']:'mysql');
-	$varsqlconfserver = ($sqlconf['varsqlconfserver']?$sqlconf['varsqlconfserver']:'localhost');
-	$varsqlconfport = ($sqlconf['varsqlconfport']?$sqlconf['varsqlconfport']:'3306');
-	$varsqlconflogin = ($sqlconf['varsqlconflogin']?$sqlconf['varsqlconflogin']:'radius');
-	$varsqlconfpassword = ($sqlconf['varsqlconfpassword']?$sqlconf['varsqlconfpassword']:'radpass');
-	$varsqlconfradiusdb = ($sqlconf['varsqlconfradiusdb']?$sqlconf['varsqlconfradiusdb']:'radius');
-	$varsqlconfaccttable1 = ($sqlconf['varsqlconfaccttable1']?$sqlconf['varsqlconfaccttable1']:'radacct');
-	$varsqlconfaccttable2 = ($sqlconf['varsqlconfaccttable2']?$sqlconf['varsqlconfaccttable2']:'radacct');
-	$varsqlconfpostauthtable = ($sqlconf['varsqlconfpostauthtable']?$sqlconf['varsqlconfpostauthtable']:'radpostauth');
-	$varsqlconfauthchecktable = ($sqlconf['varsqlconfauthchecktable']?$sqlconf['varsqlconfauthchecktable']:'radcheck');
-	$varsqlconfauthreplytable = ($sqlconf['varsqlconfauthreplytable']?$sqlconf['varsqlconfauthreplytable']:'radreply');
-	$varsqlconfgroupchecktable = ($sqlconf['varsqlconfgroupchecktable']?$sqlconf['varsqlconfgroupchecktable']:'radgroupcheck');
-	$varsqlconfgroupreplytable = ($sqlconf['varsqlconfgroupreplytable']?$sqlconf['varsqlconfgroupreplytable']:'radgroupreply');
-	$varsqlconfusergrouptable = ($sqlconf['varsqlconfusergrouptable']?$sqlconf['varsqlconfusergrouptable']:'radusergroup');
-	$varsqlconfreadgroups = ($sqlconf['varsqlconfreadgroups']?$sqlconf['varsqlconfreadgroups']:'yes');
-	$varsqlconfdeletestalesessions = ($sqlconf['varsqlconfdeletestalesessions']?$sqlconf['varsqlconfdeletestalesessions']:'yes');
-	$varsqlconfsqltrace = ($sqlconf['varsqlconfsqltrace']?$sqlconf['varsqlconfsqltrace']:'no');
-	$varsqlconfnumsqlsocks = ($sqlconf['varsqlconfnumsqlsocks']?$sqlconf['varsqlconfnumsqlsocks']:'5');
-	$varsqlconfconnectfailureretrydelay = ($sqlconf['varsqlconfconnectfailureretrydelay']?$sqlconf['varsqlconfconnectfailureretrydelay']:'60');
-	$varsqlconflifetime = ($sqlconf['varsqlconflifetime']?$sqlconf['varsqlconflifetime']:'0');
-	$varsqlconfmaxqueries = ($sqlconf['varsqlconfmaxqueries']?$sqlconf['varsqlconfmaxqueries']:'0');
-	$varsqlconfreadclients = ($sqlconf['varsqlconfreadclients']?$sqlconf['varsqlconfreadclients']:'yes');
-	$varsqlconfnastable = ($sqlconf['varsqlconfnastable']?$sqlconf['varsqlconfnastable']:'nas');
-	
-	// Additional changes were made in "freeradius_settings_resync"
+	$varsqlconfdatabase = ($sqlconf['varsqlconfdatabase'] ?: 'mysql');
+	$varsqlconfserver = ($sqlconf['varsqlconfserver'] ?: 'localhost');
+	$varsqlconfport = ($sqlconf['varsqlconfport'] ?: '3306');
+	$varsqlconflogin = ($sqlconf['varsqlconflogin'] ?: 'radius');
+	$varsqlconfpassword = ($sqlconf['varsqlconfpassword'] ?: 'radpass');
+	$varsqlconfradiusdb = ($sqlconf['varsqlconfradiusdb'] ?: 'radius');
+	$varsqlconfaccttable1 = ($sqlconf['varsqlconfaccttable1'] ?: 'radacct');
+	$varsqlconfaccttable2 = ($sqlconf['varsqlconfaccttable2'] ?: 'radacct');
+	$varsqlconfpostauthtable = ($sqlconf['varsqlconfpostauthtable'] ?: 'radpostauth');
+	$varsqlconfauthchecktable = ($sqlconf['varsqlconfauthchecktable'] ?: 'radcheck');
+	$varsqlconfauthreplytable = ($sqlconf['varsqlconfauthreplytable'] ?: 'radreply');
+	$varsqlconfgroupchecktable = ($sqlconf['varsqlconfgroupchecktable'] ?: 'radgroupcheck');
+	$varsqlconfgroupreplytable = ($sqlconf['varsqlconfgroupreplytable'] ?: 'radgroupreply');
+	$varsqlconfusergrouptable = ($sqlconf['varsqlconfusergrouptable'] ?: 'radusergroup');
+	$varsqlconfreadgroups = ($sqlconf['varsqlconfreadgroups'] ?: 'yes');
+	$varsqlconfdeletestalesessions = ($sqlconf['varsqlconfdeletestalesessions'] ?: 'yes');
+	$varsqlconfsqltrace = ($sqlconf['varsqlconfsqltrace'] ?: 'no');
+	$varsqlconfnumsqlsocks = ($sqlconf['varsqlconfnumsqlsocks'] ?: '5');
+	$varsqlconfconnectfailureretrydelay = ($sqlconf['varsqlconfconnectfailureretrydelay'] ?: '60');
+	$varsqlconflifetime = ($sqlconf['varsqlconflifetime'] ?: '0');
+	$varsqlconfmaxqueries = ($sqlconf['varsqlconfmaxqueries'] ?: '0');
+	$varsqlconfreadclients = ($sqlconf['varsqlconfreadclients'] ?: 'yes');
+	$varsqlconfnastable = ($sqlconf['varsqlconfnastable'] ?: 'nas');
+
+	// Additional changes were made in freeradius_settings_resync()
 
 	// Variables: SQL DATABASE 2
-	$varsqlconf2database = ($sqlconf['varsqlconf2database']?$sqlconf['varsqlconf2database']:'mysql');
-	$varsqlconf2server = ($sqlconf['varsqlconf2server']?$sqlconf['varsqlconf2server']:'localhost');
-	$varsqlconf2port = ($sqlconf['varsqlconf2port']?$sqlconf['varsqlconf2port']:'3306');
-	$varsqlconf2login = ($sqlconf['varsqlconf2login']?$sqlconf['varsqlconf2login']:'radius');
-	$varsqlconf2password = ($sqlconf['varsqlconf2password']?$sqlconf['varsqlconf2password']:'radpass');
-	$varsqlconf2radiusdb = ($sqlconf['varsqlconf2radiusdb']?$sqlconf['varsqlconf2radiusdb']:'radius');
-	$varsqlconf2accttable1 = ($sqlconf['varsqlconf2accttable1']?$sqlconf['varsqlconf2accttable1']:'radacct');
-	$varsqlconf2accttable2 = ($sqlconf['varsqlconf2accttable2']?$sqlconf['varsqlconf2accttable2']:'radacct');
-	$varsqlconf2postauthtable = ($sqlconf['varsqlconf2postauthtable']?$sqlconf['varsqlconf2postauthtable']:'radpostauth');
-	$varsqlconf2authchecktable = ($sqlconf['varsqlconf2authchecktable']?$sqlconf['varsqlconf2authchecktable']:'radcheck');
-	$varsqlconf2authreplytable = ($sqlconf['varsqlconf2authreplytable']?$sqlconf['varsqlconf2authreplytable']:'radreply');
-	$varsqlconf2groupchecktable = ($sqlconf['varsqlconf2groupchecktable']?$sqlconf['varsqlconf2groupchecktable']:'radgroupcheck');
-	$varsqlconf2groupreplytable = ($sqlconf['varsqlconf2groupreplytable']?$sqlconf['varsqlconf2groupreplytable']:'radgroupreply');
-	$varsqlconf2usergrouptable = ($sqlconf['varsqlconf2usergrouptable']?$sqlconf['varsqlconf2usergrouptable']:'radusergroup');
-	$varsqlconf2readgroups = ($sqlconf['varsqlconf2readgroups']?$sqlconf['varsqlconf2readgroups']:'yes');
-	$varsqlconf2deletestalesessions = ($sqlconf['varsqlconf2deletestalesessions']?$sqlconf['varsqlconf2deletestalesessions']:'yes');
-	$varsqlconf2sqltrace = ($sqlconf['varsqlconf2sqltrace']?$sqlconf['varsqlconf2sqltrace']:'no');
-	$varsqlconf2numsqlsocks = ($sqlconf['varsqlconf2numsqlsocks']?$sqlconf['varsqlconf2numsqlsocks']:'5');
-	$varsqlconf2connectfailureretrydelay = ($sqlconf['varsqlconf2connectfailureretrydelay']?$sqlconf['varsqlconf2connectfailureretrydelay']:'60');
-	$varsqlconf2lifetime = ($sqlconf['varsqlconf2lifetime']?$sqlconf['varsqlconf2lifetime']:'0');
-	$varsqlconf2maxqueries = ($sqlconf['varsqlconf2maxqueries']?$sqlconf['varsqlconf2maxqueries']:'0');
-	$varsqlconf2readclients = ($sqlconf['varsqlconf2readclients']?$sqlconf['varsqlconf2readclients']:'yes');
-	$varsqlconf2nastable = ($sqlconf['varsqlconf2nastable']?$sqlconf['varsqlconf2nastable']:'nas');
-	
-	// Additional changes were made in "freeradius_settings_resync"
-	
-	
+	$varsqlconf2database = ($sqlconf['varsqlconf2database'] ?: 'mysql');
+	$varsqlconf2server = ($sqlconf['varsqlconf2server'] ?: 'localhost');
+	$varsqlconf2port = ($sqlconf['varsqlconf2port'] ?: '3306');
+	$varsqlconf2login = ($sqlconf['varsqlconf2login'] ?: 'radius');
+	$varsqlconf2password = ($sqlconf['varsqlconf2password'] ?: 'radpass');
+	$varsqlconf2radiusdb = ($sqlconf['varsqlconf2radiusdb'] ?: 'radius');
+	$varsqlconf2accttable1 = ($sqlconf['varsqlconf2accttable1'] ?: 'radacct');
+	$varsqlconf2accttable2 = ($sqlconf['varsqlconf2accttable2'] ?: 'radacct');
+	$varsqlconf2postauthtable = ($sqlconf['varsqlconf2postauthtable'] ?: 'radpostauth');
+	$varsqlconf2authchecktable = ($sqlconf['varsqlconf2authchecktable'] ?: 'radcheck');
+	$varsqlconf2authreplytable = ($sqlconf['varsqlconf2authreplytable'] ?: 'radreply');
+	$varsqlconf2groupchecktable = ($sqlconf['varsqlconf2groupchecktable'] ?: 'radgroupcheck');
+	$varsqlconf2groupreplytable = ($sqlconf['varsqlconf2groupreplytable'] ?: 'radgroupreply');
+	$varsqlconf2usergrouptable = ($sqlconf['varsqlconf2usergrouptable'] ?: 'radusergroup');
+	$varsqlconf2readgroups = ($sqlconf['varsqlconf2readgroups'] ?: 'yes');
+	$varsqlconf2deletestalesessions = ($sqlconf['varsqlconf2deletestalesessions'] ?: 'yes');
+	$varsqlconf2sqltrace = ($sqlconf['varsqlconf2sqltrace'] ?: 'no');
+	$varsqlconf2numsqlsocks = ($sqlconf['varsqlconf2numsqlsocks'] ?: '5');
+	$varsqlconf2connectfailureretrydelay = ($sqlconf['varsqlconf2connectfailureretrydelay'] ?: '60');
+	$varsqlconf2lifetime = ($sqlconf['varsqlconf2lifetime'] ?: '0');
+	$varsqlconf2maxqueries = ($sqlconf['varsqlconf2maxqueries'] ?: '0');
+	$varsqlconf2readclients = ($sqlconf['varsqlconf2readclients'] ?: 'yes');
+	$varsqlconf2nastable = ($sqlconf['varsqlconf2nastable'] ?: 'nas');
+
+	// Additional changes were made in freeradius_settings_resync()
+
 	$conf .= <<<EOD
 
 sql {
@@ -1450,7 +1425,7 @@ EOD;
 	file_put_contents($filename, $conf);
 	chmod($filename, 0640);
 	conf_mount_ro();
-	
+
 	// We don't need a restart at this time because there are
 	// additional changes needed in freeradius_settings_resync()
 	freeradius_settings_resync();
@@ -1459,25 +1434,28 @@ EOD;
 function freeradius_serverdefault_resync() {
 	global $config;
 	$conf = '';
-		
+
 	// Get Variables from freeradiusmodulesldap.xml
-	$arrmodulesldap = $config['installedpackages']['freeradiusmodulesldap']['config'][0];
+	if (is_array($$config['installedpackages']['freeradiusmodulesldap']['config'][0])) {
+		$arrmodulesldap = $config['installedpackages']['freeradiusmodulesldap']['config'][0];
+	} else {
+		$arrmodulesldap = array();
+	}
+
 	// failover/loadbalancing mode
-	$varmodulesldap2failover = ($arrmodulesldap['varmodulesldap2failover']?$arrmodulesldap['varmodulesldap2failover']:'redundant');
-	
+	$varmodulesldap2failover = ($arrmodulesldap['varmodulesldap2failover'] ?: 'redundant');
+
 	// If unchecked then disable authorize ldap2
 	if (!$arrmodulesldap['varmodulesldap2enableauthorize']) {
 		$varmodulesldap2enableauthorize = '### ldap2 disabled ###';
-	}
-	else {
+	} else {
 		$varmodulesldap2enableauthorize = 'ldap2';
 	}
-	
+
 	// If unchecked then disable authorize ldap1
 	if (!$arrmodulesldap['varmodulesldapenableauthorize']) {
 		$varmodulesldapenableauthorize = '### ldap ###';
-	}
-	else {
+	} else {
 		$varmodulesldapenableauthorize = '';
 		$varmodulesldapenableauthorize .= "$varmodulesldap2failover {";
 		$varmodulesldapenableauthorize .= "\n\t\tldap";
@@ -1485,112 +1463,109 @@ function freeradius_serverdefault_resync() {
 		$varmodulesldapenableauthorize .= "\n\t\t$varmodulesldap2enableauthorize";
 		$varmodulesldapenableauthorize .= "\n\t}";
 	}
-	
+
 	// If unchecked then disable authenticate for ldap1
 	if (!$arrmodulesldap['varmodulesldap2enableauthenticate']) {
 		$varmodulesldap2enableauthenticate = "### ldap2 disabled ###";
-	}
-	else {
+	} else {
 		$varmodulesldap2enableauthenticate = "ldap2";
 	}
-	
+
 	// If unchecked then disable authenticate ldap2
 	if (!$arrmodulesldap['varmodulesldapenableauthenticate']) {
 		$varmodulesldapenableauthenticate = "#Auth-Type LDAP {" . "\n\t\t\t#ldap" . "\n\t\t\t$varmodulesldap2enableauthenticate" . "\n\t#}";
-	}
-	else {
+	} else {
 		$varmodulesldapenableauthenticate = "Auth-Type LDAP {" . "\n\t\t\tldap" . "\n\t\t\t$varmodulesldap2enableauthenticate" . "\n\t}";
 	}
-	
+
 	// Get Variables from freeradiussqlconf.xml for DATABASE 1
-	$sqlconf = $config['installedpackages']['freeradiussqlconf']['config'][0];
-	$varsqlconfenableauthorize = ($sqlconf['varsqlconfenableauthorize']?$sqlconf['varsqlconfenableauthorize']:'Disable');
-	$varsqlconfenableaccounting = ($sqlconf['varsqlconfenableaccounting']?$sqlconf['varsqlconfenableaccounting']:'Disable');
-	$varsqlconfenablesession = ($sqlconf['varsqlconfenablesession']?$sqlconf['varsqlconfenablesession']:'Disable');
-	$varsqlconfenablepostauth = ($sqlconf['varsqlconfenablepostauth']?$sqlconf['varsqlconfenablepostauth']:'Disable');
-	
+	if (is_array($config['installedpackages']['freeradiussqlconf']['config'][0])) {
+		$sqlconf = $config['installedpackages']['freeradiussqlconf']['config'][0];
+	} else {
+		$sqlconf = array();
+	}
+	$varsqlconfenableauthorize = ($sqlconf['varsqlconfenableauthorize'] ?: 'Disable');
+	$varsqlconfenableaccounting = ($sqlconf['varsqlconfenableaccounting'] ?: 'Disable');
+	$varsqlconfenablesession = ($sqlconf['varsqlconfenablesession'] ?: 'Disable');
+	$varsqlconfenablepostauth = ($sqlconf['varsqlconfenablepostauth'] ?: 'Disable');
+
 	// Get Variables from freeradiussqlconf.xml for DATABASE 2
-	$varsqlconf2enableauthorize = ($sqlconf['varsqlconf2enableauthorize']?$sqlconf['varsqlconf2enableauthorize']:'Disable');
-	$varsqlconf2enableaccounting = ($sqlconf['varsqlconf2enableaccounting']?$sqlconf['varsqlconf2enableaccounting']:'Disable');
-	$varsqlconf2enablesession = ($sqlconf['varsqlconf2enablesession']?$sqlconf['varsqlconf2enablesession']:'Disable');
-	$varsqlconf2enablepostauth = ($sqlconf['varsqlconf2enablepostauth']?$sqlconf['varsqlconf2enablepostauth']:'Disable');
-	
+	$varsqlconf2enableauthorize = ($sqlconf['varsqlconf2enableauthorize'] ?: 'Disable');
+	$varsqlconf2enableaccounting = ($sqlconf['varsqlconf2enableaccounting'] ?: 'Disable');
+	$varsqlconf2enablesession = ($sqlconf['varsqlconf2enablesession'] ?: 'Disable');
+	$varsqlconf2enablepostauth = ($sqlconf['varsqlconf2enablepostauth'] ?: 'Disable');
+
 	// authorize section DATABASE 2
 	if ($sqlconf['varsqlconf2enableauthorize'] == 'Enable') {
 		$varsqlconf2authorize = 'sql2';
-	}
-	else {
+	} else {
 		$varsqlconf2authorize = '### sql2 DISABLED ###';
 	}
 	// accounting section DATABASE 2
 	if ($sqlconf['varsqlconf2enableaccounting'] == 'Enable') {
 		$varsqlconf2accounting = 'sql2';
-	}
-	else {
+	} else {
 		$varsqlconf2accounting = '### sql2 DISABLED ###';
 	}
 	// session section DATABASE 2
 	if ($sqlconf['varsqlconf2enablesession'] == 'Enable') {
 		$varsqlconf2session = 'sql2';
-	}
-	else {
+	} else {
 		$varsqlconf2session = '### sql2 DISABLED ###';
 	}
 	// post-auth section DATABASE 2
 	if ($sqlconf['varsqlconf2enablepostauth'] == 'Enable') {
 		$varsqlconf2postauth = 'sql2';
-	}
-	else {
+	} else {
 		$varsqlconf2postauth = '### sql2 DISABLED ###';
-	}	
-	
+	}
+
 	// Failover mode
-	$varsqlconf2failover = ($sqlconf['varsqlconf2failover']?$sqlconf['varsqlconf2failover']:'redundant');
+	$varsqlconf2failover = ($sqlconf['varsqlconf2failover'] ?: 'redundant');
 
 	// authorize section DATABASE 1
 	if (($sqlconf['varsqlconfincludeenable'] == 'on') && ($sqlconf['varsqlconfenableauthorize'] == 'Enable')) {
 		$varsqlconfauthorize = "$varsqlconf2failover {" . "\n\t\t\tsql" . "\n\t\t\t$varsqlconf2authorize" . "\n\t}";
-	}
-	else {
+	} else {
 		$varsqlconfauthorize = '### sql DISABLED ###';
 	}
-	
+
 	// accounting section DATABASE 1
 	if (($sqlconf['varsqlconfincludeenable'] == 'on') && ($sqlconf['varsqlconfenableaccounting'] == 'Enable')) {
 		$varsqlconfaccounting = "$varsqlconf2failover {" . "\n\t\t\tsql" . "\n\t\t\t$varsqlconf2accounting" . "\n\t}";
-	}
-	else {
+	} else {
 		$varsqlconfaccounting = '### sql DISABLED ###';
 	}
-	
+
 	// session section DATABASE 1
 	if (($sqlconf['varsqlconfincludeenable'] == 'on') && ($sqlconf['varsqlconfenablesession'] == 'Enable')) {
 		$varsqlconfsession = "$varsqlconf2failover {" . "\n\t\t\tsql" . "\n\t\t\t$varsqlconf2session" . "\n\t}";
-	}
-	else {
+	} else {
 		$varsqlconfsession = 'radutmp';
 	}
 
 	// post-auth section DATABASE 1
 	if (($sqlconf['varsqlconfincludeenable'] == 'on') && ($sqlconf['varsqlconfenablepostauth'] == 'Enable')) {
 		$varsqlconfpostauth = "$varsqlconf2failover {" . "\n\t\t\tsql" . "\n\t\t\t$varsqlconf2postauth" . "\n\t}";
-	}
-	else {
+	} else {
 		$varsqlconfpostauth = '### sql DISABLED ###';
 	}
-	
+
 	// Changing authorize section for plain mac auth
 	// Variables: If not using 802.1x, mac address must be known
-	$varsettings = $config['installedpackages']['freeradiussettings']['config'][0];
-	
+	if (is_array($config['installedpackages']['freeradiussettings']['config'][0])) {
+		$varsettings = $config['installedpackages']['freeradiussettings']['config'][0];
+	} else {
+		$varsettings = array();
+	}
+
 	// If unchecked we need the normal EAP section.
 	if (!$varsettings['varsettingsenablemacauth']) {
 		$varplainmacauthenable = '##### AUTHORIZE FOR PLAIN MAC-AUTH IS DISABLED #####';
 
 		$varplainmacpreacctenable = '##### ACCOUNTING FOR PLAIN MAC-AUTH DISABLED #####';
-	}
-	// If checked we need to check if it is plain mac or eap
-	else {
+	} else {
+		// If checked we need to check if it is plain mac or eap
 		$varplainmacauthenable = '';
 		$varplainmacauthenable .= "### FIRST check MAC address in authorized_macs and if that fails proceed with other checks below in else-section ###";
 		$varplainmacauthenable .= "\n\t### if cleaning up the Calling-Station-Id...###";
@@ -1609,17 +1584,14 @@ function freeradius_serverdefault_resync() {
 		$varplainmacpreacctenable .= '##### ACCOUNTING FOR PLAIN MAC-AUTH ENABLED #####';
 		$varplainmacpreacctenable .= "\n\trewrite_calling_station_id";
 	}
-	
-	// Disable acct_unique in preacct section
-	$varsettings = $config['installedpackages']['freeradiussettings']['config'][0];
 
+	// Disable acct_unique in preacct section
 	if ($varsettings['varsettingsenableacctunique'] == 'on') {
 		$varsettingsacctuniqueenabled = '##### DISABLE acct_unique DISABLE #####';
-	}
-	else {
+	} else {
 		$varsettingsacctuniqueenabled = 'acct_unique';
 	}
-	
+
 	$conf .= <<<EOD
 ######################################################################
 #
@@ -1709,11 +1681,11 @@ authorize {
 	#  It takes care of processing the 'raddb/hints' and the
 	#  'raddb/huntgroups' files.
 	preprocess
-	
+
 	#
 	#
 	$varplainmacauthenable
-	
+
 	#
 	#  If you want to have a log of authentication requests,
 	#  un-comment the following line, and the 'detail auth_log'
@@ -1760,10 +1732,10 @@ authorize {
 	#  Otherwise, when the first style of realm doesn't match,
 	#  the other styles won't be checked.
 	#
-	
+
 	suffix
 	ntdomain
-	
+
 	#
 	#  This module takes care of EAP-MD5, EAP-TLS, and EAP-LEAP
 	#  authentication.
@@ -1782,11 +1754,11 @@ authorize {
 	#  or PEAP.  The load on those servers will therefore be reduced.
 	#
 	#
-	
+
 	eap {
 		ok = return
 	}
-	
+
 	#
 	#  Pull crypt'd passwords from /etc/passwd or /etc/shadow,
 	#  using the system API's to get the password.  If you want
@@ -1815,7 +1787,7 @@ authorize {
 	#
 	#  The ldap module will set Auth-Type to LDAP if it has not
 	#  already been set
-	
+
 	$varmodulesldapenableauthorize
 
 	#
@@ -1844,7 +1816,7 @@ authorize {
 	#  get a chance to set Auth-Type for themselves.
 	#
 	pap
-	
+
 	#
 	#  If "status_server = yes", then Status-Server messages are passed
 	#  through the following section, and ONLY the following section.
@@ -1912,7 +1884,7 @@ authenticate {
 	Auth-Type MOTP {
 		motp
 	}
-	
+
 	#
 	#  If you have a Cisco SIP server authenticating against
 	#  FreeRADIUS, uncomment the following line, and the 'digest'
@@ -1970,9 +1942,9 @@ authenticate {
 #
 preacct {
 	preprocess
-	
+
 	$varplainmacpreacctenable
-	
+
 	#
 	#  Session start times are *implied* in RADIUS.
 	#  The NAS never sends a "start time".  Instead, it sends
@@ -2032,7 +2004,7 @@ accounting {
 		datacountermonthly
 		datacounterforever
 	}
-	
+
 	#  Update the wtmp file
 	#
 	#  If you don't use "radlast", you can delete this line.
@@ -2297,8 +2269,9 @@ EOD;
 	file_put_contents($filename, $conf);
 	chmod($filename, 0640);
 	conf_mount_ro();
-	
-	// No need to restart here because the restart of the service will be done in freeradius_settings_resync()
+
+	// No need to restart here because the restart of the service
+	// will be done in freeradius_settings_resync()
 }
 
 function freeradius_cacertcnf_resync() {

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -141,12 +141,9 @@ function freeradius_install_command() {
 	}
 
 	// Disable virtual-server we do not need by default
-	if (file_exists(FREERADIUS_ETC . "/raddb/sites-enabled/control-socket")) {
-		unlink(FREERADIUS_ETC . "/raddb/sites-enabled/control-socket");
-	}
-	if (file_exists(FREERADIUS_ETC . "/raddb/sites-enabled/inner-tunnel")) {
-		unlink(FREERADIUS_ETC . "/raddb/sites-enabled/inner-tunnel");
-	}
+	unlink_if_exists(FREERADIUS_ETC . "/raddb/sites-enabled/control-socket");
+	unlink_if_exists(FREERADIUS_ETC . "/raddb/sites-enabled/inner-tunnel");
+
 
 	// We run this here just to suppress some warnings on syslog if file doesn't exist
 	freeradius_authorizedmacs_resync(false, false);
@@ -338,7 +335,7 @@ extended_expressions = $varsettingsextendedexpressions
 EOD;
 
 	// Deletes virtual-server coa by default. Will be re-enabled if there is an interface-type "coa"
-	mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/sites-enabled/coa");
+	unlink_if_exists(FREERADIUS_ETC . "/raddb/sites-enabled/coa");
 
 	if (is_array($config['installedpackages']['freeradiusinterfaces']['config'])) {
 		$arrinterfaces = $config['installedpackages']['freeradiusinterfaces']['config'];
@@ -470,9 +467,6 @@ EOD;
 	freeradius_motp_resync();
 	freeradius_serverdefault_resync();
 
-	// This is to fix the mysqlclient.so which gets lost after reboot
-	// XXX: Probably some PBI leftover, remove?
-	mwexec("/sbin/ldconfig -m /usr/local/lib/mysql");
 	// Change owner of freeradius created files
 	if (is_dir("/var/log/radacct/")) {
 		freeradius_chown_recursive("/var/log/radacct");
@@ -698,12 +692,8 @@ function freeradius_users_resync($via_rpc = false) {
 			}
 		} else {
 			// If an octet limit is NOT set we delete the files for the limit and the counter.
-			if (file_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/max-octets-$varusersusername")) {
-				unlink("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/max-octets-$varusersusername");
-			}
-			if (file_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername")) {
-				mwexec("/bin/rm -f /var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername*");
-			}
+			unlink_if_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/max-octets-$varusersusername");
+			unlink_if_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername*");
 		}
 		if ($varusersadditionaloptionsreplyitems != '') {
 			if ($varusersreplyitem != '') {
@@ -924,12 +914,8 @@ function freeradius_authorizedmacs_resync($restart_svc = true, $via_rpc = false)
 			}
 		} else {
 			// If an octet limit is NOT set we delete the files for the limit and the counter.
-			if (file_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/max-octets-$varmacsaddress")) {
-				unlink("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/max-octets-$varmacsaddress");
-			}
-			if (file_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress")) {
-				mwexec("/bin/rm -f /var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress*");
-			}
+			unlink_if_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/max-octets-$varmacsaddress");
+			unlink_if_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress*");
 		}
 		if ($varmacsadditionaloptionsreplyitems != '') {
 			if ($varmacsreplyitem != '') {
@@ -1099,9 +1085,7 @@ function freeradius_eapconf_resync($restart_svc = true) {
 		symlink(FREERADIUS_ETC . "/raddb/sites-available/soh", FREERADIUS_ETC . "/raddb/sites-enabled/");
 	} else {
 		$vareapconfpeapsoh = '### MS SoH Server is disabled ###';
-		if (file_exists(FREERADIUS_ETC . "/raddb/sites-enabled/soh")) {
-			mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/sites-enabled/soh");
-		}
+		unlink_if_exists(FREERADIUS_ETC . "/raddb/sites-enabled/soh");
 	}
 
 
@@ -2573,11 +2557,10 @@ function freeradius_allcertcnf_resync() {
 			if ($arrcerts['varcertscreateclient'] == 'yes') {
 				// delete all old certificates and keys
 				log_error("freeRADIUS: deleting all client.csr .crt .key .pem .tar in " . FREERADIUS_ETC . "/raddb/certs");
-				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.csr");
-				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.crt");
-				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.key");
-				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.pem");
-				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.tar");
+				$exts = array("csr", "crt", "key", "pem", "tar");
+				foreach ($exts as $ext) {
+					unlink_if_exists(FREERADIUS_ETC . "/raddb/certs/client.{$ext}");
+				}
 
 				// run fuction to create ONLY new client.cnf files based on user input from freeradiuscert.xml
 				freeradius_clientcertcnf_resync();
@@ -2604,17 +2587,17 @@ function freeradius_allcertcnf_resync() {
 			if ($arrcerts['varcertsdeleteall'] == 'yes') {
 				// delete all old certificates and keys - deletes certs from pfsense cert-manager IN THIS FOLDER, too.
 				log_error("freeRADIUS: deleting all CA, Server and Client certs, DH, random and database files in " . FREERADIUS_ETC . "/raddb/certs");
-				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.pem && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/server.pem && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.pem");
-				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.der && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/server.der && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.der");
-				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.csr && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/server.csr && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.csr");
-				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.crt && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/server.crt && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.crt");
-				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.key && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/server.key && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.key");
-				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.p12 && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/server.p12 && /bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.p12");
-				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/serial*");
-				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/index*");
-				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/dh");
-				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/random");
-				mwexec("/bin/rm -f " . FREERADIUS_ETC . "/raddb/certs/client.tar");
+				$exts = array("pem", "der", "csr", "crt", "key", "p12");
+				foreach ($exts as $ext) {
+					unlink_if_exists(FREERADIUS_ETC . "/raddb/certs/ca.{$ext}");
+					unlink_if_exists(FREERADIUS_ETC . "/raddb/certs/server.{$ext}");
+					unlink_if_exists(FREERADIUS_ETC . "/raddb/certs/client.{$ext}");
+				}
+				unlink_if_exists(FREERADIUS_ETC . "/raddb/certs/serial*");
+				unlink_if_exists(FREERADIUS_ETC . "/raddb/certs/index*");
+				unlink_if_exists(FREERADIUS_ETC . "/raddb/certs/dh");
+				unlink_if_exists(FREERADIUS_ETC . "/raddb/certs/random");
+				unlink_if_exists(FREERADIUS_ETC . "/raddb/certs/client.tar");
 
 				// run fuctions to create new .cnf files based on user input from freeradiuscert.xml
 				freeradius_cacertcnf_resync();
@@ -2622,9 +2605,7 @@ function freeradius_allcertcnf_resync() {
 				freeradius_clientcertcnf_resync();
 
 				// this command deletes the pfsense_cert_mgr checkfile so when we change back to pfsense cert manager a new DH + random file will be created
-				if (file_exists(FREERADIUS_ETC . "/raddb/certs/pfsense_cert_mgr")) {
-					unlink(FREERADIUS_ETC . "/raddb/certs/pfsense_cert_mgr");
-				}
+				unlink_if_exists(FREERADIUS_ETC . "/raddb/certs/pfsense_cert_mgr");
 
 				// generate new DH and RANDOM file
 				log_error("freeRADIUS: Creating new DH and random file in " . FREERADIUS_ETC . "/raddb/certs");

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -3,7 +3,7 @@
  * freeradius.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2013 Alexander Wilke <nachtfalkeaw@web.de>
  * Copyright (c) 2013 Marcello Coutinho
  * All rights reserved.
@@ -63,7 +63,7 @@ define('FREERADIUS_ETC', FREERADIUS_BASE . '/etc');
 	if ($frlib == "") {
 		log_error("freeRADIUS - No freeradius libs found on " . FREERADIUS_LIB);
 	}
-	
+
 function freeradius_deinstall_command() {
 	$pidFile = "/var/run/radiusd.pid";
 	$i = 0;
@@ -228,41 +228,49 @@ function freeradius_settings_resync($restart_svc = true) {
 		touch("/var/log/radwtmp");
 	}
 
-	$varsettings = $config['installedpackages']['freeradiussettings']['config'][0];
-	
+	if (is_array($config['installedpackages']['freeradiussettings']['config'][0])) {
+		$varsettings = $config['installedpackages']['freeradiussettings']['config'][0];
+	} else {
+		$varsettings = array();
+	}
+
 	// Variables: General configuration
-	$varsettingsmaxrequests = ($varsettings['varsettingsmaxrequests']?$varsettings['varsettingsmaxrequests']:'1024');
-	$varsettingsmaxrequesttime = ($varsettings['varsettingsmaxrequesttime']?$varsettings['varsettingsmaxrequesttime']:'30');
-	$varsettingscleanupdelay = ($varsettings['varsettingscleanupdelay']?$varsettings['varsettingscleanupdelay']:'5');
-	$varsettingshostnamelookups = ($varsettings['varsettingshostnamelookups']?$varsettings['varsettingshostnamelookups']:'no');
-	$varsettingsallowcoredumps = ($varsettings['varsettingsallowcoredumps']?$varsettings['varsettingsallowcoredumps']:'no');
-	$varsettingsregularexpressions = ($varsettings['varsettingsregularexpressions']?$varsettings['varsettingsregularexpressions']:'yes');
-	$varsettingsextendedexpressions = ($varsettings['varsettingsextendedexpressions']?$varsettings['varsettingsextendedexpressions']:'yes');
-	
+	$varsettingsmaxrequests = ($varsettings['varsettingsmaxrequests'] ?: '1024');
+	$varsettingsmaxrequesttime = ($varsettings['varsettingsmaxrequesttime'] ?: '30');
+	$varsettingscleanupdelay = ($varsettings['varsettingscleanupdelay']?: '5');
+	$varsettingshostnamelookups = ($varsettings['varsettingshostnamelookups'] ?: 'no');
+	$varsettingsallowcoredumps = ($varsettings['varsettingsallowcoredumps'] ?: 'no');
+	$varsettingsregularexpressions = ($varsettings['varsettingsregularexpressions'] ?: 'yes');
+	$varsettingsextendedexpressions = ($varsettings['varsettingsextendedexpressions'] ?:'yes');
+
 	// Variables: Logging options
-	$varsettingslogdir = ($varsettings['varsettingslogdir']?$varsettings['varsettingslogdir']:'syslog');
-	$varsettingsauth = ($varsettings['varsettingsauth']?$varsettings['varsettingsauth']:'yes');
-	$varsettingsauthbadpass = ($varsettings['varsettingsauthbadpass']?$varsettings['varsettingsauthbadpass']:'no');
-	$varsettingsauthbadpassmessage = ($varsettings['varsettingsauthbadpassmessage']?$varsettings['varsettingsauthbadpassmessage']:'');
-	$varsettingsauthgoodpass = ($varsettings['varsettingsauthgoodpass']?$varsettings['varsettingsauthgoodpass']:'no');
-	$varsettingsauthgoodpassmessage = ($varsettings['varsettingsauthgoodpassmessage']?$varsettings['varsettingsauthgoodpassmessage']:'');
-	$varsettingsstrippednames = ($varsettings['varsettingsstrippednames']?$varsettings['varsettingsstrippednames']:'no');
-	
+	$varsettingslogdir = ($varsettings['varsettingslogdir'] ?: 'syslog');
+	$varsettingsauth = ($varsettings['varsettingsauth'] ?: 'yes');
+	$varsettingsauthbadpass = ($varsettings['varsettingsauthbadpass'] ?: 'no');
+	$varsettingsauthbadpassmessage = ($varsettings['varsettingsauthbadpassmessage'] ?: '');
+	$varsettingsauthgoodpass = ($varsettings['varsettingsauthgoodpass'] ?: 'no');
+	$varsettingsauthgoodpassmessage = ($varsettings['varsettingsauthgoodpassmessage'] ?: '');
+	$varsettingsstrippednames = ($varsettings['varsettingsstrippednames'] ?: 'no');
+
 	// Variables: Security
-	$varsettingsmaxattributes = ($varsettings['varsettingsmaxattributes']?$varsettings['varsettingsmaxattributes']:'200');
-	$varsettingsrejectdelay = ($varsettings['varsettingsrejectdelay']?$varsettings['varsettingsrejectdelay']:'1');
-	
+	$varsettingsmaxattributes = ($varsettings['varsettingsmaxattributes'] ?: '200');
+	$varsettingsrejectdelay = ($varsettings['varsettingsrejectdelay'] ?: '1');
+
 	// Variables: Thread Pool
-	$varsettingsstartservers = ($varsettings['varsettingsstartservers']?$varsettings['varsettingsstartservers']:'5');
-	$varsettingsmaxservers = ($varsettings['varsettingsmaxservers']?$varsettings['varsettingsmaxservers']:'32');
-	$varsettingsminspareservers = ($varsettings['varsettingsminspareservers']?$varsettings['varsettingsminspareservers']:'3');
-	$varsettingsmaxspareservers = ($varsettings['varsettingsmaxspareservers']?$varsettings['varsettingsmaxspareservers']:'10');
-	$varsettingsmaxqueuesize = ($varsettings['varsettingsmaxqueuesize']?$varsettings['varsettingsmaxqueuesize']:'65536');
-	$varsettingsmaxrequestsperserver = ($varsettings['varsettingsmaxrequestsperserver']?$varsettings['varsettingsmaxrequestsperserver']:'0');
-	
+	$varsettingsstartservers = ($varsettings['varsettingsstartservers'] ?: '5');
+	$varsettingsmaxservers = ($varsettings['varsettingsmaxservers'] ?: '32');
+	$varsettingsminspareservers = ($varsettings['varsettingsminspareservers'] ?: '3');
+	$varsettingsmaxspareservers = ($varsettings['varsettingsmaxspareservers'] ?: '10');
+	$varsettingsmaxqueuesize = ($varsettings['varsettingsmaxqueuesize'] ?: '65536');
+	$varsettingsmaxrequestsperserver = ($varsettings['varsettingsmaxrequestsperserver'] ?: '0');
+
 	// For more details look at "freeradius_sqlconf_resync"
-	$sqlconf = $config['installedpackages']['freeradiussqlconf']['config'][0];
-		
+	if (is_array($config['installedpackages']['freeradiussqlconf']['config'][0])) {
+		$sqlconf = $config['installedpackages']['freeradiussqlconf']['config'][0];
+	} else {
+		$sqlconf = array();
+	}
+
 	// Dis-/Enable SQL in "instatiate" section in "freeradius_settings_resync" and radiusd.conf SQL SERVER 2
 	if ($sqlconf['varsqlconf2includeenable'] == 'on') {
 		$varsqlconf2instantiate = 'sql2';
@@ -270,16 +278,15 @@ function freeradius_settings_resync($restart_svc = true) {
 	else {
 		$varsqlconf2instantiate = '### sql2 DISABLED ###';
 	}
-	
-	$varsqlconf2failover = ($varsettings['varsqlconf2failover']?$varsettings['varsqlconf2failover']:'redundant');
-	
+
+	$varsqlconf2failover = ($varsettings['varsqlconf2failover'] ?: 'redundant');
+
 	// Dis-/Enable SQL in "instatiate" section in "freeradius_settings_resync" and radiusd.conf SQL SERVER 1
 	if ($sqlconf['varsqlconfincludeenable'] == 'on') {
 		$varsqlconfinclude = '$INCLUDE sql.conf';
 		$varsqlconfincludecounter = '$INCLUDE sql/mysql/counter.conf';
 		$varsqlconfinstantiate = "$varsqlconf2failover {" . "\n\t\tsql" . "\n\t\t$varsqlconf2instantiate" . "\n\t}";
-	}
-	else {
+	} else {
 		$varsqlconfinclude = '#$INCLUDE sql.conf';
 		$varsqlconfincludecounter = '#$INCLUDE sql/mysql/counter.conf';
 		$varsqlconf2failover = '';
@@ -326,11 +333,16 @@ extended_expressions = $varsettingsextendedexpressions
 
 EOD;
 
-// Deletes virtual-server coa by default. Will be re-enabled if there is an interface-type "coa"
-exec("rm -f " . FREERADIUS_ETC . "/raddb/sites-enabled/coa");
+	// Deletes virtual-server coa by default. Will be re-enabled if there is an interface-type "coa"
+	exec("rm -f " . FREERADIUS_ETC . "/raddb/sites-enabled/coa");
 
-$arrinterfaces = $config['installedpackages']['freeradiusinterfaces']['config'];
-	if (is_array($arrinterfaces)  && !empty($arrinterfaces)) {
+	if (is_array($config['installedpackages']['freeradiusinterfaces']['config'])) {
+		$arrinterfaces = $config['installedpackages']['freeradiusinterfaces']['config'];
+	} else {
+		$arrinterfaces = array();
+	}
+
+	if (!empty($arrinterfaces)) {
 		foreach ($arrinterfaces as $item) {
 			$varinterfaceip = $item['varinterfaceip'];
 			$varinterfaceport = $item['varinterfaceport'];
@@ -339,7 +351,7 @@ $arrinterfaces = $config['installedpackages']['freeradiusinterfaces']['config'];
 
 			// Begin "if" for interface-type = detail
 			if ($item['varinterfacetype'] == 'detail') {
-			$conf .= <<<EOD
+				$conf .= <<<EOD
 listen {
 		type = $varinterfacetype
 		$varinterfaceipversion = $varinterfaceip
@@ -349,13 +361,13 @@ listen {
 }
 
 EOD;
-			}	// End "if" for interface-type = detail
+			} // End "if" for interface-type = detail
 
 			// Begin "if" for interface-type = coa
 			if ($item['varinterfacetype'] == 'coa') {
 			// Enables virtual-server coa because interface-type is coa
-			exec("ln -s " . FREERADIUS_ETC . "/raddb/sites-available/coa " . FREERADIUS_ETC . "/raddb/sites-enabled/");
-			$conf .= <<<EOD
+				symlink(FREERADIUS_ETC . "/raddb/sites-available/coa", FREERADIUS_ETC . "/raddb/sites-enabled/");
+				$conf .= <<<EOD
 listen {
 		type = $varinterfacetype
 		$varinterfaceipversion = $varinterfaceip
@@ -364,7 +376,7 @@ listen {
 }
 
 EOD;
-			}	// End "if" for interface-type = coa
+			} // End "if" for interface-type = coa
 
 			// Begin "if" for interface-type = auth, acct, proxy, status
 			if (($item['varinterfacetype'] == 'auth') || ($item['varinterfacetype'] == 'acct') || ($item['varinterfacetype'] == 'proxy') || ($item['varinterfacetype'] == 'status')) {
@@ -376,12 +388,12 @@ listen {
 }
 
 EOD;
-			}	// End "if" for interface-type = auth, acct, proxy, status
-		}	// end foreach
-	}	// end if array
+			} // End "if" for interface-type = auth, acct, proxy, status
+		} // endforeach
+	} // end if array
 
 
-$conf .= <<<EOD
+	$conf .= <<<EOD
 
 log {
 	destination = $varsettingslogdir
@@ -420,10 +432,10 @@ modules {
 	\$INCLUDE eap.conf
 	### Dis-/Enable sql.conf INCLUDE
 	$varsqlconfinclude
-	
+
 	### Dis-/Enable sql/mysql/counter.conf INCLUDE
 	$varsqlconfincludecounter
-		
+
 	#\$INCLUDE sqlippool.conf
 }
 
@@ -447,14 +459,15 @@ EOD;
 	conf_mount_rw();
 	file_put_contents(FREERADIUS_ETC . '/raddb/radiusd.conf', $conf);
 	conf_mount_ro();
-	
+
 	// freeradius_sqlconf_resync() is pointing to this function because we need
 	// to run freeradius_serverdefault_resync() and after that restart freeradius.
 	freeradius_plainmacauth_resync();
 	freeradius_motp_resync();
 	freeradius_serverdefault_resync();
-	
+
 	// This is to fix the mysqlclient.so which gets lost after reboot
+	// XXX: Probably some PBI leftover, remove?
 	exec("ldconfig -m /usr/local/lib/mysql");
 	// Change owner of freeradius created files
 	if (is_dir("/var/log/radacct/")) {
@@ -467,23 +480,26 @@ EOD;
 }
 
 function freeradius_users_resync($via_rpc = false) {
-global $config;
+	global $config;
+	$conf = '';
 
-$conf = '';
+	if (is_array($config['installedpackages']['freeradius']['config'])) {
+		$arrusers = $config['installedpackages']['freeradius']['config'];
+	} else {
+		$arrusers = array();
+	}
 
-$arrusers = $config['installedpackages']['freeradius']['config'];
+	if (!empty($arrusers)) {
+		foreach ($arrusers as $users) {
 
-if (is_array($arrusers) && !empty($arrusers)) {
-	foreach ($arrusers as $users) {
-	
-	// Variables for users file defined parameters
-	
-	$varusersusername = $users['varusersusername'];
-	$varuserspassword = $users['varuserspassword'];
-	
+		// Variables for users file defined parameters
 
-	// Check password encryption
-	$varuserspasswordencryption = ($users['varuserspasswordencryption']?$users['varuserspasswordencryption']:'Cleartext-Password');
+		$varusersusername = $users['varusersusername'];
+		$varuserspassword = $users['varuserspassword'];
+
+
+		// Check password encryption
+		$varuserspasswordencryption = ($users['varuserspasswordencryption'] ?: 'Cleartext-Password');
 		switch ($varuserspasswordencryption) {
 			case "MD5-Password":
 				$varuserspassword = md5($varuserspassword);
@@ -491,201 +507,224 @@ if (is_array($arrusers) && !empty($arrusers)) {
 			default:
 				$varuserspassword = $users['varuserspassword'];
 		}
-	
-		
-	$varusersmotpinitsecret = $users['varusersmotpinitsecret'];
-	$varusersmotppin = $users['varusersmotppin'];
-	$varusersmotpoffset = ($users['varusersmotpoffset']?$users['varusersmotpoffset']:'0');
-	
-	$varuserssimultaneousconnect = ($users['varuserssimultaneousconnect']?$users['varuserssimultaneousconnect']:'');
-	$varuserswisprredirectionurl = $users['varuserswisprredirectionurl'];
-	$varusersframedipaddress = $users['varusersframedipaddress'];
-	$varusersframedipnetmask = $users['varusersframedipnetmask'];
-	$varusersframedroute = $users['varusersframedroute'];
-	$varusersexpiration = $users['varusersexpiration'];
-	$varuserssessiontimeout = $users['varuserssessiontimeout'];
-	$varuserslogintime = $users['varuserslogintime'];
-	$varusersvlanid = $users['varusersvlanid'];
-	
-	// GUI uses minutes but RADIUS needs seconds so we do a multiplication
-	$varusersamountoftime = ($users['varusersamountoftime']?$users['varusersamountoftime']:'');
-	$varusersamountoftime = $varusersamountoftime * 60;
-	$varuserspointoftime = $users['varuserspointoftime'];
-	
-	// GUI uses MB but RADIUS needs Bytes so we do a multiplication
-	$varusersmaxtotaloctets = ($users['varusersmaxtotaloctets']?$users['varusersmaxtotaloctets']:'');
-	$varusersmaxtotaloctets = $varusersmaxtotaloctets * 1024 * 1024;
-	$varusersmaxtotaloctetstimerange = $users['varusersmaxtotaloctetstimerange'];
-	
-	// GUI uses KiloBit but RADIUS needs Bits so we do a multiplication
-	$varusersmaxbandwidthup = ($users['varusersmaxbandwidthup']?$users['varusersmaxbandwidthup']:'');
-	$varusersmaxbandwidthup = $varusersmaxbandwidthup * 1024;
-	$varusersmaxbandwidthdown = ($users['varusersmaxbandwidthdown']?$users['varusersmaxbandwidthdown']:'');
-	$varusersmaxbandwidthdown = $varusersmaxbandwidthdown * 1024;
-	
-	// Accounting-Interim-Interval - Must not be smaller than 60 and should be bigger than 600s
-	if (($users['varusersacctinteriminterval'] >= '0') && ($users['varusersacctinteriminterval'] < '60')) {
-		$varusersacctinteriminterval = 60;
-	} else {
-		$varusersacctinteriminterval = $users['varusersacctinteriminterval'];
-	}
-	
-	// Clear variables for next user foreach additional options TOP
-	$varuserstopadditionaloptions = '';
-	$varusersadditionaloptionstop = '';
-	
-	if(!empty($users['varuserstopadditionaloptions'])) {
-		$varuserstopadditionaloptions = explode("|", ($users['varuserstopadditionaloptions']));
-		foreach ($varuserstopadditionaloptions as $toptmp) {
-			$varusersadditionaloptionstop .= $toptmp . "\n";
-		}
-	}
-	
-	// Clear variables for next user foreach additional options: CHECK-ITEMS
-	$varuserscheckitemsadditionaloptions = '';
-	$varusersadditionaloptionscheckitems = '';
-	
-	if(!empty($users['varuserscheckitemsadditionaloptions'])) {
-		$varuserscheckitemsadditionaloptions = explode("|", ($users['varuserscheckitemsadditionaloptions']));
-		$varusersadditionaloptionscheckitems .= '';
-		foreach ($varuserscheckitemsadditionaloptions as $checkitemtmp) {
-			$varusersadditionaloptionscheckitems .= "$checkitemtmp" . " ";
-		}
-	}
-		
-	// Clear variables for next user foreach additional options: REPLY-ITEMS
-	$varusersreplyitemsadditionaloptions = '';
-	$varusersadditionaloptionsreplyitems = '';
-	
-	if(!empty($users['varusersreplyitemsadditionaloptions'])) {
-		$varusersreplyitemsadditionaloptions = explode("|", ($users['varusersreplyitemsadditionaloptions']));
-		$varusersadditionaloptionsreplyitems .= '';
-		foreach ($varusersreplyitemsadditionaloptions as $replyitemtmp) {
-			$varusersadditionaloptionsreplyitems .= $replyitemtmp . "\n\t";
-		}
-	}
 
-	// Empty variable
-	$varuserscheckitem = '';
-	$varusersreplyitem = '';
-	
+
+		$varusersmotpinitsecret = $users['varusersmotpinitsecret'];
+		$varusersmotppin = $users['varusersmotppin'];
+		$varusersmotpoffset = ($users['varusersmotpoffset'] ?: '0');
+
+		$varuserssimultaneousconnect = ($users['varuserssimultaneousconnect'] ?: '');
+		$varuserswisprredirectionurl = $users['varuserswisprredirectionurl'];
+		$varusersframedipaddress = $users['varusersframedipaddress'];
+		$varusersframedipnetmask = $users['varusersframedipnetmask'];
+		$varusersframedroute = $users['varusersframedroute'];
+		$varusersexpiration = $users['varusersexpiration'];
+		$varuserssessiontimeout = $users['varuserssessiontimeout'];
+		$varuserslogintime = $users['varuserslogintime'];
+		$varusersvlanid = $users['varusersvlanid'];
+
+		// GUI uses minutes but RADIUS needs seconds so we do a multiplication
+		$varusersamountoftime = ($users['varusersamountoftime'] ?: '');
+		$varusersamountoftime = $varusersamountoftime * 60;
+		$varuserspointoftime = $users['varuserspointoftime'];
+
+		// GUI uses MB but RADIUS needs Bytes so we do a multiplication
+		$varusersmaxtotaloctets = ($users['varusersmaxtotaloctets'] ?: '');
+		$varusersmaxtotaloctets = $varusersmaxtotaloctets * 1024 * 1024;
+		$varusersmaxtotaloctetstimerange = $users['varusersmaxtotaloctetstimerange'];
+
+		// GUI uses KiloBit but RADIUS needs Bits so we do a multiplication
+		$varusersmaxbandwidthup = ($users['varusersmaxbandwidthup'] ?: '');
+		$varusersmaxbandwidthup = $varusersmaxbandwidthup * 1024;
+		$varusersmaxbandwidthdown = ($users['varusersmaxbandwidthdown'] ?: '');
+		$varusersmaxbandwidthdown = $varusersmaxbandwidthdown * 1024;
+
+		// Accounting-Interim-Interval - Must not be smaller than 60 and should be bigger than 600s
+		if (($users['varusersacctinteriminterval'] >= '0') && ($users['varusersacctinteriminterval'] < '60')) {
+			$varusersacctinteriminterval = 60;
+		} else {
+			$varusersacctinteriminterval = $users['varusersacctinteriminterval'];
+		}
+
+		// Clear variables for next user foreach additional options TOP
+		$varuserstopadditionaloptions = '';
+		$varusersadditionaloptionstop = '';
+
+		if (!empty($users['varuserstopadditionaloptions'])) {
+			$varuserstopadditionaloptions = explode("|", ($users['varuserstopadditionaloptions']));
+			foreach ($varuserstopadditionaloptions as $toptmp) {
+				$varusersadditionaloptionstop .= $toptmp . "\n";
+			}
+		}
+
+		// Clear variables for next user foreach additional options: CHECK-ITEMS
+		$varuserscheckitemsadditionaloptions = '';
+		$varusersadditionaloptionscheckitems = '';
+
+		if (!empty($users['varuserscheckitemsadditionaloptions'])) {
+			$varuserscheckitemsadditionaloptions = explode("|", ($users['varuserscheckitemsadditionaloptions']));
+			$varusersadditionaloptionscheckitems .= '';
+			foreach ($varuserscheckitemsadditionaloptions as $checkitemtmp) {
+				$varusersadditionaloptionscheckitems .= "$checkitemtmp" . " ";
+			}
+		}
+
+		// Clear variables for next user foreach additional options: REPLY-ITEMS
+		$varusersreplyitemsadditionaloptions = '';
+		$varusersadditionaloptionsreplyitems = '';
+
+		if (!empty($users['varusersreplyitemsadditionaloptions'])) {
+			$varusersreplyitemsadditionaloptions = explode("|", ($users['varusersreplyitemsadditionaloptions']));
+			$varusersadditionaloptionsreplyitems .= '';
+			foreach ($varusersreplyitemsadditionaloptions as $replyitemtmp) {
+				$varusersadditionaloptionsreplyitems .= $replyitemtmp . "\n\t";
+			}
+		}
+
+		// Empty variable
+		$varuserscheckitem = '';
+		$varusersreplyitem = '';
+
 		// check if mobile otp is disabled
 		if ($users['varusersmotpenable'] == '') {
 			// If someone does not want to use username/password but entry "DEFAULT" instead then we can disable this
 			if (($users['varusersusername'] == '') && ($users['varuserspassword'] == '')) {
 				$varuserscheckitem = '';
-			}
-			else {
+			} else {
 				// Add the user attributes to each user.
 				$varuserscheckitem = '"' . $varusersusername . '"' . " $varuserspasswordencryption := " . '"' . $varuserspassword .'"';
 			}
-		} // end of check if otp is enabled
-	
-		// if otp is enabled we need to set Auth-Type to accept because password will be checked when the otp script gets executed in reply-item list
-		else {
+		// end of check if otp is enabled
+		} else {
+			// if otp is enabled we need to set Auth-Type to accept because password will be checked when the otp script gets executed in reply-item list
 			$varuserscheckitem = '"' . $varusersusername . '"' . " Auth-Type = motp";
 		}
-	
-	// Add additional CHECK-ITEMS here. Different formatting in "users" file needed.
-	if ($varuserssimultaneousconnect != '') {
-	$varuserscheckitem .= ", Simultaneous-Use := " . '"' . $varuserssimultaneousconnect . '"';
-	}
-	if ($varusersexpiration != '') {
-	$varuserscheckitem .= ", Expiration := " . '"' . $varusersexpiration . '"';
-	}
-	if ($varuserslogintime != '') {
-	$varuserscheckitem .= ", Login-Time := " . '"' . $varuserslogintime . '"';
-	}	
-	if ($varusersamountoftime != '') {
-	$varuserscheckitem .= ", Max-" . "$varuserspointoftime" . "-Session := " . "$varusersamountoftime";
-	}
-	if ($varusersadditionaloptionscheckitems != '') {
-	$varuserscheckitem .= ", $varusersadditionaloptionscheckitems";
-	}
+
+		// Add additional CHECK-ITEMS here. Different formatting in "users" file needed.
+		if ($varuserssimultaneousconnect != '') {
+			$varuserscheckitem .= ", Simultaneous-Use := " . '"' . $varuserssimultaneousconnect . '"';
+		}
+		if ($varusersexpiration != '') {
+			$varuserscheckitem .= ", Expiration := " . '"' . $varusersexpiration . '"';
+		}
+		if ($varuserslogintime != '') {
+			$varuserscheckitem .= ", Login-Time := " . '"' . $varuserslogintime . '"';
+		}
+		if ($varusersamountoftime != '') {
+			$varuserscheckitem .= ", Max-" . "$varuserspointoftime" . "-Session := " . "$varusersamountoftime";
+		}
+		if ($varusersadditionaloptionscheckitems != '') {
+			$varuserscheckitem .= ", $varusersadditionaloptionscheckitems";
+		}
 
 		// this is the part for mobile otp
 		if ($users['varusersmotpenable'] == 'on') {
 			$varusersreplyitem .= "MOTP-Init-Secret = $varusersmotpinitsecret," . "\n\tMOTP-PIN = $varusersmotppin," . "\n\tMOTP-Offset = $varusersmotpoffset";
-		}
-		else {
+		} else {
 			$varusersreplyitem .= '';
 		}
-		
-	// Add additional REPLY-ITEMS here. Different formatting in "users" file needed.
-	if ($varusersframedipaddress != '') {
-		if ($varusersreplyitem != '') { $varusersreplyitem .=","; }
-		$varusersreplyitem .= "\n\tFramed-IP-Address = $varusersframedipaddress";
-	}
-	if ($varusersframedipnetmask != '') {
-		if ($varusersreplyitem != '') { $varusersreplyitem .=","; }
-		$varusersreplyitem .= "\n\tFramed-IP-Netmask = $varusersframedipnetmask";
-	}
-	if ($varusersframedroute != '') {
-		if ($varusersreplyitem != '') { $varusersreplyitem .=","; }
-		$varusersreplyitem .= "\n\tFramed-Route = " . '"' . $varusersframedroute . '"';
-	}
-	if ($varuserssessiontimeout != '') {
-		if ($varusersreplyitem != '') { $varusersreplyitem .=","; }
-		$varusersreplyitem .= "\n\tSession-Timeout := $varuserssessiontimeout";
-	}
-	if ($varusersvlanid != '') {
-		if ($varusersreplyitem != '') { $varusersreplyitem .=","; }
-		$varusersreplyitem .= "\n\tTunnel-Type = VLAN,\n\tTunnel-Medium-Type = IEEE-802,\n\tTunnel-Private-Group-ID = " . '"' . $varusersvlanid . '"';
-	}
-	if ($varusersmaxbandwidthup != '') {
-		if ($varusersreplyitem != '') { $varusersreplyitem .=","; }
-		$varusersreplyitem .= "\n\tWISPr-Bandwidth-Max-Up := $varusersmaxbandwidthup";
-	}
-	if ($varusersmaxbandwidthdown != '') {
-		if ($varusersreplyitem != '') { $varusersreplyitem .=","; }
-		$varusersreplyitem .= "\n\tWISPr-Bandwidth-Max-Down := $varusersmaxbandwidthdown";
-	}
-	if ($varusersacctinteriminterval != '') {
-		if ($varusersreplyitem != '') { $varusersreplyitem .=","; }
-		$varusersreplyitem .= "\n\tAcct-Interim-Interval := $varusersacctinteriminterval";
-	}
-	if ($varuserswisprredirectionurl != '') {
-		if ($varusersreplyitem != '') { $varusersreplyitem .=","; }
-		$varusersreplyitem .= "\n\tWISPr-Redirection-URL := $varuserswisprredirectionurl";
-	}
-	// If an octet limit is set we create the files for the limit and the counter. Further we call an exec script which checks if the limit is reached or not
-	if ($varusersmaxtotaloctets != '') {
-		if ($varusersreplyitem != '') { $varusersreplyitem .=","; }
-		//create exec script
-		$varusersreplyitem .= "\n\tExec-Program-Wait = " . '"/bin/sh ' . FREERADIUS_ETC . '/raddb/scripts/datacounter_auth.sh ' . "$varusersusername $varusersmaxtotaloctetstimerange" . '"';
-		// create limit file - will be always overwritten so we can increase limit from GUI
-		exec("`echo $varusersmaxtotaloctets > /var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/max-octets-$varusersusername`");
-		// if used-octets file exist we do NOT overwrite this file!!!
-		if (!file_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername")) { exec("echo 0 > /var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername"); }
-	}
-	// If an octet limit is NOT set we delete the files for the limit and the counter.
-	else {
-		if (file_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/max-octets-$varusersusername")) { unlink("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/max-octets-$varusersusername"); }
-		if (file_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername")) { unlink("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername*"); }
-	}
-	if ($varusersadditionaloptionsreplyitems != '') {
-		if ($varusersreplyitem != '') { $varusersreplyitem .=","; }
-		$varusersreplyitem .= "\n\t$varusersadditionaloptionsreplyitems";
-	}
-	
-	// Cosmetic fix - This is just to make a blank new line after each user entry
-	$varusersreplyitem .= "\n\n";
-	
-	
-	$conf .= <<<EOD
+
+		// Add additional REPLY-ITEMS here. Different formatting in "users" file needed.
+		if ($varusersframedipaddress != '') {
+			if ($varusersreplyitem != '') {
+				$varusersreplyitem .= ",";
+			}
+			$varusersreplyitem .= "\n\tFramed-IP-Address = $varusersframedipaddress";
+		}
+		if ($varusersframedipnetmask != '') {
+			if ($varusersreplyitem != '') {
+				$varusersreplyitem .= ",";
+			}
+			$varusersreplyitem .= "\n\tFramed-IP-Netmask = $varusersframedipnetmask";
+		}
+		if ($varusersframedroute != '') {
+			if ($varusersreplyitem != '') {
+				$varusersreplyitem .= ",";
+			}
+			$varusersreplyitem .= "\n\tFramed-Route = " . '"' . $varusersframedroute . '"';
+		}
+		if ($varuserssessiontimeout != '') {
+			if ($varusersreplyitem != '') {
+				$varusersreplyitem .= ",";
+			}
+			$varusersreplyitem .= "\n\tSession-Timeout := $varuserssessiontimeout";
+		}
+		if ($varusersvlanid != '') {
+			if ($varusersreplyitem != '') {
+				$varusersreplyitem .= ",";
+			}
+			$varusersreplyitem .= "\n\tTunnel-Type = VLAN,\n\tTunnel-Medium-Type = IEEE-802,\n\tTunnel-Private-Group-ID = " . '"' . $varusersvlanid . '"';
+		}
+		if ($varusersmaxbandwidthup != '') {
+			if ($varusersreplyitem != '') {
+				$varusersreplyitem .= ",";
+			}
+			$varusersreplyitem .= "\n\tWISPr-Bandwidth-Max-Up := $varusersmaxbandwidthup";
+		}
+		if ($varusersmaxbandwidthdown != '') {
+			if ($varusersreplyitem != '') {
+				$varusersreplyitem .= ",";
+			}
+			$varusersreplyitem .= "\n\tWISPr-Bandwidth-Max-Down := $varusersmaxbandwidthdown";
+		}
+		if ($varusersacctinteriminterval != '') {
+			if ($varusersreplyitem != '') {
+				$varusersreplyitem .= ",";
+			}
+			$varusersreplyitem .= "\n\tAcct-Interim-Interval := $varusersacctinteriminterval";
+		}
+		if ($varuserswisprredirectionurl != '') {
+			if ($varusersreplyitem != '') {
+				$varusersreplyitem .= ",";
+			}
+			$varusersreplyitem .= "\n\tWISPr-Redirection-URL := $varuserswisprredirectionurl";
+		}
+		// If an octet limit is set we create the files for the limit and the counter. Further we call an exec script which checks if the limit is reached or not
+		if ($varusersmaxtotaloctets != '') {
+			if ($varusersreplyitem != '') {
+				$varusersreplyitem .= ",";
+			}
+			// create exec script
+			$varusersreplyitem .= "\n\tExec-Program-Wait = " . '"/bin/sh ' . FREERADIUS_ETC . '/raddb/scripts/datacounter_auth.sh ' . "$varusersusername $varusersmaxtotaloctetstimerange" . '"';
+			// create limit file - will be always overwritten so we can increase limit from GUI
+			exec("`echo $varusersmaxtotaloctets > /var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/max-octets-$varusersusername`");
+			// if used-octets file exist we do NOT overwrite this file!!!
+			if (!file_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername")) {
+				exec("echo 0 > /var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername");
+			}
+		} else {
+			// If an octet limit is NOT set we delete the files for the limit and the counter.
+			if (file_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/max-octets-$varusersusername")) {
+				unlink("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/max-octets-$varusersusername");
+			}
+			if (file_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername")) {
+				unlink("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername*");
+			}
+		}
+		if ($varusersadditionaloptionsreplyitems != '') {
+			if ($varusersreplyitem != '') {
+				$varusersreplyitem .=",";
+			}
+			$varusersreplyitem .= "\n\t$varusersadditionaloptionsreplyitems";
+		}
+
+		// Cosmetic fix - This is just to make a blank new line after each user entry
+		$varusersreplyitem .= "\n\n";
+
+		$conf .= <<<EOD
 $varusersadditionaloptionstop
 $varuserscheckitem
 	$varusersreplyitem
 EOD;
-	} //end foreach
-} // end if
+		} // endforeach
+	} // endif
 
 	$filename = FREERADIUS_ETC . '/raddb/users';
 	conf_mount_rw();
 	file_put_contents($filename, $conf);
 	chmod($filename, 0640);
 	conf_mount_ro();
-	
+
 	freeradius_sync_on_changes();
 	// Do not restart on boot
 	// Will get restarted later by freeradius_clients_resync() if called via XMLRPC sync
@@ -696,194 +735,222 @@ EOD;
 
 
 function freeradius_authorizedmacs_resync($restart_svc = true, $via_rpc = false) {
-global $config;
+	global $config;
+	$conf = '';
 
-$conf = '';
-$arrmacs = $config['installedpackages']['freeradiusauthorizedmacs']['config'];
-
-if (is_array($arrmacs) && !empty($arrmacs)) {
-	foreach ($arrmacs as $macs) {
-	
-	// Variables for authorized_macs file defined parameters
-	$varmacsaddress = $macs['varmacsaddress'];
-	// We don't need a password but we need this field to make syntac correct for CHECK-ITEMS
-	$varmacspassword = $macs['varmacsaddress'];
-
-	$varmacssimultaneousconnect = ($macs['varmacssimultaneousconnect']?$macs['varmacssimultaneousconnect']:'');
-	$varmacsswisprredirectionurl = $macs['varmacsswisprredirectionurl'];
-	$varmacsframedipaddress = $macs['varmacsframedipaddress'];
-	$varmacsframedipnetmask = $macs['varmacsframedipnetmask'];
-	$varmacsframedroute = $macs['varmacsframedroute'];
-	$varmacsexpiration = $macs['varmacsexpiration'];
-	$varmacssessiontimeout = $macs['varmacssessiontimeout'];
-	$varmacslogintime = $macs['varmacslogintime'];
-	$varmacsvlanid = $macs['varmacsvlanid'];
-	
-	// GUI uses minutes but RADIUS needs seconds so we do a multiplication
-	$varmacsamountoftime = ($macs['varmacsamountoftime']?$macs['varmacsamountoftime']:'');
-	$varmacsamountoftime = $varmacsamountoftime * 60;
-	$varmacspointoftime = $macs['varmacspointoftime'];
-	
-	// GUI uses MB but RADIUS needs Bytes so we do a multiplication
-	$varmacsmaxtotaloctets = ($macs['varmacsmaxtotaloctets']?$macs['varmacsmaxtotaloctets']:'');
-	$varmacsmaxtotaloctets = $varmacsmaxtotaloctets * 1024 * 1024;
-	$varmacsmaxtotaloctetstimerange = $macs['varmacsmaxtotaloctetstimerange'];
-	
-	// GUI uses KiloBit but RADIUS needs Bits so we do a multiplication
-	$varmacsmaxbandwidthup = ($macs['varmacsmaxbandwidthup']?$macs['varmacsmaxbandwidthup']:'');
-	$varmacsmaxbandwidthup = $varmacsmaxbandwidthup * 1024;
-	$varmacsmaxbandwidthdown = ($macs['varmacsmaxbandwidthdown']?$macs['varmacsmaxbandwidthdown']:'');
-	$varmacsmaxbandwidthdown = $varmacsmaxbandwidthdown * 1024;
-	
-		
-	// Accounting-Interim-Interval
-	if (($users['varmacsacctinteriminterval'] >= '0') && ($users['varmacsacctinteriminterval'] < '60')) {
-		$varmacsacctinteriminterval = 60;
+	if (is_array($config['installedpackages']['freeradiusauthorizedmacs']['config'])) {
+		$arrmacs = $config['installedpackages']['freeradiusauthorizedmacs']['config'];
 	} else {
-		$varmacsacctinteriminterval = $users['varmacsacctinteriminterval'];
-	}
-	
-	
-	// Clear variables for next mac foreach additional options TOP
-	$varmacstopadditionaloptions = '';
-	$varmacsadditionaloptionstop = '';
-	
-	if(!empty($macs['varmacstopadditionaloptions'])) {
-		$varmacstopadditionaloptions = explode("|", ($macs['varmacstopadditionaloptions']));
-		foreach ($varmacstopadditionaloptions as $toptmp) {
-			$varmacsadditionaloptionstop .= $toptmp . "\n";
-		}
-	}
-	
-	// Clear variables for next mac foreach additional options: CHECK-ITEMS
-	$varmacscheckitemsadditionaloptions = '';
-	$varmacsadditionaloptionscheckitems = '';
-	
-	if(!empty($macs['varmacscheckitemsadditionaloptions'])) {
-		$varmacscheckitemsadditionaloptions = explode("|", ($macs['varmacscheckitemsadditionaloptions']));
-		$varmacsadditionaloptionscheckitems .= '';
-		foreach ($varmacscheckitemsadditionaloptions as $checkitemtmp) {
-			$varmacsadditionaloptionscheckitems .= "$checkitemtmp" . " ";
-		}
-	}
-		
-	// Clear variables for next mac foreach additional options: REPLY-ITEMS
-	$varmacsreplyitemsadditionaloptions = '';
-	$varmacsadditionaloptionsreplyitems = '';
-	
-	if(!empty($macs['varmacsreplyitemsadditionaloptions'])) {
-		$varmacsreplyitemsadditionaloptions = explode("|", ($macs['varmacsreplyitemsadditionaloptions']));
-		$varmacsadditionaloptionsreplyitems .= '';
-		foreach ($varmacsreplyitemsadditionaloptions as $replyitemtmp) {
-			$varmacsadditionaloptionsreplyitems .= $replyitemtmp . "\n\t";
-		}
+		$arrmacs = array();
 	}
 
-	// Empty variable
-	$varmacscheckitem = '';
-	$varmacsreplyitem = '';
-	
-	// If someone does not want to use MAC address but entry "DEFAULT" instead then we can disable this
-	if ($macs['varmacsaddress'] == '') {
+	if (!empty($arrmacs)) {
+		foreach ($arrmacs as $macs) {
+
+		// Variables for authorized_macs file defined parameters
+		$varmacsaddress = $macs['varmacsaddress'];
+		// We don't need a password but we need this field to make syntac correct for CHECK-ITEMS
+		$varmacspassword = $macs['varmacsaddress'];
+
+		$varmacssimultaneousconnect = ($macs['varmacssimultaneousconnect'] ?: '');
+		$varmacsswisprredirectionurl = $macs['varmacsswisprredirectionurl'];
+		$varmacsframedipaddress = $macs['varmacsframedipaddress'];
+		$varmacsframedipnetmask = $macs['varmacsframedipnetmask'];
+		$varmacsframedroute = $macs['varmacsframedroute'];
+		$varmacsexpiration = $macs['varmacsexpiration'];
+		$varmacssessiontimeout = $macs['varmacssessiontimeout'];
+		$varmacslogintime = $macs['varmacslogintime'];
+		$varmacsvlanid = $macs['varmacsvlanid'];
+
+		// GUI uses minutes but RADIUS needs seconds so we do a multiplication
+		$varmacsamountoftime = ($macs['varmacsamountoftime'] ?: '');
+		$varmacsamountoftime = $varmacsamountoftime * 60;
+		$varmacspointoftime = $macs['varmacspointoftime'];
+
+		// GUI uses MB but RADIUS needs Bytes so we do a multiplication
+		$varmacsmaxtotaloctets = ($macs['varmacsmaxtotaloctets'] ?: '');
+		$varmacsmaxtotaloctets = $varmacsmaxtotaloctets * 1024 * 1024;
+		$varmacsmaxtotaloctetstimerange = $macs['varmacsmaxtotaloctetstimerange'];
+
+		// GUI uses KiloBit but RADIUS needs Bits so we do a multiplication
+		$varmacsmaxbandwidthup = ($macs['varmacsmaxbandwidthup'] ?: '');
+		$varmacsmaxbandwidthup = $varmacsmaxbandwidthup * 1024;
+		$varmacsmaxbandwidthdown = ($macs['varmacsmaxbandwidthdown'] ?: '');
+		$varmacsmaxbandwidthdown = $varmacsmaxbandwidthdown * 1024;
+
+
+		// Accounting-Interim-Interval
+		if (($users['varmacsacctinteriminterval'] >= '0') && ($users['varmacsacctinteriminterval'] < '60')) {
+			$varmacsacctinteriminterval = 60;
+		} else {
+			$varmacsacctinteriminterval = $users['varmacsacctinteriminterval'];
+		}
+
+		// Clear variables for next mac foreach additional options TOP
+		$varmacstopadditionaloptions = '';
+		$varmacsadditionaloptionstop = '';
+
+		if (!empty($macs['varmacstopadditionaloptions'])) {
+			$varmacstopadditionaloptions = explode("|", ($macs['varmacstopadditionaloptions']));
+			foreach ($varmacstopadditionaloptions as $toptmp) {
+				$varmacsadditionaloptionstop .= $toptmp . "\n";
+			}
+		}
+
+		// Clear variables for next mac foreach additional options: CHECK-ITEMS
+		$varmacscheckitemsadditionaloptions = '';
+		$varmacsadditionaloptionscheckitems = '';
+
+		if (!empty($macs['varmacscheckitemsadditionaloptions'])) {
+			$varmacscheckitemsadditionaloptions = explode("|", ($macs['varmacscheckitemsadditionaloptions']));
+			$varmacsadditionaloptionscheckitems .= '';
+			foreach ($varmacscheckitemsadditionaloptions as $checkitemtmp) {
+				$varmacsadditionaloptionscheckitems .= "$checkitemtmp" . " ";
+			}
+		}
+
+		// Clear variables for next mac foreach additional options: REPLY-ITEMS
+		$varmacsreplyitemsadditionaloptions = '';
+		$varmacsadditionaloptionsreplyitems = '';
+
+		if (!empty($macs['varmacsreplyitemsadditionaloptions'])) {
+			$varmacsreplyitemsadditionaloptions = explode("|", ($macs['varmacsreplyitemsadditionaloptions']));
+			$varmacsadditionaloptionsreplyitems .= '';
+			foreach ($varmacsreplyitemsadditionaloptions as $replyitemtmp) {
+				$varmacsadditionaloptionsreplyitems .= $replyitemtmp . "\n\t";
+			}
+		}
+
+		// Empty variable
+		$varmacscheckitem = '';
+		$varmacsreplyitem = '';
+
+		// If someone does not want to use MAC address but entry "DEFAULT" instead then we can disable this
+		if ($macs['varmacsaddress'] == '') {
 			$varmacscheckitem = '';
-	}
-	else {
-		// Add the user attributes to each user.
-		$varmacscheckitem = "$varmacsaddress" . " Cleartext-Password := " . '"' . $varmacspassword . '"';
-	}
-	
-	// Add additional CHECK-ITEMS here. Different formatting in "authorized_macs" file needed.
-	if ($varmacssimultaneousconnect != '') {
-	$varmacscheckitem .= ", Simultaneous-Use := " . '"' . $varmacssimultaneousconnect . '"';
-	}
-	if ($varmacsexpiration != '') {
-	$varmacscheckitem .= ", Expiration := " . '"' . $varmacsexpiration . '"';
-	}
-	if ($varmacslogintime != '') {
-	$varmacscheckitem .= ", Login-Time := " . '"' . $varmacslogintime . '"';
-	}	
-	if ($varmacsamountoftime != '') {
-	$varmacscheckitem .= ", Max-" . "$varmacspointoftime" . "-Session := " . "$varmacsamountoftime";
-	}
-	if ($varmacsadditionaloptionscheckitems != '') {
-	$varmacscheckitem .= ", $varmacsadditionaloptionscheckitems";
-	}
+		} else {
+			// Add the user attributes to each user.
+			$varmacscheckitem = "$varmacsaddress" . " Cleartext-Password := " . '"' . $varmacspassword . '"';
+		}
 
-	// Add additional REPLY-ITEMS here. Different formatting in "authorized_macs" file needed.
-	if ($varmacsframedipaddress != '') {
-		if ($varmacsreplyitem != '') { $varmacsreplyitem .=","; }
-		$varmacsreplyitem .= "\n\tFramed-IP-Address = $varmacsframedipaddress";
-	}
-	if ($varmacsframedipnetmask != '') {
-		if ($varmacsreplyitem != '') { $varmacsreplyitem .=","; }
-		$varmacsreplyitem .= "\n\tFramed-IP-Netmask = $varmacsframedipnetmask";
-	}
-	if ($varmacsframedroute != '') {
-		if ($varmacsreplyitem != '') { $varmacsreplyitem .=","; }
-		$varmacsreplyitem .= "\n\tFramed-Route = " . '"' . $varmacsframedroute . '"';
-	}
-	if ($varmacssessiontimeout != '') {
-		if ($varmacsreplyitem != '') { $varmacsreplyitem .=","; }
-		$varmacsreplyitem .= "\n\tSession-Timeout := $varmacssessiontimeout";
-	}
-	if ($varmacsvlanid != '') {
-		if ($varmacsreplyitem != '') { $varmacsreplyitem .=","; }
-		$varmacsreplyitem .= "\n\tTunnel-Type = VLAN,\n\tTunnel-Medium-Type = IEEE-802,\n\tTunnel-Private-Group-ID = " . '"' . $varmacsvlanid . '"';
-	}
-	if ($varmacsmaxbandwidthup != '') {
-		if ($varmacsreplyitem != '') { $varmacsreplyitem .=","; }
-		$varmacsreplyitem .= "\n\tWISPr-Bandwidth-Max-Up := $varmacsmaxbandwidthup";
-	}
-	if ($varmacsmaxbandwidthdown != '') {
-		if ($varmacsreplyitem != '') { $varmacsreplyitem .=","; }
-		$varmacsreplyitem .= "\n\tWISPr-Bandwidth-Max-Down := $varmacsmaxbandwidthdown";
-	}
-	if ($varmacsacctinteriminterval != '') {
-		if ($varmacsreplyitem != '') { $varmacsreplyitem .=","; }
-		$varmacsreplyitem .= "\n\tAcct-Interim-Interval := $varmacsacctinteriminterval";
-	}
-	if ($varmacswisprredirectionurl != '') {
-		if ($varmacsreplyitem != '') { $varmacsreplyitem .=","; }
-		$varmacsreplyitem .= "\n\tWISPr-Redirection-URL := $varmacsswisprredirectionurl";
-	}
-	// If an octet limit is set we create the files for the limit and the counter. Further we call an exec script which checks if the limit is reached or not
-	if ($varmacsmaxtotaloctets != '') {
-		if ($varmacsreplyitem != '') { $varmacsreplyitem .=","; }
-		//create exec script
-		$varmacsreplyitem .= "\n\tExec-Program-Wait = " . '"/bin/sh ' . FREERADIUS_ETC . '/raddb/scripts/datacounter_auth.sh ' . "$varmacsaddress $varmacsmaxtotaloctetstimerange" . '"';
-		// create limit file - will be always overwritten so we can increase limit from GUI
-		exec("`echo $varmacsmaxtotaloctets > /var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/max-octets-$varmacsaddress`");
-		// if used-octets file exist we do NOT overwrite this file!!!
-		if (!file_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress")) { exec("echo 0 > /var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress"); }
-	}
-	// If an octet limit is NOT set we delete the files for the limit and the counter.
-	else {
-		if (file_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/max-octets-$varmacsaddress")) { unlink("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/max-octets-$varmacsaddress"); }
-		if (file_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress")) { unlink("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress*"); }
-	}
-	if ($varmacsadditionaloptionsreplyitems != '') {
-		if ($varmacsreplyitem != '') { $varmacsreplyitem .=","; }
-		$varmacsreplyitem .= "\n\t$varmacsadditionaloptionsreplyitems";
-	}
-	
-	// Cosmetic fix - This is just to make a blank new line after each macs entry
-	$varmacsreplyitem .= "\n\n";
-	
-	
+		// Add additional CHECK-ITEMS here. Different formatting in "authorized_macs" file needed.
+		if ($varmacssimultaneousconnect != '') {
+			$varmacscheckitem .= ", Simultaneous-Use := " . '"' . $varmacssimultaneousconnect . '"';
+		}
+		if ($varmacsexpiration != '') {
+			$varmacscheckitem .= ", Expiration := " . '"' . $varmacsexpiration . '"';
+		}
+		if ($varmacslogintime != '') {
+			$varmacscheckitem .= ", Login-Time := " . '"' . $varmacslogintime . '"';
+		}
+		if ($varmacsamountoftime != '') {
+			$varmacscheckitem .= ", Max-" . "$varmacspointoftime" . "-Session := " . "$varmacsamountoftime";
+		}
+		if ($varmacsadditionaloptionscheckitems != '') {
+			$varmacscheckitem .= ", $varmacsadditionaloptionscheckitems";
+		}
+
+		// Add additional REPLY-ITEMS here. Different formatting in "authorized_macs" file needed.
+		if ($varmacsframedipaddress != '') {
+			if ($varmacsreplyitem != '') {
+				$varmacsreplyitem .= ",";
+			}
+			$varmacsreplyitem .= "\n\tFramed-IP-Address = $varmacsframedipaddress";
+		}
+		if ($varmacsframedipnetmask != '') {
+			if ($varmacsreplyitem != '') {
+				$varmacsreplyitem .= ",";
+			}
+			$varmacsreplyitem .= "\n\tFramed-IP-Netmask = $varmacsframedipnetmask";
+		}
+		if ($varmacsframedroute != '') {
+			if ($varmacsreplyitem != '') {
+				$varmacsreplyitem .= ",";
+			}
+			$varmacsreplyitem .= "\n\tFramed-Route = " . '"' . $varmacsframedroute . '"';
+		}
+		if ($varmacssessiontimeout != '') {
+			if ($varmacsreplyitem != '') {
+				$varmacsreplyitem .= ",";
+			}
+			$varmacsreplyitem .= "\n\tSession-Timeout := $varmacssessiontimeout";
+		}
+		if ($varmacsvlanid != '') {
+			if ($varmacsreplyitem != '') {
+				$varmacsreplyitem .= ",";
+			}
+			$varmacsreplyitem .= "\n\tTunnel-Type = VLAN,\n\tTunnel-Medium-Type = IEEE-802,\n\tTunnel-Private-Group-ID = " . '"' . $varmacsvlanid . '"';
+		}
+		if ($varmacsmaxbandwidthup != '') {
+			if ($varmacsreplyitem != '') {
+				$varmacsreplyitem .= ",";
+			}
+			$varmacsreplyitem .= "\n\tWISPr-Bandwidth-Max-Up := $varmacsmaxbandwidthup";
+		}
+		if ($varmacsmaxbandwidthdown != '') {
+			if ($varmacsreplyitem != '') {
+				$varmacsreplyitem .= ",";
+			}
+			$varmacsreplyitem .= "\n\tWISPr-Bandwidth-Max-Down := $varmacsmaxbandwidthdown";
+		}
+		if ($varmacsacctinteriminterval != '') {
+			if ($varmacsreplyitem != '') {
+				$varmacsreplyitem .= ",";
+			}
+			$varmacsreplyitem .= "\n\tAcct-Interim-Interval := $varmacsacctinteriminterval";
+		}
+		if ($varmacswisprredirectionurl != '') {
+			if ($varmacsreplyitem != '') {
+				$varmacsreplyitem .= ",";
+			}
+			$varmacsreplyitem .= "\n\tWISPr-Redirection-URL := $varmacsswisprredirectionurl";
+		}
+		// If an octet limit is set we create the files for the limit and the counter. Further we call an exec script which checks if the limit is reached or not
+		if ($varmacsmaxtotaloctets != '') {
+			if ($varmacsreplyitem != '') {
+				$varmacsreplyitem .= ",";
+			}
+			//create exec script
+			$varmacsreplyitem .= "\n\tExec-Program-Wait = " . '"/bin/sh ' . FREERADIUS_ETC . '/raddb/scripts/datacounter_auth.sh ' . "$varmacsaddress $varmacsmaxtotaloctetstimerange" . '"';
+			// create limit file - will be always overwritten so we can increase limit from GUI
+			exec("`echo $varmacsmaxtotaloctets > /var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/max-octets-$varmacsaddress`");
+			// if used-octets file exist we do NOT overwrite this file!!!
+			if (!file_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress")) {
+				exec("echo 0 > /var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress");
+			}
+		} else {
+			// If an octet limit is NOT set we delete the files for the limit and the counter.
+			if (file_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/max-octets-$varmacsaddress")) {
+				unlink("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/max-octets-$varmacsaddress");
+			}
+			if (file_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress")) {
+				unlink("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress*");
+			}
+		}
+		if ($varmacsadditionaloptionsreplyitems != '') {
+			if ($varmacsreplyitem != '') {
+				$varmacsreplyitem .=",";
+			}
+			$varmacsreplyitem .= "\n\t$varmacsadditionaloptionsreplyitems";
+		}
+
+		// Cosmetic fix - This is just to make a blank new line after each macs entry
+		$varmacsreplyitem .= "\n\n";
+
 	$conf .= <<<EOD
 $varmacsadditionaloptionstop
 $varmacscheckitem
 	$varmacsreplyitem
 EOD;
-	} //end foreach
-} // end if
+		} // endforeach
+	} // endif
 
 	$filename = FREERADIUS_ETC . '/raddb/authorized_macs';
 	conf_mount_rw();
 	file_put_contents($filename, $conf);
 	chmod($filename, 0640);
 	conf_mount_ro();
-	
+
 	freeradius_sync_on_changes();
 	if ($restart_svc === true && $via_rpc === false) {
 		restart_service("radiusd");
@@ -892,10 +959,15 @@ EOD;
 
 function freeradius_clients_resync($restart_svc = true) {
 	global $config;
-
 	$conf = '';
-	$arrclients = $config['installedpackages']['freeradiusclients']['config'];
-	if (is_array($arrclients) && !empty($arrclients)) {
+
+	if (is_array($config['installedpackages']['freeradiusclients']['config'])) {
+		$arrclients = $config['installedpackages']['freeradiusclients']['config'];
+	} else {
+		$arrclients = array();
+	}
+
+	if (!empty($arrclients)) {
 		foreach ($arrclients as $item) {
 			$varclientip = $item['varclientip'];
 			$varclientsharedsecret = $item['varclientsharedsecret'];
@@ -905,23 +977,20 @@ function freeradius_clients_resync($restart_svc = true) {
 			$varrequiremessageauthenticator = $item['varrequiremessageauthenticator'];
 			$varclientnastype = $item['varclientnastype'];
 			$varclientmaxconnections = $item['varclientmaxconnections'];
-			$varclientlogininput = ($item['varclientlogininput']?$item['varclientlogininput']:'### login = !root ###');
-			$varclientpasswordinput = ($item['varclientpasswordinput']?$item['varclientpasswordinput']:'### password = someadminpass ###');
-			
+			$varclientlogininput = ($item['varclientlogininput'] ?: '### login = !root ###');
+			$varclientpasswordinput = ($item['varclientpasswordinput'] ?: '### password = someadminpass ###');
+
 			if ($item['varclientlogininput'] == '') {
 				$varclientlogin = '### login = !root ###';
-			}
-			else {
+			} else {
 				$varclientlogin = "login = $varclientlogininput";
 			}
 			if ($item['varclientpasswordinput'] == '') {
 				$varclientpassword = '### password = someadminpass ###';
-			}
-			else {
+			} else {
 				$varclientpassword = "password = $varclientpasswordinput";
 			}
-			
-			
+
 			$conf .= <<<EOD
 
 client "$varclientshortname" {
@@ -937,9 +1006,8 @@ client "$varclientshortname" {
 }
 
 EOD;
-		}
-	}
-	else {
+		} // endforeach
+	} else {
 		$conf .= <<<EOD
 client pfsense {
 	ipaddr = 127.0.0.1
@@ -953,7 +1021,7 @@ EOD;
 	conf_mount_rw();
 	file_put_contents(FREERADIUS_ETC . '/raddb/clients.conf', $conf);
 	conf_mount_ro();
-	
+
 	freeradius_sync_on_changes();
 	if ($restart_svc === true) {
 		restart_service("radiusd");
@@ -1021,13 +1089,12 @@ function freeradius_eapconf_resync($restart_svc = true) {
 	// This is for enable/disbable MS SoH in EAP-PEAP and the virtuial-server "soh-server"
 	if ($eapconf['vareapconfpeapsohenable'] == 'Enable') {
 		$vareapconfpeapsoh = 'soh = yes' . "\n\t\t\tsoh_virtual_server = " . '"' . "soh-server" . '"';
-		exec("ln -s " . FREERADIUS_ETC . "/raddb/sites-available/soh " . FREERADIUS_ETC . "/raddb/sites-enabled/");
-	}
-	else {
+		symlink(FREERADIUS_ETC . "/raddb/sites-available/soh", FREERADIUS_ETC . "/raddb/sites-enabled/");
+	} else {
 		$vareapconfpeapsoh = '### MS SoH Server is disabled ###';
-			if (file_exists(FREERADIUS_ETC . "/raddb/sites-enabled/soh")) {
+		if (file_exists(FREERADIUS_ETC . "/raddb/sites-enabled/soh")) {
 			exec("rm -f " . FREERADIUS_ETC . "/raddb/sites-enabled/soh");
-			}
+		}
 	}
 		
 

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -3143,148 +3143,127 @@ EOD;
 function freeradius_modulesldap_resync($restart_svc = true) {
 	global $config;
 	$conf = '';
-	
-	$arrmodulesldap = $config['installedpackages']['freeradiusmodulesldap']['config'][0];
-	
+
+	if (is_array($config['installedpackages']['freeradiusmodulesldap']['config'][0])) {
+		$arrmodulesldap = $config['installedpackages']['freeradiusmodulesldap']['config'][0];
+	} else {
+		$arrmodulesldap = array();
+	}
+
 	// Enable and Disable LDAP for "authorize" and "authenticate" will be done in "freeradius_serverdefault_resync"
 	// redundatnt-load-balancing will there be done, too
-	
-	
-	// Variables for General Configuration ldap1
-	$varmodulesldapserver = ($arrmodulesldap['varmodulesldapserver']?$arrmodulesldap['varmodulesldapserver']:'ldap.your.domain');
-	$varmodulesldapserverport = ($arrmodulesldap['varmodulesldapserverport']?$arrmodulesldap['varmodulesldapserverport']:'389');
-	$varmodulesldapidentity = ($arrmodulesldap['varmodulesldapidentity']?$arrmodulesldap['varmodulesldapidentity']:'cn=admin,o=My Org,c=UA');
-	$varmodulesldappassword = ($arrmodulesldap['varmodulesldappassword']?$arrmodulesldap['varmodulesldappassword']:'mypass');
-	$varmodulesldapbasedn = ($arrmodulesldap['varmodulesldapbasedn']?$arrmodulesldap['varmodulesldapbasedn']:'o=My Org,c=UA');
-	$varmodulesldapfilter = ($arrmodulesldap['varmodulesldapfilter']?$arrmodulesldap['varmodulesldapfilter']:'(uid=%{%{Stripped-User-Name}:-%{User-Name}})');
-	$varmodulesldapbasefilter = ($arrmodulesldap['varmodulesldapbasefilter']?$arrmodulesldap['varmodulesldapbasefilter']:'(objectclass=radiusprofile)');
-	$varmodulesldapldapconnectionsnumber = ($arrmodulesldap['varmodulesldapldapconnectionsnumber']?$arrmodulesldap['varmodulesldapldapconnectionsnumber']:'5');
-	$varmodulesldaptimeout = ($arrmodulesldap['varmodulesldaptimeout']?$arrmodulesldap['varmodulesldaptimeout']:'4');
-	$varmodulesldaptimelimit = ($arrmodulesldap['varmodulesldaptimelimit']?$arrmodulesldap['varmodulesldaptimelimit']:'3');
-	$varmodulesldapnettimeout = ($arrmodulesldap['varmodulesldapnettimeout']?$arrmodulesldap['varmodulesldapnettimeout']:'1');
-	
-	// Variables for General Configuration ldap2
-	$varmodulesldap2server = ($arrmodulesldap['varmodulesldap2server']?$arrmodulesldap['varmodulesldap2server']:'ldap.your.domain');
-	$varmodulesldap2serverport = ($arrmodulesldap['varmodulesldap2serverport']?$arrmodulesldap['varmodulesldap2serverport']:'389');
-	$varmodulesldap2identity = ($arrmodulesldap['varmodulesldap2identity']?$arrmodulesldap['varmodulesldap2identity']:'cn=admin,o=My Org,c=UA');
-	$varmodulesldap2password = ($arrmodulesldap['varmodulesldap2password']?$arrmodulesldap['varmodulesldap2password']:'mypass');
-	$varmodulesldap2basedn = ($arrmodulesldap['varmodulesldap2basedn']?$arrmodulesldap['varmodulesldap2basedn']:'o=My Org,c=UA');
-	$varmodulesldap2filter = ($arrmodulesldap['varmodulesldap2filter']?$arrmodulesldap['varmodulesldap2filter']:'(uid=%{%{Stripped-User-Name}:-%{User-Name}})');
-	$varmodulesldap2basefilter = ($arrmodulesldap['varmodulesldap2basefilter']?$arrmodulesldap['varmodulesldap2basefilter']:'(objectclass=radiusprofile)');
-	$varmodulesldap2ldapconnectionsnumber = ($arrmodulesldap['varmodulesldap2ldapconnectionsnumber']?$arrmodulesldap['varmodulesldap2ldapconnectionsnumber']:'5');
-	$varmodulesldap2timeout = ($arrmodulesldap['varmodulesldap2timeout']?$arrmodulesldap['varmodulesldap2timeout']:'4');
-	$varmodulesldap2timelimit = ($arrmodulesldap['varmodulesldap2timelimit']?$arrmodulesldap['varmodulesldap2timelimit']:'3');
-	$varmodulesldap2nettimeout = ($arrmodulesldap['varmodulesldap2nettimeout']?$arrmodulesldap['varmodulesldap2nettimeout']:'1');	
-	
-	// Variables for TLS / Certificates - ldap1
-	$varmodulesldaprequirecert = ($arrmodulesldap['varmodulesldaprequirecert']?$arrmodulesldap['varmodulesldaprequirecert']:'never');
 
-// if enabled then create the certs in ../raddb/certs/ and enable "Start_tls" in ldap1 module
-if($arrmodulesldap['varmodulesldapenabletlssupport'] == 'on') {
-		
+	// Variables for General Configuration ldap1
+	$varmodulesldapserver = ($arrmodulesldap['varmodulesldapserver'] ?: 'ldap.your.domain');
+	$varmodulesldapserverport = ($arrmodulesldap['varmodulesldapserverport'] ?: '389');
+	$varmodulesldapidentity = ($arrmodulesldap['varmodulesldapidentity'] ?: 'cn=admin,o=My Org,c=UA');
+	$varmodulesldappassword = ($arrmodulesldap['varmodulesldappassword'] ?: 'mypass');
+	$varmodulesldapbasedn = ($arrmodulesldap['varmodulesldapbasedn'] ?: 'o=My Org,c=UA');
+	$varmodulesldapfilter = ($arrmodulesldap['varmodulesldapfilter'] ?: '(uid=%{%{Stripped-User-Name}:-%{User-Name}})');
+	$varmodulesldapbasefilter = ($arrmodulesldap['varmodulesldapbasefilter'] ?: '(objectclass=radiusprofile)');
+	$varmodulesldapldapconnectionsnumber = ($arrmodulesldap['varmodulesldapldapconnectionsnumber'] ?: '5');
+	$varmodulesldaptimeout = ($arrmodulesldap['varmodulesldaptimeout'] ?: '4');
+	$varmodulesldaptimelimit = ($arrmodulesldap['varmodulesldaptimelimit'] ?: '3');
+	$varmodulesldapnettimeout = ($arrmodulesldap['varmodulesldapnettimeout'] ?: '1');
+
+	// Variables for General Configuration ldap2
+	$varmodulesldap2server = ($arrmodulesldap['varmodulesldap2server'] ?: 'ldap.your.domain');
+	$varmodulesldap2serverport = ($arrmodulesldap['varmodulesldap2serverport'] ?: '389');
+	$varmodulesldap2identity = ($arrmodulesldap['varmodulesldap2identity'] ?: 'cn=admin,o=My Org,c=UA');
+	$varmodulesldap2password = ($arrmodulesldap['varmodulesldap2password'] ?: 'mypass');
+	$varmodulesldap2basedn = ($arrmodulesldap['varmodulesldap2basedn'] ?: 'o=My Org,c=UA');
+	$varmodulesldap2filter = ($arrmodulesldap['varmodulesldap2filter'] ?: '(uid=%{%{Stripped-User-Name}:-%{User-Name}})');
+	$varmodulesldap2basefilter = ($arrmodulesldap['varmodulesldap2basefilter'] ?: '(objectclass=radiusprofile)');
+	$varmodulesldap2ldapconnectionsnumber = ($arrmodulesldap['varmodulesldap2ldapconnectionsnumber'] ?: '5');
+	$varmodulesldap2timeout = ($arrmodulesldap['varmodulesldap2timeout'] ?: '4');
+	$varmodulesldap2timelimit = ($arrmodulesldap['varmodulesldap2timelimit'] ?: '3');
+	$varmodulesldap2nettimeout = ($arrmodulesldap['varmodulesldap2nettimeout'] ?: '1');
+
+	// Variables for TLS / Certificates - ldap1
+	$varmodulesldaprequirecert = ($arrmodulesldap['varmodulesldaprequirecert'] ?: 'never');
+
+	// if enabled then create the certs in ../raddb/certs/ and enable "Start_tls" in ldap1 module
+	if($arrmodulesldap['varmodulesldapenabletlssupport'] == 'on') {
+
 		$ca_cert = lookup_ca($arrmodulesldap["ssl_ca_cert1"]);
 		if ($ca_cert != false) {
-			if(base64_decode($ca_cert['prv'])) {
-				file_put_contents(FREERADIUS_ETC . "/raddb/certs/ca_ldap1_key.pem", 
-					base64_decode($ca_cert['prv']));
+			if (base64_decode($ca_cert['prv'])) {
+				file_put_contents(FREERADIUS_ETC . "/raddb/certs/ca_ldap1_key.pem", base64_decode($ca_cert['prv']));
 				$conf['ssl_ca_key'] = FREERADIUS_ETC . '/raddb/certs/ca_ldap1_key.pem';
 			}
-
-
-			if(base64_decode($ca_cert['crt'])) {
-				file_put_contents(FREERADIUS_ETC . "/raddb/certs/ca_ldap1_cert.pem", 
-					base64_decode($ca_cert['crt']));
+			if (base64_decode($ca_cert['crt'])) {
+				file_put_contents(FREERADIUS_ETC . "/raddb/certs/ca_ldap1_cert.pem", base64_decode($ca_cert['crt']));
 				$conf['ssl_ca_cert1'] = FREERADIUS_ETC . "/raddb/certs/ca_ldap1_cert.pem";
 			}
 
-
 			$svr_cert = lookup_cert($arrmodulesldap["ssl_server_cert1"]);
 			if ($svr_cert != false) {
-				if(base64_decode($svr_cert['prv'])) {
-					file_put_contents(FREERADIUS_ETC . "/raddb/certs/radius_ldap1_cert.key", 
-						base64_decode($svr_cert['prv']));
+				if (base64_decode($svr_cert['prv'])) {
+					file_put_contents(FREERADIUS_ETC . "/raddb/certs/radius_ldap1_cert.key", base64_decode($svr_cert['prv']));
 					$conf['ssl_key'] = FREERADIUS_ETC . '/raddb/certs/radius_ldap1_cert.key';
 				}
 			}
-
-
-			if(base64_decode($svr_cert['crt'])) {
-				file_put_contents(FREERADIUS_ETC . "/raddb/certs/radius_ldap1_cert.crt", 
-					base64_decode($svr_cert['crt']));
+			if (base64_decode($svr_cert['crt'])) {
+				file_put_contents(FREERADIUS_ETC . "/raddb/certs/radius_ldap1_cert.crt", base64_decode($svr_cert['crt']));
 				$conf['ssl_server_cert1'] = FREERADIUS_ETC . "/raddb/certs/radius_ldap1_cert.crt";
 			}
 
-
 			$conf['ssl_cert_dir'] = FREERADIUS_ETC . '/raddb/certs';
 		}
-	$varmodulesldapstarttls = "yes";
-}
-else {
-	$varmodulesldapstarttls = "no";
-}
-	
-	// Variables for TLS / Certificates - ldap2
-	$varmodulesldap2requirecert = ($arrmodulesldap['varmodulesldap2requirecert']?$arrmodulesldap['varmodulesldap2requirecert']:'never');
+		$varmodulesldapstarttls = "yes";
+	} else {
+		$varmodulesldapstarttls = "no";
+	}
 
-// if enabled then create the certs in ../raddb/certs/ and enable "Start_tls" in ldap2 module
-if($arrmodulesldap['varmodulesldap2enabletlssupport'] == 'on') {	
-		
+	// Variables for TLS / Certificates - ldap2
+	$varmodulesldap2requirecert = ($arrmodulesldap['varmodulesldap2requirecert'] ?: 'never');
+
+	// if enabled then create the certs in ../raddb/certs/ and enable "Start_tls" in ldap2 module
+	if($arrmodulesldap['varmodulesldap2enabletlssupport'] == 'on') {
+
 		$ca_cert = lookup_ca($arrmodulesldap["ssl_ca_cert2"]);
 		if ($ca_cert != false) {
-			if(base64_decode($ca_cert['prv'])) {
-				file_put_contents(FREERADIUS_ETC . "/raddb/certs/ca_ldap2_key.pem", 
-					base64_decode($ca_cert['prv']));
+			if (base64_decode($ca_cert['prv'])) {
+				file_put_contents(FREERADIUS_ETC . "/raddb/certs/ca_ldap2_key.pem", base64_decode($ca_cert['prv']));
 				$conf['ssl_ca_key'] = FREERADIUS_ETC . '/raddb/certs/ca_ldap2_key.pem';
 			}
-
-
-			if(base64_decode($ca_cert['crt'])) {
-				file_put_contents(FREERADIUS_ETC . "/raddb/certs/ca_ldap2_cert.pem", 
-					base64_decode($ca_cert['crt']));
+			if (base64_decode($ca_cert['crt'])) {
+				file_put_contents(FREERADIUS_ETC . "/raddb/certs/ca_ldap2_cert.pem", base64_decode($ca_cert['crt']));
 				$conf['ssl_ca_cert2'] = FREERADIUS_ETC . "/raddb/certs/ca_ldap2_cert.pem";
 			}
 
-
 			$svr_cert = lookup_cert($arrmodulesldap["ssl_server_cert2"]);
 			if ($svr_cert != false) {
-				if(base64_decode($svr_cert['prv'])) {
-					file_put_contents(FREERADIUS_ETC . "/raddb/certs/radius_ldap2_cert.key", 
-						base64_decode($svr_cert['prv']));
+				if (base64_decode($svr_cert['prv'])) {
+					file_put_contents(FREERADIUS_ETC . "/raddb/certs/radius_ldap2_cert.key", base64_decode($svr_cert['prv']));
 					$conf['ssl_key'] = FREERADIUS_ETC . '/raddb/certs/radius_ldap2_cert.key';
 				}
 			}
-
-
-			if(base64_decode($svr_cert['crt'])) {
-				file_put_contents(FREERADIUS_ETC . "/raddb/certs/radius_ldap2_cert.crt", 
-					base64_decode($svr_cert['crt']));
+			if (base64_decode($svr_cert['crt'])) {
+				file_put_contents(FREERADIUS_ETC . "/raddb/certs/radius_ldap2_cert.crt", base64_decode($svr_cert['crt']));
 				$conf['ssl_server_cert2'] = FREERADIUS_ETC . "/raddb/certs/radius_ldap2_cert.crt";
 			}
 
-
 			$conf['ssl_cert_dir'] = FREERADIUS_ETC . '/raddb/certs';
 		}
-	$varmodulesldap2starttls = "yes";
-}
-else {
-	$varmodulesldap2starttls = "no";
-}	
+		$varmodulesldap2starttls = "yes";
+	} else {
+		$varmodulesldap2starttls = "no";
+	}
 
 	// Miscellaneous Configuration + MS Active Directory Compatibility ldap1
-	$varmodulesldapmsadcompatibilityenable = ($arrmodulesldap['varmodulesldapmsadcompatibilityenable']?$arrmodulesldap['varmodulesldapmsadcompatibilityenable']:'Disable');
+	$varmodulesldapmsadcompatibilityenable = ($arrmodulesldap['varmodulesldapmsadcompatibilityenable'] ?: 'Disable');
 	if ($arrmodulesldap['varmodulesldapmsadcompatibilityenable'] == 'Disable') {
 		$varmodulesldapmsadcompatibility = '### MS Active Directory Compatibility is disabled ###';
-	}
-	else {
+	} else {
 		$varmodulesldapmsadcompatibility = 'chase_referrals = yes' . "\n\trebind = yes";
 	}
-	
+
 	// Miscellaneous Configuration + MS Active Directory Compatibility ldap2
-	$varmodulesldap2msadcompatibilityenable = ($arrmodulesldap['varmodulesldap2msadcompatibilityenable']?$arrmodulesldap['varmodulesldap2msadcompatibilityenable']:'Disable');
+	$varmodulesldap2msadcompatibilityenable = ($arrmodulesldap['varmodulesldap2msadcompatibilityenable'] ?: 'Disable');
 	if ($arrmodulesldap['varmodulesldap2msadcompatibilityenable'] == 'Disable') {
 		$varmodulesldap2msadcompatibility = '### MS Active Directory Compatibility is disabled ###';
-	}
-	else {
+	} else {
 		$varmodulesldap2msadcompatibility = 'chase_referrals = yes' . "\n\trebind = yes";
 	}
 
@@ -3293,14 +3272,13 @@ else {
 		$varmodulesldapdefaultprofile = '### default_profile = "cn=radprofile,ou=dialup,o=My Org,c=UA" ###';
 		$varmodulesldapprofileattribute = '### profile_attribute = "radiusProfileDn" ###';
 		$varmodulesldapaccessattr = '### access_attr = "dialupAccess" ###';
-	}
-	// When enabled we put in the default values so there is no empty entry if there is not input from GUI
-	else {
-		$varmodulesldapdefaultprofile = ($arrmodulesldap['varmodulesldapdefaultprofile']?$arrmodulesldap['varmodulesldapdefaultprofile']:'cn=radprofile,ou=dialup,o=My Org,c=UA');
+	} else {
+		// When enabled we put in the default values so there is no empty entry if there is not input from GUI
+		$varmodulesldapdefaultprofile = ($arrmodulesldap['varmodulesldapdefaultprofile'] ?: 'cn=radprofile,ou=dialup,o=My Org,c=UA');
 		$varmodulesldapdefaultprofile = "default_profile = " . '"' . "$varmodulesldapdefaultprofile" . '"';
-		$varmodulesldapprofileattribute = ($arrmodulesldap['varmodulesldapprofileattribute']?$arrmodulesldap['varmodulesldapprofileattribute']:'radiusProfileDn');
+		$varmodulesldapprofileattribute = ($arrmodulesldap['varmodulesldapprofileattribute'] ?: 'radiusProfileDn');
 		$varmodulesldapprofileattribute = "profile_attribute = " . '"' . "$varmodulesldapprofileattribute" . '"';
-		$varmodulesldapaccessattr = ($arrmodulesldap['varmodulesldapaccessattr']?$arrmodulesldap['varmodulesldapaccessattr']:'dialupAccess');
+		$varmodulesldapaccessattr = ($arrmodulesldap['varmodulesldapaccessattr'] ?: 'dialupAccess');
 		$varmodulesldapaccessattr = "access_attr = " . '"' . "$varmodulesldapaccessattr" . '"';
 	}
 
@@ -3309,17 +3287,16 @@ else {
 		$varmodulesldap2defaultprofile = '### default_profile = "cn=radprofile,ou=dialup,o=My Org,c=UA" ###';
 		$varmodulesldap2profileattribute = '### profile_attribute = "radiusProfileDn" ###';
 		$varmodulesldap2accessattr = '### access_attr = "dialupAccess" ###';
-	}
-	// When enabled we put in the default values so there is no empty entry if there is not input from GUI
-	else {
-		$varmodulesldap2defaultprofile = ($arrmodulesldap['varmodulesldap2defaultprofile']?$arrmodulesldap['varmodulesldap2defaultprofile']:'cn=radprofile,ou=dialup,o=My Org,c=UA');
+	} else {
+		// When enabled we put in the default values so there is no empty entry if there is not input from GUI
+		$varmodulesldap2defaultprofile = ($arrmodulesldap['varmodulesldap2defaultprofile'] ?: 'cn=radprofile,ou=dialup,o=My Org,c=UA');
 		$varmodulesldap2defaultprofile = "default_profile = " . '"' . "$varmodulesldap2defaultprofile" . '"';
-		$varmodulesldap2profileattribute = ($arrmodulesldap['varmodulesldap2profileattribute']?$arrmodulesldap['varmodulesldap2profileattribute']:'radiusProfileDn');
+		$varmodulesldap2profileattribute = ($arrmodulesldap['varmodulesldap2profileattribute'] ?: 'radiusProfileDn');
 		$varmodulesldap2profileattribute = "profile_attribute = " . '"' . "$varmodulesldap2profileattribute" . '"';
-		$varmodulesldap2accessattr = ($arrmodulesldap['varmodulesldap2accessattr']?$arrmodulesldap['varmodulesldap2accessattr']:'dialupAccess');
+		$varmodulesldap2accessattr = ($arrmodulesldap['varmodulesldap2accessattr'] ?: 'dialupAccess');
 		$varmodulesldap2accessattr = "access_attr = " . '"' . "$varmodulesldap2accessattr" . '"';
-	}	
-	
+	}
+
 	// Group membership checking
 	// When disabled we put this in the file but commented (#) like in the default installation ldap1
 	if (!$arrmodulesldap['varmodulesldapgroupenable']) {
@@ -3329,25 +3306,22 @@ else {
 		$varmodulesldapcomparecheckitems = '### compare_check_items = yes ###';
 		$varmodulesldapdoxlat = '### do_xlat = yes ###';
 		$varmodulesldapaccessattrusedforallow = '### access_attr_used_for_allow = yes ###';
-	}
-
-	// When enabled we put in the default values so there is no empty entry if there is not input from GUI
-	else {
-		$varmodulesldapgroupnameattribute = ($arrmodulesldap['varmodulesldapgroupnameattribute']?$arrmodulesldap['varmodulesldapgroupnameattribute']:'cn');
+	} else {
+		// When enabled we put in the default values so there is no empty entry if there is not input from GUI
+		$varmodulesldapgroupnameattribute = ($arrmodulesldap['varmodulesldapgroupnameattribute'] ?: 'cn');
 		$varmodulesldapgroupnameattribute = "groupname_attribute = $varmodulesldapgroupnameattribute";
-		$varmodulesldapgroupmembershipfilter = ($arrmodulesldap['varmodulesldapgroupmembershipfilter']?$arrmodulesldap['varmodulesldapgroupmembershipfilter']:'(|(&(objectClass=GroupOfNames)(member=%{control:Ldap-UserDn}))(&(objectClass=GroupOfUniqueNames)(uniquemember=%{control:Ldap-UserDn})))');
+		$varmodulesldapgroupmembershipfilter = ($arrmodulesldap['varmodulesldapgroupmembershipfilter'] ?: '(|(&(objectClass=GroupOfNames)(member=%{control:Ldap-UserDn}))(&(objectClass=GroupOfUniqueNames)(uniquemember=%{control:Ldap-UserDn})))');
 		$varmodulesldapgroupmembershipfilter = "groupmembership_filter = " . '"' . "$varmodulesldapgroupmembershipfilter" . '"';
-		$varmodulesldapgroupmembershipattribute = ($arrmodulesldap['varmodulesldapgroupmembershipattribute']?$arrmodulesldap['varmodulesldapgroupmembershipattribute']:'radiusGroupName');
+		$varmodulesldapgroupmembershipattribute = ($arrmodulesldap['varmodulesldapgroupmembershipattribute'] ?: 'radiusGroupName');
 		$varmodulesldapgroupmembershipattribute = "groupmembership_attribute = $varmodulesldapgroupmembershipattribute";
-		
-		$varmodulesldapcomparecheckitems = ($arrmodulesldap['varmodulesldapcomparecheckitems']?$arrmodulesldap['varmodulesldapcomparecheckitems']:'yes');
+		$varmodulesldapcomparecheckitems = ($arrmodulesldap['varmodulesldapcomparecheckitems'] ?: 'yes');
 		$varmodulesldapcomparecheckitems = "compare_check_items = $varmodulesldapcomparecheckitems";
-		$varmodulesldapdoxlat = ($arrmodulesldap['varmodulesldapdoxlat']?$arrmodulesldap['varmodulesldapdoxlat']:'yes');
+		$varmodulesldapdoxlat = ($arrmodulesldap['varmodulesldapdoxlat'] ?: 'yes');
 		$varmodulesldapdoxlat = "do_xlat = $varmodulesldapdoxlat";
-		$varmodulesldapaccessattrusedforallow = ($arrmodulesldap['varmodulesldapaccessattrusedforallow']?$arrmodulesldap['varmodulesldapaccessattrusedforallow']:'yes');	
+		$varmodulesldapaccessattrusedforallow = ($arrmodulesldap['varmodulesldapaccessattrusedforallow'] ?: 'yes');
 		$varmodulesldapaccessattrusedforallow = "access_attr_used_for_allow = $varmodulesldapaccessattrusedforallow";
 	}
-	
+
 	// Group membership checking
 	// When disabled we put this in the file but commented (#) like in the default installation ldap2
 	if (!$arrmodulesldap['varmodulesldap2groupenable']) {
@@ -3357,36 +3331,34 @@ else {
 		$varmodulesldap2comparecheckitems = '### compare_check_items = yes ###';
 		$varmodulesldap2doxlat = '### do_xlat = yes ###';
 		$varmodulesldap2accessattrusedforallow = '### access_attr_used_for_allow = yes ###';
+	} else {
+		// When enabled we put in the default values so there is no empty entry if there is not input from GUI
+		$varmodulesldap2groupnameattribute = ($arrmodulesldap['varmodulesldap2groupnameattribute'] ?: 'cn');
+		$varmodulesldap2groupnameattribute = "groupname_attribute = $varmodulesldap2groupnameattribute";
+		$varmodulesldap2groupmembershipfilter = ($arrmodulesldap['varmodulesldap2groupmembershipfilter'] ?: '(|(&(objectClass=GroupOfNames)(member=%{control:Ldap-UserDn}))(&(objectClass=GroupOfUniqueNames)(uniquemember=%{control:Ldap-UserDn})))');
+		$varmodulesldap2groupmembershipfilter = "groupmembership_filter = " . '"' . "$varmodulesldap2groupmembershipfilter" . '"';
+		$varmodulesldap2groupmembershipattribute = ($arrmodulesldap['varmodulesldap2groupmembershipattribute'] ?: 'radiusGroupName');
+		$varmodulesldap2groupmembershipattribute = "groupmembership_attribute = $varmodulesldap2groupmembershipattribute";
+		$varmodulesldap2comparecheckitems = ($arrmodulesldap['varmodulesldap2comparecheckitems'] ?: 'yes');
+		$varmodulesldap2comparecheckitems = "compare_check_items = $varmodulesldap2comparecheckitems";
+		$varmodulesldap2doxlat = ($arrmodulesldap['varmodulesldap2doxlat'] ?: 'yes');
+		$varmodulesldap2doxlat = "do_xlat = $varmodulesldap2doxlat";
+		$varmodulesldap2accessattrusedforallow = ($arrmodulesldap['varmodulesldap2accessattrusedforallow'] ?: 'yes');
+		$varmodulesldap2accessattrusedforallow = "access_attr_used_for_allow = $varmodulesldap2accessattrusedforallow";
 	}
 
-	// When enabled we put in the default values so there is no empty entry if there is not input from GUI
-	else {
-		$varmodulesldap2groupnameattribute = ($arrmodulesldap['varmodulesldap2groupnameattribute']?$arrmodulesldap['varmodulesldap2groupnameattribute']:'cn');
-		$varmodulesldap2groupnameattribute = "groupname_attribute = $varmodulesldap2groupnameattribute";
-		$varmodulesldap2groupmembershipfilter = ($arrmodulesldap['varmodulesldap2groupmembershipfilter']?$arrmodulesldap['varmodulesldap2groupmembershipfilter']:'(|(&(objectClass=GroupOfNames)(member=%{control:Ldap-UserDn}))(&(objectClass=GroupOfUniqueNames)(uniquemember=%{control:Ldap-UserDn})))');
-		$varmodulesldap2groupmembershipfilter = "groupmembership_filter = " . '"' . "$varmodulesldap2groupmembershipfilter" . '"';
-		$varmodulesldap2groupmembershipattribute = ($arrmodulesldap['varmodulesldap2groupmembershipattribute']?$arrmodulesldap['varmodulesldap2groupmembershipattribute']:'radiusGroupName');
-		$varmodulesldap2groupmembershipattribute = "groupmembership_attribute = $varmodulesldap2groupmembershipattribute";
-		
-		$varmodulesldap2comparecheckitems = ($arrmodulesldap['varmodulesldap2comparecheckitems']?$arrmodulesldap['varmodulesldap2comparecheckitems']:'yes');
-		$varmodulesldap2comparecheckitems = "compare_check_items = $varmodulesldap2comparecheckitems";
-		$varmodulesldap2doxlat = ($arrmodulesldap['varmodulesldap2doxlat']?$arrmodulesldap['varmodulesldap2doxlat']:'yes');
-		$varmodulesldap2doxlat = "do_xlat = $varmodulesldap2doxlat";
-		$varmodulesldap2accessattrusedforallow = ($arrmodulesldap['varmodulesldap2accessattrusedforallow']?$arrmodulesldap['varmodulesldap2accessattrusedforallow']:'yes');	
-		$varmodulesldap2accessattrusedforallow = "access_attr_used_for_allow = $varmodulesldap2accessattrusedforallow";
-	}	
-
 	// Keepalive variables ldap1
-	$varmodulesldapkeepaliveidle = ($arrmodulesldap['varmodulesldapkeepaliveidle']?$arrmodulesldap['varmodulesldapkeepaliveidle']:'60');
-	$varmodulesldapkeepaliveprobes = ($arrmodulesldap['varmodulesldapkeepaliveprobes']?$arrmodulesldap['varmodulesldapkeepaliveprobes']:'3');
-	$varmodulesldapkeepaliveinterval = ($arrmodulesldap['varmodulesldapkeepaliveinterval']?$arrmodulesldap['varmodulesldapkeepaliveinterval']:'3');
+	$varmodulesldapkeepaliveidle = ($arrmodulesldap['varmodulesldapkeepaliveidle'] ?: '60');
+	$varmodulesldapkeepaliveprobes = ($arrmodulesldap['varmodulesldapkeepaliveprobes'] ?: '3');
+	$varmodulesldapkeepaliveinterval = ($arrmodulesldap['varmodulesldapkeepaliveinterval'] ?: '3');
 
 	// Keepalive variables ldap2
-	$varmodulesldap2keepaliveidle = ($arrmodulesldap['varmodulesldap2keepaliveidle']?$arrmodulesldap['varmodulesldap2keepaliveidle']:'60');
-	$varmodulesldap2keepaliveprobes = ($arrmodulesldap['varmodulesldap2keepaliveprobes']?$arrmodulesldap['varmodulesldap2keepaliveprobes']:'3');
-	$varmodulesldap2keepaliveinterval = ($arrmodulesldap['varmodulesldap2keepaliveinterval']?$arrmodulesldap['varmodulesldap2keepaliveinterval']:'3');
-$raddb = FREERADIUS_ETC . '/raddb';
-$conf .= <<<EOD
+	$varmodulesldap2keepaliveidle = ($arrmodulesldap['varmodulesldap2keepaliveidle'] ?: '60');
+	$varmodulesldap2keepaliveprobes = ($arrmodulesldap['varmodulesldap2keepaliveprobes'] ?: '3');
+	$varmodulesldap2keepaliveinterval = ($arrmodulesldap['varmodulesldap2keepaliveinterval'] ?: '3');
+
+	$raddb = FREERADIUS_ETC . '/raddb';
+	$conf .= <<<EOD
 # -*- text -*-
 #
 #  $Id$
@@ -3414,7 +3386,7 @@ $conf .= <<<EOD
 #
 #  Setting "Auth-Type = LDAP" is ALMOST ALWAYS WRONG.  We
 #  really can't emphasize this enough.
-#	
+#
 ldap {
 	#
 	#  Note that this needs to match the name in the LDAP
@@ -3460,7 +3432,7 @@ ldap {
 		# Set this to 'yes' to use TLS encrypted connections
 		# to the LDAP database by using the StartTLS extended
 		# operation.
-		#			
+		#
 		# The StartTLS operation is supposed to be
 		# used with normal ldap connections instead of
 		# using ldaps (port 689) connections
@@ -3540,7 +3512,7 @@ ldap {
 	#
 	#  THIS WILL ONLY WORK FOR PAP AUTHENTICATION.
 	#
-	#  THIS WILL NOT WORK FOR CHAP, MS-CHAP, or 802.1x (EAP). 
+	#  THIS WILL NOT WORK FOR CHAP, MS-CHAP, or 802.1x (EAP).
 	#
 	#  You can disable this behavior by setting the following
 	#  configuration entry to "no".
@@ -3555,7 +3527,7 @@ ldap {
 	#
 	#	default: 0x0000 (no debugging messages)
 	#	Example:(LDAP_DEBUG_FILTER+LDAP_DEBUG_CONNS)
-	#ldap_debug = 0x0028 
+	#ldap_debug = 0x0028
 
 	#
 	#  Keepalive configuration.  This MAY NOT be supported by your
@@ -3620,7 +3592,7 @@ ldap ldap2{
 		# Set this to 'yes' to use TLS encrypted connections
 		# to the LDAP database by using the StartTLS extended
 		# operation.
-		#			
+		#
 		# The StartTLS operation is supposed to be
 		# used with normal ldap connections instead of
 		# using ldaps (port 689) connections
@@ -3700,7 +3672,7 @@ ldap ldap2{
 	#
 	#  THIS WILL ONLY WORK FOR PAP AUTHENTICATION.
 	#
-	#  THIS WILL NOT WORK FOR CHAP, MS-CHAP, or 802.1x (EAP). 
+	#  THIS WILL NOT WORK FOR CHAP, MS-CHAP, or 802.1x (EAP).
 	#
 	#  You can disable this behavior by setting the following
 	#  configuration entry to "no".
@@ -3715,7 +3687,7 @@ ldap ldap2{
 	#
 	#	default: 0x0000 (no debugging messages)
 	#	Example:(LDAP_DEBUG_FILTER+LDAP_DEBUG_CONNS)
-	#ldap_debug = 0x0028 
+	#ldap_debug = 0x0028
 
 	#
 	#  Keepalive configuration.  This MAY NOT be supported by your
@@ -3741,29 +3713,34 @@ EOD;
 	file_put_contents($filename, $conf);
 	chmod($filename, 0640);
 	conf_mount_ro();
-	
+
 	// We need to rebuild "freeradius_serverdefault_resync" before restart service
-	// "freeradius_serverdefault_resync" needs to restart other dependencies so we are pointing directly to "freeradius_settings_resync()"
+	// "freeradius_serverdefault_resync" needs to restart other dependencies so
+	// we are pointing directly to freeradius_settings_resync()
 	freeradius_serverdefault_resync();
 	if ($restart_svc === true) {
 		restart_service("radiusd");
 	}
-	
+
 }
 
 function freeradius_plainmacauth_resync() {
 	global $config;
 	$conf = '';
-	
+
 	// Variables: If not using 802.1x, mac address must be known
-	$varsettings = $config['installedpackages']['freeradiussettings']['config'][0];
-	
+	if (is_array($config['installedpackages']['freeradiussettings']['config'][0])) {
+		$varsettings = $config['installedpackages']['freeradiussettings']['config'][0];
+	} else {
+		$varsettings = array();
+	}
+
 	// defining variables with filename path
 	$filepolicyconf = FREERADIUS_ETC . '/raddb/policy.conf';
 	$filepolicyconfbackup = FREERADIUS_ETC . '/raddb/policy.conf.backup';
 	$filemodulesfiles = FREERADIUS_ETC . '/raddb/modules/files';
 	$filemodulesfilesbackup = FREERADIUS_ETC . '/raddb/files.backup';
-	
+
 	// If unchecked then plain mac auth is disabled and backups of the original files will be restored
 	if ($varsettings['varsettingsenablemacauth'] == '') {
 		// This is a check - only restore files if they aren't already
@@ -3774,9 +3751,8 @@ function freeradius_plainmacauth_resync() {
 			unlink(FREERADIUS_ETC . "/raddb/plain_macauth_enabled");
 			freeradius_serverdefault_resync();
 		}
-	}
-	// If checked then plain mac auth is enabled
-	else {
+	} else {
+		// If checked then plain mac auth is enabled
 		// This is a check - only modify files if they aren't already
 		if (!file_exists(FREERADIUS_ETC . "/raddb/plain_macauth_enabled")) {
 			freeradius_modulesfiles_resync();
@@ -3945,13 +3921,13 @@ policy {
 	}
 
 
-	#	
+	#
 	#  The following policies are for the Chargeable-User-Identity
 	#  (CUI) configuration.
 	#
 
 	#
-	#  The client indicates it can do CUI by sending a CUI attribute	
+	#  The client indicates it can do CUI by sending a CUI attribute
 	#  containing one zero byte
 	#
 	cui_authorize {
@@ -4052,7 +4028,7 @@ policy {
 	#		noop
 	#	}
 	#}
-	
+
 	#####  MODIFIED FOR http://wiki.freeradius.org/Mac-Auth#Mac-Auth+or+802.1x #####
 	#  Add "rewrite_calling_station_id" in the "authorize" and "preacct"
 	#  sections.
@@ -4081,15 +4057,19 @@ function freeradius_motp_resync() {
 	global $config, $bash_path;
 	$conf = '';
 
-	$varsettings = $config['installedpackages']['freeradiussettings']['config'][0];
-	
-	$varsettingsmotptimespan = ($varsettings['varsettingsmotptimespan']?$varsettings['varsettingsmotptimespan']:'2');
+	if (is_array($config['installedpackages']['freeradiussettings']['config'][0])) {
+		$varsettings = $config['installedpackages']['freeradiussettings']['config'][0];
+	} else {
+		$varsettings = array();
+	}
+
+	$varsettingsmotptimespan = ($varsettings['varsettingsmotptimespan'] ?: '2');
 	$varsettingsmotptimespanbeforeafter = $varsettingsmotptimespan + $varsettingsmotptimespan;
 	$varsettingsmotpdeleteoldpasswords = $varsettingsmotptimespanbeforeafter + 1;
-	$varsettingsmotppasswordattempts = ($varsettings['varsettingsmotppasswordattempts']?$varsettings['varsettingsmotppasswordattempts']:'5');
-	$varsettingsmotpchecksumtype = ($varsettings['varsettingsmotpchecksumtype']?$varsettings['varsettingsmotpchecksumtype']:'md5');
-	$varsettingsmotptokenlength = ($varsettings['varsettingsmotptokenlength']?$varsettings['varsettingsmotptokenlength']:'1-6');
-	
+	$varsettingsmotppasswordattempts = ($varsettings['varsettingsmotppasswordattempts'] ?: '5');
+	$varsettingsmotpchecksumtype = ($varsettings['varsettingsmotpchecksumtype'] ?: 'md5');
+	$varsettingsmotptokenlength = ($varsettings['varsettingsmotptokenlength'] ?: '1-6');
+
 	// check if disabled then we delete otpverify.sh script
 	if ($varsettings['varsettingsmotpenable'] == '') {
 		if (file_exists(FREERADIUS_ETC . "/raddb/scripts/otpverify.sh")) {
@@ -4110,7 +4090,7 @@ function freeradius_motp_resync() {
 # modify it under the terms of the GNU Library General Public
 # License as published by the Free Software Foundation; either
 # version 2 of the License, or (at your option) any later version.
-# 
+#
 # This software is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
@@ -4118,13 +4098,13 @@ function freeradius_motp_resync() {
 #
 # arguments:  \$1 \$2 \$3 \$4 \$5
 # \$1 - username
-# \$2 - one-time-password that is to be checked 
+# \$2 - one-time-password that is to be checked
 # \$3 - init-secred from token (to init token: #**#)
 # \$4 - user PIN
 # \$5 - time difference between token and server in 10s of seconds (360 = 1 hour)
 #
 # one-time-password must match md5(EPOCHTIME+SECRET+PIN)
-# 
+#
 #
 # otpverify.sh version 1.04b, Feb. 2003
 # otpverify.sh version 1.04c, Nov. 2008
@@ -4146,7 +4126,7 @@ function chop
 {
 	num=`echo -n "\$1" | wc -c | sed 's/ //g' `
 	nummin1=`expr \$num "-" 1`
-	echo -n "\$1" | cut -b 1-\$nummin1 
+	echo -n "\$1" | cut -b 1-\$nummin1
 }
 
 if [ ! \$# -eq 5 ] ; then
@@ -4214,13 +4194,13 @@ exit 11
 
 
 EOD;
-		$filename = FREERADIUS_ETC . '/raddb/scripts/otpverify.sh';
-		conf_mount_rw();
-		file_put_contents($filename, $conf);
-		chmod($filename, 0750);
-		conf_mount_ro();
-	}
 
+	$filename = FREERADIUS_ETC . '/raddb/scripts/otpverify.sh';
+	conf_mount_rw();
+	file_put_contents($filename, $conf);
+	chmod($filename, 0750);
+	conf_mount_ro();
+	}
 }
 
 function freeradius_modulesmotp_resync() {
@@ -4234,7 +4214,7 @@ function freeradius_modulesmotp_resync() {
 exec motp {
 		wait = yes
 		program = "{$bash_path} {$varFREERADIUS_ETC}/raddb/scripts/otpverify.sh %{request:User-Name} %{request:User-Password} %{reply:MOTP-Init-Secret} %{reply:MOTP-PIN} %{reply:MOTP-Offset}"
-	}	
+	}
 EOD;
 
 	$filename = FREERADIUS_ETC . '/raddb/modules/motp';
@@ -4242,7 +4222,6 @@ EOD;
 	file_put_contents($filename, $conf);
 	chmod($filename, 0640);
 	conf_mount_ro();
-
 }
 
 function freeradius_modulesdatacounter_resync() {
@@ -4276,7 +4255,6 @@ EOD;
 	file_put_contents($filename, $conf);
 	chmod($filename, 0640);
 	conf_mount_ro();
-
 }
 
 function freeradius_datacounter_auth_resync() {
@@ -4316,7 +4294,6 @@ EOD;
 	file_put_contents($filename, $conf);
 	chmod($filename, 0750);
 	conf_mount_ro();
-
 }
 
 function freeradius_datacounter_acct_resync() {
@@ -4378,7 +4355,6 @@ EOD;
 	file_put_contents($filename, $conf);
 	chmod($filename, 0750);
 	conf_mount_ro();
-
 }
 
 function freeradius_dictionary_resync() {
@@ -4446,7 +4422,6 @@ EOD;
 	file_put_contents($filename, $conf);
 	chmod($filename, 0640);
 	conf_mount_ro();
-
 }
 
 ?>

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -489,223 +489,219 @@ function freeradius_users_resync($via_rpc = false) {
 
 	if (!empty($arrusers)) {
 		foreach ($arrusers as $users) {
+			// Variables for users file defined parameters
+			$varusersusername = $users['varusersusername'];
+			$varuserspassword = $users['varuserspassword'];
 
-		// Variables for users file defined parameters
-
-		$varusersusername = $users['varusersusername'];
-		$varuserspassword = $users['varuserspassword'];
-
-
-		// Check password encryption
-		$varuserspasswordencryption = ($users['varuserspasswordencryption'] ?: 'Cleartext-Password');
-		switch ($varuserspasswordencryption) {
-			case "MD5-Password":
-				$varuserspassword = md5($varuserspassword);
-				break;
-			default:
-				$varuserspassword = $users['varuserspassword'];
-		}
-
-
-		$varusersmotpinitsecret = $users['varusersmotpinitsecret'];
-		$varusersmotppin = $users['varusersmotppin'];
-		$varusersmotpoffset = ($users['varusersmotpoffset'] ?: '0');
-
-		$varuserssimultaneousconnect = ($users['varuserssimultaneousconnect'] ?: '');
-		$varuserswisprredirectionurl = $users['varuserswisprredirectionurl'];
-		$varusersframedipaddress = $users['varusersframedipaddress'];
-		$varusersframedipnetmask = $users['varusersframedipnetmask'];
-		$varusersframedroute = $users['varusersframedroute'];
-		$varusersexpiration = $users['varusersexpiration'];
-		$varuserssessiontimeout = $users['varuserssessiontimeout'];
-		$varuserslogintime = $users['varuserslogintime'];
-		$varusersvlanid = $users['varusersvlanid'];
-
-		// GUI uses minutes but RADIUS needs seconds so we do a multiplication
-		$varusersamountoftime = ($users['varusersamountoftime'] ?: '');
-		$varusersamountoftime = $varusersamountoftime * 60;
-		$varuserspointoftime = $users['varuserspointoftime'];
-
-		// GUI uses MB but RADIUS needs Bytes so we do a multiplication
-		$varusersmaxtotaloctets = ($users['varusersmaxtotaloctets'] ?: '');
-		$varusersmaxtotaloctets = $varusersmaxtotaloctets * 1024 * 1024;
-		$varusersmaxtotaloctetstimerange = $users['varusersmaxtotaloctetstimerange'];
-
-		// GUI uses KiloBit but RADIUS needs Bits so we do a multiplication
-		$varusersmaxbandwidthup = ($users['varusersmaxbandwidthup'] ?: '');
-		$varusersmaxbandwidthup = $varusersmaxbandwidthup * 1024;
-		$varusersmaxbandwidthdown = ($users['varusersmaxbandwidthdown'] ?: '');
-		$varusersmaxbandwidthdown = $varusersmaxbandwidthdown * 1024;
-
-		// Accounting-Interim-Interval - Must not be smaller than 60 and should be bigger than 600s
-		if (($users['varusersacctinteriminterval'] >= '0') && ($users['varusersacctinteriminterval'] < '60')) {
-			$varusersacctinteriminterval = 60;
-		} else {
-			$varusersacctinteriminterval = $users['varusersacctinteriminterval'];
-		}
-
-		// Clear variables for next user foreach additional options TOP
-		$varuserstopadditionaloptions = '';
-		$varusersadditionaloptionstop = '';
-
-		if (!empty($users['varuserstopadditionaloptions'])) {
-			$varuserstopadditionaloptions = explode("|", ($users['varuserstopadditionaloptions']));
-			foreach ($varuserstopadditionaloptions as $toptmp) {
-				$varusersadditionaloptionstop .= $toptmp . "\n";
+			// Check password encryption
+			$varuserspasswordencryption = ($users['varuserspasswordencryption'] ?: 'Cleartext-Password');
+			switch ($varuserspasswordencryption) {
+				case "MD5-Password":
+					$varuserspassword = md5($varuserspassword);
+					break;
+				default:
+					$varuserspassword = $users['varuserspassword'];
 			}
-		}
 
-		// Clear variables for next user foreach additional options: CHECK-ITEMS
-		$varuserscheckitemsadditionaloptions = '';
-		$varusersadditionaloptionscheckitems = '';
+			$varusersmotpinitsecret = $users['varusersmotpinitsecret'];
+			$varusersmotppin = $users['varusersmotppin'];
+			$varusersmotpoffset = ($users['varusersmotpoffset'] ?: '0');
 
-		if (!empty($users['varuserscheckitemsadditionaloptions'])) {
-			$varuserscheckitemsadditionaloptions = explode("|", ($users['varuserscheckitemsadditionaloptions']));
-			$varusersadditionaloptionscheckitems .= '';
-			foreach ($varuserscheckitemsadditionaloptions as $checkitemtmp) {
-				$varusersadditionaloptionscheckitems .= "$checkitemtmp" . " ";
-			}
-		}
+			$varuserssimultaneousconnect = ($users['varuserssimultaneousconnect'] ?: '');
+			$varuserswisprredirectionurl = $users['varuserswisprredirectionurl'];
+			$varusersframedipaddress = $users['varusersframedipaddress'];
+			$varusersframedipnetmask = $users['varusersframedipnetmask'];
+			$varusersframedroute = $users['varusersframedroute'];
+			$varusersexpiration = $users['varusersexpiration'];
+			$varuserssessiontimeout = $users['varuserssessiontimeout'];
+			$varuserslogintime = $users['varuserslogintime'];
+			$varusersvlanid = $users['varusersvlanid'];
 
-		// Clear variables for next user foreach additional options: REPLY-ITEMS
-		$varusersreplyitemsadditionaloptions = '';
-		$varusersadditionaloptionsreplyitems = '';
+			// GUI uses minutes but RADIUS needs seconds so we do a multiplication
+			$varusersamountoftime = ($users['varusersamountoftime'] ?: '');
+			$varusersamountoftime = $varusersamountoftime * 60;
+			$varuserspointoftime = $users['varuserspointoftime'];
 
-		if (!empty($users['varusersreplyitemsadditionaloptions'])) {
-			$varusersreplyitemsadditionaloptions = explode("|", ($users['varusersreplyitemsadditionaloptions']));
-			$varusersadditionaloptionsreplyitems .= '';
-			foreach ($varusersreplyitemsadditionaloptions as $replyitemtmp) {
-				$varusersadditionaloptionsreplyitems .= $replyitemtmp . "\n\t";
-			}
-		}
+			// GUI uses MB but RADIUS needs Bytes so we do a multiplication
+			$varusersmaxtotaloctets = ($users['varusersmaxtotaloctets'] ?: '');
+			$varusersmaxtotaloctets = $varusersmaxtotaloctets * 1024 * 1024;
+			$varusersmaxtotaloctetstimerange = $users['varusersmaxtotaloctetstimerange'];
 
-		// Empty variable
-		$varuserscheckitem = '';
-		$varusersreplyitem = '';
+			// GUI uses KiloBit but RADIUS needs Bits so we do a multiplication
+			$varusersmaxbandwidthup = ($users['varusersmaxbandwidthup'] ?: '');
+			$varusersmaxbandwidthup = $varusersmaxbandwidthup * 1024;
+			$varusersmaxbandwidthdown = ($users['varusersmaxbandwidthdown'] ?: '');
+			$varusersmaxbandwidthdown = $varusersmaxbandwidthdown * 1024;
 
-		// check if mobile otp is disabled
-		if ($users['varusersmotpenable'] == '') {
-			// If someone does not want to use username/password but entry "DEFAULT" instead then we can disable this
-			if (($users['varusersusername'] == '') && ($users['varuserspassword'] == '')) {
-				$varuserscheckitem = '';
+			// Accounting-Interim-Interval - Must not be smaller than 60 and should be bigger than 600s
+			if (($users['varusersacctinteriminterval'] >= '0') && ($users['varusersacctinteriminterval'] < '60')) {
+				$varusersacctinteriminterval = 60;
 			} else {
-				// Add the user attributes to each user.
-				$varuserscheckitem = '"' . $varusersusername . '"' . " $varuserspasswordencryption := " . '"' . $varuserspassword .'"';
+				$varusersacctinteriminterval = $users['varusersacctinteriminterval'];
 			}
-		// end of check if otp is enabled
-		} else {
-			// if otp is enabled we need to set Auth-Type to accept because password will be checked when the otp script gets executed in reply-item list
-			$varuserscheckitem = '"' . $varusersusername . '"' . " Auth-Type = motp";
-		}
 
-		// Add additional CHECK-ITEMS here. Different formatting in "users" file needed.
-		if ($varuserssimultaneousconnect != '') {
-			$varuserscheckitem .= ", Simultaneous-Use := " . '"' . $varuserssimultaneousconnect . '"';
-		}
-		if ($varusersexpiration != '') {
-			$varuserscheckitem .= ", Expiration := " . '"' . $varusersexpiration . '"';
-		}
-		if ($varuserslogintime != '') {
-			$varuserscheckitem .= ", Login-Time := " . '"' . $varuserslogintime . '"';
-		}
-		if ($varusersamountoftime != '') {
-			$varuserscheckitem .= ", Max-" . "$varuserspointoftime" . "-Session := " . "$varusersamountoftime";
-		}
-		if ($varusersadditionaloptionscheckitems != '') {
-			$varuserscheckitem .= ", $varusersadditionaloptionscheckitems";
-		}
+			// Clear variables for next user foreach additional options TOP
+			$varuserstopadditionaloptions = '';
+			$varusersadditionaloptionstop = '';
 
-		// this is the part for mobile otp
-		if ($users['varusersmotpenable'] == 'on') {
-			$varusersreplyitem .= "MOTP-Init-Secret = $varusersmotpinitsecret," . "\n\tMOTP-PIN = $varusersmotppin," . "\n\tMOTP-Offset = $varusersmotpoffset";
-		} else {
-			$varusersreplyitem .= '';
-		}
+			if (!empty($users['varuserstopadditionaloptions'])) {
+				$varuserstopadditionaloptions = explode("|", ($users['varuserstopadditionaloptions']));
+				foreach ($varuserstopadditionaloptions as $toptmp) {
+					$varusersadditionaloptionstop .= $toptmp . "\n";
+				}
+			}
 
-		// Add additional REPLY-ITEMS here. Different formatting in "users" file needed.
-		if ($varusersframedipaddress != '') {
-			if ($varusersreplyitem != '') {
-				$varusersreplyitem .= ",";
-			}
-			$varusersreplyitem .= "\n\tFramed-IP-Address = $varusersframedipaddress";
-		}
-		if ($varusersframedipnetmask != '') {
-			if ($varusersreplyitem != '') {
-				$varusersreplyitem .= ",";
-			}
-			$varusersreplyitem .= "\n\tFramed-IP-Netmask = $varusersframedipnetmask";
-		}
-		if ($varusersframedroute != '') {
-			if ($varusersreplyitem != '') {
-				$varusersreplyitem .= ",";
-			}
-			$varusersreplyitem .= "\n\tFramed-Route = " . '"' . $varusersframedroute . '"';
-		}
-		if ($varuserssessiontimeout != '') {
-			if ($varusersreplyitem != '') {
-				$varusersreplyitem .= ",";
-			}
-			$varusersreplyitem .= "\n\tSession-Timeout := $varuserssessiontimeout";
-		}
-		if ($varusersvlanid != '') {
-			if ($varusersreplyitem != '') {
-				$varusersreplyitem .= ",";
-			}
-			$varusersreplyitem .= "\n\tTunnel-Type = VLAN,\n\tTunnel-Medium-Type = IEEE-802,\n\tTunnel-Private-Group-ID = " . '"' . $varusersvlanid . '"';
-		}
-		if ($varusersmaxbandwidthup != '') {
-			if ($varusersreplyitem != '') {
-				$varusersreplyitem .= ",";
-			}
-			$varusersreplyitem .= "\n\tWISPr-Bandwidth-Max-Up := $varusersmaxbandwidthup";
-		}
-		if ($varusersmaxbandwidthdown != '') {
-			if ($varusersreplyitem != '') {
-				$varusersreplyitem .= ",";
-			}
-			$varusersreplyitem .= "\n\tWISPr-Bandwidth-Max-Down := $varusersmaxbandwidthdown";
-		}
-		if ($varusersacctinteriminterval != '') {
-			if ($varusersreplyitem != '') {
-				$varusersreplyitem .= ",";
-			}
-			$varusersreplyitem .= "\n\tAcct-Interim-Interval := $varusersacctinteriminterval";
-		}
-		if ($varuserswisprredirectionurl != '') {
-			if ($varusersreplyitem != '') {
-				$varusersreplyitem .= ",";
-			}
-			$varusersreplyitem .= "\n\tWISPr-Redirection-URL := $varuserswisprredirectionurl";
-		}
-		// If an octet limit is set we create the files for the limit and the counter. Further we call an exec script which checks if the limit is reached or not
-		if ($varusersmaxtotaloctets != '') {
-			if ($varusersreplyitem != '') {
-				$varusersreplyitem .= ",";
-			}
-			// create exec script
-			$varusersreplyitem .= "\n\tExec-Program-Wait = " . '"/bin/sh ' . FREERADIUS_ETC . '/raddb/scripts/datacounter_auth.sh ' . "$varusersusername $varusersmaxtotaloctetstimerange" . '"';
-			// create limit file - will be always overwritten so we can increase limit from GUI
-			file_put_contents("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/max-octets-$varusersusername", $varusersmaxtotaloctets, LOCK_EX);
-			// if used-octets file exist we do NOT overwrite this file!!!
-			if (!file_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername")) {
-				file_put_contents("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername", "0", LOCK_EX);
-			}
-		} else {
-			// If an octet limit is NOT set we delete the files for the limit and the counter.
-			unlink_if_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/max-octets-$varusersusername");
-			unlink_if_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername*");
-		}
-		if ($varusersadditionaloptionsreplyitems != '') {
-			if ($varusersreplyitem != '') {
-				$varusersreplyitem .= ",";
-			}
-			$varusersreplyitem .= "\n\t$varusersadditionaloptionsreplyitems";
-		}
+			// Clear variables for next user foreach additional options: CHECK-ITEMS
+			$varuserscheckitemsadditionaloptions = '';
+			$varusersadditionaloptionscheckitems = '';
 
-		// Cosmetic fix - This is just to make a blank new line after each user entry
-		$varusersreplyitem .= "\n\n";
+			if (!empty($users['varuserscheckitemsadditionaloptions'])) {
+				$varuserscheckitemsadditionaloptions = explode("|", ($users['varuserscheckitemsadditionaloptions']));
+				$varusersadditionaloptionscheckitems .= '';
+				foreach ($varuserscheckitemsadditionaloptions as $checkitemtmp) {
+					$varusersadditionaloptionscheckitems .= "$checkitemtmp" . " ";
+				}
+			}
 
-		$conf .= <<<EOD
+			// Clear variables for next user foreach additional options: REPLY-ITEMS
+			$varusersreplyitemsadditionaloptions = '';
+			$varusersadditionaloptionsreplyitems = '';
+
+			if (!empty($users['varusersreplyitemsadditionaloptions'])) {
+				$varusersreplyitemsadditionaloptions = explode("|", ($users['varusersreplyitemsadditionaloptions']));
+				$varusersadditionaloptionsreplyitems .= '';
+				foreach ($varusersreplyitemsadditionaloptions as $replyitemtmp) {
+					$varusersadditionaloptionsreplyitems .= $replyitemtmp . "\n\t";
+				}
+			}
+
+			// Empty variable
+			$varuserscheckitem = '';
+			$varusersreplyitem = '';
+
+			// check if mobile otp is disabled
+			if ($users['varusersmotpenable'] == '') {
+				// If someone does not want to use username/password but entry "DEFAULT" instead then we can disable this
+				if (($users['varusersusername'] == '') && ($users['varuserspassword'] == '')) {
+					$varuserscheckitem = '';
+				} else {
+					// Add the user attributes to each user.
+					$varuserscheckitem = '"' . $varusersusername . '"' . " $varuserspasswordencryption := " . '"' . $varuserspassword .'"';
+				}
+			// end of check if otp is enabled
+			} else {
+				// if otp is enabled we need to set Auth-Type to accept because password will be checked when the otp script gets executed in reply-item list
+				$varuserscheckitem = '"' . $varusersusername . '"' . " Auth-Type = motp";
+			}
+
+			// Add additional CHECK-ITEMS here. Different formatting in "users" file needed.
+			if ($varuserssimultaneousconnect != '') {
+				$varuserscheckitem .= ", Simultaneous-Use := " . '"' . $varuserssimultaneousconnect . '"';
+			}
+			if ($varusersexpiration != '') {
+				$varuserscheckitem .= ", Expiration := " . '"' . $varusersexpiration . '"';
+			}
+			if ($varuserslogintime != '') {
+				$varuserscheckitem .= ", Login-Time := " . '"' . $varuserslogintime . '"';
+			}
+			if ($varusersamountoftime != '') {
+				$varuserscheckitem .= ", Max-" . "$varuserspointoftime" . "-Session := " . "$varusersamountoftime";
+			}
+			if ($varusersadditionaloptionscheckitems != '') {
+				$varuserscheckitem .= ", $varusersadditionaloptionscheckitems";
+			}
+
+			// this is the part for mobile otp
+			if ($users['varusersmotpenable'] == 'on') {
+				$varusersreplyitem .= "MOTP-Init-Secret = $varusersmotpinitsecret," . "\n\tMOTP-PIN = $varusersmotppin," . "\n\tMOTP-Offset = $varusersmotpoffset";
+			} else {
+				$varusersreplyitem .= '';
+			}
+
+			// Add additional REPLY-ITEMS here. Different formatting in "users" file needed.
+			if ($varusersframedipaddress != '') {
+				if ($varusersreplyitem != '') {
+					$varusersreplyitem .= ",";
+				}
+				$varusersreplyitem .= "\n\tFramed-IP-Address = $varusersframedipaddress";
+			}
+			if ($varusersframedipnetmask != '') {
+				if ($varusersreplyitem != '') {
+					$varusersreplyitem .= ",";
+				}
+				$varusersreplyitem .= "\n\tFramed-IP-Netmask = $varusersframedipnetmask";
+			}
+			if ($varusersframedroute != '') {
+				if ($varusersreplyitem != '') {
+					$varusersreplyitem .= ",";
+				}
+				$varusersreplyitem .= "\n\tFramed-Route = " . '"' . $varusersframedroute . '"';
+			}
+			if ($varuserssessiontimeout != '') {
+				if ($varusersreplyitem != '') {
+					$varusersreplyitem .= ",";
+				}
+				$varusersreplyitem .= "\n\tSession-Timeout := $varuserssessiontimeout";
+			}
+			if ($varusersvlanid != '') {
+				if ($varusersreplyitem != '') {
+					$varusersreplyitem .= ",";
+				}
+				$varusersreplyitem .= "\n\tTunnel-Type = VLAN,\n\tTunnel-Medium-Type = IEEE-802,\n\tTunnel-Private-Group-ID = " . '"' . $varusersvlanid . '"';
+			}
+			if ($varusersmaxbandwidthup != '') {
+				if ($varusersreplyitem != '') {
+					$varusersreplyitem .= ",";
+				}
+				$varusersreplyitem .= "\n\tWISPr-Bandwidth-Max-Up := $varusersmaxbandwidthup";
+			}
+			if ($varusersmaxbandwidthdown != '') {
+				if ($varusersreplyitem != '') {
+					$varusersreplyitem .= ",";
+				}
+				$varusersreplyitem .= "\n\tWISPr-Bandwidth-Max-Down := $varusersmaxbandwidthdown";
+			}
+			if ($varusersacctinteriminterval != '') {
+				if ($varusersreplyitem != '') {
+					$varusersreplyitem .= ",";
+				}
+				$varusersreplyitem .= "\n\tAcct-Interim-Interval := $varusersacctinteriminterval";
+			}
+			if ($varuserswisprredirectionurl != '') {
+				if ($varusersreplyitem != '') {
+					$varusersreplyitem .= ",";
+				}
+				$varusersreplyitem .= "\n\tWISPr-Redirection-URL := $varuserswisprredirectionurl";
+			}
+			// If an octet limit is set we create the files for the limit and the counter. Further we call an exec script which checks if the limit is reached or not
+			if ($varusersmaxtotaloctets != '') {
+				if ($varusersreplyitem != '') {
+					$varusersreplyitem .= ",";
+				}
+				// create exec script
+				$varusersreplyitem .= "\n\tExec-Program-Wait = " . '"/bin/sh ' . FREERADIUS_ETC . '/raddb/scripts/datacounter_auth.sh ' . "$varusersusername $varusersmaxtotaloctetstimerange" . '"';
+				// create limit file - will be always overwritten so we can increase limit from GUI
+				file_put_contents("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/max-octets-$varusersusername", $varusersmaxtotaloctets, LOCK_EX);
+				// if used-octets file exist we do NOT overwrite this file!!!
+				if (!file_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername")) {
+					file_put_contents("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername", "0", LOCK_EX);
+				}
+			} else {
+				// If an octet limit is NOT set we delete the files for the limit and the counter.
+				unlink_if_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/max-octets-$varusersusername");
+				unlink_if_exists("/var/log/radacct/datacounter/$varusersmaxtotaloctetstimerange/used-octets-$varusersusername*");
+			}
+			if ($varusersadditionaloptionsreplyitems != '') {
+				if ($varusersreplyitem != '') {
+					$varusersreplyitem .= ",";
+				}
+				$varusersreplyitem .= "\n\t$varusersadditionaloptionsreplyitems";
+			}
+
+			// Cosmetic fix - This is just to make a blank new line after each user entry
+			$varusersreplyitem .= "\n\n";
+
+			$conf .= <<<EOD
 $varusersadditionaloptionstop
 $varuserscheckitem
 	$varusersreplyitem
@@ -740,194 +736,192 @@ function freeradius_authorizedmacs_resync($restart_svc = true, $via_rpc = false)
 
 	if (!empty($arrmacs)) {
 		foreach ($arrmacs as $macs) {
+			// Variables for authorized_macs file defined parameters
+			$varmacsaddress = $macs['varmacsaddress'];
+			// We don't need a password but we need this field to make syntac correct for CHECK-ITEMS
+			$varmacspassword = $macs['varmacsaddress'];
 
-		// Variables for authorized_macs file defined parameters
-		$varmacsaddress = $macs['varmacsaddress'];
-		// We don't need a password but we need this field to make syntac correct for CHECK-ITEMS
-		$varmacspassword = $macs['varmacsaddress'];
+			$varmacssimultaneousconnect = ($macs['varmacssimultaneousconnect'] ?: '');
+			$varmacsswisprredirectionurl = $macs['varmacsswisprredirectionurl'];
+			$varmacsframedipaddress = $macs['varmacsframedipaddress'];
+			$varmacsframedipnetmask = $macs['varmacsframedipnetmask'];
+			$varmacsframedroute = $macs['varmacsframedroute'];
+			$varmacsexpiration = $macs['varmacsexpiration'];
+			$varmacssessiontimeout = $macs['varmacssessiontimeout'];
+			$varmacslogintime = $macs['varmacslogintime'];
+			$varmacsvlanid = $macs['varmacsvlanid'];
 
-		$varmacssimultaneousconnect = ($macs['varmacssimultaneousconnect'] ?: '');
-		$varmacsswisprredirectionurl = $macs['varmacsswisprredirectionurl'];
-		$varmacsframedipaddress = $macs['varmacsframedipaddress'];
-		$varmacsframedipnetmask = $macs['varmacsframedipnetmask'];
-		$varmacsframedroute = $macs['varmacsframedroute'];
-		$varmacsexpiration = $macs['varmacsexpiration'];
-		$varmacssessiontimeout = $macs['varmacssessiontimeout'];
-		$varmacslogintime = $macs['varmacslogintime'];
-		$varmacsvlanid = $macs['varmacsvlanid'];
+			// GUI uses minutes but RADIUS needs seconds so we do a multiplication
+			$varmacsamountoftime = ($macs['varmacsamountoftime'] ?: '');
+			$varmacsamountoftime = $varmacsamountoftime * 60;
+			$varmacspointoftime = $macs['varmacspointoftime'];
 
-		// GUI uses minutes but RADIUS needs seconds so we do a multiplication
-		$varmacsamountoftime = ($macs['varmacsamountoftime'] ?: '');
-		$varmacsamountoftime = $varmacsamountoftime * 60;
-		$varmacspointoftime = $macs['varmacspointoftime'];
+			// GUI uses MB but RADIUS needs Bytes so we do a multiplication
+			$varmacsmaxtotaloctets = ($macs['varmacsmaxtotaloctets'] ?: '');
+			$varmacsmaxtotaloctets = $varmacsmaxtotaloctets * 1024 * 1024;
+			$varmacsmaxtotaloctetstimerange = $macs['varmacsmaxtotaloctetstimerange'];
 
-		// GUI uses MB but RADIUS needs Bytes so we do a multiplication
-		$varmacsmaxtotaloctets = ($macs['varmacsmaxtotaloctets'] ?: '');
-		$varmacsmaxtotaloctets = $varmacsmaxtotaloctets * 1024 * 1024;
-		$varmacsmaxtotaloctetstimerange = $macs['varmacsmaxtotaloctetstimerange'];
+			// GUI uses KiloBit but RADIUS needs Bits so we do a multiplication
+			$varmacsmaxbandwidthup = ($macs['varmacsmaxbandwidthup'] ?: '');
+			$varmacsmaxbandwidthup = $varmacsmaxbandwidthup * 1024;
+			$varmacsmaxbandwidthdown = ($macs['varmacsmaxbandwidthdown'] ?: '');
+			$varmacsmaxbandwidthdown = $varmacsmaxbandwidthdown * 1024;
 
-		// GUI uses KiloBit but RADIUS needs Bits so we do a multiplication
-		$varmacsmaxbandwidthup = ($macs['varmacsmaxbandwidthup'] ?: '');
-		$varmacsmaxbandwidthup = $varmacsmaxbandwidthup * 1024;
-		$varmacsmaxbandwidthdown = ($macs['varmacsmaxbandwidthdown'] ?: '');
-		$varmacsmaxbandwidthdown = $varmacsmaxbandwidthdown * 1024;
-
-
-		// Accounting-Interim-Interval
-		if (($users['varmacsacctinteriminterval'] >= '0') && ($users['varmacsacctinteriminterval'] < '60')) {
-			$varmacsacctinteriminterval = 60;
-		} else {
-			$varmacsacctinteriminterval = $users['varmacsacctinteriminterval'];
-		}
-
-		// Clear variables for next mac foreach additional options TOP
-		$varmacstopadditionaloptions = '';
-		$varmacsadditionaloptionstop = '';
-
-		if (!empty($macs['varmacstopadditionaloptions'])) {
-			$varmacstopadditionaloptions = explode("|", ($macs['varmacstopadditionaloptions']));
-			foreach ($varmacstopadditionaloptions as $toptmp) {
-				$varmacsadditionaloptionstop .= $toptmp . "\n";
+			// Accounting-Interim-Interval
+			if (($users['varmacsacctinteriminterval'] >= '0') && ($users['varmacsacctinteriminterval'] < '60')) {
+				$varmacsacctinteriminterval = 60;
+			} else {
+				$varmacsacctinteriminterval = $users['varmacsacctinteriminterval'];
 			}
-		}
 
-		// Clear variables for next mac foreach additional options: CHECK-ITEMS
-		$varmacscheckitemsadditionaloptions = '';
-		$varmacsadditionaloptionscheckitems = '';
+			// Clear variables for next mac foreach additional options TOP
+			$varmacstopadditionaloptions = '';
+			$varmacsadditionaloptionstop = '';
 
-		if (!empty($macs['varmacscheckitemsadditionaloptions'])) {
-			$varmacscheckitemsadditionaloptions = explode("|", ($macs['varmacscheckitemsadditionaloptions']));
-			$varmacsadditionaloptionscheckitems .= '';
-			foreach ($varmacscheckitemsadditionaloptions as $checkitemtmp) {
-				$varmacsadditionaloptionscheckitems .= "$checkitemtmp" . " ";
+			if (!empty($macs['varmacstopadditionaloptions'])) {
+				$varmacstopadditionaloptions = explode("|", ($macs['varmacstopadditionaloptions']));
+				foreach ($varmacstopadditionaloptions as $toptmp) {
+					$varmacsadditionaloptionstop .= $toptmp . "\n";
+				}
 			}
-		}
 
-		// Clear variables for next mac foreach additional options: REPLY-ITEMS
-		$varmacsreplyitemsadditionaloptions = '';
-		$varmacsadditionaloptionsreplyitems = '';
+			// Clear variables for next mac foreach additional options: CHECK-ITEMS
+			$varmacscheckitemsadditionaloptions = '';
+			$varmacsadditionaloptionscheckitems = '';
 
-		if (!empty($macs['varmacsreplyitemsadditionaloptions'])) {
-			$varmacsreplyitemsadditionaloptions = explode("|", ($macs['varmacsreplyitemsadditionaloptions']));
-			$varmacsadditionaloptionsreplyitems .= '';
-			foreach ($varmacsreplyitemsadditionaloptions as $replyitemtmp) {
-				$varmacsadditionaloptionsreplyitems .= $replyitemtmp . "\n\t";
+			if (!empty($macs['varmacscheckitemsadditionaloptions'])) {
+				$varmacscheckitemsadditionaloptions = explode("|", ($macs['varmacscheckitemsadditionaloptions']));
+				$varmacsadditionaloptionscheckitems .= '';
+				foreach ($varmacscheckitemsadditionaloptions as $checkitemtmp) {
+					$varmacsadditionaloptionscheckitems .= "$checkitemtmp" . " ";
+				}
 			}
-		}
 
-		// Empty variable
-		$varmacscheckitem = '';
-		$varmacsreplyitem = '';
+			// Clear variables for next mac foreach additional options: REPLY-ITEMS
+			$varmacsreplyitemsadditionaloptions = '';
+			$varmacsadditionaloptionsreplyitems = '';
 
-		// If someone does not want to use MAC address but entry "DEFAULT" instead then we can disable this
-		if ($macs['varmacsaddress'] == '') {
+			if (!empty($macs['varmacsreplyitemsadditionaloptions'])) {
+				$varmacsreplyitemsadditionaloptions = explode("|", ($macs['varmacsreplyitemsadditionaloptions']));
+				$varmacsadditionaloptionsreplyitems .= '';
+				foreach ($varmacsreplyitemsadditionaloptions as $replyitemtmp) {
+					$varmacsadditionaloptionsreplyitems .= $replyitemtmp . "\n\t";
+				}
+			}
+
+			// Empty variable
 			$varmacscheckitem = '';
-		} else {
-			// Add the user attributes to each user.
-			$varmacscheckitem = "$varmacsaddress" . " Cleartext-Password := " . '"' . $varmacspassword . '"';
-		}
+			$varmacsreplyitem = '';
 
-		// Add additional CHECK-ITEMS here. Different formatting in "authorized_macs" file needed.
-		if ($varmacssimultaneousconnect != '') {
-			$varmacscheckitem .= ", Simultaneous-Use := " . '"' . $varmacssimultaneousconnect . '"';
-		}
-		if ($varmacsexpiration != '') {
-			$varmacscheckitem .= ", Expiration := " . '"' . $varmacsexpiration . '"';
-		}
-		if ($varmacslogintime != '') {
-			$varmacscheckitem .= ", Login-Time := " . '"' . $varmacslogintime . '"';
-		}
-		if ($varmacsamountoftime != '') {
-			$varmacscheckitem .= ", Max-" . "$varmacspointoftime" . "-Session := " . "$varmacsamountoftime";
-		}
-		if ($varmacsadditionaloptionscheckitems != '') {
-			$varmacscheckitem .= ", $varmacsadditionaloptionscheckitems";
-		}
+			// If someone does not want to use MAC address but entry "DEFAULT" instead then we can disable this
+			if ($macs['varmacsaddress'] == '') {
+				$varmacscheckitem = '';
+			} else {
+				// Add the user attributes to each user.
+				$varmacscheckitem = "$varmacsaddress" . " Cleartext-Password := " . '"' . $varmacspassword . '"';
+			}
 
-		// Add additional REPLY-ITEMS here. Different formatting in "authorized_macs" file needed.
-		if ($varmacsframedipaddress != '') {
-			if ($varmacsreplyitem != '') {
-				$varmacsreplyitem .= ",";
+			// Add additional CHECK-ITEMS here. Different formatting in "authorized_macs" file needed.
+			if ($varmacssimultaneousconnect != '') {
+				$varmacscheckitem .= ", Simultaneous-Use := " . '"' . $varmacssimultaneousconnect . '"';
 			}
-			$varmacsreplyitem .= "\n\tFramed-IP-Address = $varmacsframedipaddress";
-		}
-		if ($varmacsframedipnetmask != '') {
-			if ($varmacsreplyitem != '') {
-				$varmacsreplyitem .= ",";
+			if ($varmacsexpiration != '') {
+				$varmacscheckitem .= ", Expiration := " . '"' . $varmacsexpiration . '"';
 			}
-			$varmacsreplyitem .= "\n\tFramed-IP-Netmask = $varmacsframedipnetmask";
-		}
-		if ($varmacsframedroute != '') {
-			if ($varmacsreplyitem != '') {
-				$varmacsreplyitem .= ",";
+			if ($varmacslogintime != '') {
+				$varmacscheckitem .= ", Login-Time := " . '"' . $varmacslogintime . '"';
 			}
-			$varmacsreplyitem .= "\n\tFramed-Route = " . '"' . $varmacsframedroute . '"';
-		}
-		if ($varmacssessiontimeout != '') {
-			if ($varmacsreplyitem != '') {
-				$varmacsreplyitem .= ",";
+			if ($varmacsamountoftime != '') {
+				$varmacscheckitem .= ", Max-" . "$varmacspointoftime" . "-Session := " . "$varmacsamountoftime";
 			}
-			$varmacsreplyitem .= "\n\tSession-Timeout := $varmacssessiontimeout";
-		}
-		if ($varmacsvlanid != '') {
-			if ($varmacsreplyitem != '') {
-				$varmacsreplyitem .= ",";
+			if ($varmacsadditionaloptionscheckitems != '') {
+				$varmacscheckitem .= ", $varmacsadditionaloptionscheckitems";
 			}
-			$varmacsreplyitem .= "\n\tTunnel-Type = VLAN,\n\tTunnel-Medium-Type = IEEE-802,\n\tTunnel-Private-Group-ID = " . '"' . $varmacsvlanid . '"';
-		}
-		if ($varmacsmaxbandwidthup != '') {
-			if ($varmacsreplyitem != '') {
-				$varmacsreplyitem .= ",";
-			}
-			$varmacsreplyitem .= "\n\tWISPr-Bandwidth-Max-Up := $varmacsmaxbandwidthup";
-		}
-		if ($varmacsmaxbandwidthdown != '') {
-			if ($varmacsreplyitem != '') {
-				$varmacsreplyitem .= ",";
-			}
-			$varmacsreplyitem .= "\n\tWISPr-Bandwidth-Max-Down := $varmacsmaxbandwidthdown";
-		}
-		if ($varmacsacctinteriminterval != '') {
-			if ($varmacsreplyitem != '') {
-				$varmacsreplyitem .= ",";
-			}
-			$varmacsreplyitem .= "\n\tAcct-Interim-Interval := $varmacsacctinteriminterval";
-		}
-		if ($varmacswisprredirectionurl != '') {
-			if ($varmacsreplyitem != '') {
-				$varmacsreplyitem .= ",";
-			}
-			$varmacsreplyitem .= "\n\tWISPr-Redirection-URL := $varmacsswisprredirectionurl";
-		}
-		// If an octet limit is set we create the files for the limit and the counter. Further we call an exec script which checks if the limit is reached or not
-		if ($varmacsmaxtotaloctets != '') {
-			if ($varmacsreplyitem != '') {
-				$varmacsreplyitem .= ",";
-			}
-			//create exec script
-			$varmacsreplyitem .= "\n\tExec-Program-Wait = " . '"/bin/sh ' . FREERADIUS_ETC . '/raddb/scripts/datacounter_auth.sh ' . "$varmacsaddress $varmacsmaxtotaloctetstimerange" . '"';
-			// create limit file - will be always overwritten so we can increase limit from GUI
-			file_put_contents("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/max-octets-$varmacsaddress", $varmacsmaxtotaloctets, LOCK_EX);
-			// if used-octets file exist we do NOT overwrite this file!!!
-			if (!file_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress")) {
-				file_put_contents("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress", "0", LOCK_EX);
-			}
-		} else {
-			// If an octet limit is NOT set we delete the files for the limit and the counter.
-			unlink_if_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/max-octets-$varmacsaddress");
-			unlink_if_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress*");
-		}
-		if ($varmacsadditionaloptionsreplyitems != '') {
-			if ($varmacsreplyitem != '') {
-				$varmacsreplyitem .= ",";
-			}
-			$varmacsreplyitem .= "\n\t$varmacsadditionaloptionsreplyitems";
-		}
 
-		// Cosmetic fix - This is just to make a blank new line after each macs entry
-		$varmacsreplyitem .= "\n\n";
+			// Add additional REPLY-ITEMS here. Different formatting in "authorized_macs" file needed.
+			if ($varmacsframedipaddress != '') {
+				if ($varmacsreplyitem != '') {
+					$varmacsreplyitem .= ",";
+				}
+				$varmacsreplyitem .= "\n\tFramed-IP-Address = $varmacsframedipaddress";
+			}
+			if ($varmacsframedipnetmask != '') {
+				if ($varmacsreplyitem != '') {
+					$varmacsreplyitem .= ",";
+				}
+				$varmacsreplyitem .= "\n\tFramed-IP-Netmask = $varmacsframedipnetmask";
+			}
+			if ($varmacsframedroute != '') {
+				if ($varmacsreplyitem != '') {
+					$varmacsreplyitem .= ",";
+				}
+				$varmacsreplyitem .= "\n\tFramed-Route = " . '"' . $varmacsframedroute . '"';
+			}
+			if ($varmacssessiontimeout != '') {
+				if ($varmacsreplyitem != '') {
+					$varmacsreplyitem .= ",";
+				}
+				$varmacsreplyitem .= "\n\tSession-Timeout := $varmacssessiontimeout";
+			}
+			if ($varmacsvlanid != '') {
+				if ($varmacsreplyitem != '') {
+					$varmacsreplyitem .= ",";
+				}
+				$varmacsreplyitem .= "\n\tTunnel-Type = VLAN,\n\tTunnel-Medium-Type = IEEE-802,\n\tTunnel-Private-Group-ID = " . '"' . $varmacsvlanid . '"';
+			}
+			if ($varmacsmaxbandwidthup != '') {
+				if ($varmacsreplyitem != '') {
+					$varmacsreplyitem .= ",";
+				}
+				$varmacsreplyitem .= "\n\tWISPr-Bandwidth-Max-Up := $varmacsmaxbandwidthup";
+			}
+			if ($varmacsmaxbandwidthdown != '') {
+				if ($varmacsreplyitem != '') {
+					$varmacsreplyitem .= ",";
+				}
+				$varmacsreplyitem .= "\n\tWISPr-Bandwidth-Max-Down := $varmacsmaxbandwidthdown";
+			}
+			if ($varmacsacctinteriminterval != '') {
+				if ($varmacsreplyitem != '') {
+					$varmacsreplyitem .= ",";
+				}
+				$varmacsreplyitem .= "\n\tAcct-Interim-Interval := $varmacsacctinteriminterval";
+			}
+			if ($varmacswisprredirectionurl != '') {
+				if ($varmacsreplyitem != '') {
+					$varmacsreplyitem .= ",";
+				}
+				$varmacsreplyitem .= "\n\tWISPr-Redirection-URL := $varmacsswisprredirectionurl";
+			}
+			// If an octet limit is set we create the files for the limit and the counter. Further we call an exec script which checks if the limit is reached or not
+			if ($varmacsmaxtotaloctets != '') {
+				if ($varmacsreplyitem != '') {
+					$varmacsreplyitem .= ",";
+				}
+				//create exec script
+				$varmacsreplyitem .= "\n\tExec-Program-Wait = " . '"/bin/sh ' . FREERADIUS_ETC . '/raddb/scripts/datacounter_auth.sh ' . "$varmacsaddress $varmacsmaxtotaloctetstimerange" . '"';
+				// create limit file - will be always overwritten so we can increase limit from GUI
+				file_put_contents("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/max-octets-$varmacsaddress", $varmacsmaxtotaloctets, LOCK_EX);
+				// if used-octets file exist we do NOT overwrite this file!!!
+				if (!file_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress")) {
+					file_put_contents("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress", "0", LOCK_EX);
+				}
+			} else {
+				// If an octet limit is NOT set we delete the files for the limit and the counter.
+				unlink_if_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/max-octets-$varmacsaddress");
+				unlink_if_exists("/var/log/radacct/datacounter/$varmacsmaxtotaloctetstimerange/used-octets-$varmacsaddress*");
+			}
+			if ($varmacsadditionaloptionsreplyitems != '') {
+				if ($varmacsreplyitem != '') {
+					$varmacsreplyitem .= ",";
+				}
+				$varmacsreplyitem .= "\n\t$varmacsadditionaloptionsreplyitems";
+			}
 
-	$conf .= <<<EOD
+			// Cosmetic fix - This is just to make a blank new line after each macs entry
+			$varmacsreplyitem .= "\n\n";
+
+			$conf .= <<<EOD
 $varmacsadditionaloptionstop
 $varmacscheckitem
 	$varmacsreplyitem

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -1530,8 +1530,10 @@ function freeradius_serverdefault_resync() {
 	// post-auth section DATABASE 1
 	if (($sqlconf['varsqlconfincludeenable'] == 'on') && ($sqlconf['varsqlconfenablepostauth'] == 'Enable')) {
 		$varsqlconfpostauth = "$varsqlconf2failover {" . "\n\t\t\tsql" . "\n\t\t\t$varsqlconf2postauth" . "\n\t}";
+		$varsqlconfpostauthtypereject = 'sql';
 	} else {
 		$varsqlconfpostauth = '### sql DISABLED ###';
+		$varsqlconfpostauthtypereject = '# sql';
 	}
 
 	// Changing authorize section for plain mac auth
@@ -2163,7 +2165,7 @@ post-auth {
 	Post-Auth-Type REJECT {
 
 		# log failed authentications in SQL, too.
-		# sql
+		$varsqlconfpostauthtypereject
 		attr_filter.access_reject
 	}
 }

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -2278,24 +2278,25 @@ function freeradius_cacertcnf_resync() {
 	global $config;
 	$conf = '';
 
-	$arrcerts = $config['installedpackages']['freeradiuscerts']['config'][0];
-	
+	if (is_array($config['installedpackages']['freeradiuscerts']['config'][0])) {
+		$arrcerts = $config['installedpackages']['freeradiuscerts']['config'][0];
+	} else {
+		$arrcerts = array();
+	}
+
 	// General variables: CA, Server, Client
-	$varcertsdefaultdays = ($arrcerts['varcertsdefaultdays']?$arrcerts['varcertsdefaultdays']:'3650');
-	$varcertsdefaultmd = ($arrcerts['varcertsdefaultmd']?$arrcerts['varcertsdefaultmd']:'md5');
-	$varcertsdefaultbits = ($arrcerts['varcertsdefaultbits']?$arrcerts['varcertsdefaultbits']:'2048');
-	$varcertspassword = ($arrcerts['varcertspassword']?$arrcerts['varcertspassword']:'whatever');
-	$varcertscountryname = ($arrcerts['varcertscountryname']?$arrcerts['varcertscountryname']:'US');
-	$varcertsstateorprovincename = ($arrcerts['varcertsstateorprovincename']?$arrcerts['varcertsstateorprovincename']:'Texas');
-	$varcertslocalityname = ($arrcerts['varcertslocalityname']?$arrcerts['varcertslocalityname']:'Austin');
-	$varcertsorganizationname = ($arrcerts['varcertsorganizationname']?$arrcerts['varcertsorganizationname']:'My Company Inc');
+	$varcertsdefaultdays = ($arrcerts['varcertsdefaultdays'] ?: '3650');
+	$varcertsdefaultmd = ($arrcerts['varcertsdefaultmd'] ?: 'md5');
+	$varcertsdefaultbits = ($arrcerts['varcertsdefaultbits'] ?: '2048');
+	$varcertspassword = ($arrcerts['varcertspassword'] ?: 'whatever');
+	$varcertscountryname = ($arrcerts['varcertscountryname'] ?: 'US');
+	$varcertsstateorprovincename = ($arrcerts['varcertsstateorprovincename'] ?: 'Texas');
+	$varcertslocalityname = ($arrcerts['varcertslocalityname'] ?: 'Austin');
+	$varcertsorganizationname = ($arrcerts['varcertsorganizationname'] ?: 'My Company Inc');
 
 	// Variables: Only for CA
-	$varcertscaemailaddress = ($arrcerts['varcertscaemailaddress']?$arrcerts['varcertscaemailaddress']:'admin@mycompany.com');
-	$varcertscacommonname = ($arrcerts['varcertscacommonname']?$arrcerts['varcertscacommonname']:'internal-ca');
-	
-	
-	
+	$varcertscaemailaddress = ($arrcerts['varcertscaemailaddress'] ?: 'admin@mycompany.com');
+	$varcertscacommonname = ($arrcerts['varcertscacommonname'] ?: 'internal-ca');
 
 	$conf .= <<<EOD
 [ ca ]
@@ -2371,22 +2372,25 @@ function freeradius_servercertcnf_resync() {
 	global $config;
 	$conf = '';
 
-	$arrcerts = $config['installedpackages']['freeradiuscerts']['config'][0];
-	
+	if (is_array($config['installedpackages']['freeradiuscerts']['config'][0])) {
+		$arrcerts = $config['installedpackages']['freeradiuscerts']['config'][0];
+	} else {
+		$arrcerts = array();
+	}
+
 	// General variables: CA, Server, Client
-	$varcertsdefaultdays = ($arrcerts['varcertsdefaultdays']?$arrcerts['varcertsdefaultdays']:'3650');
-	$varcertsdefaultmd = ($arrcerts['varcertsdefaultmd']?$arrcerts['varcertsdefaultmd']:'md5');
-	$varcertsdefaultbits = ($arrcerts['varcertsdefaultbits']?$arrcerts['varcertsdefaultbits']:'2048');
-	$varcertspassword = ($arrcerts['varcertspassword']?$arrcerts['varcertspassword']:'whatever');
-	$varcertscountryname = ($arrcerts['varcertscountryname']?$arrcerts['varcertscountryname']:'US');
-	$varcertsstateorprovincename = ($arrcerts['varcertsstateorprovincename']?$arrcerts['varcertsstateorprovincename']:'Texas');
-	$varcertslocalityname = ($arrcerts['varcertslocalityname']?$arrcerts['varcertslocalityname']:'Austin');
-	$varcertsorganizationname = ($arrcerts['varcertsorganizationname']?$arrcerts['varcertsorganizationname']:'My Company Inc');
+	$varcertsdefaultdays = ($arrcerts['varcertsdefaultdays'] ?: '3650');
+	$varcertsdefaultmd = ($arrcerts['varcertsdefaultmd'] ?: 'md5');
+	$varcertsdefaultbits = ($arrcerts['varcertsdefaultbits'] ?: '2048');
+	$varcertspassword = ($arrcerts['varcertspassword'] ?: 'whatever');
+	$varcertscountryname = ($arrcerts['varcertscountryname'] ?: 'US');
+	$varcertsstateorprovincename = ($arrcerts['varcertsstateorprovincename'] ?: 'Texas');
+	$varcertslocalityname = ($arrcerts['varcertslocalityname'] ?: 'Austin');
+	$varcertsorganizationname = ($arrcerts['varcertsorganizationname'] ?: 'My Company Inc');
 
 	// Variables: Only for Server
-	$varcertsserveremailaddress = ($arrcerts['varcertsserveremailaddress']?$arrcerts['varcertsserveremailaddress']:'webadmin@mycompany.com');
-	$varcertsservercommonname = ($arrcerts['varcertsservercommonname']?$arrcerts['varcertsservercommonname']:'server-cert');
-	
+	$varcertsserveremailaddress = ($arrcerts['varcertsserveremailaddress'] ?: 'webadmin@mycompany.com');
+	$varcertsservercommonname = ($arrcerts['varcertsservercommonname'] ?: 'server-cert');
 
 	$conf .= <<<EOD
 [ ca ]
@@ -2456,22 +2460,25 @@ function freeradius_clientcertcnf_resync() {
 	global $config;
 	$conf = '';
 
-	$arrcerts = $config['installedpackages']['freeradiuscerts']['config'][0];
-	
+	if (is_array($config['installedpackages']['freeradiuscerts']['config'][0])) {
+		$arrcerts = $config['installedpackages']['freeradiuscerts']['config'][0];
+	} else {
+		$arrcerts = array();
+	}
+
 	// General variables: CA, Server, Client
-	$varcertsdefaultdays = ($arrcerts['varcertsdefaultdays']?$arrcerts['varcertsdefaultdays']:'3650');
-	$varcertsdefaultmd = ($arrcerts['varcertsdefaultmd']?$arrcerts['varcertsdefaultmd']:'md5');
-	$varcertsdefaultbits = ($arrcerts['varcertsdefaultbits']?$arrcerts['varcertsdefaultbits']:'2048');
-	$varcertspassword = ($arrcerts['varcertspassword']?$arrcerts['varcertspassword']:'whatever');
-	$varcertscountryname = ($arrcerts['varcertscountryname']?$arrcerts['varcertscountryname']:'US');
-	$varcertsstateorprovincename = ($arrcerts['varcertsstateorprovincename']?$arrcerts['varcertsstateorprovincename']:'Texas');
-	$varcertslocalityname = ($arrcerts['varcertslocalityname']?$arrcerts['varcertslocalityname']:'Austin');
-	$varcertsorganizationname = ($arrcerts['varcertsorganizationname']?$arrcerts['varcertsorganizationname']:'My Company Inc');
+	$varcertsdefaultdays = ($arrcerts['varcertsdefaultdays'] ?: '3650');
+	$varcertsdefaultmd = ($arrcerts['varcertsdefaultmd'] ?: 'md5');
+	$varcertsdefaultbits = ($arrcerts['varcertsdefaultbits'] ?: '2048');
+	$varcertspassword = ($arrcerts['varcertspassword'] ?: 'whatever');
+	$varcertscountryname = ($arrcerts['varcertscountryname'] ?: 'US');
+	$varcertsstateorprovincename = ($arrcerts['varcertsstateorprovincename'] ?: 'Texas');
+	$varcertslocalityname = ($arrcerts['varcertslocalityname'] ?: 'Austin');
+	$varcertsorganizationname = ($arrcerts['varcertsorganizationname'] ?: 'My Company Inc');
 
 	// Variables: Only for Client
-	$varcertsclientemailaddress = ($arrcerts['varcertsclientemailaddress']?$arrcerts['varcertsclientemailaddress']:'user@mycompany.com');
-	$varcertsclientcommonname = ($arrcerts['varcertsclientcommonname']?$arrcerts['varcertsclientcommonname']:'client-cert');
-	
+	$varcertsclientemailaddress = ($arrcerts['varcertsclientemailaddress'] ?: 'user@mycompany.com');
+	$varcertsclientcommonname = ($arrcerts['varcertsclientcommonname'] ?: 'client-cert');
 
 	$conf .= <<<EOD
 [ ca ]
@@ -2539,122 +2546,115 @@ EOD;
 
 function freeradius_allcertcnf_resync() {
 	global $config;
-		// We need to make this write enabled for embedded systems to write certs
-		conf_mount_rw();
-	
-	
-// Only proceed these steps if freeRADIUS Cert-Manager is activated. if pfSense cert manager is used skip this.
-$eapconf = $config['installedpackages']['freeradiuseapconf']['config'][0];
-if ($eapconf['vareapconfchoosecertmanager'] == '') {
-	
 
-	$arrcerts = $config['installedpackages']['freeradiuscerts']['config'][0];
-	
-	// General variable for deleting and generation of further Client-Cert
-	$varcertscreateclient = ($arrcerts['varcertscreateclient']?$arrcerts['varcertscreateclient']:'no');
-	
-	// General variables for deleting: CA, Server, Client
-	$varcertsdeleteall = ($arrcerts['varcertsdeleteall']?$arrcerts['varcertsdeleteall']:'no');
-		
-	// If all certs should be deleted, we do not need to delete and recreate client-certs first.
-	if ($arrcerts['varcertsdeleteall'] == 'no') {
+	conf_mount_rw();
 
-		if ($arrcerts['varcertscreateclient'] == 'yes') {
-		
-		// delete all old certificates and keys
-		log_error("freeRADIUS: deleting all client.csr .crt .key .pem .tar in " . FREERADIUS_ETC . "/raddb/certs");
-		exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.csr");
-		exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.crt");
-		exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.key");
-		exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.pem");
-		exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.tar");
-				
-			
-		// run fuction to create ONLY new client.cnf files based on user input from freeradiuscert.xml
-		freeradius_clientcertcnf_resync();
-	
-	
-		// make bootstrap executable and run to create cert based on client.cnf files
-		exec("chmod 0770 " . FREERADIUS_ETC . "/raddb/certs/bootstrap");
-		exec(FREERADIUS_ETC . "/raddb/certs/bootstrap");
-			
-		// rename client generated XX.pem to client.pem // use regex to replace spaces and so on.
-		$varserial = preg_replace("/\s/","",file_get_contents(FREERADIUS_ETC . '/raddb/certs/serial.old'));
-		if (file_exists(FREERADIUS_ETC . "/raddb/certs/$varserial.pem"))
-		rename(FREERADIUS_ETC . "/raddb/certs/$varserial.pem",FREERADIUS_ETC . "/raddb/certs/client.pem");
-		
-		
-		// tar client-cert files
-		exec("cd " . FREERADIUS_ETC . "/raddb/certs && tar -cf client.tar client.crt client.csr client.key ca.der client.pem");
-		
-		// Make all files in certs folder read/write only for root
-		exec("chmod -R 0600 " . FREERADIUS_ETC . "/raddb/certs/");
-		log_error("freeRADIUS: Created new client.csr .crt .key .pem and added them together with ca.der in " . FREERADIUS_ETC . "/raddb/certs/client.tar");
-		}
+	// Only proceed these steps if freeRADIUS Cert-Manager is activated. if pfSense cert manager is used skip this.
+	if (is_array($config['installedpackages']['freeradiuseapconf']['config'][0])) {
+		$eapconf = $config['installedpackages']['freeradiuseapconf']['config'][0];
+	} else {
+		$eapconf = array();
 	}
-	else {
-		
-		if ($arrcerts['varcertsdeleteall'] == 'yes') {
-	
-		// delete all old certificates and keys - deletes certs from pfsense cert-manager IN THIS FOLDER, too.
-		log_error("freeRADIUS: deleting all CA, Server and Client certs, DH, random and database files in " . FREERADIUS_ETC . "/raddb/certs");
-		exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.pem && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.pem && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.pem");
-		exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.der && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.der && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.der");
-		exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.csr && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.csr && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.csr");
-		exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.crt && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.crt && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.crt");
-		exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.key && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.key && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.key");
-		exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.p12 && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.p12 && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.p12");
-		exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/serial*");
-		exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/index*");
-		exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/dh");
-		exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/random");
-		exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.tar");
-		
-	
-		// run fuctions to create new .cnf files based on user input from freeradiuscert.xml
-		freeradius_cacertcnf_resync();
-		freeradius_servercertcnf_resync();
-		freeradius_clientcertcnf_resync();
-		
-		// this command deletes the pfsense_cert_mgr checkfile so when we change back to pfsense cert manager a new DH + random file will be created
-		if (file_exists(FREERADIUS_ETC . "/raddb/certs/pfsense_cert_mgr")) {
-			unlink(FREERADIUS_ETC . "/raddb/certs/pfsense_cert_mgr");
+
+	if ($eapconf['vareapconfchoosecertmanager'] == '') {
+		$arrcerts = $config['installedpackages']['freeradiuscerts']['config'][0];
+		// General variable for deleting and generation of further Client-Cert
+		$varcertscreateclient = ($arrcerts['varcertscreateclient'] ?: 'no');
+		// General variables for deleting: CA, Server, Client
+		$varcertsdeleteall = ($arrcerts['varcertsdeleteall'] ?: 'no');
+
+		// If all certs should be deleted, we do not need to delete and recreate client-certs first.
+		if ($arrcerts['varcertsdeleteall'] == 'no') {
+			if ($arrcerts['varcertscreateclient'] == 'yes') {
+				// delete all old certificates and keys
+				log_error("freeRADIUS: deleting all client.csr .crt .key .pem .tar in " . FREERADIUS_ETC . "/raddb/certs");
+				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.csr");
+				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.crt");
+				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.key");
+				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.pem");
+				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.tar");
+
+				// run fuction to create ONLY new client.cnf files based on user input from freeradiuscert.xml
+				freeradius_clientcertcnf_resync();
+
+				// make bootstrap executable and run to create cert based on client.cnf files
+				exec("chmod 0770 " . FREERADIUS_ETC . "/raddb/certs/bootstrap");
+				exec(FREERADIUS_ETC . "/raddb/certs/bootstrap");
+
+				// rename client generated XX.pem to client.pem 
+				// use regex to replace spaces and so on.
+				$varserial = preg_replace("/\s/","",file_get_contents(FREERADIUS_ETC . '/raddb/certs/serial.old'));
+					if (file_exists(FREERADIUS_ETC . "/raddb/certs/$varserial.pem"))
+						rename(FREERADIUS_ETC . "/raddb/certs/$varserial.pem",FREERADIUS_ETC . "/raddb/certs/client.pem");
+
+
+				// tar client-cert files
+				exec("cd " . FREERADIUS_ETC . "/raddb/certs && tar -cf client.tar client.crt client.csr client.key ca.der client.pem");
+
+				// Make all files in certs folder read/write only for root
+				exec("chmod -R 0600 " . FREERADIUS_ETC . "/raddb/certs/");
+				log_error("freeRADIUS: Created new client.csr .crt .key .pem and added them together with ca.der in " . FREERADIUS_ETC . "/raddb/certs/client.tar");
+			}
+		} else {
+			if ($arrcerts['varcertsdeleteall'] == 'yes') {
+				// delete all old certificates and keys - deletes certs from pfsense cert-manager IN THIS FOLDER, too.
+				log_error("freeRADIUS: deleting all CA, Server and Client certs, DH, random and database files in " . FREERADIUS_ETC . "/raddb/certs");
+				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.pem && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.pem && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.pem");
+				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.der && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.der && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.der");
+				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.csr && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.csr && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.csr");
+				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.crt && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.crt && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.crt");
+				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.key && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.key && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.key");
+				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/ca.p12 && rm -f " . FREERADIUS_ETC . "/raddb/certs/server.p12 && rm -f " . FREERADIUS_ETC . "/raddb/certs/client.p12");
+				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/serial*");
+				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/index*");
+				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/dh");
+				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/random");
+				exec("rm -f " . FREERADIUS_ETC . "/raddb/certs/client.tar");
+
+				// run fuctions to create new .cnf files based on user input from freeradiuscert.xml
+				freeradius_cacertcnf_resync();
+				freeradius_servercertcnf_resync();
+				freeradius_clientcertcnf_resync();
+
+				// this command deletes the pfsense_cert_mgr checkfile so when we change back to pfsense cert manager a new DH + random file will be created
+				if (file_exists(FREERADIUS_ETC . "/raddb/certs/pfsense_cert_mgr")) {
+					unlink(FREERADIUS_ETC . "/raddb/certs/pfsense_cert_mgr");
+				}
+
+				// generate new DH and RANDOM file
+				log_error("freeRADIUS: Creating new DH and random file in " . FREERADIUS_ETC . "/raddb/certs");
+				exec("cd " . FREERADIUS_ETC . "/raddb/certs && openssl dhparam -out dh 1024");
+				exec("cd " . FREERADIUS_ETC . "/raddb/certs && dd if=/dev/urandom of=./random count=10");
+
+				log_error("freeRADIUS: Creating new CA, Server and Client certs in " . FREERADIUS_ETC . "/raddb/certs");
+				// make bootstrap executable and run to create certs based on .cnf files
+				exec("chmod 0770 " . FREERADIUS_ETC . "/raddb/certs/bootstrap");
+				exec(FREERADIUS_ETC . "/raddb/certs/bootstrap");
+
+				// rename client generated 02.pem to client.pem
+				if (file_exists(FREERADIUS_ETC . "/raddb/certs/02.pem")) {
+					rename(FREERADIUS_ETC . "/raddb/certs/02.pem", FREERADIUS_ETC . "/raddb/certs/client.pem");
+				}
+
+				// tar client-cert files
+				exec("cd " . FREERADIUS_ETC . "/raddb/certs && tar -cf client.tar client.crt client.csr client.key ca.der client.pem");
+				exec("chmod -R 0600 " . FREERADIUS_ETC . "/raddb/certs/");
+				log_error("freeRADIUS: Added client.csr .crt .key .pem together with ca.der in " . FREERADIUS_ETC . "/raddb/certs/client.tar");
+
+				// If there were changes on the certificates we need to restart freeradius
+				// Note: this function is currently only called from freeradiuscerts.xml functions
+				if ($restart_svc === true) {
+					restart_service("radiusd");
+				}
+			}
 		}
-		
-		// generate new DH and RANDOM file
-		log_error("freeRADIUS: Creating new DH and random file in " . FREERADIUS_ETC . "/raddb/certs");
-		exec("cd " . FREERADIUS_ETC . "/raddb/certs && openssl dhparam -out dh 1024");
-		exec("cd " . FREERADIUS_ETC . "/raddb/certs && dd if=/dev/urandom of=./random count=10");
-		
-		log_error("freeRADIUS: Creating new CA, Server and Client certs in " . FREERADIUS_ETC . "/raddb/certs");
-		// make bootstrap executable and run to create certs based on .cnf files
-		exec("chmod 0770 " . FREERADIUS_ETC . "/raddb/certs/bootstrap");
-		exec(FREERADIUS_ETC . "/raddb/certs/bootstrap");
-		
-		// rename client generated 02.pem to client.pem
-		if (file_exists(FREERADIUS_ETC . "/raddb/certs/02.pem")) {
-			rename(FREERADIUS_ETC . "/raddb/certs/02.pem", FREERADIUS_ETC . "/raddb/certs/client.pem");
-		}
-		
-		// tar client-cert files
-		exec("cd " . FREERADIUS_ETC . "/raddb/certs && tar -cf client.tar client.crt client.csr client.key ca.der client.pem");
-		exec("chmod -R 0600 " . FREERADIUS_ETC . "/raddb/certs/");
-		log_error("freeRADIUS: Added client.csr .crt .key .pem together with ca.der in " . FREERADIUS_ETC . "/raddb/certs/client.tar");
-		
-		// If there were changes on the certificates we need to restart freeradius
-		// Note: this function is currently only called from freeradiuscerts.xml functions
-		if ($restart_svc === true) { restart_service("radiusd"); }
-		}
+	//end choose pfSense cert-manager
+	} else {
+		return;
 	}
-} //end choose pfSense cert-manager
-else {
-	return;
+
+	conf_mount_ro();
 }
-// Read-only because of embedded systems
-conf_mount_ro();
-} //end of function
-
-// ##### The following part is based on the code of pfblocker #####
 
 /* Uses XMLRPC to synchronize the changes to a remote node */
 function freeradius_sync_on_changes() {
@@ -2703,7 +2703,7 @@ function freeradius_sync_on_changes() {
 				log_error("[FreeRADIUS]: XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
 				return;
 			}
-			break;		
+			break;
 		default:
 			return;
 			break;
@@ -2794,7 +2794,7 @@ function freeradius_do_xmlrpc_sync($sync_to_ip, $username, $password, $varsyncpo
 	} else {
 		// pfSense before 2.4
 		require_once('xmlrpc.inc');
-	
+
 		/* Take care of IPv6 literal address */
 		if (is_ipaddrv6($sync_to_ip)) {
 			$sync_to_ip = "[{$sync_to_ip}]";
@@ -2858,7 +2858,8 @@ function freeradius_do_xmlrpc_sync($sync_to_ip, $username, $password, $varsyncpo
 	}
 }
 
-// This function restarts all other needed functions after XMLRPC so that the content of .XML + .INC will be written in the files (clients.conf, users)
+// This function restarts all other needed functions after XMLRPC 
+// so that the content of .XML + .INC will be written in the files (clients.conf, users)
 // Adding more functions will increase the to sync
 function freeradius_all_after_XMLRPC_resync() {
 	// Make sure we only (re)start the service once below
@@ -2868,7 +2869,7 @@ function freeradius_all_after_XMLRPC_resync() {
 	freeradius_authorizedmacs_resync(false, true);
 	// Restart now when XMLRPC sync is completely finished
 	freeradius_clients_resync();
-	
+
 	log_error("[FreeRADIUS]: Finished XMLRPC process. It should be OK. For more information look at the host which started sync.");
 }
 

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -2574,7 +2574,10 @@ function freeradius_allcertcnf_resync() {
 				mwexec("/usr/bin/tar -C " . FREERADIUS_ETC . "/raddb/certs -cf " . FREERADIUS_ETC . "/raddb/certs/client.tar client.crt client.csr client.key ca.der client.pem");
 
 				// Make all files in certs folder read/write only for root
-				mwexec("/bin/chmod -R 0600 " . FREERADIUS_ETC . "/raddb/certs/");
+				$certs = glob(FREERADIUS_ETC . "/raddb/certs/*");
+				array_walk($certs, function($cert_file) {
+					chmod($cert_file, 0600);
+				});
 				log_error("freeRADIUS: Created new client.csr .crt .key .pem and added them together with ca.der in " . FREERADIUS_ETC . "/raddb/certs/client.tar");
 			}
 		} else {
@@ -2619,7 +2622,10 @@ function freeradius_allcertcnf_resync() {
 
 				// tar client-cert files
 				mwexec("/usr/bin/tar -C " . FREERADIUS_ETC . "/raddb/certs -cf " . FREERADIUS_ETC . "/raddb/certs/client.tar client.crt client.csr client.key ca.der client.pem");
-				mwexec("/bin/chmod -R 0600 " . FREERADIUS_ETC . "/raddb/certs/");
+				$certs = glob(FREERADIUS_ETC . "/raddb/certs/*");
+				array_walk($certs, function($cert_file) {
+					chmod($cert_file, 0600);
+				});
 				log_error("freeRADIUS: Added client.csr .crt .key .pem together with ca.der in " . FREERADIUS_ETC . "/raddb/certs/client.tar");
 
 				// If there were changes on the certificates we need to restart freeradius

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.xml
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.xml
@@ -8,7 +8,7 @@
  * freeradius.xml
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2013 Alexander Wilke <nachtfalkeaw@web.de>
  * All rights reserved.
  *
@@ -154,7 +154,8 @@
 			<fieldname>varusersusername</fieldname>
 			<description>
 				<![CDATA[
-				Enter the username. Whitespace is possible. If you do not want to use username/password but custom options then leave this field empty.
+				Enter the username. Whitespace is possible.
+				If you do not want to use username/password but custom options, leave this field empty.
 				]]>
 			</description>
 			<type>input</type>
@@ -164,7 +165,8 @@
 			<fieldname>varuserspassword</fieldname>
 			<description>
 				<![CDATA[
-				Enter the password for this username. If you do not  want to use username/password but custom options then leave this field empty.
+				Enter the password for this username.
+				If you do not want to use username/password but custom options, leave this field empty.
 				]]>
 			</description>
 			<type>password</type>
@@ -190,8 +192,10 @@
 			<description>Enable One-Time-Password for this user</description>
 			<sethelp>
 				<![CDATA[
-				This enables the possibility to authenticate against an username and an one-time-password. The client to generate OTP can be installed on various mobile device plattforms like Android and more.<br/><br/>
-				<b>IMPORTANT:</b> You need to enabled mOTP first in FreeRADIUS => Settings (Default: unchecked)
+				This enables the possibility to authenticate against an username and an one-time-password.<br/>
+				The client to generate OTP can be installed on various mobile device platforms like Android and more.<br/>
+				<strong><span class="text-danger">IMPORTANT: </span>You need to enable mOTP first in 'FreeRADIUS > Settings'.</strong><br/>
+				(Default: unchecked)
 				]]>
 			</sethelp>
 			<type>checkbox</type>
@@ -222,10 +226,14 @@
 			<fieldname>varusersmotpoffset</fieldname>
 			<description>
 				<![CDATA[
-				If the client is not in the correct time zone or is not changing time zone automatically than you have to calculate the offset and enter it here. To calculate it do the following:<br/><br/>
+				If the client is not in the correct time zone or is not changing time zone automatically,
+				you have to calculate the offset and enter it here. Click Info for details. (Default: 0)
+				<div class="infoblock">
+				To calculate it do the following:<br/><br/>
 				1. Write down the first 9 digits of the Epoch-Time on the client.<br/>
 				2. Check with <b>date +%s</b> the Epoch-Time on your FreeRADIUS server and write down the first 9 digits.<br/>
-				3. Subtract both values, multiply the result with 10 and enter the value in this field. Example: 30 or -180 (Default: 0)
+				3. Subtract both values, multiply the result with 10 and enter the value in this field. Example: 30 or -180
+				</div>
 				]]>
 			</description>
 			<type>input</type>
@@ -240,8 +248,8 @@
 			<fieldname>varuserssimultaneousconnect</fieldname>
 			<description>
 				<![CDATA[
-				The maximum of simultaneous connections with this username. If you leave this field empty than there is no limit. If you are using FreeRADIUS with Captive Portal you should leave this empty.
-				Read the documentation!
+				The maximum of simultaneous connections with this username. If you leave this field empty than there is no limit.
+				If you are using FreeRADIUS with Captive Portal you should leave this empty. Read the documentation!
 				]]>
 			</description>
 			<type>input</type>
@@ -278,7 +286,8 @@
 				<b>Framed-IP-Address</b> must be supported by NAS.<br/><br/>
 				If you want this user to be assigned a specific IP address from radius, enter the IP address here.<br/>
 				Continuous IP address is available with "+" suffix (e.g. 192.168.1.5+). Could be useful for simultaneous connections.<br/><br/>
-				<b>IMPORTANT:</b> You must enter an IP address here if you checked "RADIUS issued IP" on VPN PPTP or VPN PPPoE configuration.
+				<strong><span class="text-danger">IMPORTANT: </span></strong>
+				You must enter an IP address here if you checked 'RADIUS issued IP' on PPPoE VPN configuration.
 				]]>
 			</description>
 			<type>input</type>
@@ -296,7 +305,11 @@
 		<field>
 			<fielddescr>Gateway</fielddescr>
 			<fieldname>varusersframedroute</fieldname>
-			<description><![CDATA[<b>Framed-Route</b> must be supported by NAS. Format is: Subnet Gateway Metric (e.g. 192.168.10.0 192.168.10.1 1).]]></description>
+			<description>
+				<![CDATA[
+				<b>Framed-Route</b> must be supported by NAS. Format is: Subnet Gateway Metric (e.g. 192.168.10.0 192.168.10.1 1).
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
@@ -305,11 +318,13 @@
 			<description>
 				<![CDATA[
 				Enter the VLAN ID (integer from 1-4095) or the VLAN name that this username should be assigned to.<br/>
-				Must be supported by the NAS.<br/>
+				Must be supported by the NAS. Click Info for details.
+				<div class="infoblock">
 				This setting can be used for a NAS that supports the following RADIUS parameters:<br/><br/>
 				Tunnel-Type = VLAN<br/>
 				Tunnel-Medium-Type = IEEE-802<br/>
 				Tunnel-Private-Group-ID = "<b>THIS IS YOUR INPUT</b>"
+				</div>
 				]]>
 			</description>
 			<type>input</type>
@@ -323,7 +338,9 @@
 			<fieldname>varusersexpiration</fieldname>
 			<description>
 				<![CDATA[
-				Enter the date when this account should expire. Format is: Mmm dd yyyy (e.g. Jan 01 2012).
+				Enter the date when this account should expire.<br/>
+				<strong><span class="text-danger">IMPORTANT: </span></strong>
+				Format is: Mmm dd yyyy (e.g. Jan 01 2018).
 				]]>
 			</description>
 			<type>input</type>
@@ -331,7 +348,11 @@
 		<field>
 			<fielddescr>Session Timeout</fielddescr>
 			<fieldname>varuserssessiontimeout</fieldname>
-			<description><![CDATA[Enter the time this user has until relogin in seconds.]]></description>
+			<description>
+				<![CDATA[
+				Enter the time this user has until relogin in seconds.
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
@@ -340,10 +361,14 @@
 			<description>
 				<![CDATA[
 				Enter the time when this user should have access. If no time is entered it means "always".<br/>
-				Every time string contains a day (Mo,Tu,We,Th,Fr,Sa,Su) or all weekdays which is from monday till friday (Wk).<br/>
-				All weekdays plus weekend which means all days from monday till sunday is (Al).<br/><br/>
-				<b>Wk0855-2305,Sa,Su2230-0230</b><br/><br/>
-				This means weekdays after 8:55 AM and before 11:05 PM | any time on saturday | sunday after 10:30 PM and before 02:30 AM.
+				Click Info for details.
+				<div class="infoblock">
+				Every time string contains a day (Mo,Tu,We,Th,Fr,Sa,Su) or 'Wk' for all weekdays which is from Monday till Friday.<br/>
+				All weekdays plus weekend which means all days from Monday till Sunday is defined as 'Al'.<br/><br/>
+				<strong><span class="text-info">Example: </span></strong>
+				<b>Wk0855-2305,Sa,Su2230-0230</b><br/>
+				This means weekdays after 8:55 AM and before 11:05 PM | any time on Saturday | Sunday after 10:30 PM and before 02:30 AM.
+				</div>
 				]]>
 			</description>
 			<type>input</type>
@@ -432,7 +457,8 @@
 			<fieldname>varusersacctinteriminterval</fieldname>
 			<description>
 				<![CDATA[
-				Enter the seconds which should be between every interim-update. It MUST be more than 60s and SHOULD NOT be less than 600s. (Default: 600)
+				Enter the seconds which should be between every interim-update. It MUST be more than 60s and SHOULD NOT be less than 600s.
+				(Default: 600)
 				]]>
 			</description>
 			<type>input</type>
@@ -446,12 +472,17 @@
 			<fieldname>varuserstopadditionaloptions</fieldname>
 			<description>
 				<![CDATA[
-				This is for experts only and should be treat with care!<br/>
+				This is for experts only and should be treated with care! Click Info for details.
+				<div class="infoblock">
 				You may append custom RADIUS options to this user account. If the syntax needs it, you have to set quotes and commas.<br/>
 				To put a command in a new line use a vertical bar (|).<br/><br/>
 				Example: DEFAULT Auth-Type = System<br/><br/>
-				<b>IMPORTANT:</b> If you don't format this field correctly freeRADIUS will not start because of syntax errors.<br/>
-				Verify your changes by checking users file (View config -> users).
+				<strong>
+				<span class="text-danger">IMPORTANT: </span>
+				If you don't format this field correctly FreeRADIUS will not start because of syntax errors.
+				</strong><br/>
+				Verify your changes by checking users file (View config > Users).
+				</div>
 				]]>
 			</description>
 			<type>textarea</type>
@@ -459,16 +490,21 @@
 			<cols>75</cols>
 		</field>
 		<field>
-			<fielddescr>Additional RADIUS Attributes (CHECK-ITEM).</fielddescr>
+			<fielddescr>Additional RADIUS Attributes (CHECK-ITEM)</fielddescr>
 			<fieldname>varuserscheckitemsadditionaloptions</fieldname>
 			<description>
 				<![CDATA[
-				This is for experts only and should be treat with care!<br/>
+				This is for experts only and should be treated with care! Click Info for details.
+				<div class="infoblock">
 				You may append custom RADIUS options to this user account. If the syntax needs it, you have to set quotes and commas.<br/>
 				To put a command in a new line use a vertical bar (|).<br/><br/>
 				Example: Max-Daily-Session := 36000<br/><br/>
-				<b>IMPORTANT:</b> If you don't format this field correctly freeRADIUS will not start because of syntax errors.<br/>
-				Verify your changes by checking users file (View config -> users).
+				<strong>
+				<span class="text-danger">IMPORTANT: </span>
+				If you don't format this field correctly FreeRADIUS will not start because of syntax errors.
+				</strong><br/>
+				Verify your changes by checking users file (View config > Users).
+				</div>
 				]]>
 			</description>
 			<type>textarea</type>
@@ -476,16 +512,21 @@
 			<cols>75</cols>
 		</field>
 		<field>
-			<fielddescr>Additional RADIUS Attributes (REPLY-ITEM).</fielddescr>
+			<fielddescr>Additional RADIUS Attributes (REPLY-ITEM)</fielddescr>
 			<fieldname>varusersreplyitemsadditionaloptions</fieldname>
 			<description>
 				<![CDATA[
-				This is for experts only and should be treat with care!<br/>
+				This is for experts only and should be treated with care! Click Info for details.
+				<div class="infoblock">
 				You may append custom RADIUS options to this user account. If the syntax needs it, you have to set quotes and commas.<br/>
 				To put a command in a new line use a vertical bar (|).<br/><br/>
 				Example: Service-Type == Login-User,|Login-Service == Telnet,|Login-IP-Host == 192.168.1.2<br/><br/>
-				<b>IMPORTANT:</b> If you don't format this field correctly freeRADIUS will not start because of syntax errors.<br/>
-				Verify your changes by checking users file (View config -> users).
+				<strong>
+				<span class="text-danger">IMPORTANT: </span>
+				If you don't format this field correctly FreeRADIUS will not start because of syntax errors.
+				</strong><br/>
+				Verify your changes by checking users file (View config > Users).
+				</div>
 				]]>
 			</description>
 			<type>textarea</type>
@@ -498,7 +539,6 @@
 	</custom_delete_php_command>
 	<custom_php_resync_config_command>
 		freeradius_settings_resync(false);
-		sleep(1);
 		freeradius_users_resync();
 	</custom_php_resync_config_command>
 	<custom_php_install_command>

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradiusauthorizedmacs.xml
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradiusauthorizedmacs.xml
@@ -3,12 +3,12 @@
 <?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-<![CDATA[	
+<![CDATA[
 /*
  * freeradiusauthorizedmacs.xml
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2013 Alexander Wilke <nachtfalkeaw@web.de>
  * All rights reserved.
  *
@@ -29,9 +29,6 @@
  * limitations under the License.
  */
 ]]>	</copyright>
-	<description><![CDATA[Describe your package here]]></description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiusauthorizedmacs</name>
 	<title>FreeRADIUS: MACs</title>
 	<include_file>/usr/local/pkg/freeradius.inc</include_file>
@@ -148,30 +145,47 @@
 		<field>
 			<fielddescr>MAC Address</fielddescr>
 			<fieldname>varmacsaddress</fieldname>
-			<description><![CDATA[Enter the MAC address.Format must be: 0a-1b-2c-4d-5f-fa<br>If you do not want to use MAC address but custom options then leave this field empty.]]></description>
+			<description>
+				<![CDATA[
+				Enter the MAC address.Format must be: 0a-1b-2c-4d-5f-fa<br/>
+				If you do not want to use MAC address but custom options then leave this field empty.
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<name>Miscellaneous Configuration</name>
 			<type>listtopic</type>
-		</field>		
+		</field>
 		<field>
 			<fielddescr>Redirection URL</fielddescr>
-			<fieldname>varmacsswisprredirectionurl</fieldname>			
-			<description><![CDATA[Enter the URL the MAC should be redirected to after successful login. (e.g.: http://www.google.com)]]></description>
+			<fieldname>varmacsswisprredirectionurl</fieldname>
+			<description>
+				<![CDATA[
+				Enter the URL the MAC should be redirected to after successful login. (e.g.: http://www.google.com)
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
-			<fielddescr>Number of simultaneous connections</fielddescr>
+			<fielddescr>Number of Simultaneous Connections</fielddescr>
 			<fieldname>varmacssimultaneousconnect</fieldname>
-			<description><![CDATA[The maximum of simultaneous connections with this MAC address. If you leave this field empty than there is no limit. If you are using FreeRADIUS with CaptivePortal you should leave this empty. Read the documentation!]]></description>
-			<default_value></default_value>
+			<description>
+				<![CDATA[
+				The maximum of simultaneous connections with this MAC address. If you leave this field empty than there is no limit.
+				If you are using FreeRADIUS with CaptivePortal you should leave this empty. Read the documentation!
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Description</fielddescr>
-			<fieldname>description</fieldname>			
-			<description><![CDATA[Enter any description for this MAC address you like.]]></description>
+			<fieldname>description</fieldname>
+			<description>
+				<![CDATA[
+				Enter any description for this MAC address you like.
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
@@ -181,71 +195,106 @@
 		<field>
 			<fielddescr>IP Address</fielddescr>
 			<fieldname>varmacsframedipaddress</fieldname>
-			<description><![CDATA[<b>Framed-IP-Address</b> must be supported by NAS.<br><br>
-							If you want this MAC address to be assigned a specific IP address from radius, enter the IP address here.<br>
-							Continuous IP address is available with "+" suffix (e.g. 192.168.1.5+). Could be useful for simultaneous connections.<br><br>
-							<b>IMPORTANT:</b> You must enter an IP address here if you checked "RADIUS issued IP" on VPN PPTP or VPN PPPoE configuration.]]></description>
+			<description>
+				<![CDATA[
+				<b>Framed-IP-Address</b> must be supported by NAS.<br/><br/>
+				If you want this MAC address to be assigned a specific IP address from radius, enter the IP address here.<br/>
+				Continuous IP address is available with "+" suffix (e.g. 192.168.1.5+). Could be useful for simultaneous connections.<br/><br/>
+				<b>IMPORTANT:</b> You must enter an IP address here if you checked "RADIUS issued IP" on VPN PPTP or VPN PPPoE configuration.
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Subnet Mask</fielddescr>
-			<fieldname>varmacsframedipnetmask</fieldname>			
-			<description><![CDATA[<b>Framed-IP-Netmask</b> must be supported by NAS. (e.g. 255.255.255.0)]]></description>
+			<fieldname>varmacsframedipnetmask</fieldname>
+			<description>
+				<![CDATA[
+				<b>Framed-IP-Netmask</b> must be supported by NAS. (e.g. 255.255.255.0)
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Gateway</fielddescr>
-			<fieldname>varmacsframedroute</fieldname>			
-			<description><![CDATA[<b>Framed-Route</b> must be supported by NAS. Format is: Subnet Gateway Metric (e.g. 192.168.10.0 192.168.10.1 1).]]></description>
+			<fieldname>varmacsframedroute</fieldname>
+			<description>
+				<![CDATA[
+				<b>Framed-Route</b> must be supported by NAS. Format is: Subnet Gateway Metric (e.g. 192.168.10.0 192.168.10.1 1).
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>VLAN ID</fielddescr>
-			<fieldname>varmacsvlanid</fieldname>			
-			<description><![CDATA[Enter the VLAN ID (integer from 1-4095) or the VLAN name that this MAC address should be assigned to.<br>
-								Must be supported by the NAS.<br>
-								This setting can be used for a NAS that supports the following RADIUS parameters:<br><br>
-								
-								Tunnel-Type = VLAN<br>
-								Tunnel-Medium-Type = IEEE-802<br>
-								Tunnel-Private-Group-ID = "<b>THIS IS YOUR INPUT</b>"]]></description>
+			<fieldname>varmacsvlanid</fieldname>
+			<description>
+				<![CDATA[
+				Enter the VLAN ID (integer from 1-4095) or the VLAN name that this MAC address should be assigned to.<br/>
+				Must be supported by the NAS.<br/>
+				This setting can be used for a NAS that supports the following RADIUS parameters:<br/><br/>
+				Tunnel-Type = VLAN<br/>
+				Tunnel-Medium-Type = IEEE-802<br/>
+				Tunnel-Private-Group-ID = "<b>THIS IS YOUR INPUT</b>"
+				]]>
+			</description>
 			<type>input</type>
-		</field>		
+		</field>
 		<field>
 			<name>Time Configuration</name>
 			<type>listtopic</type>
 		</field>
 		<field>
 			<fielddescr>Expiration Date</fielddescr>
-			<fieldname>varmacsexpiration</fieldname>			
-			<description><![CDATA[Enter the date when this account should expire. Format is: Mmm dd yyyy (e.g. Jan 01 2012).]]></description>
+			<fieldname>varmacsexpiration</fieldname>
+			<description>
+				<![CDATA[
+				Enter the date when this account should expire. Format is: Mmm dd yyyy (e.g. Jan 01 2012).
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Session Timeout</fielddescr>
-			<fieldname>varmacssessiontimeout</fieldname>			
-			<description><![CDATA[Enter the time this MAC address has until relogin in seconds.]]></description>
+			<fieldname>varmacssessiontimeout</fieldname>
+			<description>
+				<![CDATA[
+				Enter the time this MAC address has until relogin in seconds.
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Possible Login Times</fielddescr>
-			<fieldname>varmacslogintime</fieldname>			
-			<description><![CDATA[Enter the time when this MAC address should have access. If no time is entered it means "always".<br>
-							Every time string contains a day (Mo,Tu,We,Th,Fr,Sa,Su) or all weekdays which is from monday till friday (Wk).<br><br>
-							<b>Wk0855-2305,Sa,Su2230-0230</b><br><br>
-							This means weekdays after 8:55 AM and before 11:05 PM | any time on saturday | sunday after 10:30 PM and before 02:30 AM.]]></description>
+			<fieldname>varmacslogintime</fieldname>
+			<description>
+				<![CDATA[
+				Enter the time when this MAC address should have access. If no time is entered it means "always".<br/>
+				Every time string contains a day (Mo,Tu,We,Th,Fr,Sa,Su) or all weekdays which is from monday till friday (Wk).<br/><br/>
+				<b>Wk0855-2305,Sa,Su2230-0230</b><br/><br/>
+				This means weekdays after 8:55 AM and before 11:05 PM | any time on saturday | sunday after 10:30 PM and before 02:30 AM.
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Amount of Time</fielddescr>
-			<fieldname>varmacsamountoftime</fieldname>			
-			<description><![CDATA[Enter the amount of time for this MAC address in minutes.]]></description>
+			<fieldname>varmacsamountoftime</fieldname>
+			<description>
+				<![CDATA[
+				Enter the amount of time for this MAC address in minutes.
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Time Period</fielddescr>
-			<fieldname>varmacspointoftime</fieldname>			
-			<description><![CDATA[Select the time period for the amount of time.]]></description>
+			<fieldname>varmacspointoftime</fieldname>
+			<description>
+				<![CDATA[
+				Select the time period for the amount of time.
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>daily</default_value>
 				<options>
@@ -261,14 +310,23 @@
 		</field>
 		<field>
 			<fielddescr>Amount of Download and Upload Traffic</fielddescr>
-			<fieldname>varmacsmaxtotaloctets</fieldname>			
-			<description><![CDATA[Enter the amount of download and upload traffic (summarized) for this MAC in <b>MegaByte (MB)</b>. There is a bug in CP (pfSense v2.0.x) which counts the real traffic many times faster and incorrect.]]></description>
+			<fieldname>varmacsmaxtotaloctets</fieldname>
+			<description>
+				<![CDATA[
+				Enter the amount of download and upload traffic (summarized) for this MAC in <b>MegaByte (MB)</b>.
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Time Period</fielddescr>
-			<fieldname>varmacsmaxtotaloctetstimerange</fieldname>			
-			<description><![CDATA[Select the time period for the amount of download and upload traffic. This does not automatically reset the counter. You need to setup a cronjob (with cron package) which will reset the counter. Read the documentation!]]></description>
+			<fieldname>varmacsmaxtotaloctetstimerange</fieldname>
+			<description>
+				<![CDATA[
+				Select the time period for the amount of download and upload traffic. This does not automatically reset the counter.<br/>
+				You need to setup a cronjob (with cron package) which will reset the counter. Read the documentation!
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>daily</default_value>
 				<options>
@@ -280,61 +338,86 @@
 		</field>
 		<field>
 			<fielddescr>Maximum Bandwidth Down</fielddescr>
-			<fieldname>varmacsmaxbandwidthdown</fieldname>			
-			<description><![CDATA[Enter the maximum bandwidth for download in <b>KiloBits</b> per second.]]></description>
+			<fieldname>varmacsmaxbandwidthdown</fieldname>
+			<description>
+				<![CDATA[
+				Enter the maximum bandwidth for download in <b>KiloBits</b> per second.
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Maximum Bandwidth Up</fielddescr>
-			<fieldname>varmacsmaxbandwidthup</fieldname>			
-			<description><![CDATA[Enter the maximum bandwidth for upload in <b>KiloBits</b> per second.]]></description>
+			<fieldname>varmacsmaxbandwidthup</fieldname>
+			<description>
+				<![CDATA[
+				Enter the maximum bandwidth for upload in <b>KiloBits</b> per second.
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Accounting Interim Interval</fielddescr>
-			<fieldname>varmacsacctinteriminterval</fieldname>			
-			<description><![CDATA[Enter the seconds which should be between every interim-update. It MUST be more than 60s and SHOULD NOT be less than 600s. (Default: 600)]]></description>
+			<fieldname>varmacsacctinteriminterval</fieldname>
+			<description>
+				<![CDATA[
+				Enter the seconds which should be between every interim-update.
+				It MUST be more than 60s and SHOULD NOT be less than 600s. (Default: 600)
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<name>Advanced Configuration</name>
 			<type>listtopic</type>
-		</field>		
+		</field>
 		<field>
 			<fielddescr>Additional RADIUS Attributes on the TOP of this entry</fielddescr>
-			<fieldname>varmacstopadditionaloptions</fieldname>			
-			<description><![CDATA[This is for experts only and should be treat with care!<br>
-								You may append custom RADIUS options to this MAC address account. If the syntax needs it, you have to set quotes and commas.<br>
-								To put a command in a new line use a vertical bar (|).<br><br>
-								Example: DEFAULT Auth-Type = System<br><br>
-								<b>IMPORTANT:</b> If you don't format this field correctly freeRADIUS will not start because of syntax errors.<br>
-								Verify your changes by checking authorized_macs file (View config -> macs).]]></description>
+			<fieldname>varmacstopadditionaloptions</fieldname>
+			<description>
+				<![CDATA[
+				This is for experts only and should be treated with care!<br/>
+				You may append custom RADIUS options to this MAC address account. If the syntax needs it, you have to set quotes and commas.<br/>
+				To put a command in a new line use a vertical bar (|).<br/><br/>
+				Example: DEFAULT Auth-Type = System<br/><br/>
+				<b>IMPORTANT:</b> If you don't format this field correctly freeRADIUS will not start because of syntax errors.<br/>
+				Verify your changes by checking authorized_macs file (View config -> macs).
+				]]>
+			</description>
 			<type>textarea</type>
 			<rows>4</rows>
 			<cols>75</cols>
 		</field>
 		<field>
 			<fielddescr>Additional RADIUS Attributes (CHECK-ITEM).</fielddescr>
-			<fieldname>varmacscheckitemsadditionaloptions</fieldname>			
-			<description><![CDATA[This is for experts only and should be treat with care!<br>
-								You may append custom RADIUS options to this MAC address account. If the syntax needs it, you have to set quotes and commas.<br>
-								To put a command in a new line use a vertical bar (|).<br><br>
-								Example: Max-Daily-Session := 36000<br><br>
-								<b>IMPORTANT:</b> If you don't format this field correctly freeRADIUS will not start because of syntax errors.<br>
-								Verify your changes by checking authorized_macs file (View config -> macs).]]></description>
+			<fieldname>varmacscheckitemsadditionaloptions</fieldname>
+			<description>
+				<![CDATA[
+				This is for experts only and should be treated with care!<br/>
+				You may append custom RADIUS options to this MAC address account. If the syntax needs it, you have to set quotes and commas.<br/>
+				To put a command in a new line use a vertical bar (|).<br/><br/>
+				Example: Max-Daily-Session := 36000<br/><br/>
+				<b>IMPORTANT:</b> If you don't format this field correctly freeRADIUS will not start because of syntax errors.<br/>
+				Verify your changes by checking authorized_macs file (View config -> macs).
+				]]>
+			</description>
 			<type>textarea</type>
 			<rows>4</rows>
 			<cols>75</cols>
 		</field>
 		<field>
 			<fielddescr>Additional RADIUS Attributes (REPLY-ITEM).</fielddescr>
-			<fieldname>varmacsreplyitemsadditionaloptions</fieldname>			
-			<description><![CDATA[This is for experts only and should be treat with care!<br>
-								You may append custom RADIUS options to this MAC address account. If the syntax needs it, you have to set quotes and commas.<br>
-								To put a command in a new line use a vertical bar (|).<br><br>
-								Example: Service-Type == Login-User,|Login-Service == Telnet,|Login-IP-Host == 192.168.1.2<br><br>
-								<b>IMPORTANT:</b> If you don't format this field correctly freeRADIUS will not start because of syntax errors.<br>
-								Verify your changes by checking authorized_macs file (View config -> macs).]]></description>
+			<fieldname>varmacsreplyitemsadditionaloptions</fieldname>
+			<description>
+				<![CDATA[
+				This is for experts only and should be treated with care!<br/>
+				You may append custom RADIUS options to this MAC address account. If the syntax needs it, you have to set quotes and commas.<br/>
+				To put a command in a new line use a vertical bar (|).<br/><br/>
+				Example: Service-Type == Login-User,|Login-Service == Telnet,|Login-IP-Host == 192.168.1.2<br/><br/>
+				<b>IMPORTANT:</b> If you don't format this field correctly freeRADIUS will not start because of syntax errors.<br/>
+				Verify your changes by checking authorized_macs file (View config -> macs).
+				]]>
+			</description>
 			<type>textarea</type>
 			<rows>4</rows>
 			<cols>75</cols>

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradiuscerts.xml
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradiuscerts.xml
@@ -3,12 +3,12 @@
 <?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-<![CDATA[	
+<![CDATA[
 /*
  * freeradiuscerts.xml
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2013 Alexander Wilke <nachtfalkeaw@web.de>
  * All rights reserved.
  *
@@ -29,9 +29,6 @@
  * limitations under the License.
  */
 ]]>	</copyright>
-	<description><![CDATA[Describe your package here]]></description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiuscerts</name>
 	<title>FreeRADIUS: Certificates</title>
 	<aftersaveredirect>pkg_edit.php?xml=freeradiuscerts.xml&amp;id=0</aftersaveredirect>
@@ -89,30 +86,45 @@
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>Delete ALL existing Certificates ?</fielddescr>
+			<fielddescr>Delete ALL Existing Certificates?</fielddescr>
 			<fieldname>varcertsdeleteall</fieldname>
-			<description><![CDATA[This will delete <b>ALL</b> existing CAs, Server-Certs and Client-Certs in freeradius certs folder!<br>
-								You <b>must</b> delete all existing if you want to create new ones. (Default: No)<br>
-								<b>Important:</b><br>
-								If you like to use certs created on another PC just disable this and click save.]]></description>
+			<description>
+				<![CDATA[
+				This will delete <b>ALL</b> existing CAs, Server-Certs and Client-Certs in freeradius certs folder!<br/>
+				You <b>must</b> delete all existing if you want to create new ones. (Default: No)<br/>
+				<b>Important:</b> If you like to use certs created on another PC just disable this and click save.
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>READ BEFORE DOING ANYTHING HERE!</fielddescr>
 			<fieldname>varcertsREADBEFORE</fieldname>
-			<description><![CDATA[<b>This field is just to make sure you know what you are doing here!</b><br>
-									<b>If you enter anything the changes here will take effect after "save" - if it's empty - nothing will happen</b><br><br>
-									
-									This page uses the freeradius2 built-in script called "bootstrap" to create CA and certs. The disatvantage of this script is that nothing of your changes will be saved in the global config.xml file. So after a systemcrash or reinstallation of freeradius2 package
-									all your CA and certs will be lost. If you have a backup of all these files on an USB stick or another server than you can copy them back in the freeradius certs folder.<br><br>
-									
-									<b>The better way is to use the firewall's built-in Cert Manager (SYSTEM-> Cert Manager).</b> The CA-Cert and Server-Cert you created there you just have to choose in EAP.
-									The advantage of this is that all your CA and certs will be saved in global config.xml and can be restored.]]></description>
+			<description>
+				<![CDATA[
+				<strong>
+				<span class="text-danger">WARNING!!! THIS FEATURE IS DEPRECATED!!!</span><br/>
+				This feature is not maintained, uses obsolete insecure cryptography (MD5/SHA1)
+				offers no backup capabilities and is pending removal in near future.<br/>
+				Users are strongly urged to transition to the Cert Manager built into pfSense as soon as possible.
+				See 'Choose Cert Manager' on the <a href="/pkg_edit.php?xml=freeradiuseapconf.xml">'EAP' configuration tab</a>
+				and <a href="system_camanager.php">'System > Cert Manager'</a> for certificate management.<br/>
+				<span class="text-danger">WARNING!!! THIS FEATURE IS DEPRECATED!!!</span>
+				</strong><br/><br/>
+				<b>If you enter anything the changes here will take effect after "Save" - if it's empty - nothing will happen</b><br/><br/>
+				This page uses the freeradius2 built-in script called "bootstrap" to create CA and certs.
+				The disadvantage of this script is that nothing of your changes will be saved in the global config.xml file.
+				So, after a systemcrash or reinstallation of freeradius2 package all your CA and certs will be lost.
+				If you have a backup of all these files on an USB stick or another server than you can copy them back in the freeradius certs folder.<br/><br/>
+				<b>Use the <a href="system_camanager.php">built-in Cert Manager</a> so that all your CA and certs
+				can be saved in global config.xml and restored if needed.</b>
+				]]>
+			</description>
 			<type>input</type>
 			<required/>
 			<default_value></default_value>
@@ -124,68 +136,101 @@
 		<field>
 			<fielddescr>Country Code</fielddescr>
 			<fieldname>varcertscountryname</fieldname>
-			<description><![CDATA[Enter your country Code. (Default: US)]]></description>
+			<description>
+				<![CDATA[
+				Enter your country code. (Default: US)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>US</default_value>
 		</field>
 		<field>
 			<fielddescr>State or Province</fielddescr>
 			<fieldname>varcertsstateorprovincename</fieldname>
-			<description><![CDATA[Enter your state or province. (Default: Texas)]]></description>
+			<description>
+				<![CDATA[
+				Enter your state or province. (Default: Texas)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>Texas</default_value>
 		</field>
 		<field>
 			<fielddescr>City</fielddescr>
 			<fieldname>varcertslocalityname</fieldname>
-			<description><![CDATA[Enter your city. (Default: Austin)]]></description>
+			<description>
+				<![CDATA[
+				Enter your city. (Default: Austin)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>Austin</default_value>
 		</field>
 		<field>
 			<fielddescr>Organization</fielddescr>
 			<fieldname>varcertsorganizationname</fieldname>
-			<description><![CDATA[Enter your organization. (Default: My Company Inc)]]></description>
+			<description>
+				<![CDATA[
+				Enter your organization. (Default: My Company Inc)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>My Company Inc</default_value>
 		</field>
-				<field>
+		<field>
 			<fielddescr>Lifetime</fielddescr>
 			<fieldname>varcertsdefaultdays</fieldname>
-			<description><![CDATA[Enter the time after which the CA, Server and Client should expire in days. (Default: 3650)]]></description>
+			<description>
+				<![CDATA[
+				Enter the time after which the CA, Server and Client should expire in days. (Default: 3650)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>3650</default_value>
 		</field>
 		<field>
 			<fielddescr>Key Length</fielddescr>
 			<fieldname>varcertsdefaultbits</fieldname>
-			<description><![CDATA[Enter the key length of CA, Server and Client. (Default: 2048)]]></description>
+			<description>
+				<![CDATA[
+				Enter the key length of CA, Server and Client. (Default: 2048)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>2048</default_value>
-					<options>
-						<option><name>512</name><value>512</value></option>
-						<option><name>1024</name><value>1024</value></option>
-						<option><name>2048</name><value>2048</value></option>
-						<option><name>4096</name><value>4096</value></option>
-					</options>
+			<options>
+				<option><name>512</name><value>512</value></option>
+				<option><name>1024</name><value>1024</value></option>
+				<option><name>2048</name><value>2048</value></option>
+				<option><name>4096</name><value>4096</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Key Creation Algorithm</fielddescr>
 			<fieldname>varcertsdefaultmd</fieldname>
-			<description><![CDATA[Choose the algotithem which should be used to create the key.<br>
-								There seems to be some OS which do not support all algorithms. (Default: md5)]]></description>
+			<description>
+				<![CDATA[
+				Choose the algotithem which should be used to create the key.<br/>
+				There seems to be some OS which do not support all algorithms. (Default: md5)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>md5</default_value>
-					<options>
-						<option><name>MD5</name><value>md5</value></option>
-						<option><name>SHA1</name><value>sha1</value></option>
-					</options>
+			<options>
+				<option><name>MD5 (extremely insecure!)</name><value>md5</value></option>
+				<option><name>SHA1 (insecure!)</name><value>sha1</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Certificate Password (CA, Server and Client)</fielddescr>
 			<fieldname>varcertspassword</fieldname>
-			<description><![CDATA[Enter the password for the CA, Server and Client.	This is the password you need to enter in eap.conf
-								so that freeradius can read the cert. This field could be empty. (Default: whatever)]]></description>
+			<description>
+				<![CDATA[
+				Enter the password for the CA, Server and Client.
+				This is the password you need to enter in eap.conf so that freeradius can read the cert. This field could be empty.
+				(Default: whatever)
+				]]>
+			</description>
 			<type>password</type>
 			<default_value>whatever</default_value>
 		</field>
@@ -196,14 +241,22 @@
 		<field>
 			<fielddescr>E-Mail Address</fielddescr>
 			<fieldname>varcertscaemailaddress</fieldname>
-			<description><![CDATA[Enter the E-Mail address for the CA. (Default: admin@mycompany.com)]]></description>
+			<description>
+				<![CDATA[
+				Enter the E-Mail address for the CA. (Default: admin@mycompany.com)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>admin@mycompany.com</default_value>
 		</field>
 		<field>
 			<fielddescr>Common Name</fielddescr>
 			<fieldname>varcertscacommonname</fieldname>
-			<description><![CDATA[Enter the common name for the CA. (Default: internal-ca)]]></description>
+			<description>
+				<![CDATA[
+				Enter the common name for the CA. (Default: internal-ca)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>internal-ca</default_value>
 		</field>
@@ -214,14 +267,22 @@
 		<field>
 			<fielddescr>E-Mail Address</fielddescr>
 			<fieldname>varcertsserveremailaddress</fieldname>
-			<description><![CDATA[Enter the E-Mail address for the Server-Cert. (Default: webadmin@mycompany.com)]]></description>
+			<description>
+				<![CDATA[
+				Enter the E-Mail address for the Server-Cert. (Default: webadmin@mycompany.com)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>webadmin@mycompany.com</default_value>
 		</field>
 		<field>
 			<fielddescr>Common Name</fielddescr>
 			<fieldname>varcertsservercommonname</fieldname>
-			<description><![CDATA[Enter the common name for the Server-Cert. (Default: server-cert)]]></description>
+			<description>
+				<![CDATA[
+				Enter the common name for the Server-Cert. (Default: server-cert)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>server-cert</default_value>
 		</field>
@@ -232,41 +293,50 @@
 		<field>
 			<fielddescr>Create a further Client-Certificate</fielddescr>
 			<fieldname>varcertscreateclient</fieldname>
-			<description><![CDATA[This will delete existing <b>Client-Certs</b> in freeradius certs folder!<br>
-								Choose this option if you need multiple Client-Certs.<br>
-								<b>Important:</b> You must backup your old Client-Cert before enabling this option. The new Client-Cert <b>must not</b> have any Common Name as other certificates your created before. (Default: No)<br><br>
-								
-								This is what you should do the very first time when creating certs here:<br>
-								1. Check "Delete ALL Certs...", fill out all fields and create a new CA, new Server and Client Cert<br>
-								2. If you need more than one Client-Cert than backup your first cert using DIAGNOSTICS->COMMAND PROMPT->Download<br>
-								/usr/local/etc/raddb/certs/client.tar<br>
-								3. Disable "Delete ALL Certs..." and enable "Create a further Client-Certificate" and fill out the Client fields<br>
-								4. Repeat step 2. as long as you need.<br><br>
-								
-								
-								<b>Limitations:</b><br>
-								There is no CRL. Deleting of existing certs from the database (../certs/index.txt) isn't possible from GUI.<br>
-								If you choose a Common Name which already exists in the database (check view config) the .crt will be zero bytes.<br>
-								Choose other Common Name and create a new Client-Cert.
-								]]></description>
+			<description>
+				<![CDATA[
+				This will delete existing <b>Client-Certs</b> in freeradius certs folder!<br/>
+				Choose this option if you need multiple Client-Certs.<br/>
+				<b>Important:</b> You must backup your old Client-Cert before enabling this option.
+				The new Client-Cert <b>must not</b> have any Common Name as other certificates your created before. (Default: No)<br/><br/>
+				This is what you should do the very first time when creating certs here:<br/>
+				1. Check "Delete ALL Certs...", fill out all fields and create a new CA, new Server and Client Cert<br/>
+				2. If you need more than one Client-Cert than backup your first cert using DIAGNOSTICS->COMMAND PROMPT->Download<br/>
+				/usr/local/etc/raddb/certs/client.tar<br/>
+				3. Disable "Delete ALL Certs..." and enable "Create a further Client-Certificate" and fill out the Client fields<br/>
+				4. Repeat step 2. as long as you need.<br/><br/>
+				<b>Limitations:</b><br/>
+				There is no CRL. Deleting of existing certs from the database (../certs/index.txt) isn't possible from GUI.<br/>
+				If you choose a Common Name which already exists in the database (check view config) the .crt will be zero bytes.<br/>
+				Choose other Common Name and create a new Client-Cert.
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>E-Mail Address</fielddescr>
 			<fieldname>varcertsclientemailaddress</fieldname>
-			<description><![CDATA[Enter the E-Mail address for the Client-Cert. (Default: user@mycompany.com)]]></description>
+			<description>
+				<![CDATA[
+				Enter the E-Mail address for the Client-Cert. (Default: user@mycompany.com)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>user@mycompany.com</default_value>
 		</field>
 		<field>
 			<fielddescr>Common Name</fielddescr>
 			<fieldname>varcertsclientcommonname</fieldname>
-			<description><![CDATA[Enter the common name for the Client-Cert. (Default: client-cert)]]></description>
+			<description>
+				<![CDATA[
+				Enter the common name for the Client-Cert. (Default: client-cert)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>client-cert</default_value>
 		</field>

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradiusclients.xml
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradiusclients.xml
@@ -3,12 +3,12 @@
 <?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-<![CDATA[	
+<![CDATA[
 /*
  * freeradiusclients.xml
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2013 Alexander Wilke <nachtfalkeaw@web.de>
  * All rights reserved.
  *
@@ -29,9 +29,6 @@
  * limitations under the License.
  */
 ]]>	</copyright>
-	<description><![CDATA[Describe your package here]]></description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiusclients</name>
 	<title>FreeRADIUS: Clients</title>
 	<include_file>/usr/local/pkg/freeradius.inc</include_file>
@@ -121,11 +118,15 @@
 		<field>
 			<name>General Configuration</name>
 			<type>listtopic</type>
-		</field>	
+		</field>
 		<field>
 			<fielddescr>Client IP Address</fielddescr>
 			<fieldname>varclientip</fieldname>
-			<description><![CDATA[Enter the IP address of the RADIUS client. This is the IP of the NAS (switch, access point, firewall, router, etc.).]]></description>
+			<description>
+				<![CDATA[
+				Enter the IP address of the RADIUS client. This is the IP of the NAS (switch, access point, firewall, router, etc.).
+				]]>
+			</description>
 			<type>input</type>
 			<required/>
 		</field>
@@ -134,96 +135,138 @@
 			<fieldname>varclientipversion</fieldname>
 			<type>select</type>
 			<default_value>ipaddr</default_value>
-					<options>
-						<option><name>IPv4</name><value>ipaddr</value></option>
-						<option><name>IPv6</name><value>ipv6addr</value></option>
-					</options>
+			<options>
+				<option><name>IPv4</name><value>ipaddr</value></option>
+				<option><name>IPv6</name><value>ipv6addr</value></option>
+			</options>
 			<required/>
-		</field>		
+		</field>
 		<field>
 			<fielddescr>Client Shortname</fielddescr>
 			<fieldname>varclientshortname</fieldname>
-			<description><![CDATA[Enter a short name for the client. This is generally the hostname of the NAS.]]></description>
+			<description>
+				<![CDATA[
+				Enter a short name for the client. This is generally the hostname of the NAS.
+				]]>
+			</description>
 			<type>input</type>
 			<required/>
 		</field>
 		<field>
 			<fielddescr>Client Shared Secret</fielddescr>
 			<fieldname>varclientsharedsecret</fieldname>
-			<description><![CDATA[Enter the shared secret of the RADIUS client here. This is the shared secret (password) which the NAS (switch or accesspoint) needs to communicate with the RADIUS server. FreeRADIUS is limited to 31 characters for the shared secret.]]></description>
+			<description>
+				<![CDATA[
+				Enter the shared secret of the RADIUS client here. This is the shared secret (password)
+				which the NAS (switch or accesspoint) needs to communicate with the RADIUS server.<br/>
+				FreeRADIUS is limited to 31 characters for the shared secret.
+				]]>
+			</description>
 			<type>password</type>
 			<required/>
 		</field>
 		<field>
 			<name>Miscellaneous Configuration</name>
 			<type>listtopic</type>
-		</field>		
+		</field>
 		<field>
 			<fielddescr>Client Protocol</fielddescr>
 			<fieldname>varclientproto</fieldname>
-			<description><![CDATA[Enter the protocol the client uses. (Default: UDP)]]></description>
+			<description>
+				<![CDATA[
+				Enter the protocol the client uses. (Default: UDP)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>udp</default_value>
-					<options>
-						<option><name>UDP</name><value>udp</value></option>
-						<option><name>TCP</name><value>tcp</value></option>
-					</options>
+			<options>
+				<option><name>UDP</name><value>udp</value></option>
+				<option><name>TCP</name><value>tcp</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Client Type</fielddescr>
 			<fieldname>varclientnastype</fieldname>
-			<description><![CDATA[Enter the NAS type of the client. This is used by checkrad.pl for simultaneous use checks. (Default: other)]]></description>
+			<description>
+				<![CDATA[
+				Enter the NAS type of the client. This is used by checkrad.pl for simultaneous use checks. (Default: other)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>other</default_value>
-					<options>
-						<option><name>CISCO Systems</name><value>cisco</value></option>
-						<option><name>Computone PowerRack</name><value>computone</value></option>
-						<option><name>Livingston PortMaster</name><value>livingston</value></option>
-						<option><name>Ascend Max 4000 family</name><value>max40xx</value></option>
-						<option><name>Multitech CommPlete Server</name><value>multitech</value></option>
-						<option><name>3Com/USR NetServer</name><value>netserver</value></option>
-						<option><name>Cyclades PathRAS</name><value>pathras</value></option>
-						<option><name>Patton 2800 family</name><value>patton</value></option>
-						<option><name>Cistron PortSlave</name><value>portslave</value></option>
-						<option><name>3Com/USR TotalControl</name><value>tc</value></option>
-						<option><name>3Com/USR Hiper Arc Total Control</name><value>usrhiper</value></option>
-						<option><name>other</name><value>other</value></option>
-					</options>
+			<options>
+				<option><name>CISCO Systems</name><value>cisco</value></option>
+				<option><name>Computone PowerRack</name><value>computone</value></option>
+				<option><name>Livingston PortMaster</name><value>livingston</value></option>
+				<option><name>Ascend Max 4000 family</name><value>max40xx</value></option>
+				<option><name>Multitech CommPlete Server</name><value>multitech</value></option>
+				<option><name>3Com/USR NetServer</name><value>netserver</value></option>
+				<option><name>Cyclades PathRAS</name><value>pathras</value></option>
+				<option><name>Patton 2800 family</name><value>patton</value></option>
+				<option><name>Cistron PortSlave</name><value>portslave</value></option>
+				<option><name>3Com/USR TotalControl</name><value>tc</value></option>
+				<option><name>3Com/USR Hiper Arc Total Control</name><value>usrhiper</value></option>
+				<option><name>other</name><value>other</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Require Message Authenticator</fielddescr>
 			<fieldname>varrequiremessageauthenticator</fieldname>
-			<description><![CDATA[RFC5080 requires Message-Authenticator in Access-Request. But older NAS (switches or accesspoints) do not include that. (Default: no)]]></description>
+			<description>
+				<![CDATA[
+				RFC5080 requires Message-Authenticator in Access-Request.
+				But older NAS (switches or accesspoints) do not include that. (Default: no)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>No</name><value>no</value></option>
-						<option><name>Yes</name><value>yes</value></option>
-					</options>
+			<options>
+				<option><name>No</name><value>no</value></option>
+				<option><name>Yes</name><value>yes</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Max Connections</fielddescr>
 			<fieldname>varclientmaxconnections</fieldname>
-			<description><![CDATA[Takes only effect if you use TCP as protocol. This is the mirror of "Max Requests Server" from "Settings" tab. (Default 16)]]></description>
+			<description>
+				<![CDATA[
+				Takes only effect if you use TCP as protocol.
+				This is the mirror of "Max Requests Server" from "Settings" tab. (Default 16)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>16</default_value>
 		</field>
 		<field>
 			<fielddescr>NAS Login</fielddescr>
 			<fieldname>varclientlogininput</fieldname>
-			<description><![CDATA[If your NAS supports it you can use SNMP or finger for simultaneous-use checks instead of (s)radutmp file and accounting. Leave empty to choose (s)radutmp. (Default: empty)]]></description>
+			<description>
+				<![CDATA[
+				If your NAS supports it you can use SNMP or finger for simultaneous-use checks instead of (s)radutmp file and accounting.
+				Leave empty to choose (s)radutmp. (Default: empty)
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>NAS Password</fielddescr>
 			<fieldname>varclientpasswordinput</fieldname>
-			<description><![CDATA[If your NAS supports it you can use SNMP or finger for simultaneous-use checks instead of (s)radutmp file and accounting. Leave empty to choose (s)radutmp. (Default: empty)]]></description>
+			<description>
+				<![CDATA[
+				If your NAS supports it you can use SNMP or finger for simultaneous-use checks instead of (s)radutmp file and accounting.
+				Leave empty to choose (s)radutmp. (Default: empty)
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Description</fielddescr>
 			<fieldname>description</fieldname>
-			<description><![CDATA[Enter any description you like for this client.]]></description>
+			<description>
+				<![CDATA[
+				Enter any description you like for this client.
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 	</fields>

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradiuseapconf.xml
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradiuseapconf.xml
@@ -3,12 +3,12 @@
 <?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-<![CDATA[	
+<![CDATA[
 /*
  * freeradiuseapconf.xml
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2013 Alexander Wilke <nachtfalkeaw@web.de>
  * Copyright (c) 2013 Marcello Coutinho (revocation list code)
  * All rights reserved.
@@ -30,9 +30,6 @@
  * limitations under the License.
  */
 ]]>	</copyright>
-	<description><![CDATA[Describe your package here]]></description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiuseapconf</name>
 	<title>FreeRADIUS: EAP</title>
 	<aftersaveredirect>pkg_edit.php?xml=freeradiuseapconf.xml&amp;id=0</aftersaveredirect>
@@ -104,52 +101,77 @@
 		<field>
 			<fielddescr>Default EAP Type</fielddescr>
 			<fieldname>vareapconfdefaulteaptype</fieldname>
-			<description><![CDATA[Invoke the default supported EAP type when EAP-Identity response is received. If you disabled the weak EAP types you must not select here MD5. Try PEAP. (Default: md5)]]></description>
+			<description>
+				<![CDATA[
+				Invoke the default supported EAP type when EAP-Identity response is received.
+				If you disabled the weak EAP types you must not select here MD5. Try PEAP. (Default: md5)
+			]]></description>
 			<type>select</type>
 			<default_value>md5</default_value>
-					<options>
-						<option><name>MD5</name><value>md5</value></option>
-						<option><name>GTC</name><value>gtc</value></option>
-						<option><name>LEAP</name><value>leap</value></option>
-						<option><name>TLS</name><value>tls</value></option>
-						<option><name>TTLS</name><value>ttls</value></option>
-						<option><name>PEAP</name><value>peap</value></option>
-						<option><name>MSCHAPv2</name><value>mschapv2</value></option>
-					</options>
+			<options>
+				<option><name>MD5 (insecure)</name><value>md5</value></option>
+				<option><name>GTC</name><value>gtc</value></option>
+				<option><name>LEAP</name><value>leap</value></option>
+				<option><name>TLS</name><value>tls</value></option>
+				<option><name>TTLS</name><value>ttls</value></option>
+				<option><name>PEAP</name><value>peap</value></option>
+				<option><name>MSCHAPv2</name><value>mschapv2</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Expiration of EAP-Response / EAP-Request List</fielddescr>
 			<fieldname>vareapconftimerexpire</fieldname>
-			<description><![CDATA[A list is maintained to correlate EAP-Response packets with EAP-Request packets. Define the expire time of the list. (Default: 60)]]></description>
+			<description>
+				<![CDATA[
+				A list is maintained to correlate EAP-Response packets with EAP-Request packets.
+				Define the expire time of the list. (Default: 60)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>60</default_value>
 		</field>
 		<field>
 			<fielddescr>Ignore Unknown EAP Types</fielddescr>
 			<fieldname>vareapconfignoreunknowneaptypes</fieldname>
-			<description><![CDATA[If the RADIUS server does not know the EAP type, it rejects it. If set to "yes" another module <b>must</b> be configured to proxy the request to a further RADIUS server. (Default: no)]]></description>
+			<description>
+				<![CDATA[
+				If the RADIUS server does not know the EAP type, it rejects it.
+				If set to "yes" another module <b>must</b> be configured to proxy the request to a further RADIUS server.
+				(Default: no)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>No</name><value>no</value></option>
-						<option><name>Yes</name><value>yes</value></option>
-					</options>
+			<options>
+				<option><name>No</name><value>no</value></option>
+				<option><name>Yes</name><value>yes</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>CISCO Accounting Username Bug</fielddescr>
 			<fieldname>vareapconfciscoaccountingusernamebug</fieldname>
-			<description><![CDATA[CISCO AP1230B firmware 12.2(13)JA1 has a bug which can be workaround by setting this to "yes". (Default: no)]]></description>
+			<description>
+				<![CDATA[
+				CISCO AP1230B firmware 12.2(13)JA1 has a bug which can be workaround by setting this to "yes".
+				(Default: no)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>No</name><value>no</value></option>
-						<option><name>Yes</name><value>yes</value></option>
-					</options>
+			<options>
+				<option><name>No</name><value>no</value></option>
+				<option><name>Yes</name><value>yes</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Maximum Sessions Tracking per Server</fielddescr>
 			<fieldname>vareapconfmaxsessions</fieldname>
-			<description><![CDATA[Help to prevent DoS attacks by limiting the number of sessions that the server is tracking. (Default: 4096)]]></description>
+			<description>
+				<![CDATA[
+				Help to prevent DoS attacks by limiting the number of sessions that the server is tracking.
+				(Default: 4096)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>4096</default_value>
 		</field>
@@ -164,11 +186,19 @@
 			<sethelp>
 				<![CDATA[
 				Selects which system will manage certificates.
-				By default it is the freeradius cert manager because the server needs some default certs to start services.
-				For more information take al look at the Certificates Tab.<br>
-				To use the built-in Certificate Manager on pfSense, first create a CA and a Server Certificate at System > Cert Manager.<br><br>
-				<b>unchecked</b>: FreeRADIUS Cert Manager (not recommended)<br>
-				<b>checked</b>: Firewall Cert Manager (recommended)
+				By default it is the FreeRADIUS Cert Manager because the server needs some default certs to start services.<br/><br/>
+				<strong>
+				<span class="text-danger">WARNING!!!</span><br/>
+				The FreeRADIUS Cert Manager is not maintained, uses obsolete insecure cryptography (MD5/SHA1)
+				offers no backup capabilities and is pending removal in near future.<br/>
+				Users are strongly urged to transition to the Cert Manager built into pfSense as soon as possible.<br/>
+				To use the built-in Certificate Manager on pfSense, first create a CA and a Server Certificate at 
+				<a href="system_camanager.php">'System &gt; Cert Manager'</a>.<br/>
+				<span class="text-danger">WARNING!!!</span>
+				</strong><br/><br/>
+				For more information take al look at the Certificates Tab.<br/>
+				<b>unchecked</b>: FreeRADIUS Cert Manager (Deprecated, do NOT use!)<br/>
+				<b>checked</b>: Firewall Cert Manager (Strongly recommended)
 				]]>
 			</sethelp>
 			<type>checkbox</type>
@@ -177,15 +207,27 @@
 		<field>
 			<fielddescr>Private Key Password</fielddescr>
 			<fieldname>vareapconfprivatekeypassword</fieldname>
-			<description><![CDATA[By default the certificates created by freeradius are protected with an "input/ouput" password from reading the certificate. The certificates created by the firewall's built-in Cert Manager are not protected so you must leave this field empty.]]></description>
+			<description>
+				<![CDATA[
+				By default the certificates created by freeradius are protected with an "input/ouput" password
+				from reading the certificate.
+				<strong><span class="text-danger">IMPORTANT: </span>
+				Leave this field empty if using the certificates created by the firewall's built-in Cert Manager.</strong>
+				]]>
+			</description>
 			<type>password</type>
 			<default_value>whatever</default_value>
 		</field>
 		<field>
 			<fielddescr>SSL CA Certificate</fielddescr>
 			<fieldname>ssl_ca_cert</fieldname>
-			<description><![CDATA[Choose the SSL CA Certficate here which you created with the firewall's Cert Manager.<br>
-									Choose "none" if you do not use any kind of certificates or the freeradius Cert Manager. (Default: none)]]></description>
+			<description>
+				<![CDATA[
+				Choose the SSL CA Certficate here which you created with the firewall's Cert Manager.<br/>
+				Choose "none" if you do not use any kind of certificates or are using the deprecated FreeRADIUS Cert Manager.
+				(Default: none)
+				]]>
+			</description>
 			<type>select_source</type>
 			<source><![CDATA[freeradius_get_ca_certs()]]></source>
 			<source_name>descr</source_name>
@@ -194,9 +236,15 @@
 		<field>
 			<fielddescr>SSL Revocation List</fielddescr>
 			<fieldname>ssl_ca_crl</fieldname>
-			<description><![CDATA[Choose the SSL CA Certficate revocation list here which you created with the firewall's Cert Manager.<br>
-									<b>HINT:</b> You need to restart freeradius service after adding a certificate to the CRL.<br>
-									Choose "none" if you do not use any kind of certificates or the freeradius Cert Manager. (Default: none)]]></description>
+			<description>
+				<![CDATA[
+				Choose the SSL CA Certficate revocation list here which you created with the firewall's Cert Manager.<br/>
+				<strong><span class="text-danger">HINT: </span></strong>
+				You need to restart freeradius service after adding a certificate to the CRL.<br/>
+				Choose "none" if you do not use any kind of certificates or are using the deprecated FreeRADIUS Cert Manager.
+				(Default: none)
+				]]>
+			</description>
 			<type>select_source</type>
 			<source><![CDATA[freeradius_get_ca_crl()]]></source>
 			<source_name>descr</source_name>
@@ -206,32 +254,18 @@
 		<field>
 			<fielddescr>SSL Server Certificate</fielddescr>
 			<fieldname>ssl_server_cert</fieldname>
-			<description><![CDATA[Choose the SSL Server Certficate here which you created with the firewall's Cert Manager.<br>
-									Choose "none" if you do not use any kind of certificates or the freeradius Cert Manager. (Default: none)]]></description>
+			<description>
+				<![CDATA[
+				Choose the SSL Server Certficate here which you created with the firewall's Cert Manager.<br/>
+				Choose "none" if you do not use any kind of certificates or are using the deprecated FreeRADIUS Cert Manager.
+				(Default: none)
+				]]>
+			</description>
 			<type>select_source</type>
 			<source><![CDATA[freeradius_get_server_certs()]]></source>
 			<source_name>descr</source_name>
 			<source_value>refid</source_value>
 		</field>
-		<!-- Not needed anymore because pfsense itself can do this now>
-		<field>
-			<fielddescr>Create client.p12 for export</fielddescr>
-			<fieldname>vareapconfenableclientp12</fieldname>
-			<description><![CDATA[Choose if you would like to create a client.p12 to export it to a windows client. You need this file if you use EAP-TLS.]]></description>
-			<type>checkbox</type>
-			<enablefields>ssl_client_cert</enablefields>
-		</field>
-		<field>
-			<fielddescr>SSL Client Certificate</fielddescr>
-			<fieldname>ssl_client_cert</fieldname>
-			<description><![CDATA[Choose the SSL Client Certficate here which you created with the firewall's Cert Manager.<br>
-									Choose "none" if you do not use any kind of certificates or the freeradius Cert Manager. (Default: none)]]></description>
-			<type>select_source</type>
-			<source><![CDATA[freeradius_get_server_certs()]]></source>
-			<source_name>descr</source_name>
-			<source_value>refid</source_value>
-		</field>
-		-->
 		<field>
 			<name>EAP-TLS</name>
 			<type>listtopic</type>
@@ -239,18 +273,31 @@
 		<field>
 			<fielddescr>Include Length</fielddescr>
 			<fieldname>vareapconfincludelength</fieldname>
-			<description><![CDATA[include_length is a flag which is by default set to yes If set to yes, Total Length of the message is included in EVERY packet we send. If set to no, Total Length of the message is included ONLY in the first packet of a fragment series. (Default: Yes)]]></description>
+			<description>
+				<![CDATA[
+				If set to yes, Total Length of the message is included in EVERY packet we send.<br/>
+				If set to no, Total Length of the message is included ONLY in the first packet of a fragment series.
+				(Default: Yes)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>yes</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Fragment Size</fielddescr>
 			<fieldname>vareapconffragmentsize</fieldname>
-			<description><![CDATA[This can never exceed the size of a RADIUS packet (4096 bytes), and is preferably half that, to accomodate other attributes in RADIUS packet.  On most APs the MAX packet length is configured between 1500 - 1600 In these cases, fragment size should be 1024 or less. (Default: 1024)]]></description>
+			<description>
+				<![CDATA[
+				This can never exceed the size of a RADIUS packet (4096 bytes), and is preferably half of that,
+				to accomodate other attributes in RADIUS packet. On most APs the MAX packet length is configured between 1500 - 1600.
+				In these cases, fragment size should be 1024 or less.
+				(Default: 1024)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>1024</default_value>
 		</field>
@@ -265,37 +312,73 @@
 		<field>
 			<fielddescr>Country</fielddescr>
 			<fieldname>vareapconfcountry</fieldname>
-			<description><![CDATA[Enter the country of your CA. <b>Must</b> match the value you set in <b>SYSTEM => Cert Manager => CAs</b>. (e.g: US)]]></description>
+			<description>
+				<![CDATA[
+				Enter the country of your CA.
+				<b>Must</b> match the value you set in <a href="system_camanager.php">'System &gt; Cert Manager &gt; CAs'</a>
+				(e.g: US)
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>State or Province</fielddescr>
 			<fieldname>vareapconfstate</fieldname>
-			<description><![CDATA[Enter the state or province of your CA. <b>Must</b> match the value you set in <b>SYSTEM => Cert Manager => CAs</b>. (e.g: Texas)]]></description>
+			<description>
+				<![CDATA[
+				Enter the state or province of your CA.
+				<b>Must</b> match the value you set in <a href="system_camanager.php">'System &gt; Cert Manager &gt; CAs'</a>.
+				(e.g: Texas)
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>City</fielddescr>
 			<fieldname>vareapconfcity</fieldname>
-			<description><![CDATA[Enter the city of your CA. <b>Must</b> match the value you set in <b>SYSTEM => Cert Manager => CAs</b>. (e.g: Austin)]]></description>
+			<description>
+				<![CDATA[
+				Enter the city of your CA.
+				<b>Must</b> match the value you set in <a href="system_camanager.php">'System &gt; Cert Manager &gt; CAs'</a>.
+				(e.g: Austin)
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Organization</fielddescr>
 			<fieldname>vareapconforganization</fieldname>
-			<description><![CDATA[Enter the organization of your CA. <b>Must</b> match the value you set in <b>SYSTEM => Cert Manager => CAs</b>. (e.g: My Company Ltd)]]></description>
+			<description>
+				<![CDATA[
+				Enter the organization of your CA.
+				<b>Must</b> match the value you set in <a href="system_camanager.php">'System &gt; Cert Manager &gt; CAs'</a>.
+				(e.g: My Company Ltd)
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>E-Mail Address</fielddescr>
 			<fieldname>vareapconfemail</fieldname>
-			<description><![CDATA[Enter the e-mail address of your CA. <b>Must</b> match the value you set in <b>SYSTEM => Cert Manager => CAs</b>. (e.g: My Company Ltd)]]></description>
+			<description>
+				<![CDATA[
+				Enter the e-mail address of your CA.
+				<b>Must</b> match the value you set in <a href="system_camanager.php">'System &gt; Cert Manager &gt; CAs'</a>.
+				(e.g: My Company Ltd)
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Common Name</fielddescr>
 			<fieldname>vareapconfcommonname</fieldname>
-			<description><![CDATA[Enter the common name of your CA. <b>Must</b> match the value you set in <b>SYSTEM => Cert Manager => CAs</b>. (e.g: My Company Ltd)]]></description>
+			<description>
+				<![CDATA[
+				Enter the common name of your CA.
+				<b>Must</b> match the value you set in <a href="system_camanager.php">'System &gt; Cert Manager &gt; CAs'</a>.
+				(e.g: My Company Ltd)
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
@@ -304,13 +387,12 @@
 			<description>Validate the Client Certificate Common Name (Default: unchecked)</description>
 			<sethelp>
 				<![CDATA[
-				When enabled, the Common Name of the client certificate must match the username set in <b>FreeRADIUS => Users</b>.
+				When enabled, the Common Name of the client certificate must match the username set in
+				<a href="/pkg.php?xml=freeradius.xml">FreeRADIUS &gt; Users</a>.
 				]]>
 			</sethelp>
 			<type>checkbox</type>
 		</field>
-		
-		
 		<field>
 			<name>EAP-TLS - Enable Cache</name>
 			<type>listtopic</type>
@@ -318,35 +400,58 @@
 		<field>
 			<fielddescr>Enable cache</fielddescr>
 			<fieldname>vareapconfcacheenablecache</fieldname>
-			<description><![CDATA[Session resumption / fast reauthentication cache.<br>
-								The cache contains the following information:<br><br>
-								session Id - unique identifier, managed by SSL User-Name - from the Access-Accept Stripped-User-Name - from the Access-Request Cached-Session-Policy - from the Access-Accept<br><br>
-								The "Cached-Session-Policy" is the name of a policy which should be applied to the cached session.  This policy can be used to assign VLANs, IP addresses, etc. It serves as a useful way to re-apply the policy from the original Access-Accept to the subsequent Access-Accept for the cached session.<br><br>
-								On session resumption, these attributes are copied from the cache, and placed into the reply list. You probably also want "use_tunneled_reply = yes" when using fast session resumption. (Default: Disable)]]></description>
+			<description>
+				<![CDATA[
+				Session resumption / fast reauthentication cache.
+				<span class="text-info">Click Info for details. (Default: Disable)</span>
+				<div class="infoblock">
+				The cache contains the following information:<br/><br/>
+				<dl class="dl-horizontal responsive">
+				<dt>Session Id</dt><dd>Unique identifier, managed by SSL</dd>
+				<dt>User-Name</dt><dd>From the Access-Accept</dd>
+				<dt>Stripped-User-Name</dt><dd>From the Access-Request</dd>
+				<dt>Cached-Session-Policy</dt><dd>From the Access-Accept</dd>
+				</dl>
+				The "Cached-Session-Policy" is the name of a policy which should be applied to the cached session.
+				This policy can be used to assign VLANs, IP addresses, etc.
+				It serves as a useful way to re-apply the policy from the original Access-Accept to the subsequent Access-Accept
+				for the cached session.<br/><br/>
+				On session resumption, these attributes are copied from the cache, and placed into the reply list.
+				You probably also want "use_tunneled_reply = yes" when using fast session resumption.
+				</div>
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>Enable</name><value>yes</value></option>
-						<option><name>Disable</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Enable</name><value>yes</value></option>
+				<option><name>Disable</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Lifetime</fielddescr>
 			<fieldname>vareapconfcachelifetime</fieldname>
-			<description><![CDATA[Lifetime of the cached entries, in hours. The sessions will be deleted after this time. (Default: 24)]]></description>
+			<description>
+				<![CDATA[
+				Lifetime of the cached entries, in hours.
+				The sessions will be deleted after this time. (Default: 24)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>24</default_value>
 		</field>
 		<field>
 			<fielddescr>Max Entries</fielddescr>
 			<fieldname>vareapconfcachemaxentries</fieldname>
-			<description><![CDATA[The maximum number of entries in the cache.  Set to "0" for "infinite." (Default: 255)]]></description>
+			<description>
+				<![CDATA[
+				The maximum number of entries in the cache. Set to "0" for "infinite."
+				(Default: 255)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>255</default_value>
 		</field>
-		
-		
-		
 		<field>
 			<name>EAP-TLS with OCSP support</name>
 			<type>listtopic</type>
@@ -354,29 +459,44 @@
 		<field>
 			<fielddescr>Enable OCSP</fielddescr>
 			<fieldname>vareapconfocspenable</fieldname>
-			<description><![CDATA[Choose if you like to enable or disable OCSP support. (Default: Disable)]]></description>
+			<description>
+				<![CDATA[
+				Choose if you like to enable or disable OCSP support.
+				(Default: Disable)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>Disable</name><value>no</value></option>
-						<option><name>Enable</name><value>yes</value></option>
-					</options>
+			<options>
+				<option><name>Disable</name><value>no</value></option>
+				<option><name>Enable</name><value>yes</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Override OCSP Responder URL</fielddescr>
 			<fieldname>vareapconfocspoverridecerturl</fieldname>
-			<description><![CDATA[The OCSP responder URL is extracted from the certificate. You can override it below. (Default: no)]]></description>
+			<description>
+				<![CDATA[
+				The OCSP responder URL is extracted from the certificate. You can override it below.
+				(Default: no)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>No</name><value>no</value></option>
-						<option><name>Yes</name><value>yes</value></option>
-					</options>
+			<options>
+				<option><name>No</name><value>no</value></option>
+				<option><name>Yes</name><value>yes</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>OCSP Responder</fielddescr>
 			<fieldname>vareapconfocspurl</fieldname>
-			<description><![CDATA[Enter the URL of the OCSP responder. OCSP <b>must</b> be enabled for this to work. (Default: http://127.0.0.1/ocsp/)]]></description>
+			<description>
+				<![CDATA[
+				Enter the URL of the OCSP responder. OCSP <b>must</b> be enabled for this to work.
+				(Default: http://127.0.0.1/ocsp/)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>http://127.0.0.1/ocsp/</default_value>
 		</field>
@@ -387,50 +507,75 @@
 		<field>
 			<fielddescr>Default EAP Type</fielddescr>
 			<fieldname>vareapconfttlsdefaulteaptype</fieldname>
-			<description><![CDATA[The tunneled EAP session needs a default EAP type which is separate from the one for the non-tunneled EAP module.  Inside of the TTLS tunnel, we recommend using EAP-MD5. If the request does not contain an EAP conversation, then this configuration entry is ignored. (Default: MD5)]]></description>
+			<description>
+				<![CDATA[
+				The tunneled EAP session needs a default EAP type which is separate from the one for the non-tunneled EAP module.
+				Inside of the TTLS tunnel, we recommend using EAP-MD5.
+				If the request does not contain an EAP conversation, then this configuration entry is ignored.
+				(Default: MD5)]]></description>
 			<type>select</type>
 			<default_value>md5</default_value>
-					<options>
-						<option><name>MD5</name><value>md5</value></option>
-						<option><name>GTC</name><value>gtc</value></option>
-						<option><name>OTP</name><value>otp</value></option>
-						<option><name>TLS</name><value>tls</value></option>
-						<option><name>MSCHAPv2</name><value>mschapv2</value></option>
-					</options>
+			<options>
+				<option><name>MD5</name><value>md5</value></option>
+				<option><name>GTC</name><value>gtc</value></option>
+				<option><name>OTP</name><value>otp</value></option>
+				<option><name>TLS</name><value>tls</value></option>
+				<option><name>MSCHAPv2</name><value>mschapv2</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Copy Request to Tunnel</fielddescr>
 			<fieldname>vareapconfttlscopyrequesttotunnel</fieldname>
-			<description><![CDATA[The tunneled authentication request does not usually contain useful attributes like 'Calling-Station-Id', etc.  These attributes are outside of the tunnel, and normally unavailable to the tunneled authentication request.<br>
-								By setting this configuration entry to 'yes', any attribute which NOT in the tunneled authentication request, but which IS available outside of the tunnel, is copied to the tunneled request. (Default: no)]]></description>
+			<description>
+				<![CDATA[
+				The tunneled authentication request does not usually contain useful attributes like 'Calling-Station-Id', etc.
+				These attributes are outside of the tunnel, and normally unavailable to the tunneled authentication request.<br/>
+				By setting this configuration entry to 'yes', any attribute which NOT in the tunneled authentication request,
+				but which IS available outside of the tunnel, is copied to the tunneled request.
+				(Default: no)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>No</name><value>no</value></option>
-						<option><name>Yes</name><value>yes</value></option>
-					</options>
-		</field>		
+			<options>
+				<option><name>No</name><value>no</value></option>
+				<option><name>Yes</name><value>yes</value></option>
+			</options>
+		</field>
 		<field>
 			<fielddescr>Use Tunneled Reply</fielddescr>
 			<fieldname>vareapconfttlsusetunneledreply</fieldname>
-			<description><![CDATA[The reply attributes sent to the NAS are usually based on the name of the user 'outside' of the tunnel (usually 'anonymous').  If you want to send the reply attributes based on the user name inside of the tunnel, then set this configuration entry to 'yes', and the reply to the NAS will be taken from the reply to the tunneled request. (Default: no)]]></description>
+			<description>
+				<![CDATA[
+				The reply attributes sent to the NAS are usually based on the name of the user 'outside' of the tunnel (usually 'anonymous').
+				If you want to send the reply attributes based on the user name inside of the tunnel, then set this configuration entry to 'yes',
+				and the reply to the NAS will be taken from the reply to the tunneled request.
+				(Default: no)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>No</name><value>no</value></option>
-						<option><name>Yes</name><value>yes</value></option>
-					</options>
+			<options>
+				<option><name>No</name><value>no</value></option>
+				<option><name>Yes</name><value>yes</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Include Length</fielddescr>
 			<fieldname>vareapconfttlsincludelength</fieldname>
-			<description><![CDATA[include_length is a flag which is by default set to yes If set to yes, Total Length of the message is included in EVERY packet we send. If set to no, Total Length of the message is included ONLY in the first packet of a fragment series. (Default: Yes)]]></description>
+			<description>
+				<![CDATA[
+				If set to yes, Total Length of the message is included in EVERY packet we send.<br/>
+				If set to no, Total Length of the message is included ONLY in the first packet of a fragment series.
+				(Default: Yes)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>yes</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<name>EAP-PEAP</name>
@@ -439,50 +584,77 @@
 		<field>
 			<fielddescr>Default EAP Type</fielddescr>
 			<fieldname>vareapconfpeapdefaulteaptype</fieldname>
-			<description><![CDATA[The tunneled EAP session needs a default EAP type which is separate from the one for the non-tunneled EAP module.  Inside of the PEAP tunnel, we recommend using MS-CHAPv2, as that is the default type supported by Windows clients. (Default: MSCHAPv2)]]></description>
+			<description>
+				<![CDATA[
+				The tunneled EAP session needs a default EAP type which is separate from the one for the non-tunneled EAP module.
+				Inside of the PEAP tunnel, we recommend using MS-CHAPv2, as that is the default type supported by Windows clients.
+				(Default: MSCHAPv2)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>mschapv2</default_value>
-					<options>
-						<option><name>MD5</name><value>md5</value></option>
-						<option><name>GTC</name><value>gtc</value></option>
-						<option><name>OTP</name><value>otp</value></option>
-						<option><name>TLS</name><value>tls</value></option>
-						<option><name>MSCHAPv2</name><value>mschapv2</value></option>
-					</options>
+			<options>
+				<option><name>MD5</name><value>md5</value></option>
+				<option><name>GTC</name><value>gtc</value></option>
+				<option><name>OTP</name><value>otp</value></option>
+				<option><name>TLS</name><value>tls</value></option>
+				<option><name>MSCHAPv2</name><value>mschapv2</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Copy Request to Tunnel</fielddescr>
 			<fieldname>vareapconfpeapcopyrequesttotunnel</fieldname>
-			<description><![CDATA[The tunneled authentication request does not usually contain useful attributes like 'Calling-Station-Id', etc.  These attributes are outside of the tunnel, and normally unavailable to the tunneled authentication request.<br>
-								By setting this configuration entry to 'yes', any attribute which NOT in the tunneled authentication request, but which IS available outside of the tunnel, is copied to the tunneled request. (Default: no)]]></description>
+			<description>
+				<![CDATA[
+				The tunneled authentication request does not usually contain useful attributes like 'Calling-Station-Id', etc.
+				These attributes are outside of the tunnel, and normally unavailable to the tunneled authentication request.<br/>
+				By setting this configuration entry to 'yes', any attribute which NOT in the tunneled authentication request,
+				but which IS available outside of the tunnel, is copied to the tunneled request.
+				(Default: no)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>No</name><value>no</value></option>
-						<option><name>Yes</name><value>yes</value></option>
-					</options>
-		</field>		
+			<options>
+				<option><name>No</name><value>no</value></option>
+				<option><name>Yes</name><value>yes</value></option>
+			</options>
+		</field>
 		<field>
 			<fielddescr>Use Tunneled Reply</fielddescr>
 			<fieldname>vareapconfpeapusetunneledreply</fieldname>
-			<description><![CDATA[The reply attributes sent to the NAS are usually based on the name of the user 'outside' of the tunnel (usually 'anonymous').  If you want to send the reply attributes based on the user name inside of the tunnel, then set this configuration entry to 'yes', and the reply to the NAS will be taken from the reply to the tunneled request. (Default: no)]]></description>
+			<description>
+				<![CDATA[
+				The reply attributes sent to the NAS are usually based on the name of the user 'outside' of the tunnel (usually 'anonymous').
+				If you want to send the reply attributes based on the user name inside of the tunnel, then set this configuration entry to 'yes',
+				and the reply to the NAS will be taken from the reply to the tunneled request.
+				(Default: no)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>No</name><value>no</value></option>
-						<option><name>Yes</name><value>yes</value></option>
-					</options>
+			<options>
+				<option><name>No</name><value>no</value></option>
+				<option><name>Yes</name><value>yes</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Microsoft Statement of Health (SoH) Support</fielddescr>
 			<fieldname>vareapconfpeapsohenable</fieldname>
-			<description><![CDATA[You can accept/reject clients based on Microsoft's Statement of Health, such as if they are missing Windows updates, don't have a firewall enabled, antivirus not in line with policy, etc. You need to change server-file for your needs. It cannot be changed from GUI and will be deleted after package reinstallation. (/usr/local/etc/raddb/sites-available/soh). (Default: Disable)]]></description>
+			<description>
+				<![CDATA[
+				You can accept/reject clients based on Microsoft's Statement of Health, such as if they are missing Windows updates,
+				don't have a firewall enabled, antivirus not in line with policy, etc. You need to change server-file for your needs.
+				It cannot be changed from GUI and will be deleted after package reinstallation. (See /usr/local/etc/raddb/sites-available/soh).
+				(Default: Disable)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>Disable</default_value>
-					<options>
-						<option><name>Disable</name><value>Disable</value></option>
-						<option><name>Enable</name><value>Enable</value></option>
-					</options>
+			<options>
+				<option><name>Disable</name><value>Disable</value></option>
+				<option><name>Enable</name><value>Enable</value></option>
+			</options>
 		</field>
 	</fields>
 	<custom_delete_php_command>

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradiusinterfaces.xml
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradiusinterfaces.xml
@@ -3,12 +3,12 @@
 <?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-<![CDATA[	
+<![CDATA[
 /*
  * freeradiusinterfaces.xml
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2013 Alexander Wilke <nachtfalkeaw@web.de>
  * All rights reserved.
  *
@@ -29,9 +29,6 @@
  * limitations under the License.
  */
 ]]>	</copyright>
-	<description><![CDATA[Describe your package here]]></description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiusinterfaces</name>
 	<title>FreeRADIUS: Interfaces</title>
 	<include_file>/usr/local/pkg/freeradius.inc</include_file>
@@ -109,11 +106,16 @@
 		<field>
 			<name>General Configuration</name>
 			<type>listtopic</type>
-		</field>	
+		</field>
 		<field>
 			<fielddescr>Interface IP Address</fielddescr>
 			<fieldname>varinterfaceip</fieldname>
-			<description><![CDATA[Enter the IP address (e.g. 192.168.100.1) of the listening interface. If you choose <b>*</b> then it means all interfaces. (Default: *)]]></description>
+			<description>
+				<![CDATA[
+				Enter the IP address (e.g. 192.168.100.1) of the listening interface.
+				If you choose <b>*</b> then it means all interfaces. (Default: *)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>*</default_value>
 			<required/>
@@ -121,12 +123,22 @@
 		<field>
 			<fielddescr>Port</fielddescr>
 			<fieldname>varinterfaceport</fieldname>
-			<description><![CDATA[Enter the port number of the listening interface. Different interface types need different ports.<br>
-							You could use this as an example:<br>
-							Authentication  = 1812<br>
-							Accounting  = 1813<br>
-							Status = 1816<br>
-							<b>IMPORTANT:</b> For <b>every interface type</b> listening on the <b>same IP address</b> you need <b>different ports</b>.]]></description>
+			<description>
+				<![CDATA[
+				Enter the port number of the listening interface. Different interface types need different ports.
+				Click Info for details.
+				<div class="infoblock">
+				You could use this as an example:
+				<dl class="dl-horizontal responsive">
+				<dt>Authentication</dt><dd>Using port 1812</dd>
+				<dt>Accounting</dt><dd>Using port 1813</dd>
+				<dt>Status</dt><dd>Using port 1816</dd>
+				</dl>
+				<strong><span class="text-danger">IMPORTANT: </span><strong>
+				For <b>every interface type</b> listening on the <b>same IP address</b> you need <b>different ports</b>.
+				</div>
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>1812</default_value>
 			<required/>
@@ -134,35 +146,49 @@
 		<field>
 			<fielddescr>Interface Type</fielddescr>
 			<fieldname>varinterfacetype</fieldname>
-			<description><![CDATA[Enter the type of the listening interface. (Default: auth)]]></description>
+			<description>
+				<![CDATA[
+				Enter the type of the listening interface.
+				(Default: auth)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>auth</default_value>
-					<options>
-						<option><name>Authentication</name><value>auth</value></option>
-						<option><name>Accounting</name><value>acct</value></option>
-						<option><name>Proxy</name><value>proxy</value></option>
-						<option><name>Detail</name><value>detail</value></option>
-						<option><name>Status</name><value>status</value></option>
-						<option><name>CoA</name><value>coa</value></option>
-					</options>
+			<options>
+				<option><name>Authentication</name><value>auth</value></option>
+				<option><name>Accounting</name><value>acct</value></option>
+				<option><name>Proxy</name><value>proxy</value></option>
+				<option><name>Detail</name><value>detail</value></option>
+				<option><name>Status</name><value>status</value></option>
+				<option><name>CoA</name><value>coa</value></option>
+			</options>
 			<required/>
 		</field>
 		<field>
 			<fielddescr>IP Version</fielddescr>
 			<fieldname>varinterfaceipversion</fieldname>
-			<description><![CDATA[Enter the IP version of the listening interface. (Default: IPv4)]]></description>
+			<description>
+				<![CDATA[
+				Enter the IP version of the listening interface.
+				(Default: IPv4)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>ipaddr</default_value>
-					<options>
-						<option><name>IPv4</name><value>ipaddr</value></option>
-						<option><name>IPv6</name><value>ipv6addr</value></option>
-					</options>
+			<options>
+				<option><name>IPv4</name><value>ipaddr</value></option>
+				<option><name>IPv6</name><value>ipv6addr</value></option>
+			</options>
 			<required/>
 		</field>
 		<field>
 			<fielddescr>Description</fielddescr>
 			<fieldname>description</fieldname>
-			<description><![CDATA[Optionally enter a description here for your reference.]]></description>
+			<description>
+				<![CDATA[
+				Optionally enter a description here for your reference.
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 	</fields>

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradiusmodulesldap.xml
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradiusmodulesldap.xml
@@ -3,12 +3,12 @@
 <?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-<![CDATA[	
+<![CDATA[
 /*
  * freeradiusmodulesldap.xml
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2013 Alexander Wilke <nachtfalkeaw@web.de>
  * All rights reserved.
  *
@@ -29,9 +29,6 @@
  * limitations under the License.
  */
 ]]>	</copyright>
-	<description><![CDATA[Describe your package here]]></description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiusmodulesldap</name>
 	<title>FreeRADIUS: LDAP</title>
 	<aftersaveredirect>pkg_edit.php?xml=freeradiusmodulesldap.xml&amp;id=0</aftersaveredirect>
@@ -85,9 +82,9 @@
 	</tabs>
 	<fields>
 		<field>
-			<name>ENABLE LDAP SUPPORT - SERVER 1</name>
+			<name>Enable LDAP Support - Server 1</name>
 			<type>listtopic</type>
-		</field>		
+		</field>
 		<field>
 			<fielddescr>LDAP Authorization Support</fielddescr>
 			<fieldname>varmodulesldapenableauthorize</fieldname>
@@ -115,13 +112,17 @@
 			<type>checkbox</type>
 		</field>
 		<field>
-			<name>General Configuration - SERVER 1</name>
+			<name>General Configuration - Server 1</name>
 			<type>listtopic</type>
 		</field>
 		<field>
 			<fielddescr>Server</fielddescr>
 			<fieldname>varmodulesldapserver</fieldname>
-			<description><![CDATA[No description. (Default: ldap.your.domain )]]></description>
+			<description>
+				<![CDATA[
+				LDAP server FQDN or IP address. (Default: ldap.your.domain)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>ldap.your.domain</default_value>
@@ -129,7 +130,11 @@
 		<field>
 			<fielddescr>Port</fielddescr>
 			<fieldname>varmodulesldapserverport</fieldname>
-			<description><![CDATA[No description. (Default: 389 )]]></description>
+			<description>
+				<![CDATA[
+				LDAP server port. (Default: 389)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>389</default_value>
@@ -137,7 +142,11 @@
 		<field>
 			<fielddescr>Identity</fielddescr>
 			<fieldname>varmodulesldapidentity</fieldname>
-			<description><![CDATA[No description. (Default: cn=admin,o=My Org,c=UA )]]></description>
+			<description>
+				<![CDATA[
+				LDAP ID for authentication. (Default: cn=admin,o=My Org,c=UA)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value><![CDATA[cn=admin,o=My Org,c=UA]]></default_value>
@@ -145,15 +154,23 @@
 		<field>
 			<fielddescr>Password</fielddescr>
 			<fieldname>varmodulesldappassword</fieldname>
-			<description><![CDATA[No description. (Default: mypass)]]></description>
+			<description>
+				<![CDATA[
+				LDAP password for authentication. (Default: mypass)
+				]]>
+			</description>
 			<type>password</type>
 			<size>80</size>
 			<default_value>mypass</default_value>
 		</field>
 		<field>
-			<fielddescr>Basedn</fielddescr>
+			<fielddescr>Base DN</fielddescr>
 			<fieldname>varmodulesldapbasedn</fieldname>
-			<description><![CDATA[No description (Default: o=My Org,c=UA )]]></description>
+			<description>
+				<![CDATA[
+				Base DN for LDAP search. (Default: o=My Org,c=UA)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value><![CDATA[o=My Org,c=UA]]></default_value>
@@ -161,7 +178,11 @@
 		<field>
 			<fielddescr>Filter</fielddescr>
 			<fieldname>varmodulesldapfilter</fieldname>
-			<description><![CDATA[No description. (Default:   (uid=%{%{Stripped-User-Name}:-%{User-Name}})   )]]></description>
+			<description>
+				<![CDATA[
+				LDAP search filter. Default: (uid=%{%{Stripped-User-Name}:-%{User-Name}})
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value><![CDATA[(uid=%{%{Stripped-User-Name}:-%{User-Name}})]]></default_value>
@@ -169,7 +190,11 @@
 		<field>
 			<fielddescr>Base Filter</fielddescr>
 			<fieldname>varmodulesldapbasefilter</fieldname>
-			<description><![CDATA[No description. (Default:   (objectclass=radiusprofile)   )]]></description>
+			<description>
+				<![CDATA[
+				Default: (objectclass=radiusprofile)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value><![CDATA[(objectclass=radiusprofile)]]></default_value>
@@ -177,7 +202,13 @@
 		<field>
 			<fielddescr>LDAP Connections Number</fielddescr>
 			<fieldname>varmodulesldapldapconnectionsnumber</fieldname>
-			<description><![CDATA[How many connections to keep open to the LDAP server. This saves time over opening a new LDAP socket for every authentication request. (Default: 5)]]></description>
+			<description>
+				<![CDATA[
+				How many connections to keep open to the LDAP server.
+				This saves time over opening a new LDAP socket for every authentication request.
+				(Default: 5)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>5</default_value>
@@ -185,44 +216,63 @@
 		<field>
 			<fielddescr>Timeout</fielddescr>
 			<fieldname>varmodulesldaptimeout</fieldname>
-			<description><![CDATA[Seconds to wait for LDAP query to finish. (Default: 4)]]></description>
+			<description>
+				<![CDATA[
+				Seconds to wait for LDAP query to finish. (Default: 4)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>4</default_value>
 		</field>
 		<field>
-			<fielddescr>Timelimit</fielddescr>
+			<fielddescr>Time Limit</fielddescr>
 			<fieldname>varmodulesldaptimelimit</fieldname>
-			<description><![CDATA[Seconds the LDAP server has to process the query (server-side time limit). (Default: 3)]]></description>
+			<description>
+				<![CDATA[
+				Seconds the LDAP server has to process the query (server-side time limit).
+				(Default: 3)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>3</default_value>
 		</field>
 		<field>
-			<fielddescr>Net Timeout</fielddescr>
+			<fielddescr>Network Timeout</fielddescr>
 			<fieldname>varmodulesldapnettimeout</fieldname>
-			<description><![CDATA[Seconds to wait for response of the server because of network failures. (Default: 1)]]></description>
+			<description>
+				<![CDATA[
+				Seconds to wait for response of the server because of network failures.
+				(Default: 1)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>1</default_value>
 		</field>
 		<field>
-			<name>Miscellaneous Configuration - SERVER 1</name>
+			<name>Miscellaneous Configuration - Server 1</name>
 			<type>listtopic</type>
 		</field>
 		<field>
 			<fielddescr>Active Directory Compatibility</fielddescr>
 			<fieldname>varmodulesldapmsadcompatibilityenable</fieldname>
-			<description><![CDATA[If you see the helpful "operations error" being returned to the LDAP module enable this. (Default: Disable)]]></description>
+			<description>
+				<![CDATA[
+				If you see the helpful "operations error" being returned to the LDAP module, enable this.
+				(Default: Disable)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>Disable</default_value>
-					<options>
-						<option><name>Disable</name><value>Disable</value></option>
-						<option><name>Enable</name><value>Enable</value></option>
-					</options>
+			<options>
+				<option><name>Disable</name><value>Disable</value></option>
+				<option><name>Enable</name><value>Enable</value></option>
+			</options>
 		</field>
 		<field>
-			<fielddescr>Misc Configuration - SERVER 1</fielddescr>
+			<fielddescr>Misc Configuration - Server 1</fielddescr>
 			<fieldname>varmodulesldapdmiscenable</fieldname>
 			<description>Enable Miscellaneous Configuration for Server 1 (Default: unchecked)</description>
 			<sethelp>By default the options below are not active in the configuration.</sethelp>
@@ -232,7 +282,11 @@
 		<field>
 			<fielddescr>Default Profile</fielddescr>
 			<fieldname>varmodulesldapdefaultprofile</fieldname>
-			<description><![CDATA[No description. (Default: cn=radprofile,ou=dialup,o=My Org,c=UA )]]></description>
+			<description>
+				<![CDATA[
+				(Default: cn=radprofile,ou=dialup,o=My Org,c=UA)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value><![CDATA[cn=radprofile,ou=dialup,o=My Org,c=UA]]></default_value>
@@ -240,7 +294,11 @@
 		<field>
 			<fielddescr>Profile Attribute</fielddescr>
 			<fieldname>varmodulesldapprofileattribute</fieldname>
-			<description><![CDATA[No description. (Default: radiusProfileDn)]]></description>
+			<description>
+				<![CDATA[
+				(Default: radiusProfileDn)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>radiusProfileDn</default_value>
@@ -248,13 +306,17 @@
 		<field>
 			<fielddescr>Access Attribute</fielddescr>
 			<fieldname>varmodulesldapaccessattr</fieldname>
-			<description><![CDATA[No description. (Default: dialupAccess)]]></description>
+			<description>
+				<![CDATA[
+				(Default: dialupAccess)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>dialupAccess</default_value>
 		</field>
 		<field>
-			<name>Group Membership Options - SERVER 1</name>
+			<name>Group Membership Options - Server 1</name>
 			<type>listtopic</type>
 		</field>
 		<field>
@@ -268,23 +330,35 @@
 		<field>
 			<fielddescr>Groupname Attribute</fielddescr>
 			<fieldname>varmodulesldapgroupnameattribute</fieldname>
-			<description><![CDATA[No description. (Default: cn)]]></description>
+			<description>
+				<![CDATA[
+				(Default: cn)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>cn</default_value>
 		</field>
 		<field>
-			<fielddescr>Groupmembership Filter</fielddescr>
+			<fielddescr>Group Membership Filter</fielddescr>
 			<fieldname>varmodulesldapgroupmembershipfilter</fieldname>
-			<description><![CDATA[No description. (Default: (|(&(objectClass=GroupOfNames)(member=%{control:Ldap-UserDn}))(&(objectClass=GroupOfUniqueNames)(uniquemember=%{control:Ldap-UserDn})))  )]]></description>
+			<description>
+				<![CDATA[
+				Default: (|(&(objectClass=GroupOfNames)(member=%{control:Ldap-UserDn}))(&(objectClass=GroupOfUniqueNames)(uniquemember=%{control:Ldap-UserDn})))  )
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value><![CDATA[(|(&(objectClass=GroupOfNames)(member=%{control:Ldap-UserDn}))(&(objectClass=GroupOfUniqueNames)(uniquemember=%{control:Ldap-UserDn})))]]></default_value>
 		</field>
 		<field>
-			<fielddescr>Groupmembership Attribute</fielddescr>
+			<fielddescr>Group Membership Attribute</fielddescr>
 			<fieldname>varmodulesldapgroupmembershipattribute</fieldname>
-			<description><![CDATA[No description. (Default: radiusGroupName)]]></description>
+			<description>
+				<![CDATA[
+				(Default: radiusGroupName)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>radiusGroupName</default_value>
@@ -292,70 +366,94 @@
 		<field>
 			<fielddescr>Compare Check Items</fielddescr>
 			<fieldname>varmodulesldapcomparecheckitems</fieldname>
-			<description><![CDATA[No description. (Default: Yes)]]></description>
+			<description>
+				<![CDATA[
+				(Default: Yes)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>Yes</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Do XLAT</fielddescr>
 			<fieldname>varmodulesldapdoxlat</fieldname>
-			<description><![CDATA[No description. (Default: Yes)]]></description>
+			<description>
+				<![CDATA[
+				(Default: Yes)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>Yes</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Access Attribute Used For Allow</fielddescr>
 			<fieldname>varmodulesldapaccessattrusedforallow</fieldname>
-			<description><![CDATA[No description. (Default: Yes)]]></description>
+			<description>
+				<![CDATA[
+				(Default: Yes)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>Yes</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
-			<name>KEEPALIVE CONFIGURATION - SERVER 1</name>
+			<name>KeepAlive Configuration - Server 1</name>
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>LDAP OPT X KEEPALIVE IDLE</fielddescr>
+			<fielddescr>LDAP OPT X KeepAlive Idle</fielddescr>
 			<fieldname>varmodulesldapkeepaliveidle</fieldname>
-			<description><![CDATA[No description. (Default: 60)]]></description>
+			<description>
+				<![CDATA[
+				(Default: 60)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>60</default_value>
 		</field>
 		<field>
-			<fielddescr>LDAP OPT X KEEPALIVE PROBES</fielddescr>
+			<fielddescr>LDAP OPT X KeepAlive Probes</fielddescr>
 			<fieldname>varmodulesldapkeepaliveprobes</fieldname>
-			<description><![CDATA[No description. (Default: 3)]]></description>
+			<description>
+				<![CDATA[
+				(Default: 3)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>3</default_value>
 		</field>
 		<field>
-			<fielddescr>LDAP OPT X KEEPALIVE INTERVAL</fielddescr>
+			<fielddescr>LDAP OPT X KeepAlive Interval</fielddescr>
 			<fieldname>varmodulesldapkeepaliveinterval</fieldname>
-			<description><![CDATA[No description. (Default: 3)]]></description>
+			<description>
+				<![CDATA[
+				(Default: 3)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>3</default_value>
 		</field>
 		<field>
-			<name>LDAP TLS SUPPORT - SERVER 1</name>
+			<name>LDAP TLS Support - Server 1</name>
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>TLS support</fielddescr>
+			<fielddescr>TLS Support</fielddescr>
 			<fieldname>varmodulesldapenabletlssupport</fieldname>
 			<description>Enable TLS support for LDAP server 1</description>
 			<sethelp>
@@ -369,8 +467,13 @@
 		<field>
 			<fielddescr>SSL CA Certificate</fielddescr>
 			<fieldname>ssl_ca_cert1</fieldname>
-			<description><![CDATA[Choose the SSL CA Certficate here which you created with the firewall's Cert Manager.<br>
-									Choose "none" if you do not use any kind of certificates or the freeradius Cert Manager. (Default: none)]]></description>
+			<description>
+				<![CDATA[
+				Choose the SSL CA Certficate here which you created with the firewall's Cert Manager.<br/>
+				Choose "none" if you do not use any kind of certificates or are using the deprecated FreeRADIUS Cert Manager.
+				(Default: none)
+				]]>
+			</description>
 			<type>select_source</type>
 			<source><![CDATA[freeradius_get_ca_certs()]]></source>
 			<source_name>descr</source_name>
@@ -379,8 +482,13 @@
 		<field>
 			<fielddescr>SSL Server Certificate</fielddescr>
 			<fieldname>ssl_server_cert1</fieldname>
-			<description><![CDATA[Choose the SSL Server Certficate here which you created with the firewall's Cert Manager.<br>
-									Choose "none" if you do not use any kind of certificates or the freeradius Cert Manager. (Default: none)]]></description>
+			<description>
+				<![CDATA[
+				Choose the SSL Server Certficate here which you created with the firewall's Cert Manager.<br/>
+				Choose "none" if you do not use any kind of certificates or are using the deprecated FreeRADIUS Cert Manager.
+				(Default: none)
+				]]>
+			</description>
 			<type>select_source</type>
 			<source><![CDATA[freeradius_get_server_certs()]]></source>
 			<source_name>descr</source_name>
@@ -389,42 +497,51 @@
 		<field>
 			<fielddescr>Choose certificate verification method</fielddescr>
 			<fieldname>varmodulesldaprequirecert</fieldname>
-			<description><![CDATA[Choose how the certs should be checked:<br><br>
-			
-									<b>never: </b>don't even bother trying<br>
-									<b>allow: </b>try but don't fail if the certificate can't be verified<br>
-									<b>demand: </b>fail if the certificate doesn't verify]]></description>
+			<description>
+				<![CDATA[
+				Choose how the certs should be checked. (Default: never)<br/>
+				<dl class="dl-horizontal responsive">
+				<dt>Never</dt><dd>Don't even bother trying.</dd>
+				<dt>Allow</dt><dd>Try but don't fail if the certificate can't be verified.</dd>
+				<dt>Demand</dt><dd>Fail if the certificate doesn't verify.</dd>
+				</dl>
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>never</default_value>
-					<options>
-						<option><name>Never</name><value>never</value></option>
-						<option><name>Allow</name><value>allow</value></option>
-						<option><name>Demand</name><value>demand</value></option>
-					</options>
+			<options>
+				<option><name>Never</name><value>never</value></option>
+				<option><name>Allow</name><value>allow</value></option>
+				<option><name>Demand</name><value>demand</value></option>
+			</options>
 		</field>
-		
-		
 		<field>
-			<name>ENABLE REDUNDANT LDAP SERVER SUPPORT</name>
+			<name>Enable Redundant LDAP Server Support</name>
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>Choose Failover/Loadbalancing Mode</fielddescr>
+			<fielddescr>Choose Failover/Load Balancing Mode</fielddescr>
 			<fieldname>varmodulesldap2failover</fieldname>
-			<description><![CDATA[Choose the interaction of the two LDAP servers: (Default: redundant)<br><br>
-								<b>redundant:</b> If server 1 fails failover to server 2<br>
-								<b>load-balance:</b> The load is balanced 50:50 to both servers<br>
-								<b>redundant-load-balance:</b> The load is balanced 50:50 to both servers. If one is down the other does 100%.]]></description>
+			<description>
+				<![CDATA[
+				Choose the interaction of the two LDAP servers. (Default: redundant)<br/>
+				<dl class="dl-horizontal responsive">
+				<dt>Redundant</dt><dd>If server1 fails failover to server2.</dd>
+				<dt>Load-Balance</dt><dd>The load is balanced 50:50 to both servers.</dd>
+				<dt>Redundant-Load-Balance</dt><dd>The load is balanced 50:50 to both servers. If one is down the other does 100%.</dd>
+				</dl>
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>redundant</default_value>
-					<options>
-						<option><name>Redundant</name><value>redundant</value></option>
-						<option><name>Load-Balance</name><value>load-balance</value></option>
-						<option><name>Redundant-Load-Balance</name><value>redundant-load-balance</value></option>
-					</options>
+			<options>
+				<option><name>Redundant</name><value>redundant</value></option>
+				<option><name>Load-Balance</name><value>load-balance</value></option>
+				<option><name>Redundant-Load-Balance</name><value>redundant-load-balance</value></option>
+			</options>
 		</field>
 		<field>
-			<name>ENABLE LDAP SUPPORT - SERVER 2</name>
+			<name>Enable LDAP Support - Server 2</name>
 			<type>listtopic</type>
 		</field>
 		<field>
@@ -454,13 +571,17 @@
 			<type>checkbox</type>
 		</field>
 		<field>
-			<name>General Configuration - SERVER 2</name>
+			<name>General Configuration - Server 2</name>
 			<type>listtopic</type>
 		</field>
 		<field>
 			<fielddescr>Server</fielddescr>
 			<fieldname>varmodulesldap2server</fieldname>
-			<description><![CDATA[No description. (Default: ldap.your.domain )]]></description>
+			<description>
+				<![CDATA[
+				LDAP server FQDN or IP address. (Default: ldap.your.domain)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>ldap.your.domain</default_value>
@@ -468,7 +589,11 @@
 		<field>
 			<fielddescr>Port</fielddescr>
 			<fieldname>varmodulesldap2serverport</fieldname>
-			<description><![CDATA[No description. (Default: 389 )]]></description>
+			<description>
+				<![CDATA[
+				LDAP server port. (Default: 389)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>389</default_value>
@@ -476,7 +601,11 @@
 		<field>
 			<fielddescr>Identity</fielddescr>
 			<fieldname>varmodulesldap2identity</fieldname>
-			<description><![CDATA[No description. (Default: cn=admin,o=My Org,c=UA )]]></description>
+			<description>
+				<![CDATA[
+				LDAP ID for authentication. (Default: cn=admin,o=My Org,c=UA)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value><![CDATA[cn=admin,o=My Org,c=UA]]></default_value>
@@ -484,15 +613,23 @@
 		<field>
 			<fielddescr>Password</fielddescr>
 			<fieldname>varmodulesldap2password</fieldname>
-			<description><![CDATA[No description. (Default: mypass)]]></description>
+			<description>
+				<![CDATA[
+				LDAP password for authentication. (Default: mypass)
+				]]>
+			</description>
 			<type>password</type>
 			<size>80</size>
 			<default_value>mypass</default_value>
 		</field>
 		<field>
-			<fielddescr>Basedn</fielddescr>
+			<fielddescr>Base DN</fielddescr>
 			<fieldname>varmodulesldap2basedn</fieldname>
-			<description><![CDATA[No description (Default: o=My Org,c=UA )]]></description>
+			<description>
+				<![CDATA[
+				Base DN for LDAP search. (Default: o=My Org,c=UA)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value><![CDATA[o=My Org,c=UA]]></default_value>
@@ -500,7 +637,11 @@
 		<field>
 			<fielddescr>Filter</fielddescr>
 			<fieldname>varmodulesldap2filter</fieldname>
-			<description><![CDATA[No description. (Default:   (uid=%{%{Stripped-User-Name}:-%{User-Name}})   )]]></description>
+			<description>
+				<![CDATA[
+				LDAP search filter. Default: (uid=%{%{Stripped-User-Name}:-%{User-Name}})
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value><![CDATA[(uid=%{%{Stripped-User-Name}:-%{User-Name}})]]></default_value>
@@ -508,7 +649,11 @@
 		<field>
 			<fielddescr>Base Filter</fielddescr>
 			<fieldname>varmodulesldap2basefilter</fieldname>
-			<description><![CDATA[No description. (Default:   (objectclass=radiusprofile)   )]]></description>
+			<description>
+				<![CDATA[
+				Default: (objectclass=radiusprofile)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value><![CDATA[(objectclass=radiusprofile)]]></default_value>
@@ -516,7 +661,13 @@
 		<field>
 			<fielddescr>LDAP Connections Number</fielddescr>
 			<fieldname>varmodulesldap2ldapconnectionsnumber</fieldname>
-			<description><![CDATA[How many connections to keep open to the LDAP server. This saves time over opening a new LDAP socket for every authentication request. (Default: 5)]]></description>
+			<description>
+				<![CDATA[
+				How many connections to keep open to the LDAP server.
+				This saves time over opening a new LDAP socket for every authentication request.
+				(Default: 5)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>5</default_value>
@@ -524,41 +675,60 @@
 		<field>
 			<fielddescr>Timeout</fielddescr>
 			<fieldname>varmodulesldap2timeout</fieldname>
-			<description><![CDATA[Seconds to wait for LDAP query to finish. (Default: 4)]]></description>
+			<description>
+				<![CDATA[
+				Seconds to wait for LDAP query to finish. (Default: 4)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>4</default_value>
 		</field>
 		<field>
-			<fielddescr>Timelimit</fielddescr>
+			<fielddescr>Time Limit</fielddescr>
 			<fieldname>varmodulesldap2timelimit</fieldname>
-			<description><![CDATA[Seconds the LDAP server has to process the query (server-side time limit). (Default: 3)]]></description>
+			<description>
+				<![CDATA[
+				Seconds the LDAP server has to process the query (server-side time limit).
+				(Default: 3)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>3</default_value>
 		</field>
 		<field>
-			<fielddescr>Net Timeout</fielddescr>
+			<fielddescr>Network Timeout</fielddescr>
 			<fieldname>varmodulesldap2nettimeout</fieldname>
-			<description><![CDATA[Seconds to wait for response of the server because of network failures. (Default: 1)]]></description>
+			<description>
+				<![CDATA[
+				Seconds to wait for response of the server because of network failures.
+				(Default: 1)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>1</default_value>
 		</field>
 		<field>
-			<name>Miscellaneous Configuration - SERVER 2</name>
+			<name>Miscellaneous Configuration - Server 2</name>
 			<type>listtopic</type>
 		</field>
 		<field>
 			<fielddescr>Active Directory Compatibility</fielddescr>
 			<fieldname>varmodulesldap2msadcompatibilityenable</fieldname>
-			<description><![CDATA[If you see the helpful "operations error" being returned to the LDAP module enable this. (Default: Disable)]]></description>
+			<description>
+				<![CDATA[
+				If you see the helpful "operations error" being returned to the LDAP module, enable this.
+				(Default: Disable)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>Disable</default_value>
-					<options>
-						<option><name>Disable</name><value>Disable</value></option>
-						<option><name>Enable</name><value>Enable</value></option>
-					</options>
+			<options>
+				<option><name>Disable</name><value>Disable</value></option>
+				<option><name>Enable</name><value>Enable</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Misc Configuration</fielddescr>
@@ -571,7 +741,11 @@
 		<field>
 			<fielddescr>Default Profile</fielddescr>
 			<fieldname>varmodulesldap2defaultprofile</fieldname>
-			<description><![CDATA[No description. (Default: cn=radprofile,ou=dialup,o=My Org,c=UA )]]></description>
+			<description>
+				<![CDATA[
+				(Default: cn=radprofile,ou=dialup,o=My Org,c=UA)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value><![CDATA[cn=radprofile,ou=dialup,o=My Org,c=UA]]></default_value>
@@ -579,7 +753,11 @@
 		<field>
 			<fielddescr>Profile Attribute</fielddescr>
 			<fieldname>varmodulesldap2profileattribute</fieldname>
-			<description><![CDATA[No description. (Default: radiusProfileDn)]]></description>
+			<description>
+				<![CDATA[
+				(Default: radiusProfileDn)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>radiusProfileDn</default_value>
@@ -587,13 +765,17 @@
 		<field>
 			<fielddescr>Access Attribute</fielddescr>
 			<fieldname>varmodulesldap2accessattr</fieldname>
-			<description><![CDATA[No description. (Default: dialupAccess)]]></description>
+			<description>
+				<![CDATA[
+				(Default: dialupAccess)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>dialupAccess</default_value>
 		</field>
 		<field>
-			<name>Group Membership Options - SERVER 2</name>
+			<name>Group Membership Options - Server 2</name>
 			<type>listtopic</type>
 		</field>
 		<field>
@@ -607,23 +789,35 @@
 		<field>
 			<fielddescr>Groupname Attribute</fielddescr>
 			<fieldname>varmodulesldap2groupnameattribute</fieldname>
-			<description><![CDATA[No description. (Default: cn)]]></description>
+			<description>
+				<![CDATA[
+				(Default: cn)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>cn</default_value>
 		</field>
 		<field>
-			<fielddescr>Groupmembership Filter</fielddescr>
+			<fielddescr>Group Membership Filter</fielddescr>
 			<fieldname>varmodulesldap2groupmembershipfilter</fieldname>
-			<description><![CDATA[No description. (Default: (|(&(objectClass=GroupOfNames)(member=%{control:Ldap-UserDn}))(&(objectClass=GroupOfUniqueNames)(uniquemember=%{control:Ldap-UserDn})))  )]]></description>
+			<description>
+				<![CDATA[
+				Default: (|(&(objectClass=GroupOfNames)(member=%{control:Ldap-UserDn}))(&(objectClass=GroupOfUniqueNames)(uniquemember=%{control:Ldap-UserDn})))  )
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value><![CDATA[(|(&(objectClass=GroupOfNames)(member=%{control:Ldap-UserDn}))(&(objectClass=GroupOfUniqueNames)(uniquemember=%{control:Ldap-UserDn})))]]></default_value>
 		</field>
 		<field>
-			<fielddescr>Groupmembership Attribute</fielddescr>
+			<fielddescr>Group Membership Attribute</fielddescr>
 			<fieldname>varmodulesldap2groupmembershipattribute</fieldname>
-			<description><![CDATA[No description. (Default: radiusGroupName)]]></description>
+			<description>
+				<![CDATA[
+				(Default: radiusGroupName)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>radiusGroupName</default_value>
@@ -631,24 +825,32 @@
 		<field>
 			<fielddescr>Compare Check Items</fielddescr>
 			<fieldname>varmodulesldap2comparecheckitems</fieldname>
-			<description><![CDATA[No description. (Default: Yes)]]></description>
+			<description>
+				<![CDATA[
+				(Default: Yes)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>Yes</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Do XLAT</fielddescr>
 			<fieldname>varmodulesldap2doxlat</fieldname>
-			<description><![CDATA[No description. (Default: Yes)]]></description>
+			<description>
+				<![CDATA[
+				(Default: Yes)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>Yes</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Access Attribute Used For Allow</fielddescr>
@@ -662,35 +864,47 @@
 					</options>
 		</field>
 		<field>
-			<name>KEEPALIVE CONFIGURATION - SERVER 2</name>
+			<name>KeepAlive Configuration - Server 2</name>
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>LDAP OPT X KEEPALIVE IDLE</fielddescr>
+			<fielddescr>LDAP OPT X KeepAlive Idle</fielddescr>
 			<fieldname>varmodulesldap2keepaliveidle</fieldname>
-			<description><![CDATA[No description. (Default: 60)]]></description>
+			<description>
+				<![CDATA[
+				(Default: 60)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>60</default_value>
 		</field>
 		<field>
-			<fielddescr>LDAP OPT X KEEPALIVE PROBES</fielddescr>
+			<fielddescr>LDAP OPT X KeepAlive Probes</fielddescr>
 			<fieldname>varmodulesldap2keepaliveprobes</fieldname>
-			<description><![CDATA[No description. (Default: 3)]]></description>
+			<description>
+				<![CDATA[
+				(Default: 3)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>3</default_value>
 		</field>
 		<field>
-			<fielddescr>LDAP OPT X KEEPALIVE INTERVAL</fielddescr>
+			<fielddescr>LDAP OPT X KeepAlive Interval</fielddescr>
 			<fieldname>varmodulesldap2keepaliveinterval</fieldname>
-			<description><![CDATA[No description. (Default: 3)]]></description>
+			<description>
+				<![CDATA[
+				(Default: 3)
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 			<default_value>3</default_value>
 		</field>
 		<field>
-			<name>LDAP TLS SUPPORT - SERVER 2</name>
+			<name>LDAP TLS Support - Server 2</name>
 			<type>listtopic</type>
 		</field>
 		<field>
@@ -708,8 +922,13 @@
 		<field>
 			<fielddescr>SSL CA Certificate</fielddescr>
 			<fieldname>ssl_ca_cert2</fieldname>
-			<description><![CDATA[Choose the SSL CA Certficate here which you created with the firewall's Cert Manager.<br>
-									Choose "none" if you do not use any kind of certificates or the freeradius Cert Manager. (Default: none)]]></description>
+			<description>
+				<![CDATA[
+				Choose the SSL CA Certficate here which you created with the firewall's Cert Manager.<br/>
+				Choose "none" if you do not use any kind of certificates or are using the deprecated FreeRADIUS Cert Manager.
+				(Default: none)
+				]]>
+			</description>
 			<type>select_source</type>
 			<source><![CDATA[freeradius_get_ca_certs()]]></source>
 			<source_name>descr</source_name>
@@ -718,8 +937,13 @@
 		<field>
 			<fielddescr>SSL Server Certificate</fielddescr>
 			<fieldname>ssl_server_cert2</fieldname>
-			<description><![CDATA[Choose the SSL Server Certficate here which you created with the firewall's Cert Manager.<br>
-									Choose "none" if you do not use any kind of certificates or the freeradius Cert Manager. (Default: none)]]></description>
+			<description>
+				<![CDATA[
+				Choose the SSL Server Certficate here which you created with the firewall's Cert Manager.<br/>
+				Choose "none" if you do not use any kind of certificates or are using the deprecated FreeRADIUS Cert Manager.
+				(Default: none)
+				]]>
+			</description>
 			<type>select_source</type>
 			<source><![CDATA[freeradius_get_server_certs()]]></source>
 			<source_name>descr</source_name>
@@ -728,18 +952,23 @@
 		<field>
 			<fielddescr>Choose certificate verification method</fielddescr>
 			<fieldname>varmodulesldap2requirecert</fieldname>
-			<description><![CDATA[Choose how the certs should be checked:<br><br>
-			
-									<b>never: </b>don't even bother trying<br>
-									<b>allow: </b>try but don't fail if the cerificate can't be verified<br>
-									<b>demand: </b>fail if the certificate doesn't verify]]></description>
+			<description>
+				<![CDATA[
+				Choose how the certs should be checked. (Default: never)<br/>
+				<dl class="dl-horizontal responsive">
+				<dt>Never</dt><dd>Don't even bother trying.</dd>
+				<dt>Allow</dt><dd>Try but don't fail if the certificate can't be verified.</dd>
+				<dt>Demand</dt><dd>Fail if the certificate doesn't verify.</dd>
+				</dl>
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>never</default_value>
-					<options>
-						<option><name>Never</name><value>never</value></option>
-						<option><name>Allow</name><value>allow</value></option>
-						<option><name>Demand</name><value>demand</value></option>
-					</options>
+			<options>
+				<option><name>Never</name><value>never</value></option>
+				<option><name>Allow</name><value>allow</value></option>
+				<option><name>Demand</name><value>demand</value></option>
+			</options>
 		</field>
 	</fields>
 	<custom_delete_php_command>

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradiussettings.xml
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradiussettings.xml
@@ -3,12 +3,12 @@
 <?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-<![CDATA[	
+<![CDATA[
 /*
  * freeradiussettings.xml
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2014 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2014-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2013 Alexander Wilke <nachtfalkeaw@web.de>
  * All rights reserved.
  *
@@ -29,9 +29,6 @@
  * limitations under the License.
  */
 ]]>	</copyright>
-	<description><![CDATA[Describe your package here]]></description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiussettings</name>
 	<title>FreeRADIUS: Settings</title>
 	<aftersaveredirect>pkg_edit.php?xml=freeradiussettings.xml&amp;id=0</aftersaveredirect>
@@ -87,217 +84,333 @@
 		<field>
 			<name>General Configuration</name>
 			<type>listtopic</type>
-		</field>		
+		</field>
 		<field>
 			<fielddescr>Maximum Requests Server</fielddescr>
 			<fieldname>varsettingsmaxrequests</fieldname>
-			<description><![CDATA[The maximum number of requests the server could handle at a time until "Cleanup Delay" deletes them. Useful range 256 * NAS. If it is set to low it will make the server busy. A higher value is better (but increased RAM usage) but it shouldn't be higher than 1000 * NAS. (Default: 1024)]]></description>
+			<description>
+				<![CDATA[
+				The maximum number of requests the server could handle at a time until "Cleanup Delay" deletes them.
+				Useful range 256 * NAS. If it is set to low it will make the server busy.
+				A higher value is better (but increased RAM usage) but it shouldn't be higher than 1000 * NAS.
+				(Default: 1024)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>1024</default_value>
 		</field>
 		<field>
 			<fielddescr>Max Request Timeout</fielddescr>
 			<fieldname>varsettingsmaxrequesttime</fieldname>
-			<description><![CDATA[The maximum time to handle a request in seconds. (Default: 30)]]></description>
+			<description>
+				<![CDATA[
+				The maximum time to handle a request in seconds.
+				(Default: 30)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>30</default_value>
 		</field>
 		<field>
 			<fielddescr>Cleanup Delay</fielddescr>
 			<fieldname>varsettingscleanupdelay</fieldname>
-			<description><![CDATA[The time to wait before cleaning up a reply which was sent to the NAS in seconds. (Default: 5)]]></description>
+			<description>
+				<![CDATA[
+				The time to wait before cleaning up a reply which was sent to the NAS in seconds.
+				(Default: 5)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>5</default_value>
 		</field>
 		<field>
 			<fielddescr>Allow Core Dumps</fielddescr>
 			<fieldname>varsettingsallowcoredumps</fieldname>
-			<description><![CDATA[Only turn this on if you need to debug the RADIUS server! (Default: no)]]></description>
+			<description>
+				<![CDATA[
+				Only turn this on if you need to debug the RADIUS server!
+				(Default: no)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>Disable</name><value>no</value></option>
-						<option><name>Enable</name><value>yes</value></option>
-					</options>
-		</field>		
+			<options>
+				<option><name>Disable</name><value>no</value></option>
+				<option><name>Enable</name><value>yes</value></option>
+			</options>
+		</field>
 		<field>
 			<fielddescr>Regular Expressions</fielddescr>
 			<fieldname>varsettingsregularexpressions</fieldname>
-			<description><![CDATA[Allows regular expressions. (Default: yes)]]></description>
+			<description>
+				<![CDATA[
+				Allows regular expressions. (Default: yes)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>yes</default_value>
-					<options>
-						<option><name>Disable</name><value>no</value></option>
-						<option><name>Enable</name><value>yes</value></option>
-					</options>
+			<options>
+				<option><name>Disable</name><value>no</value></option>
+				<option><name>Enable</name><value>yes</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Extended Expressions</fielddescr>
 			<fieldname>varsettingsextendedexpressions</fieldname>
-			<description><![CDATA[Allows extended expressions. (Default: yes)]]></description>
+			<description>
+				<![CDATA[
+				Allows extended expressions. (Default: yes)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>yes</default_value>
-					<options>
-						<option><name>Disable</name><value>no</value></option>
-						<option><name>Enable</name><value>yes</value></option>
-					</options>
+			<options>
+				<option><name>Disable</name><value>no</value></option>
+				<option><name>Enable</name><value>yes</value></option>
+			</options>
 		</field>
 		<field>
-			<name>LOGGING CONFIGURATION</name>
+			<name>Logging Configuration</name>
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>Logging Destination of RADIUS</fielddescr>
+			<fielddescr>RADIUS Logging Destination</fielddescr>
 			<fieldname>varsettingslogdir</fieldname>
-			<description><![CDATA[Choose the destination where freeRADIUS will log. This will log general service information, but no authentication information. (Default: radius.log)]]></description>
+			<description>
+				<![CDATA[
+				Choose the destination where freeRADIUS will log.
+				This will log general service information, but no authentication information.
+				(Default: /var/log/radius.log)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>syslog</default_value>
-					<options>
-						<option><name>/var/log/radius.log</name><value>files</value></option>
-						<option><name>System Logs -> System</name><value>syslog</value></option>
-					</options>
+			<options>
+				<option><name>/var/log/radius.log</name><value>files</value></option>
+				<option><name>System Logs</name><value>syslog</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>RADIUS Logging</fielddescr>
 			<fieldname>varsettingsauth</fieldname>
-			<description><![CDATA[This enables logging if an authentication is accepted or rejected. (Default: Disabled)]]></description>
+			<description>
+				<![CDATA[
+				This enables logging if an authentication is accepted or rejected.
+				(Default: Disabled)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>yes</default_value>
-					<options>
-						<option><name>Disable</name><value>no</value></option>
-						<option><name>Enable</name><value>yes</value></option>
-					</options>
+			<options>
+				<option><name>Disable</name><value>no</value></option>
+				<option><name>Enable</name><value>yes</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Log Password on Authentication Failure</fielddescr>
 			<fieldname>varsettingsauthbadpass</fieldname>
-			<description><![CDATA[Log the <b>password</b> of failed authentication attempts to syslog. Not recommended for security reasons. Logging must be enabled. (Default: no)]]></description>
+			<description>
+				<![CDATA[
+				Log the <b>password</b> of failed authentication attempts to syslog.
+				Not recommended for security reasons. Logging must be enabled.
+				(Default: no)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>no</name><value>no</value></option>
-						<option><name>Log</name><value>yes</value></option>
-					</options>
+			<options>
+				<option><name>No</name><value>no</value></option>
+				<option><name>Log</name><value>yes</value></option>
+			</options>
 		</field>
 		<field>
-			<fielddescr>Additional information for bad attempts</fielddescr>
+			<fielddescr>Additional Information for Bad Attempts</fielddescr>
 			<fieldname>varsettingsauthbadpassmessage</fieldname>
-			<description><![CDATA[You can add additional information to the syslog output if a user connects. You can use variables for any attributes.<br><br>
-			
-									%{User-Name} - shows the username<br>
-									%{reply:Acct-Output-Octets} - shows the remaining output octets]]></description>
+			<description>
+				<![CDATA[
+				You can add additional information to the syslog output if a user connects.
+				You can use variables for any attributes.<br/><br/>
+				%{User-Name} - shows the username.<br/>
+				%{reply:Acct-Output-Octets} - shows the remaining output octets.
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 		</field>
 		<field>
 			<fielddescr>Log Password on Authentication Success</fielddescr>
 			<fieldname>varsettingsauthgoodpass</fieldname>
-			<description><![CDATA[Log the <b>password</b> of successful authentication attempts to syslog. Not recommended for security reasons. Logging must be enabled. (Default: no)]]></description>
+			<description>
+				<![CDATA[
+				Log the <b>password</b> of successful authentication attempts to syslog.
+				Not recommended for security reasons. Logging must be enabled.
+				(Default: no)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>no</name><value>no</value></option>
-						<option><name>Log</name><value>yes</value></option>
-					</options>
+			<options>
+				<option><name>No</name><value>no</value></option>
+				<option><name>Log</name><value>yes</value></option>
+			</options>
 		</field>
 		<field>
-			<fielddescr>Additional information for good attempts</fielddescr>
+			<fielddescr>Additional Information for Good Attempts</fielddescr>
 			<fieldname>varsettingsauthgoodpassmessage</fieldname>
-			<description><![CDATA[You can add additional information to the syslog output if a user is rejected. You can use variables for any attributes.<br><br>
-			
-									%{User-Name} - shows the username<br>
-									%{reply:Acct-Output-Octets} - shows the remaining output octets]]></description>
+			<description>
+				<![CDATA[
+				You can add additional information to the syslog output if a user is rejected.
+				You can use variables for any attributes.<br/><br/>
+				%{User-Name} - shows the username.<br/>
+				%{reply:Acct-Output-Octets} - shows the remaining output octets.
+				]]>
+			</description>
 			<type>input</type>
 			<size>80</size>
 		</field>
 		<field>
 			<fielddescr>Log Stripped Names</fielddescr>
 			<fieldname>varsettingsstrippednames</fieldname>
-			<description><![CDATA[Choose this if you want to log the full User-Name attribute as it was found in the request. Logging must be enabled. (Default: no)]]></description>
+			<description>
+				<![CDATA[
+				Choose this if you want to log the full User-Name attribute as it was found in the request. Logging must be enabled.
+				(Default: no)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>no</name><value>no</value></option>
-						<option><name>Log</name><value>yes</value></option>
-					</options>
+			<options>
+				<option><name>No</name><value>no</value></option>
+				<option><name>Log</name><value>yes</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>NAS Hostname Lookup</fielddescr>
 			<fieldname>varsettingshostnamelookups</fieldname>
-			<description><![CDATA[Log the names of NAS instead of IP addresses. Turning this on can result in lock ups of the RADIUS Server. (Default: no)]]></description>
+			<description>
+				<![CDATA[
+				Log the names of NAS instead of IP addresses.
+				<span class="text-danger">Warning: Turning this on can result in lock ups of the RADIUS Server.</span>
+				(Default: no)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>Disable</name><value>no</value></option>
-						<option><name>Enable</name><value>yes</value></option>
-					</options>
+			<options>
+				<option><name>Disable</name><value>no</value></option>
+				<option><name>Enable</name><value>yes</value></option>
+			</options>
 		</field>
 		<field>
-			<name>SECURITY CONFIGURATION</name>
+			<name>Security Configuration</name>
 			<type>listtopic</type>
 		</field>
 		<field>
 			<fielddescr>Maximum Number of Attributes</fielddescr>
 			<fieldname>varsettingsmaxattributes</fieldname>
-			<description><![CDATA[The maximum number of attributes permitted in a RADIUS packet. Packets which have more than this number of attributes in them will be dropped. (Default: 200)]]></description>
+			<description>
+				<![CDATA[
+				The maximum number of attributes permitted in a RADIUS packet.
+				Packets which have more than this number of attributes in them will be dropped.
+				(Default: 200)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>200</default_value>
 		</field>
 		<field>
 			<fielddescr>Access-Reject Delay</fielddescr>
 			<fieldname>varsettingsrejectdelay</fieldname>
-			<description><![CDATA[When sending an Access-Reject it can be delayed for a few seconds. This may help slow down a DoS attack. It also helps to slow down people trying to brute-force crack a users password. (Default: 1)(Immediately: 0)]]></description>
+			<description>
+				<![CDATA[
+				When sending an Access-Reject it can be delayed for a few seconds. This may help slow down a DoS attack.
+				It also helps to slow down people trying to brute-force crack a users password.
+				(Default: 1. To send Access-Reject immediately, set to '0'.)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>1</default_value>
 		</field>
 		<field>
-			<name>THREAD POOL CONFIGURATION</name>
+			<name>Thread Pool Configuration</name>
 			<type>listtopic</type>
 		</field>
 		<field>
 			<fielddescr>Number of Threads After Start</fielddescr>
 			<fieldname>varsettingsstartservers</fieldname>
-			<description><![CDATA[The thread pool is a long-lived group of threads which take turns (round-robin) handling any incoming requests. (Default: 5)]]></description>
+			<description>
+				<![CDATA[
+				The thread pool is a long-lived group of threads which take turns (round-robin) handling any incoming requests.
+				(Default: 5)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>5</default_value>
 		</field>
 		<field>
 			<fielddescr>Maximum Number of Threads</fielddescr>
 			<fieldname>varsettingsmaxservers</fieldname>
-			<description><![CDATA[If this limit is ever reached, clients will be locked out so it should not be set to low. (Default: 32)]]></description>
+			<description>
+				<![CDATA[
+				If this limit is ever reached, clients will be locked out so it should not be set to low.
+				(Default: 32)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>32</default_value>
 		</field>
 		<field>
 			<fielddescr>Min Spare Servers</fielddescr>
 			<fieldname>varsettingsminspareservers</fieldname>
-			<description><![CDATA[This dynamically adjusts the "Number of Threads After Start". If the RADIUS server has to handle MANY requests and LESS than "Min Spare Servers" are left than the RADIUS server will INCREASE the number of running threads. (Default: 3)]]></description>
+			<description>
+				<![CDATA[
+				This dynamically adjusts the "Number of Threads After Start". If the RADIUS server has to handle MANY requests
+				and LESS than "Min Spare Servers" are left than the RADIUS server will INCREASE the number of running threads.
+				(Default: 3)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>3</default_value>
 		</field>
 		<field>
 			<fielddescr>Max Spare Servers</fielddescr>
 			<fieldname>varsettingsmaxspareservers</fieldname>
-			<description><![CDATA[This dynamically adjusts the "Number of Threads After Start". If the RADIUS server has to handle FEW requests and MORE than "Max Spare Servers" are left than the RADIUS server will DECREASE the number of running threads. (Default: 10)]]></description>
+			<description>
+				<![CDATA[
+				This dynamically adjusts the "Number of Threads After Start". If the RADIUS server has to handle FEW requests
+				and MORE than "Max Spare Servers" are left than the RADIUS server will DECREASE the number of running threads.
+				(Default: 10)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>10</default_value>
 		</field>
 		<field>
 			<fielddescr>Server Packet Queue Size</fielddescr>
 			<fieldname>varsettingsmaxqueuesize</fieldname>
-			<description><![CDATA[This is the queue size where the server stores packets before processing them. (Default: 65536)]]></description>
+			<description>
+				<![CDATA[
+				This is the queue size where the server stores packets before processing them.
+				(Default: 65536)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>65536</default_value>
 		</field>
 		<field>
 			<fielddescr>Maximum Requests per Server</fielddescr>
 			<fieldname>varsettingsmaxrequestsperserver</fieldname>
-			<description><![CDATA[You should only change this if you encounter memory leaks while running RADIUS. (Default: 0)]]></description>
+			<description>
+				<![CDATA[
+				You should only change this if you encounter memory leaks while running RADIUS.
+				(Default: 0)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>0</default_value>
 		</field>
 		<field>
-			<name>MOBILE-ONE-TIME-PASSWORD CONFIGURATION</name>
+			<name>Mobile-One-Time-Password Configuration</name>
 			<type>listtopic</type>
 		</field>
 		<field>
@@ -316,33 +429,57 @@
 		<field>
 			<fielddescr>OTP Lifetime</fielddescr>
 			<fieldname>varsettingsmotptimespan</fieldname>
-			<description><![CDATA[Enter the lifetime of the OTP. 1=10s, 2=20s, 3=30s (Default: 2)]]></description>
+			<description>
+				<![CDATA[
+				Enter the lifetime of the OTP. 1=10s, 2=20s, 3=30s.
+				(Default: 2)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>2</default_value>
 		</field>
 		<field>
-			<fielddescr>Number of invalid password attempts</fielddescr>
+			<fielddescr>Number of Invalid Password Attempts</fielddescr>
 			<fieldname>varsettingsmotppasswordattempts</fieldname>
-			<description><![CDATA[After this many failed attempts, the user will be locked out until an admin unlocks the user. (Default: 5)]]></description>
+			<description>
+				<![CDATA[
+				After this many failed attempts, the user will be locked out until an admin unlocks the user.
+				(Default: 5)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>5</default_value>
 		</field>
 		<field>
-			<fielddescr>Hash algorithm</fielddescr>
+			<fielddescr>Hash Algorithm</fielddescr>
 			<fieldname>varsettingsmotpchecksumtype</fieldname>
-			<description><![CDATA[We build a hash of "EPOCHTIME+INIT-SECRET+PIN" and then use the digits as password. Perhaps there are some other/hardware tokens which use other hash types so you can perhaps adjust this here. This <b>must</b> be equal on both sides!  (Default: md5)]]></description>
+			<description>
+				<![CDATA[
+				We build a hash of "EPOCHTIME+INIT-SECRET+PIN" and then use the digits as password.
+				Perhaps there are some other/hardware tokens which use other hash types so you can perhaps adjust this here.
+				This <b>must</b> be equal on both sides!
+				(Default: md5)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>md5</default_value>
-					<options>
-						<option><name>MD5</name><value>md5</value></option>
-						<option><name>SHA1</name><value>sha1</value></option>
-						<option><name>SHA256</name><value>sha256</value></option>
-					</options>
+			<options>
+				<option><name>MD5</name><value>md5</value></option>
+				<option><name>SHA1</name><value>sha1</value></option>
+				<option><name>SHA256</name><value>sha256</value></option>
+			</options>
 		</field>
 		<field>
-			<fielddescr>Token Password length</fielddescr>
+			<fielddescr>Token Password Length</fielddescr>
 			<fieldname>varsettingsmotptokenlength</fieldname>
-			<description><![CDATA[We build a hash of "EPOCHTIME+INIT-SECRET+PIN" and then use the digits 1 to 6 as password. Perhaps there are some other/hardware tokens which use other digits so you can perhaps adjust this here. This <b>must</b> be equal on both sides! (Default: 1-6)]]></description>
+			<description>
+				<![CDATA[
+				We build a hash of "EPOCHTIME+INIT-SECRET+PIN" and then use the digits 1 to 6 as password.
+				Perhaps there are some other/hardware tokens which use other digits so you can perhaps adjust this here.
+				This <b>must</b> be equal on both sides!
+				(Default: 1-6)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>1-6</default_value>
 		</field>

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradiussqlconf.xml
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradiussqlconf.xml
@@ -3,12 +3,12 @@
 <?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-<![CDATA[	
+<![CDATA[
 /*
  * freeradiussqlconf.xml
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2013 Alexander Wilke <nachtfalkeaw@web.de>
  * All rights reserved.
  *
@@ -29,9 +29,6 @@
  * limitations under the License.
  */
 ]]>	</copyright>
-	<description><![CDATA[Describe your package here]]></description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiussqlconf</name>
 	<title>FreeRADIUS: SQL</title>
 	<aftersaveredirect>pkg_edit.php?xml=freeradiussqlconf.xml&amp;id=0</aftersaveredirect>
@@ -94,7 +91,7 @@
 			<description>Enable SQL Support (Default: unchecked)</description>
 			<sethelp>
 				<![CDATA[
-				Enable this to allow connections from FreeRADIUS to a SQL database.<br>
+				Enable this to allow connections from FreeRADIUS to a SQL database.<br/>
 				At least one of the following options <strong>must be enabled</strong>: Authorization, Accounting, Session, Post-Auth.
 				]]>
 			</sethelp>
@@ -104,50 +101,69 @@
 		<field>
 			<fielddescr>Enable SQL Authorization</fielddescr>
 			<fieldname>varsqlconfenableauthorize</fieldname>
-			<description><![CDATA[Enable this if usernames and passwords are stored on a SQL database.<br>
-								SQL support must be enabled for this to work. (Default: Disable)]]></description>
+			<description>
+				<![CDATA[
+				Enable this if usernames and passwords are stored on a SQL database.<br/>
+				SQL support must be enabled for this to work.
+				(Default: Disable)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>Disable</default_value>
-					<options>
-						<option><name>Disable</name><value>Disable</value></option>
-						<option><name>Enable</name><value>Enable</value></option>
-					</options>
+			<options>
+				<option><name>Disable</name><value>Disable</value></option>
+				<option><name>Enable</name><value>Enable</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Enable SQL Accounting</fielddescr>
 			<fieldname>varsqlconfenableaccounting</fieldname>
-			<description><![CDATA[Enable this if accounting packets should be logged to a SQL database.<br>
-								SQL support must be enabled for this to work. (Default: Disable)]]></description>
+			<description>
+				<![CDATA[
+				Enable this if accounting packets should be logged to a SQL database.<br/>
+				SQL support must be enabled for this to work.
+				(Default: Disable)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>Disable</default_value>
-					<options>
-						<option><name>Disable</name><value>Disable</value></option>
-						<option><name>Enable</name><value>Enable</value></option>
-					</options>
+			<options>
+				<option><name>Disable</name><value>Disable</value></option>
+				<option><name>Enable</name><value>Enable</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Enable SQL Session</fielddescr>
 			<fieldname>varsqlconfenablesession</fieldname>
-			<description><![CDATA[Enable this to use the "rlm_sql" module (fast) to check for simultaneous connections instead of "radutmp" (slow).<br>
-								SQL support must be enabled for this to work. (Default: Disable)]]></description>
+			<description>
+				<![CDATA[
+				Enable this to use the "rlm_sql" module (fast) to check for simultaneous connections instead of "radutmp" (slow).<br/>
+				SQL support must be enabled for this to work. (Default: Disable)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>Disable</default_value>
-					<options>
-						<option><name>Disable</name><value>Disable</value></option>
-						<option><name>Enable</name><value>Enable</value></option>
-					</options>
+			<options>
+				<option><name>Disable</name><value>Disable</value></option>
+				<option><name>Enable</name><value>Enable</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Enable SQL Post-Auth</fielddescr>
 			<fieldname>varsqlconfenablepostauth</fieldname>
-			<description><![CDATA[Enable this if you like to store post-authentication data on a SQL database.<br>
-								SQL support must be enabled for this to work. (Default: Disable)]]></description>
+			<description>
+				<![CDATA[
+				Enable this if you like to store post-authentication data on a SQL database.<br/>
+				SQL support must be enabled for this to work.
+				(Default: Disable)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>Disable</default_value>
-					<options>
-						<option><name>Disable</name><value>Disable</value></option>
-						<option><name>Enable</name><value>Enable</value></option>
-					</options>
+			<options>
+				<option><name>Disable</name><value>Disable</value></option>
+				<option><name>Enable</name><value>Enable</value></option>
+			</options>
 		</field>
 		<field>
 			<name>SQL Database Configuration - Server 1</name>
@@ -156,185 +172,291 @@
 		<field>
 			<fielddescr>Database Type</fielddescr>
 			<fieldname>varsqlconfdatabase</fieldname>
-			<description><![CDATA[Choose the database type. (Default: mysql)]]></description>
+			<description>
+				<![CDATA[
+				Choose the database type. (Default: mysql)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>mysql</default_value>
-					<options>
-						<option><name>MySQL</name><value>mysql</value></option>
-						<option><name>PostgreSQL</name><value>postgresql</value></option>
-					</options>
+			<options>
+				<option><name>MySQL</name><value>mysql</value></option>
+				<option><name>PostgreSQL</name><value>postgresql</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Server IP Address</fielddescr>
 			<fieldname>varsqlconfserver</fieldname>
-			<description><![CDATA[Enter the IP address of the database server (Default: localhost)]]></description>
+			<description>
+				<![CDATA[
+				Enter the IP address of the database server (Default: localhost)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>localhost</default_value>
 		</field>
 		<field>
 			<fielddescr>Server Port Address</fielddescr>
 			<fieldname>varsqlconfport</fieldname>
-			<description><![CDATA[Enter the port address of the database server (Default: 3306)]]></description>
+			<description>
+				<![CDATA[
+				Enter the port address of the database server (Default: 3306)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>3306</default_value>
 		</field>
 		<field>
 			<fielddescr>Database Username</fielddescr>
 			<fieldname>varsqlconflogin</fieldname>
-			<description><![CDATA[Enter the username of the database server (Default: radius)]]></description>
+			<description>
+				<![CDATA[
+				Enter the username for the database server.
+				(Default: radius)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radius</default_value>
 		</field>
 		<field>
 			<fielddescr>Database Password</fielddescr>
 			<fieldname>varsqlconfpassword</fieldname>
-			<description><![CDATA[Enter the password of the database server (Default: radpass)]]></description>
+			<description>
+				<![CDATA[
+				Enter the password for the database server user.
+				(Default: radpass)
+				]]>
+			</description>
 			<type>password</type>
 			<default_value>radpass</default_value>
 		</field>
 		<field>
 			<fielddescr>Database Table Configuration</fielddescr>
 			<fieldname>varsqlconfradiusdb</fieldname>
-			<description><![CDATA[Choose database table configuration: (Default: radius) <br>
-									For all <b>except</b> Oracle choose:  <b>radius</b> <br>
-									For Oracle change and paste the following line according your environment:<br>
-									<b>(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521))(CONNECT_DATA=(SID=your_sid)))</b>]]></description>
+			<description>
+				<![CDATA[
+				Choose database table configuration: (Default: radius)<br/>
+				For all <b>except</b> Oracle choose:  <b>radius</b> <br/>
+				For Oracle change and paste the following line according to your environment:<br/>
+				<b>(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521))(CONNECT_DATA=(SID=your_sid)))</b>
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radius</default_value>
 		</field>
 		<field>
 			<fielddescr>Accounting Table 1 (Start)</fielddescr>
 			<fieldname>varsqlconfaccttable1</fieldname>
-			<description><![CDATA[This is the accounting "Start" table. If you want to log "Start" and "Stop" to the same table choose the same name for both. (Default: radacct)]]></description>
+			<description>
+				<![CDATA[
+				This is the accounting "Start" table.
+				If you want to log "Start" and "Stop" to the same table choose the same name for both.
+				(Default: radacct)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radacct</default_value>
 		</field>
 		<field>
 			<fielddescr>Accounting Table 2 (Stop)</fielddescr>
 			<fieldname>varsqlconfaccttable2</fieldname>
-			<description><![CDATA[This is the accounting "Stop" table. If you want to log "Stop" and "Stop" to the same table choose the same name for both. (Default: radacct)]]></description>
+			<description>
+				<![CDATA[
+				This is the accounting "Stop" table.
+				If you want to log "Stop" and "Stop" to the same table choose the same name for both.
+				(Default: radacct)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radacct</default_value>
 		</field>
 		<field>
 			<fielddescr>Post Auth Table</fielddescr>
 			<fieldname>varsqlconfpostauthtable</fieldname>
-			<description><![CDATA[Choose Post Auth Table. (Default: radpostauth)]]></description>
+			<description>
+				<![CDATA[
+				Choose Post Auth Table. (Default: radpostauth)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radpostauth</default_value>
 		</field>
 		<field>
 			<fielddescr>Auth Check Table</fielddescr>
 			<fieldname>varsqlconfauthchecktable</fieldname>
-			<description><![CDATA[Choose Auth Check Table. (Default: radcheck)]]></description>
+			<description>
+				<![CDATA[
+				Choose Auth Check Table. (Default: radcheck)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radcheck</default_value>
 		</field>
 		<field>
 			<fielddescr>Auth Reply Table</fielddescr>
 			<fieldname>varsqlconfauthreplytable</fieldname>
-			<description><![CDATA[Choose Auth Reply Table. (Default: radreply)]]></description>
+			<description>
+				<![CDATA[
+				Choose Auth Reply Table. (Default: radreply)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radreply</default_value>
 		</field>
 		<field>
 			<fielddescr>Group Check Table</fielddescr>
 			<fieldname>varsqlconfgroupchecktable</fieldname>
-			<description><![CDATA[Choose Group Check Table. (Default: radgroupcheck)]]></description>
+			<description>
+				<![CDATA[
+				Choose Group Check Table. (Default: radgroupcheck)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radgroupcheck</default_value>
 		</field>
 		<field>
 			<fielddescr>Group Reply Table</fielddescr>
 			<fieldname>varsqlconfgroupreplytable</fieldname>
-			<description><![CDATA[Choose Group Check Table. (Default: radgroupreply)]]></description>
+			<description>
+				<![CDATA[
+				Choose Group Check Table. (Default: radgroupreply)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radgroupreply</default_value>
 		</field>
 		<field>
 			<fielddescr>User Group Table</fielddescr>
 			<fieldname>varsqlconfusergrouptable</fieldname>
-			<description><![CDATA[Choose Group Check Table. (Default: radusergroup)]]></description>
+			<description>
+				<![CDATA[
+				Choose Group Check Table. (Default: radusergroup)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radusergroup</default_value>
 		</field>
 		<field>
 			<fielddescr>Read the Group Tables</fielddescr>
 			<fieldname>varsqlconfreadgroups</fieldname>
-			<description><![CDATA[If set to <b>yes</b> (default) we read the group tables.<br>
-								If set to <b>no</b> the user <b>must</b> have Fall-Through = Yes in the radreply table]]></description>
+			<description>
+				<![CDATA[
+				If set to <b>yes</b> (default) we read the group tables.<br/>
+				If set to <b>no</b> the user <b>must</b> have Fall-Through = Yes in the radreply table.
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>yes</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Delete Stale Sessions</fielddescr>
 			<fieldname>varsqlconfdeletestalesessions</fieldname>
-			<description><![CDATA[Remove stale session if checkrad does not see a double login. (Default: yes)]]></description>
+			<description>
+				<![CDATA[
+				Remove stale session if checkrad does not see a double login.
+				(Default: yes)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>yes</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Print all SQL Statements</fielddescr>
 			<fieldname>varsqlconfsqltrace</fieldname>
-			<description><![CDATA[Print all SQL statements when in debug mode. (Default: no)]]></description>
+			<description>
+				<![CDATA[
+				Print all SQL statements when in debug mode. (Default: no)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Number of SQL Connections</fielddescr>
 			<fieldname>varsqlconfnumsqlsocks</fieldname>
-			<description><![CDATA[Number of SQL connections to make to the server. (Default: 5)]]></description>
+			<description>
+				<![CDATA[
+				Number of SQL connections to make to the server. (Default: 5)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>5</default_value>
 		</field>
 		<field>
 			<fielddescr>Failed Database Connection Delay</fielddescr>
 			<fieldname>varsqlconfconnectfailureretrydelay</fieldname>
-			<description><![CDATA[Number of seconds btween a retry after a failed database connection. (Default: 60)]]></description>
+			<description>
+				<![CDATA[
+				Number of seconds btween a retry after a failed database connection.
+				(Default: 60)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>60</default_value>
 		</field>
 		<field>
 			<fielddescr>SQL Socket Lifetime</fielddescr>
 			<fieldname>varsqlconflifetime</fieldname>
-			<description><![CDATA[If you are having network issues such as TCP sessions expiring, you may need to set the socket lifetime.  If set to non-zero, any open connections will be closed X seconds after they were first opened. (Default: 0)]]></description>
+			<description>
+				<![CDATA[
+				If you are having network issues such as TCP sessions expiring, you may need to set the socket lifetime.
+				If set to non-zero, any open connections will be closed X seconds after they were first opened.
+				(Default: 0)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>0</default_value>
 		</field>
 		<field>
 			<fielddescr>SQL Socket Maximum Queries</fielddescr>
 			<fieldname>varsqlconfmaxqueries</fieldname>
-			<description><![CDATA[If you have issues with SQL sockets lasting too long, you can limit the number of queries performed over one socket. After X queries, the socket will be closed. Use 0 for no limit. (Default: 0)]]></description>
+			<description>
+				<![CDATA[
+				If you have issues with SQL sockets lasting too long, you can limit the number of queries performed over one socket.
+				After X queries, the socket will be closed. Use 0 for no limit.
+				(Default: 0)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>0</default_value>
 		</field>
 		<field>
 			<fielddescr>Read Clients from Database</fielddescr>
 			<fieldname>varsqlconfreadclients</fieldname>
-			<description><![CDATA[Set to <b>yes</b> to read RADIUS clients from the database ('nas' table). Clients will only be read on server startup. (Default: yes)]]></description>
+			<description>
+				<![CDATA[
+				Set to <b>yes</b> to read RADIUS clients from the database ('nas' table).
+				Clients will only be read on server startup.
+				(Default: yes)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>yes</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>RADIUS Client Table</fielddescr>
 			<fieldname>varsqlconfnastable</fieldname>
-			<description><![CDATA[Choose the table to keep RADIUS client info. (Default: nas)]]></description>
+			<description>
+				<![CDATA[
+				Choose the table to keep RADIUS client info. (Default: nas)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>nas</default_value>
 		</field>
@@ -343,19 +465,25 @@
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>Choose Failover/Loadbalancing Mode</fielddescr>
+			<fielddescr>Choose Failover/Load Balancing Mode</fielddescr>
 			<fieldname>varsqlconf2failover</fieldname>
-			<description><![CDATA[Choose the interaction of the two SQL databases: (Default: redundant)<br><br>
-								<b>redundant:</b> If server 1 fails failover to server 2<br>
-								<b>load-balance:</b> The load is balanced 50:50 to both databases<br>
-								<b>redundant-load-balance:</b> The load is balanced 50:50 to both databases. If one is down the other does 100%.]]></description>
+			<description>
+				<![CDATA[
+				Choose the interaction of the two SQL databases: (Default: Redundant)<br/>
+				<dl class="dl-horizontal responsive">
+				<dt>Redundant</dt><dd>If server1 fails failover to server2.</dd>
+				<dt>Load-Balance</dt><dd>The load is balanced 50:50 to both databases.</dd>
+				<dt>Redundant-Load-Balance</dt><dd>The load is balanced 50:50 to both databases. If one is down the other does 100%.</dd>
+				</dl>
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>redundant</default_value>
-					<options>
-						<option><name>Redundant</name><value>redundant</value></option>
-						<option><name>Load-Balance</name><value>load-balance</value></option>
-						<option><name>Redundant-Load-Balance</name><value>redundant-load-balance</value></option>
-					</options>
+			<options>
+				<option><name>Redundant</name><value>redundant</value></option>
+				<option><name>Load-Balance</name><value>load-balance</value></option>
+				<option><name>Redundant-Load-Balance</name><value>redundant-load-balance</value></option>
+			</options>
 		</field>
 		<field>
 			<name>Enable SQL Database - Server 2</name>
@@ -367,7 +495,7 @@
 			<description>Enable SQL Support (Default: unchecked)</description>
 			<sethelp>
 				<![CDATA[
-				Enable this to allow connections from FreeRADIUS to a SQL database.<br>
+				Enable this to allow connections from FreeRADIUS to a SQL database.<br/>
 				At least one of the following options <strong>must be enabled</strong>: Authorization, Accounting, Session, Post-Auth.
 				]]>
 			</sethelp>
@@ -377,50 +505,69 @@
 		<field>
 			<fielddescr>Enable SQL Authorization</fielddescr>
 			<fieldname>varsqlconf2enableauthorize</fieldname>
-			<description><![CDATA[Enable this if usernames and passwords are stored on a SQL database.<br>
-								SQL support must be enabled for this to work. (Default: Disable)]]></description>
+			<description>
+				<![CDATA[
+				Enable this if usernames and passwords are stored on a SQL database.<br/>
+				SQL support must be enabled for this to work.
+				(Default: Disable)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>Disable</default_value>
-					<options>
-						<option><name>Disable</name><value>Disable</value></option>
-						<option><name>Enable</name><value>Enable</value></option>
-					</options>
+			<options>
+				<option><name>Disable</name><value>Disable</value></option>
+				<option><name>Enable</name><value>Enable</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Enable SQL Accounting</fielddescr>
 			<fieldname>varsqlconf2enableaccounting</fieldname>
-			<description><![CDATA[Enable this if accounting packets should be logged to a SQL database.<br>
-								SQL support must be enabled for this to work. (Default: Disable)]]></description>
+			<description>
+				<![CDATA[
+				Enable this if accounting packets should be logged to a SQL database.<br/>
+				SQL support must be enabled for this to work.
+				(Default: Disable)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>Disable</default_value>
-					<options>
-						<option><name>Disable</name><value>Disable</value></option>
-						<option><name>Enable</name><value>Enable</value></option>
-					</options>
+			<options>
+				<option><name>Disable</name><value>Disable</value></option>
+				<option><name>Enable</name><value>Enable</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Enable SQL Session</fielddescr>
 			<fieldname>varsqlconf2enablesession</fieldname>
-			<description><![CDATA[Enable this to use the "rlm_sql" module (fast) to check for simultaneous connections instead of "radutmp" (slow).<br>
-								SQL support must be enabled for this to work. (Default: Disable)]]></description>
+			<description>
+				<![CDATA[
+				Enable this to use the "rlm_sql" module (fast) to check for simultaneous connections instead of "radutmp" (slow).<br/>
+				SQL support must be enabled for this to work. (Default: Disable)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>Disable</default_value>
-					<options>
-						<option><name>Disable</name><value>Disable</value></option>
-						<option><name>Enable</name><value>Enable</value></option>
-					</options>
+			<options>
+				<option><name>Disable</name><value>Disable</value></option>
+				<option><name>Enable</name><value>Enable</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Enable SQL Post-Auth</fielddescr>
 			<fieldname>varsqlconf2enablepostauth</fieldname>
-			<description><![CDATA[Enable this if you like to store post-authentication data on a SQL database.<br>
-								SQL support must be enabled for this to work. (Default: Disable)]]></description>
+			<description>
+				<![CDATA[
+				Enable this if you like to store post-authentication data on a SQL database.<br/>
+				SQL support must be enabled for this to work.
+				(Default: Disable)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>Disable</default_value>
-					<options>
-						<option><name>Disable</name><value>Disable</value></option>
-						<option><name>Enable</name><value>Enable</value></option>
-					</options>
+			<options>
+				<option><name>Disable</name><value>Disable</value></option>
+				<option><name>Enable</name><value>Enable</value></option>
+			</options>
 		</field>
 		<field>
 			<name>SQL Database Configuration - Server 2</name>
@@ -429,185 +576,291 @@
 		<field>
 			<fielddescr>Database Type</fielddescr>
 			<fieldname>varsqlconf2database</fieldname>
-			<description><![CDATA[Choose the database type. (Default: mysql)]]></description>
+			<description>
+				<![CDATA[
+				Choose the database type. (Default: mysql)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>mysql</default_value>
-					<options>
-						<option><name>MySQL</name><value>mysql</value></option>
-						<option><name>PostgreSQL</name><value>postgresql</value></option>
-					</options>
+			<options>
+				<option><name>MySQL</name><value>mysql</value></option>
+				<option><name>PostgreSQL</name><value>postgresql</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Server IP Address</fielddescr>
 			<fieldname>varsqlconf2server</fieldname>
-			<description><![CDATA[Enter the IP address of the database server (Default: localhost)]]></description>
+			<description>
+				<![CDATA[
+				Enter the IP address of the database server (Default: localhost)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>localhost</default_value>
 		</field>
 		<field>
 			<fielddescr>Server Port Address</fielddescr>
 			<fieldname>varsqlconf2port</fieldname>
-			<description><![CDATA[Enter the port address of the database server (Default: 3306)]]></description>
+			<description>
+				<![CDATA[
+				Enter the port address of the database server (Default: 3306)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>3306</default_value>
 		</field>
 		<field>
 			<fielddescr>Database Username</fielddescr>
 			<fieldname>varsqlconf2login</fieldname>
-			<description><![CDATA[Enter the username of the database server (Default: radius)]]></description>
+			<description>
+				<![CDATA[
+				Enter the username for the database server.
+				(Default: radius)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radius</default_value>
 		</field>
 		<field>
 			<fielddescr>Database Password</fielddescr>
 			<fieldname>varsqlconf2password</fieldname>
-			<description><![CDATA[Enter the password of the database server (Default: radpass)]]></description>
+			<description>
+				<![CDATA[
+				Enter the password for the database server user.
+				(Default: radpass)
+				]]>
+			</description>
 			<type>password</type>
 			<default_value>radpass</default_value>
 		</field>
 		<field>
 			<fielddescr>Database Table Configuration</fielddescr>
 			<fieldname>varsqlconf2radiusdb</fieldname>
-			<description><![CDATA[Choose database table configuration: (Default: radius) <br>
-									For all <b>except</b> Oracle choose:  <b>radius</b> <br>
-									For Oracle change and paste the following line according your environment:<br>
-									<b>(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521))(CONNECT_DATA=(SID=your_sid)))</b>]]></description>
+			<description>
+				<![CDATA[
+				Choose database table configuration: (Default: radius)<br/>
+				For all <b>except</b> Oracle choose:  <b>radius</b> <br/>
+				For Oracle change and paste the following line according to your environment:<br/>
+				<b>(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521))(CONNECT_DATA=(SID=your_sid)))</b>
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radius</default_value>
 		</field>
 		<field>
 			<fielddescr>Accounting Table 1 (Start)</fielddescr>
 			<fieldname>varsqlconf2accttable1</fieldname>
-			<description><![CDATA[This is the accounting "Start" table. If you want to log "Start" and "Stop" to the same table choose the same name for both. (Default: radacct)]]></description>
+			<description>
+				<![CDATA[
+				This is the accounting "Start" table.
+				If you want to log "Start" and "Stop" to the same table choose the same name for both.
+				(Default: radacct)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radacct</default_value>
 		</field>
 		<field>
 			<fielddescr>Accounting Table 2 (Stop)</fielddescr>
 			<fieldname>varsqlconf2accttable2</fieldname>
-			<description><![CDATA[This is the accounting "Stop" table. If you want to log "Stop" and "Stop" to the same table choose the same name for both. (Default: radacct)]]></description>
+			<description>
+				<![CDATA[
+				This is the accounting "Stop" table.
+				If you want to log "Stop" and "Stop" to the same table choose the same name for both.
+				(Default: radacct)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radacct</default_value>
 		</field>
 		<field>
 			<fielddescr>Post Auth Table</fielddescr>
 			<fieldname>varsqlconf2postauthtable</fieldname>
-			<description><![CDATA[Choose Post Auth Table. (Default: radpostauth)]]></description>
+			<description>
+				<![CDATA[
+				Choose Post Auth Table. (Default: radpostauth)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radpostauth</default_value>
 		</field>
 		<field>
 			<fielddescr>Auth Check Table</fielddescr>
 			<fieldname>varsqlconf2authchecktable</fieldname>
-			<description><![CDATA[Choose Auth Check Table. (Default: radcheck)]]></description>
+			<description>
+				<![CDATA[
+				Choose Auth Check Table. (Default: radcheck)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radcheck</default_value>
 		</field>
 		<field>
 			<fielddescr>Auth Reply Table</fielddescr>
 			<fieldname>varsqlconf2authreplytable</fieldname>
-			<description><![CDATA[Choose Auth Reply Table. (Default: radreply)]]></description>
+			<description>
+				<![CDATA[
+				Choose Auth Reply Table. (Default: radreply)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radreply</default_value>
 		</field>
 		<field>
 			<fielddescr>Group Check Table</fielddescr>
 			<fieldname>varsqlconf2groupchecktable</fieldname>
-			<description><![CDATA[Choose Group Check Table. (Default: radgroupcheck)]]></description>
+			<description>
+				<![CDATA[
+				Choose Group Check Table. (Default: radgroupcheck)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radgroupcheck</default_value>
 		</field>
 		<field>
 			<fielddescr>Group Reply Table</fielddescr>
 			<fieldname>varsqlconf2groupreplytable</fieldname>
-			<description><![CDATA[Choose Group Check Table. (Default: radgroupreply)]]></description>
+			<description>
+				<![CDATA[
+				Choose Group Check Table. (Default: radgroupreply)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radgroupreply</default_value>
 		</field>
 		<field>
 			<fielddescr>User Group Table</fielddescr>
 			<fieldname>varsqlconf2usergrouptable</fieldname>
-			<description><![CDATA[Choose Group Check Table. (Default: radusergroup)]]></description>
+			<description>
+				<![CDATA[
+				Choose Group Check Table. (Default: radusergroup)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>radusergroup</default_value>
 		</field>
 		<field>
 			<fielddescr>Read the Group Tables</fielddescr>
 			<fieldname>varsqlconf2readgroups</fieldname>
-			<description><![CDATA[If set to <b>yes</b> (default) we read the group tables.<br>
-								If set to <b>no</b> the user <b>must</b> have Fall-Through = Yes in the radreply table]]></description>
+			<description>
+				<![CDATA[
+				If set to <b>yes</b> (default) we read the group tables.<br/>
+				If set to <b>no</b> the user <b>must</b> have Fall-Through = Yes in the radreply table.
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>yes</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Delete Stale Sessions</fielddescr>
 			<fieldname>varsqlconf2deletestalesessions</fieldname>
-			<description><![CDATA[Remove stale session if checkrad does not see a double login. (Default: yes)]]></description>
+			<description>
+				<![CDATA[
+				Remove stale session if checkrad does not see a double login.
+				(Default: yes)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>yes</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Print all SQL Statements</fielddescr>
 			<fieldname>varsqlconf2sqltrace</fieldname>
-			<description><![CDATA[Print all SQL statements when in debug mode. (Default: no)]]></description>
+			<description>
+				<![CDATA[
+				Print all SQL statements when in debug mode. (Default: no)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>no</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Number of SQL Connections</fielddescr>
 			<fieldname>varsqlconf2numsqlsocks</fieldname>
-			<description><![CDATA[Number of SQL connections to make to the server. (Default: 5)]]></description>
+			<description>
+				<![CDATA[
+				Number of SQL connections to make to the server. (Default: 5)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>5</default_value>
 		</field>
 		<field>
 			<fielddescr>Failed Database Connection Delay</fielddescr>
 			<fieldname>varsqlconf2connectfailureretrydelay</fieldname>
-			<description><![CDATA[Number of seconds btween a retry after a failed database connection. (Default: 60)]]></description>
+			<description>
+				<![CDATA[
+				Number of seconds btween a retry after a failed database connection.
+				(Default: 60)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>60</default_value>
 		</field>
 		<field>
 			<fielddescr>SQL Socket Lifetime</fielddescr>
 			<fieldname>varsqlconf2lifetime</fieldname>
-			<description><![CDATA[If you are having network issues such as TCP sessions expiring, you may need to set the socket lifetime.  If set to non-zero, any open connections will be closed X seconds after they were first opened. (Default: 0)]]></description>
+			<description>
+				<![CDATA[
+				If you are having network issues such as TCP sessions expiring, you may need to set the socket lifetime.
+				If set to non-zero, any open connections will be closed X seconds after they were first opened.
+				(Default: 0)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>0</default_value>
 		</field>
 		<field>
 			<fielddescr>SQL Socket Maximum Queries</fielddescr>
 			<fieldname>varsqlconf2maxqueries</fieldname>
-			<description><![CDATA[If you have issues with SQL sockets lasting too long, you can limit the number of queries performed over one socket. After X queries, the socket will be closed. Use 0 for no limit. (Default: 0)]]></description>
+			<description>
+				<![CDATA[
+				If you have issues with SQL sockets lasting too long, you can limit the number of queries performed over one socket.
+				After X queries, the socket will be closed. Use 0 for no limit.
+				(Default: 0)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>0</default_value>
 		</field>
 		<field>
 			<fielddescr>Read Clients from Database</fielddescr>
 			<fieldname>varsqlconf2readclients</fieldname>
-			<description><![CDATA[Set to <b>yes</b> to read RADIUS clients from the database ('nas' table). Clients will only be read on server startup. (Default: yes)]]></description>
+			<description>
+				<![CDATA[
+				Set to <b>yes</b> to read RADIUS clients from the database ('nas' table).
+				Clients will only be read on server startup.
+				(Default: yes)
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>yes</default_value>
-					<options>
-						<option><name>Yes</name><value>yes</value></option>
-						<option><name>No</name><value>no</value></option>
-					</options>
+			<options>
+				<option><name>Yes</name><value>yes</value></option>
+				<option><name>No</name><value>no</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>RADIUS Client Table</fielddescr>
 			<fieldname>varsqlconf2nastable</fieldname>
-			<description><![CDATA[Choose the table to keep RADIUS client info. (Default: nas)]]></description>
+			<description>
+				<![CDATA[
+				Choose the table to keep RADIUS client info. (Default: nas)
+				]]>
+			</description>
 			<type>input</type>
 			<default_value>nas</default_value>
 		</field>

--- a/net/pfSense-pkg-freeradius2/files/usr/local/www/freeradius_view_config.php
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/www/freeradius_view_config.php
@@ -3,7 +3,7 @@
  * freeradius_view_config.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2013 Alexander Wilke <nachtfalkeaw@web.de>
  * Copyright (c) 2011 Marcello Coutinho <marcellocoutinho@gmail.com>
  * All rights reserved.
@@ -28,24 +28,23 @@
 require("guiconfig.inc");
 define('RADDB', '/usr/local/etc/raddb');
 
-function get_file($file){
-	$files['radiusd']=RADDB . "/radiusd.conf";
-	$files['eap']=RADDB . "/eap.conf";
-	$files['sql']=RADDB . "/sql.conf";
-	$files['clients']=RADDB . "/clients.conf";
-	$files['users']=RADDB . "/users";
-	$files['macs']=RADDB . "/authorized_macs";
-	$files['virtual-server-default']=RADDB . "/sites-enabled/default";
-	$files['ca']=RADDB . "/certs/ca.cnf";
-	$files['server']=RADDB . "/certs/server.cnf";
-	$files['client']=RADDB . "/certs/client.cnf";
-	$files['index']=RADDB . "/certs/index.txt";
-	$files['ldap']=RADDB . "/modules/ldap";
+function get_file($file) {
+	$files['radiusd'] = RADDB . "/radiusd.conf";
+	$files['eap'] = RADDB . "/eap.conf";
+	$files['sql'] = RADDB . "/sql.conf";
+	$files['clients'] = RADDB . "/clients.conf";
+	$files['users'] = RADDB . "/users";
+	$files['macs'] = RADDB . "/authorized_macs";
+	$files['virtual-server-default'] = RADDB . "/sites-enabled/default";
+	$files['ca'] = RADDB . "/certs/ca.cnf";
+	$files['server'] = RADDB . "/certs/server.cnf";
+	$files['client'] = RADDB . "/certs/client.cnf";
+	$files['index'] = RADDB . "/certs/index.txt";
+	$files['ldap'] = RADDB . "/modules/ldap";
 
-
-	if ($files[$file]!="" && file_exists($files[$file])){
+	if ($files[$file] != "" && file_exists($files[$file])) {
 		print '<pre>';
-		print $files[$file]."\n".file_get_contents($files[$file]);
+		print $files[$file] . "\n" . file_get_contents($files[$file]);
 		print '</pre>';
 	}
 }


### PR DESCRIPTION
Code style/other fixes
- Fix code style, whitespace, indentation
- Make things much more readable by leaving out the  middle part of the```?:``` ternary operator
- Replace exec() with mwexec() 
- Use native PHP functions where possible/suitable
- Replace horrible code using echo redirection from shell with file_put_contents()
- Use openvpn_create_dhparams() to create DH params file
- Do not use code like ```exec("cd $foo; bar")```
- Use full paths to executables in mwexec()
- Improve comments
- Etc. ...

Others:
- Add prominent deprecation warnings to 'Certificates' and 'EAP' tabs regarding the redundant FreeRADIUS Cert Manager feature. See https://redmine.pfsense.org/issues/7170.
- Fix Bug #6928 - "Access-Reject" not logged in MySQL radpostauth table