### PR TITLE
tinc - fix interface group handling, avoid rename() producing a crash report on save due to non-empty directory

### DIFF
--- a/security/pfSense-pkg-tinc/Makefile
+++ b/security/pfSense-pkg-tinc/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-tinc
 PORTVERSION=	1.0.28
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-tinc/files/usr/local/pkg/tinc.inc
+++ b/security/pfSense-pkg-tinc/files/usr/local/pkg/tinc.inc
@@ -100,7 +100,7 @@ function tinc_save() {
 		$_output = base64_decode($tincconf['tinc_up']) . "\n";
 	} else {
 		$_output = "ifconfig \$INTERFACE " . $tincconf['localip'] . " netmask " . $tincconf['vpnnetmask'] . "\n";
-		$_output .= "ifconfig \$INTERFACE group pkg-tinc\n";
+		$_output .= "ifconfig \$INTERFACE group pkg_tinc\n";
 	}
 	file_put_contents("{$configpath}/tinc-up", $_output);
 	chmod("{$configpath}/tinc-up", 0744);
@@ -166,7 +166,7 @@ function tinc_install() {
 	$ifgroupentry = array();
 	$ifgroupentry['members'] = '';
 	$ifgroupentry['descr'] = 'tinc mesh VPN interface group';
-	$ifgroupentry['ifname'] = 'pkg-tinc';
+	$ifgroupentry['ifname'] = 'pkg_tinc';
 	$a_ifgroups[] = $ifgroupentry;
 
 	/* XXX: Do not remove this. WTH?! */
@@ -188,7 +188,7 @@ function tinc_deinstall() {
 	$myid = -1;
 	$i = 0;
 	foreach ($a_ifgroups as $ifgroupentry) {
-		if ($ifgroupentry['ifname'] == 'pkg-tinc') {
+		if ($ifgroupentry['ifname'] == 'pkg_tinc') {
 			$myid = $i;
 			break;
 		}

--- a/security/pfSense-pkg-tinc/files/usr/local/pkg/tinc.inc
+++ b/security/pfSense-pkg-tinc/files/usr/local/pkg/tinc.inc
@@ -30,6 +30,7 @@ function tinc_save() {
 
 	conf_mount_rw();
 
+	rmdir_recursive("{$configpath}.old");
 	rename("{$configpath}", "{$configpath}.old");
 	safe_mkdir("{$configpath}");
 	safe_mkdir("{$configpath}/hosts");

--- a/security/pfSense-pkg-tinc/files/usr/local/pkg/tinc.inc
+++ b/security/pfSense-pkg-tinc/files/usr/local/pkg/tinc.inc
@@ -139,7 +139,6 @@ function tinc_save() {
 		unlink_if_exists("/usr/local/etc/rc.d/tinc.sh");
 	}
 
-	rmdir_recursive("/usr/local/etc/tinc.old");
 	conf_mount_ro();
 }
 


### PR DESCRIPTION
https://redmine.pfsense.org/issues/7173

@rbgarga  Switched this to use ```pkg_``` as an interface group reserved for packages, since dash is clearly not viable character here. Whatever is agreed on here, needs a couple of other commits in pfSense itself.