### PR TITLE
darkstat - Hardcode to HTTP, add optional custom hostname/IP address configuration

### DIFF
--- a/net-mgmt/pfSense-pkg-darkstat/Makefile
+++ b/net-mgmt/pfSense-pkg-darkstat/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-darkstat
 PORTVERSION=	3.1.3
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-darkstat/files/usr/local/pkg/darkstat.inc
+++ b/net-mgmt/pfSense-pkg-darkstat/files/usr/local/pkg/darkstat.inc
@@ -171,7 +171,7 @@ function validate_input_darkstat($post, &$input_errors) {
 		if (!is_ipaddrv4($post['host']) && !is_hostname($post['host']) && !is_domain($post['host'])) {
 			$input_errors[] = gettext("The value for 'Web Interface Hostname' must be a valid IPv4 address, hostname or domain");
 		} elseif (is_ipaddrv4($post['host']) && !is_ipaddr_configured($post['host'])) {
-			$input_errors[] = "Web Interface IP must be a valid, locally configured IPv4 address!";
+			$input_errors[] = gettext("Web Interface IP must be a valid, locally configured IPv4 address");
 		}
 	}
 	/* Validate Maximum Hosts Count */

--- a/net-mgmt/pfSense-pkg-darkstat/files/usr/local/pkg/darkstat.inc
+++ b/net-mgmt/pfSense-pkg-darkstat/files/usr/local/pkg/darkstat.inc
@@ -21,6 +21,7 @@
 
 require_once('config.inc');
 require_once('interfaces.inc');
+require_once('pfsense-utils.inc');
 require_once('services.inc');
 require_once('service-utils.inc');
 require_once('util.inc');
@@ -163,6 +164,14 @@ function validate_input_darkstat($post, &$input_errors) {
 		}
 		if ($post['port'] == "{$webgui_port}") {
 			$input_errors[] = gettext("The value for 'Web Interface Port' must not be the same port where pfSense WebGUI is running ($webgui_port).");
+		}
+	}
+	/* Validate Web Interface Hostname or IP */
+	if ($post['host']) {
+		if (!is_ipaddrv4($post['host']) && !is_hostname($post['host']) && !is_domain($post['host'])) {
+			$input_errors[] = gettext("The value for 'Web Interface Hostname' must be a valid IPv4 address, hostname or domain");
+		} elseif (is_ipaddrv4($post['host']) && !is_ipaddr_configured($post['host'])) {
+			$input_errors[] = "Web Interface IP must be a valid, locally configured IPv4 address!";
 		}
 	}
 	/* Validate Maximum Hosts Count */

--- a/net-mgmt/pfSense-pkg-darkstat/files/usr/local/pkg/darkstat.xml
+++ b/net-mgmt/pfSense-pkg-darkstat/files/usr/local/pkg/darkstat.xml
@@ -108,14 +108,17 @@
 			<default_value>666</default_value>
 		</field>
 		<field>
-			<fielddescr>Web Interface Hostname</fielddescr>
+			<fielddescr>Web Interface Hostname or IP Address (Optional)</fielddescr>
 			<fieldname>host</fieldname>
 			<description>
 				<![CDATA[
 				Darkstat web interface can use HTTP only; HTTPS protocol is not supported.
 				If pfSense is <a href="/system_advanced_admin.php">configured to use HTTPS for webConfigurator</a>, it will force HTTPS via HSTS header.
-				That will make it impossible to use the webConfigurator FQDN to access darkstat web interface via HTTP.<br />
-				Configure a custom hostname here for use with darkstat web interface to work around this limitation. Click Info for details.
+				That will make it impossible to use the webConfigurator FQDN to access darkstat web interface via HTTP.<br/>
+				Configure a custom hostname here for use with darkstat web interface to work around this limitation.<br />
+				<strong><span class="text-info">Hint: </span></strong>Use the IPv4 address of one of the 'Web Interface Binding' interfaces selected above
+				if you do not want want to deal with DNS configuration.<br/>
+				Click Info for details.
 				<div class="infoblock">
 				<strong><span class="text-danger">Important:</span></strong><br />
 				- You need to set up a 'Host Override' in <a href="/services_unbound.php">Services &gt; DNS Resolver</a>

--- a/net-mgmt/pfSense-pkg-darkstat/files/usr/local/pkg/darkstat.xml
+++ b/net-mgmt/pfSense-pkg-darkstat/files/usr/local/pkg/darkstat.xml
@@ -108,6 +108,33 @@
 			<default_value>666</default_value>
 		</field>
 		<field>
+			<fielddescr>Web Interface Hostname</fielddescr>
+			<fieldname>host</fieldname>
+			<description>
+				<![CDATA[
+				Darkstat web interface can use HTTP only; HTTPS protocol is not supported.
+				If pfSense is <a href="/system_advanced_admin.php">configured to use HTTPS for webConfigurator</a>, it will force HTTPS via HSTS header.
+				That will make it impossible to use the webConfigurator FQDN to access darkstat web interface via HTTP.<br />
+				Configure a custom hostname here for use with darkstat web interface to work around this limitation. Click Info for details.
+				<div class="infoblock">
+				<strong><span class="text-danger">Important:</span></strong><br />
+				- You need to set up a 'Host Override' in <a href="/services_unbound.php">Services &gt; DNS Resolver</a>
+				or <a href="/services_dnsmasq.php">Services &gt; DNS Forwarder</a> (depending on which of these you are using)
+				in order to make use of the 'Web Interface Hostname' configured here.<br/>
+				- If your clients are not using the DNS server on pfSense for DNS resolution, you need to set up such 'Host Override' (A record or CNAME pointing to pfSense)
+				on the DNS server that the clients are using, or locally on the clients (using hosts file or similar) for 'Web Interface Hostname' to work for such clients.<br/><br/>
+				<strong><span class="text-info">Hint:</span></strong><br />
+				As an alternative, you may want to put the darkstat web interface behind haproxy. 
+				You can use the <a href="https://doc.pfsense.org/index.php/Haproxy_package" target="_blank">haproxy package</a> for this purpose.
+				In that way, you can continue using HTTPS <em>and</em> the pfSense webConfigurator FQDN to aceess darkstat, and can even make it accessible via IPv6.<br/>
+				See the <a href="https://github.com/PiBa-NL/pfsense-haproxy-package-doc/wiki" target="_blank">HAProxy pfSense Package Howto</a> for usage instructions.
+				</div>
+				]]>
+			</description>
+			<type>input</type>
+			<size>30</size>
+		</field>
+		<field>
 			<fielddescr>Local Network Traffic</fielddescr>
 			<fieldname>localnetworkenable</fieldname>
 			<description>All traffic entering or leaving this network will be graphed.</description>

--- a/net-mgmt/pfSense-pkg-darkstat/files/usr/local/www/darkstat_redirect.php
+++ b/net-mgmt/pfSense-pkg-darkstat/files/usr/local/www/darkstat_redirect.php
@@ -22,8 +22,7 @@
 require_once("config.inc");
 global $config;
 
-// Protocol and port
-$proto = $config['system']['webgui']['protocol'];
+// Port
 if (is_array($config['installedpackages']['darkstat'])) {
 	$darkstat_config = $config['installedpackages']['darkstat']['config'][0];
 } else {
@@ -41,7 +40,7 @@ if ($colonpos) {
 }
 
 // Final redirect URL
-$url = "{$proto}://{$baseurl}:{$port}";
+$url = "http://{$baseurl}:{$port}";
 header("Location: {$url}");
 
 ?>

--- a/net-mgmt/pfSense-pkg-darkstat/files/usr/local/www/darkstat_redirect.php
+++ b/net-mgmt/pfSense-pkg-darkstat/files/usr/local/www/darkstat_redirect.php
@@ -28,19 +28,26 @@ if (is_array($config['installedpackages']['darkstat'])) {
 } else {
 	$darkstat_config = array();
 }
-$port= $darkstat_config['port'] ?: '666';
+$port = $darkstat_config['port'] ?: '666';
+$host = $darkstat_config['host'] ?: '';
 
-// Hostname
-$httphost = getenv("HTTP_HOST");
-$colonpos = strpos($httphost, ":");
-if ($colonpos) {
-	$baseurl = substr($httphost, 0, $colonpos);
+if (empty($host)) {
+	// Get hostname automagically
+	$httphost = getenv("HTTP_HOST");
+	$colonpos = strpos($httphost, ":");
+	if ($colonpos) {
+		$baseurl = substr($httphost, 0, $colonpos);
+	} else {
+		$baseurl = $httphost;
+	}
 } else {
-	$baseurl = $httphost;
+	// Use the configured 'Web Interface Hostname'
+	$baseurl = $host;
 }
 
 // Final redirect URL
 $url = "http://{$baseurl}:{$port}";
 header("Location: {$url}");
+exit;
 
 ?>


### PR DESCRIPTION
Hardcoding HTTP still has effect no on people using HTTPS, due to the hardcoded HSTS header in nginx (https://redmine.pfsense.org/issues/6650). Was broken before with ```$myurl```, still exactly same broken now, no regression, except that the port is configurable.

As a workaround, I added a field where people can put their own hostname or IP used for the redirect, instead of the pfSense hostname. Pretty much required for everyone on HTTPS.