### PR TITLE
darkstat - make port configurable, split PHP from XML, add work around for Bug #7178

### DIFF
--- a/net-mgmt/pfSense-pkg-darkstat/Makefile
+++ b/net-mgmt/pfSense-pkg-darkstat/Makefile
@@ -26,10 +26,15 @@ do-extract:
 
 do-install:
 	${MKDIR} ${STAGEDIR}${PREFIX}/pkg
+	${MKDIR} ${STAGEDIR}${PREFIX}/www
 	${MKDIR} ${STAGEDIR}/etc/inc/priv
 	${MKDIR} ${STAGEDIR}${DATADIR}
-	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/darkstat.xml \
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/darkstat.xml \
 		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/darkstat.inc \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/darkstat_redirect.php \
+		${STAGEDIR}${PREFIX}/www
 	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/darkstat.priv.inc \
 		${STAGEDIR}/etc/inc/priv
 	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \

--- a/net-mgmt/pfSense-pkg-darkstat/Makefile
+++ b/net-mgmt/pfSense-pkg-darkstat/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-darkstat
 PORTVERSION=	3.1.3
+PORTREVISION=	1
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-darkstat/files/usr/local/pkg/darkstat.inc
+++ b/net-mgmt/pfSense-pkg-darkstat/files/usr/local/pkg/darkstat.inc
@@ -1,0 +1,221 @@
+<?php
+/*
+ * darkstat.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2009-2017 Rubicon Communications, LLC (Netgate)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once('config.inc');
+require_once('interfaces.inc');
+require_once('services.inc');
+require_once('service-utils');
+require_once('util.inc');
+
+function sync_package_darkstat() {
+	global $config, $darkstat_config;
+	if (is_array($config['installedpackages']['darkstat'])) {
+		$darkstat_config =& $config['installedpackages']['darkstat']['config'][0];
+	} else {
+		$darkstat_config = array();
+	}
+	conf_mount_rw();
+
+	/* If the service is (being) disabled, stop it (if running), remove rc script and do nothing else */
+	if ($darkstat_config['enable'] != "on") {
+		if (is_process_running("darkstat")) {
+			stop_service("darkstat");
+		}
+		unlink_if_exists('/usr/local/etc/rc.d/darkstat.sh');
+		return;
+	}
+
+	/* Configure capture interface(s) */
+	$capture_interfaces = $darkstat_config['capture_interfaces'] ?: 'lan';
+	foreach (explode(",", $capture_interfaces) as $iface) {
+		$if = convert_friendly_interface_to_real_interface_name($iface);
+		if ($if) {
+			$ifaces_final .= " -i {$if}";
+		}
+	}
+	$start = "/usr/local/sbin/darkstat {$ifaces_final}";
+
+	/* Configure bind interface(s) */
+	foreach (explode(",", $darkstat_config['bind_interfaces']) as $iface) {
+		$if = convert_friendly_interface_to_real_interface_name($iface);
+		$if = get_interface_ip("$iface");
+		if ($if) {
+			$bind_ifaces_final .= " -b {$if}";
+		}
+	}
+	$start .= "{$bind_ifaces_final}";
+
+	/* Configure darkstat webgui port */
+	if (is_port($darkstat_config['port'])) {
+		$port = $darkstat_config['port'];
+	} else {
+		$port = '666';
+	}
+	$start .= " -p {$port}";
+
+	/* Deal with the rest of configured options here */
+	/* Local Network Traffic */
+	$localnetworkenable = $darkstat_config['localnetworkenable'];
+	$lif = $darkstat_config['localnetwork'];
+	/* Local Networks Only */
+	if ($localnetworkenable != "") {
+		if (is_ipaddrv4(get_interface_ip($lif))) {
+			$start .= " -l " . escapeshellarg(gen_subnet(get_interface_ip($lif), get_interface_subnet($lif)) . '/' . gen_subnet_mask(get_interface_subnet($lif)));
+		}
+		if ($darkstat_config['localnetworkonly'] != "") {
+			$start .= " --local-only";
+		}
+	}
+	/* No Promiscuous Mode */
+	if (($localnetworkenable == "") && ($darkstat_config['nopromisc'] != "")) {
+		$start .= " --no-promisc";
+	}
+	/* Disable DNS Resolution */
+	if ($darkstat_config['nodns'] != "") {
+		$start .= " --no-dns";
+	}
+	/* Disable MAC Display */
+	if ($darkstat_config['nomacs'] != "") {
+		$start .= " --no-macs";
+	}
+	/* Disable Seen Time */
+	if ($darkstat_config['nolastseen'] != "") {
+		$start .= " --no-lastseen";
+	}
+	/* Maximum Hosts Count */
+	$hostsmax = $darkstat_config['hostsmax'];
+	$hostskeep = $darkstat_config['hostskeep'];
+	if (($hostsmax > 0) && ($hostsmax > $hostskeep)) {
+		$start .= " --hosts-max {$hostsmax}";
+	}
+	/* Maximum Hosts to Keep */
+	if (($hostskeep > 0) && ($hostskeep < $hostsmax)) {
+		$start .= " --hosts-keep {$hostskeep}";
+	}
+	/* Maximum Ports Count */
+	$portsmax = $darkstat_config['portsmax'];
+	$portskeep = $darkstat_config['portskeep'];
+	if (($portsmax > 0) && ($portsmax > $portskeep)) {
+		$start .= " --ports-max {$portsmax}";
+	}
+	/* Maximum Ports to Keep */
+	if (($portskeep > 0) && ($portskeep < $portsmax)) {
+		$start .= " --ports-keep {$portskeep}";
+	}
+	/* Advanced Filtering Options */
+	$advfilter = $darkstat_config['advfilter'];
+	if ($advfilter != "") {
+		$start .= " -f " . escapeshellarg(base64_decode($advfilter));
+	}
+
+	/* Create rc script */
+	write_rcfile(array(
+			"file" => "darkstat.sh",
+			"start" => $start,
+			"stop" => "/usr/bin/killall darkstat"
+		)
+	);
+
+	/* Do not (re)start service on boot */
+	if (platform_booting()) {
+		return;
+	} elseif (is_process_running("darkstat")) {
+		restart_service("darkstat");
+	} else {
+		start_service("darkstat");
+	}
+
+	conf_mount_ro();
+}
+
+function validate_input_darkstat($post, &$input_errors) {
+	global $config;
+	/* Validate Web Interface Port */
+	if ($post['port']) {
+		if (!is_port($post['port'])) {
+			$input_errors[] = gettext("The value for 'Web Interface Port' must be a valid port (1-65535).");
+		}
+		// Check webGUI port conflicts
+		$webgui_port = $config['system']['webgui']['port'];
+		if ($config['system']['webgui']['port'] == "") {
+			if ($config['system']['webgui']['protocol'] == "http") {
+				$webgui_port = 80;
+			} elseif ($config['system']['webgui']['protocol'] == "https") {
+				$webgui_port = 443;
+			}
+		}
+		if ($post['port'] == "{$webgui_port}") {
+			$input_errors[] = gettext("The value for 'Web Interface Port' must not be the same port where pfSense WebGUI is running ($webgui_port).");
+		}
+	}
+	/* Validate Maximum Hosts Count */
+	if ($post['hostsmax']) {
+		if ($post['hostsmax'] < 1 || !is_numericint($post['hostsmax'])) {
+			$input_errors[] = gettext("The value for 'Maximum Hosts Count' must be a positive integer.");
+		}
+	}
+	/* Validate Maximum Hosts to Keep */
+	if ($post['hostskeep']) {
+		if ($post['hostskeep'] < 1 || !is_numericint($post['hostskeep'])) {
+			$input_errors[] = gettext("The value for 'Maximum Hosts to Keep' must be a positive integer.");
+		}
+	}
+	/* Validate sanity for hosts limits */
+	if ($post['hostsmax'] || $post['hostskeep']) {
+		if ($post['hostsmax'] <= $post['hostskeep']) {
+			$input_errors[] = gettext("'Maximum Hosts Count' must be greater than 'Maximum Hosts to Keep'.");
+		}
+	}
+	/* Validate Maximum Ports Count */
+	if ($post['portsmax']) {
+		if ($post['portsmax'] < 1 || !is_numericint($post['portsmax'])) {
+			$input_errors[] = gettext("The value for 'Maximum Ports Count' must be a positive integer.");
+		}
+	}
+	/* Validate Maximum Ports to Keep */
+	if ($post['portskeep']) {
+		if ($post['portskeep'] < 1 || !is_numericint($post['portskeep'])) {
+			$input_errors[] = gettext("The value for 'Maximum Ports to Keep' to keep' must be a positive integer.");
+		}
+	}
+	/* Validate sanity for ports limits */
+	if ($post['portsmax'] || $post['portskeep']) {
+		if ($post['portsmax'] <= $post['portskeep']) {
+			$input_errors[] = gettext("'Maximum Ports to Keep' must be greater than 'Maximum Ports Count'.");
+		}
+	}
+	/* Validate Local Network Traffic */
+	if ($post['localnetworkenable'] && $post['nopromisc'] != "") {
+		$input_errors[] = gettext("'No Promiscuous Mode' cannot be used when the 'Local Network' feature is enabled.");
+	}
+	/* Local Network must be IPv4 - no IPv6 support in darkstat */
+	if ($post['localnetwork']) {
+		$int = convert_friendly_interface_to_real_interface_name($post['localnetwork']);
+		$ip = find_interface_ip($int);
+		if (!is_ipaddrv4($ip)) {
+			$input_errors[] = gettext("The selected 'local network' interface has no IPv4 configured. Configured IPv4 is required.");
+		}
+	}
+	/* Basic sanity validation for Advanced Filtering Options*/
+	if (($post['advfilter']) && !preg_match("/^[a-zA-Z0-9\+\-\=\(\):. ]*$/", $post['advfilter'])) {
+		$input_errors[] = gettext('Advanced traffic filtering options may only contain characters matching ^[a-zA-Z0-9\+\-\=\(\):. ]*$ regexp.');
+	}
+}

--- a/net-mgmt/pfSense-pkg-darkstat/files/usr/local/pkg/darkstat.inc
+++ b/net-mgmt/pfSense-pkg-darkstat/files/usr/local/pkg/darkstat.inc
@@ -55,7 +55,6 @@ function sync_package_darkstat() {
 
 	/* Configure bind interface(s) */
 	foreach (explode(",", $darkstat_config['bind_interfaces']) as $iface) {
-		$if = convert_friendly_interface_to_real_interface_name($iface);
 		$if = get_interface_ip("$iface");
 		if ($if) {
 			$bind_ifaces_final .= " -b {$if}";

--- a/net-mgmt/pfSense-pkg-darkstat/files/usr/local/pkg/darkstat.xml
+++ b/net-mgmt/pfSense-pkg-darkstat/files/usr/local/pkg/darkstat.xml
@@ -56,6 +56,7 @@
 			<fielddescr>Enable darkstat</fielddescr>
 			<fieldname>enable</fieldname>
 			<type>checkbox</type>
+			<description>Check to enable darkstat.</description>
 		</field>
 		<field>
 			<fielddescr>Capture Interfaces</fielddescr>

--- a/net-mgmt/pfSense-pkg-darkstat/files/usr/local/pkg/darkstat.xml
+++ b/net-mgmt/pfSense-pkg-darkstat/files/usr/local/pkg/darkstat.xml
@@ -27,11 +27,18 @@
 	</copyright>
 	<name>Darkstat</name>
 	<title>Diagnostics: Darkstat</title>
+	<include_file>/usr/local/pkg/darkstat.inc</include_file>
 	<menu>
-		<name>Darkstat Settings</name>
+		<name>darkstat Settings</name>
 		<tooltiptext>Setup darkstat specific settings.</tooltiptext>
 		<section>Diagnostics</section>
 		<url>/pkg_edit.php?xml=darkstat.xml</url>
+	</menu>
+	<menu>
+		<name>darkstat</name>
+		<tooltiptext>Access darkstat</tooltiptext>
+		<section>Diagnostics</section>
+		<url>/darkstat_redirect.php</url>
 	</menu>
 	<service>
 		<name>darkstat</name>
@@ -41,13 +48,13 @@
 	</service>
 	<tabs>
 		<tab>
-			<text>Darkstat Settings</text>
+			<text>darkstat Settings</text>
 			<url>/pkg_edit.php?xml=darkstat.xml</url>
 			<active/>
 		</tab>
 		<tab>
-			<text>Access Darkstat</text>
-			<url>http://$myurl:666</url>
+			<text>Access darkstat</text>
+			<url>/darkstat_redirect.php</url>
 		</tab>
 	</tabs>
 	<advanced_options>enabled</advanced_options>
@@ -86,22 +93,20 @@
 			<size>3</size>
 			<multiple>true</multiple>
 		</field>
-		<!-- Disabled until there is some way to handle the $myurl thing in the tabs/url tag above -->
-		<!--
 		<field>
-			<fielddescr>Port</fielddescr>
+			<fielddescr>Web Interface Port</fielddescr>
 			<fieldname>port</fieldname>
 			<description>
 				<![CDATA[
 				Bind the darkstat web interface to the specified port.<br />
-				<strong>WARNING: Do NOT set this to the same port where pfSense WebGUI is running (usually 80/443)!</strong><br />
-				(Default is 666.)
+				<span class="text-danger">WARNING: </span>Do NOT set this to the same port where pfSense WebGUI is running (usually 80/443)!<br />
+				<span class="text-info">Default: 666</span>
 				]]>
 			</description>
 			<type>input</type>
 			<size>5</size>
+			<default_value>666</default_value>
 		</field>
-		-->
 		<field>
 			<fielddescr>Local Network Traffic</fielddescr>
 			<fieldname>localnetworkenable</fieldname>
@@ -235,153 +240,6 @@
 			<advancedfield/>
 		</field>
 	</fields>
-	<custom_php_global_functions>
-	<![CDATA[
-		function sync_package_darkstat() {
-			conf_mount_rw();
-			global $config, $darkstat_config;
-			$darkstat_config =& $config['installedpackages']['darkstat']['config'][0];
-
-			/* If the service is (being) disabled, stop it (if running), remove rc script and do nothing else */
-			if ($darkstat_config['enable'] != "on") {
-				if (is_process_running("darkstat")) {
-					stop_service("darkstat");
-				}
-				unlink_if_exists('/usr/local/etc/rc.d/darkstat.sh');
-				return;
-			}
-
-			/* Configure capture interface(s) */
-			$capture_interfaces = $darkstat_config['capture_interfaces'] ?: 'lan';
-			foreach (explode(",", $capture_interfaces) as $iface) {
-				$if = convert_friendly_interface_to_real_interface_name($iface);
-				if ($if) {
-					$ifaces_final .= " -i {$if}";
-				}
-			}
-			$start = "/usr/local/sbin/darkstat {$ifaces_final}";
-
-			/* Configure bind interface(s) */
-			foreach (explode(",", $darkstat_config['bind_interfaces']) as $iface) {
-				$if = convert_friendly_interface_to_real_interface_name($iface);
-				$if = get_interface_ip("$iface");
-				if ($if) {
-					$bind_ifaces_final .= " -b {$if}";
-				}
-			}
-			$start .= "{$bind_ifaces_final}";
-
-			/* Configure darkstat webgui port
-			NOTE: This will be always be 666 for now, until the 'Port' field is re-enabled in darkstat.xml
-			*/
-			$port = $darkstat_config['port'] ?: '666';
-			$start .= " -p {$port}";
-
-			/* Deal with the rest of configured options here */
-			$localnetworkenable = $darkstat_config['localnetworkenable'];
-			$lif = $darkstat_config['localnetwork'];
-			if ($localnetworkenable != "") {
-				if (is_ipaddrv4(get_interface_ip($lif))) {
-					$start .= " -l " . escapeshellarg(gen_subnet(get_interface_ip($lif), get_interface_subnet($lif)) . '/' . gen_subnet_mask(get_interface_subnet($lif)));
-				}
-				if ($darkstat_config['localnetworkonly'] != "") {
-					$start .= " --local-only";
-				}
-			}
-			if (($localnetworkenable == "") && ($darkstat_config['nopromisc'] != "")) {
-				$start .= " --no-promisc";
-			}
-			if ($darkstat_config['nodns'] != "") {
-				$start .= " --no-dns";
-			}
-			if ($darkstat_config['nomacs'] != "") {
-				$start .= " --no-macs";
-			}
-			if ($darkstat_config['nolastseen'] != "") {
-				$start .= " --no-lastseen";
-			}
-			$hostsmax = $darkstat_config['hostsmax'];
-			$hostskeep = $darkstat_config['hostskeep'];
-			if (($hostsmax > 0) && ($hostsmax > $hostskeep)) {
-				$start .= " --hosts-max {$hostsmax}";
-			}
-			if (($hostskeep > 0) && ($hostskeep < $hostsmax)) {
-				$start .= " --hosts-keep {$hostskeep}";
-			}
-			$portsmax = $darkstat_config['portsmax'];
-			$portskeep = $darkstat_config['portskeep'];
-			if (($portsmax > 0) && ($portsmax > $portskeep)) {
-				$start .= " --ports-max {$portsmax}";
-			}
-			if (($portskeep > 0) && ($portskeep < $portsmax)) {
-				$start .= " --ports-keep {$portskeep}";
-			}
-			$advfilter = $darkstat_config['advfilter'];
-			if ($advfilter != "") {
-				$start .= " -f " . escapeshellarg(base64_decode($advfilter));
-			}
-
-			write_rcfile(array(
-					"file" => "darkstat.sh",
-					"start" => $start,
-					"stop" => "/usr/bin/killall darkstat"
-				)
-			);
-
-			/* Do not (re)start service on boot */
-			if (platform_booting()) {
-				return;
-			} elseif (is_process_running("darkstat")) {
-				restart_service("darkstat");
-			} else {
-				start_service("darkstat");
-			}
-
-			conf_mount_ro();
-		}
-
-		function validate_input_darkstat($post, &$input_errors) {
-			if (($_POST['port']) && ($_POST['port'] < 1 || $_POST['port'] < 65535 || !is_numericint($_POST['port']))) {
-				$input_errors[] = gettext("The value for 'Maximum number of ports' to keep' must be a positive integer between 1 and 65535.");
-			}
-			if (($_POST['hostsmax']) && ($_POST['hostsmax'] < 1 || !is_numericint($_POST['hostsmax']))) {
-				$input_errors[] = gettext("The value for 'Maximum hosts count' must be a positive integer.");
-			}
-			if (($_POST['hostskeep']) && ($_POST['hostskeep'] < 1 || !is_numericint($_POST['hostskeep']))) {
-				$input_errors[] = gettext("The value for 'Maximum number of hosts to keep' must be a positive integer.");
-			}
-			if ($_POST['hostsmax'] || $_POST['hostskeep']) {
-				if ($_POST['hostsmax'] <= $_POST['hostskeep']) {
-					$input_errors[] = gettext("'Maximum hosts count' must be greater than 'Maximum number of hosts to keep'.");
-				}
-			}
-			if (($_POST['portsmax']) && ($_POST['portsmax'] < 1 || !is_numericint($_POST['portsmax']))) {
-				$input_errors[] = gettext("The value for 'Maximum ports count' must be a positive integer.");
-			}
-			if (($_POST['portskeep']) && ($_POST['portskeep'] < 1 || !is_numericint($_POST['portskeep']))) {
-				$input_errors[] = gettext("The value for 'Maximum number of ports' to keep' must be a positive integer.");
-			}
-			if ($_POST['portsmax'] || $_POST['portskeep']) {
-				if ($_POST['portsmax'] <= $_POST['portskeep']) {
-					$input_errors[] = gettext("'Maximum ports count' must be greater than 'Maximum number of ports to keep'.");
-				}
-			}
-			if ($_POST['localnetworkenable'] && $_POST['nopromisc'] != "") {
-				$input_errors[] = gettext("'Do not use promiscuous mode to capture' cannot be used when the 'local network' feature is enabled.");
-			}
-			if ($_POST['localnetwork']) {
-				$int = convert_friendly_interface_to_real_interface_name($post['localnetwork']);
-				$ip = find_interface_ip($int);
-				if (!is_ipaddrv4($ip)) {
-					$input_errors[] = gettext("The selected 'local network' interface has no IPv4 configured. Configured IPv4 is required.");
-				}
-			}
-			if (($post['advfilter']) && !preg_match("/^[a-zA-Z0-9\+\-\=\(\):. ]*$/", $post['advfilter'])) {
-				$input_errors[] = gettext('Advanced traffic filtering options may only contain characters matching ^[a-zA-Z0-9\+\-\=\(\):. ]*$ regexp.');
-			}
-		}
-	]]>
-	</custom_php_global_functions>
 	<custom_php_resync_config_command>
 		sync_package_darkstat();
 	</custom_php_resync_config_command>

--- a/net-mgmt/pfSense-pkg-darkstat/files/usr/local/www/darkstat_redirect.php
+++ b/net-mgmt/pfSense-pkg-darkstat/files/usr/local/www/darkstat_redirect.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * darkstat_redirect.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2017 Rubicon Communications, LLC (Netgate)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once("config.inc");
+global $config;
+
+// Protocol and port
+$proto = $config['system']['webgui']['protocol'];
+if (is_array($config['installedpackages']['darkstat'])) {
+	$darkstat_config = $config['installedpackages']['darkstat']['config'][0];
+} else {
+	$darkstat_config = array();
+}
+$port= $darkstat_config['port'] ?: '666';
+
+// Hostname
+$httphost = getenv("HTTP_HOST");
+$colonpos = strpos($httphost, ":");
+if ($colonpos) {
+	$baseurl = substr($httphost, 0, $colonpos);
+} else {
+	$baseurl = $httphost;
+}
+
+// Final redirect URL
+$url = "{$proto}://{$baseurl}:{$port}";
+header("Location: {$url}");
+
+?>

--- a/net-mgmt/pfSense-pkg-darkstat/pkg-plist
+++ b/net-mgmt/pfSense-pkg-darkstat/pkg-plist
@@ -1,4 +1,6 @@
 pkg/darkstat.xml
+pkg/darkstat.inc
+www/darkstat_redirect.php
 /etc/inc/priv/darkstat.priv.inc
 %%DATADIR%%/info.xml
 @dir /etc/inc/priv


### PR DESCRIPTION
- Split PHP code out of XML to darkstat.inc
- Make darkstat webgui port configurable
- Add a description tag to XML work around Bug #7178 - impossible to enable the service on pfSense themes otherwise; works properly with Compact-Red)