### PR TITLE
pfSense-pkg-apcupsd - new option for set shutdown behavior

### DIFF
--- a/sysutils/pfSense-pkg-apcupsd/Makefile
+++ b/sysutils/pfSense-pkg-apcupsd/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-apcupsd
 PORTVERSION=	0.3.9
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-apcupsd/files/usr/local/pkg/apcupsd.inc
+++ b/sysutils/pfSense-pkg-apcupsd/files/usr/local/pkg/apcupsd.inc
@@ -140,6 +140,7 @@ function sync_package_apcupsd() {
 			$annoy = $apcupsd_config['annoy'] ?: "300";
 			$annoydelay = $apcupsd_config['annoydelay'] ?: "60";
 			$killdelay = $apcupsd_config['killdelay'] ?: "0";
+			$shutdownbehavior = $apcupsd_config['shutdownbehavior'];
 			$netserver = $apcupsd_config['netserver'];
 			$nisip= $apcupsd_config['nisip'] ?: "0.0.0.0";
 			$nisport = $apcupsd_config['nisport'] ?: "3551";
@@ -184,7 +185,7 @@ function sync_package_apcupsd() {
 			)
 		);
 
-		apccontrol_scripts_install($emailnotification);
+		apccontrol_scripts_install($emailnotification,$shutdownbehavior);
 
 		if (!file_exists("{$g['tmp_path']}/.rc.start_packages.running")) {
 			log_error("Starting service apcupsd");
@@ -195,7 +196,7 @@ function sync_package_apcupsd() {
 	conf_mount_ro();
 }
 
-function apccontrol_scripts_install($emailnotification) {
+function apccontrol_scripts_install($emailnotification,$shutdownbehavior) {
 	global $config, $g;
 
 	define('APCUPSD_BASE', '/usr/local');
@@ -257,6 +258,23 @@ EOF;
 		}
 
 		file_put_contents(APCUPSD_BASE . "/etc/apcupsd/" . $apccontrol_script, $apccontrol_script_file, LOCK_EX);
+	}
+
+	if ($shutdownbehavior == "poweroff") {
+		$doshutdown_script_file =<<<EOF
+#!/bin/sh
+
+printf "Beginning Shutdown Sequence (shutdown -p)" | wall
+/sbin/shutdown -p now "apcupsd initiated shutdown"
+
+exit 99
+
+EOF;
+
+		file_put_contents(APCUPSD_BASE . "/etc/apcupsd/doshutdown", $doshutdown_script_file, LOCK_EX);
+		@chmod(APCUPSD_BASE . "/etc/apcupsd/doshutdown", 0744);
+	} else {
+		unlink_if_exists(APCUPSD_BASE . "/etc/apcupsd/doshutdown");
 	}
 
 }

--- a/sysutils/pfSense-pkg-apcupsd/files/usr/local/pkg/apcupsd.inc
+++ b/sysutils/pfSense-pkg-apcupsd/files/usr/local/pkg/apcupsd.inc
@@ -265,7 +265,7 @@ EOF;
 #!/bin/sh
 
 printf "Beginning Shutdown Sequence (shutdown -p)" | wall
-/etc/rc.halt
+/sbin/shutdown -p now "apcupsd initiated shutdown"
 
 exit 99
 

--- a/sysutils/pfSense-pkg-apcupsd/files/usr/local/pkg/apcupsd.inc
+++ b/sysutils/pfSense-pkg-apcupsd/files/usr/local/pkg/apcupsd.inc
@@ -265,7 +265,7 @@ EOF;
 #!/bin/sh
 
 printf "Beginning Shutdown Sequence (shutdown -p)" | wall
-/sbin/shutdown -p now "apcupsd initiated shutdown"
+/etc/rc.halt
 
 exit 99
 

--- a/sysutils/pfSense-pkg-apcupsd/files/usr/local/pkg/apcupsd.xml
+++ b/sysutils/pfSense-pkg-apcupsd/files/usr/local/pkg/apcupsd.xml
@@ -247,6 +247,25 @@
 			<default_value>0</default_value>
 		</field>
 		<field>
+			<fielddescr>Shutdown Behavior</fielddescr>
+			<fieldname>shutdownbehavior</fieldname>
+			<description>
+				<![CDATA[
+				Halt - /sbin/shutdown -h now <br />
+				The system is halted at the specified time. (default) <br />
+				<br />
+				Power Off - /sbin/shutdown -p now <br />
+				The system is halted and the power is turned off (hardware support required) at the specified time.
+				]]>
+				</description>
+			<type>select</type>
+			<default_value>halt</default_value>
+			<options>
+				<option><name>Halt</name><value>halt</value></option>
+				<option><name>Power Off</name><value>poweroff</value></option>
+			</options>
+		</field>
+		<field>
 			<name>Configuration statements for Network Information Server</name>
 			<type>listtopic</type>
 		</field>


### PR DESCRIPTION
This quote from apccontrol explains:
```
[...]
# You can customize every single command creating an executable file (may be a
# script or a compiled program) and calling it the same as the $1 parameter
# passed by apcupsd to this script.
#
# After executing your script, apccontrol continues with the default action.
# If you do not want apccontrol to continue, exit your script with exit 
# code 99. E.g. "exit 99".
[...]
```

Suggested and tested by LucaTo from pfsense forum. Thank you.