### PR TITLE
Squid - firewall rules sanitization

### DIFF
--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
@@ -2139,9 +2139,9 @@ function squid_generate_rules($type) {
 			}
 			/* Handle PPPOE case */
 			if (($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) || (function_exists("is_pppoe_server_enabled") && is_pppoe_server_enabled())) {
-				$rules .= "rdr pass on $pppoe proto tcp from any to {$config['pppoe']['localip']} port 80 -> 127.0.0.1 port {$port}\n";
+				$rules .= "rdr pass on $pppoe proto tcp from any to !127.0.0.1 port 80 -> 127.0.0.1 port {$port}\n";
 				if ($squid_conf['ssl_proxy'] == "on") {
-					$rules .= "rdr pass on $pppoe proto tcp from any to {$config['pppoe']['localip']} port 443 -> 127.0.0.1 port {$ssl_port}\n";
+					$rules .= "rdr pass on $pppoe proto tcp from any to !127.0.0.1 port 443 -> 127.0.0.1 port {$ssl_port}\n";
 				}
 			}
 			$rules .= "\n";

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
@@ -2157,11 +2157,11 @@ function squid_generate_rules($type) {
 		case 'rule':
 			foreach ($proxy_ifaces as $iface) {
 				$rules .= "# Setup squid pass rules for proxy\n";
-				$rules .= "pass in quick on $iface proto tcp from any to !127.0.0.1 port {$pf_rule_ports} flags S/SA keep state\n";
+				$rules .= "pass in quick on $iface proto tcp from any to ($iface) port {$pf_rule_ports} flags S/SA keep state\n";
 				$rules .= "\n";
 			}
 			if ($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) {
-				$rules .= "pass in quick on $PPPOE_ALIAS proto tcp from any to !127.0.0.1 port {$pf_rule_ports} flags S/SA keep state\n";
+				$rules .= "pass in quick on $PPPOE_ALIAS proto tcp from any to ($PPPOE_ALIAS) port {$pf_rule_ports} flags S/SA keep state\n";
 			}
 			break;
 		default:

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
@@ -2084,7 +2084,7 @@ function squid_generate_rules($type) {
 				}
 				/* Handle PPPOE case */
 				if (($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) || (function_exists("is_pppoe_server_enabled") && is_pppoe_server_enabled())) {
-					$rules .= "no rdr on $pppoe proto tcp from any to { 192.168.0.0/16, 172.16.0.0/12, 10.0.0.0/8 } port {$pf_nat_ports}\n";
+					$rules .= "no rdr on \$pppoe proto tcp from any to { 192.168.0.0/16, 172.16.0.0/12, 10.0.0.0/8 } port {$pf_nat_ports}\n";
 				}
 			}
 			if (!empty($squid_conf['defined_ip_proxy_off'])) {
@@ -2106,7 +2106,7 @@ function squid_generate_rules($type) {
 				}
 				/* Handle PPPOE case */
 				if (($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) || (function_exists("is_pppoe_server_enabled") && is_pppoe_server_enabled())) {
-					$rules .= "no rdr on $pppoe proto tcp from { $exempt_ip } to any port {$pf_nat_ports}\n";
+					$rules .= "no rdr on \$pppoe proto tcp from { $exempt_ip } to any port {$pf_nat_ports}\n";
 				}
 			}
 			if (!empty($squid_conf['defined_ip_proxy_off_dest'])) {
@@ -2128,7 +2128,7 @@ function squid_generate_rules($type) {
 				}
 				/* Handle PPPOE case */
 				if (($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) || (function_exists("is_pppoe_server_enabled") && is_pppoe_server_enabled())) {
-					$rules .= "no rdr on $pppoe proto tcp from any to { $exempt_dest } port {$pf_nat_ports}\n";
+					$rules .= "no rdr on \$pppoe proto tcp from any to { $exempt_dest } port {$pf_nat_ports}\n";
 				}
 			}
 			foreach ($transparent_ifaces as $t_iface) {
@@ -2139,9 +2139,9 @@ function squid_generate_rules($type) {
 			}
 			/* Handle PPPOE case */
 			if (($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) || (function_exists("is_pppoe_server_enabled") && is_pppoe_server_enabled())) {
-				$rules .= "rdr pass on $pppoe proto tcp from any to !127.0.0.1 port 80 -> 127.0.0.1 port {$port}\n";
+				$rules .= "rdr pass on \$pppoe proto tcp from any to !127.0.0.1 port 80 -> 127.0.0.1 port {$port}\n";
 				if ($squid_conf['ssl_proxy'] == "on") {
-					$rules .= "rdr pass on $pppoe proto tcp from any to !127.0.0.1 port 443 -> 127.0.0.1 port {$ssl_port}\n";
+					$rules .= "rdr pass on \$pppoe proto tcp from any to !127.0.0.1 port 443 -> 127.0.0.1 port {$ssl_port}\n";
 				}
 			}
 			$rules .= "\n";
@@ -2154,7 +2154,7 @@ function squid_generate_rules($type) {
 				$rules .= "\n";
 			}
 			if ($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) {
-				$rules .= "pass in quick on $pppoe proto tcp from any to {$config['pppoe']['localip']} port {$pf_rule_ports} flags S/SA keep state\n";
+				$rules .= "pass in quick on \$pppoe proto tcp from any to {$config['pppoe']['localip']} port {$pf_rule_ports} flags S/SA keep state\n";
 			}
 			break;
 		default:

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
@@ -2072,11 +2072,6 @@ function squid_generate_rules($type) {
 	$ssl_port = ($squid_conf['ssl_proxy_port'] ? $squid_conf['ssl_proxy_port'] : 3129);
 
 	$fw_aliases = filter_generate_aliases();
-	if (strstr($fw_aliases, "pptp =")) {
-		$PPTP_ALIAS = "\$pptp";
-	} else {
-		$PPTP_ALIAS = "\$PPTP";
-	}
 	if (strstr($fw_aliases, "PPPoE =")) {
 		$PPPOE_ALIAS = "\$PPPoE";
 	} else {
@@ -2084,7 +2079,8 @@ function squid_generate_rules($type) {
 	}
 
 	// define ports based on transparent options and ssl filtering
-	$pf_rule_port = ($squid_conf['ssl_proxy'] == "on" ? "{80,443}" : "80");
+	$pf_nat_ports = ($squid_conf['ssl_proxy'] == "on" ? "{80,443}" : "80");
+	$pf_rule_ports = "{{$port},{$ssl_port}}";
 	switch($type) {
 		case 'nat':
 			$rules .= "\n# Setup Squid proxy redirect\n";
@@ -2095,7 +2091,7 @@ function squid_generate_rules($type) {
 				}
 				/* Handle PPPOE case */
 				if (($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) || (function_exists("is_pppoe_server_enabled") && is_pppoe_server_enabled())) {
-					$rules .= "no rdr on $PPPOE_ALIAS proto tcp from any to { 192.168.0.0/16, 172.16.0.0/12, 10.0.0.0/8 } port {$pf_rule_port}\n";
+					$rules .= "no rdr on $PPPOE_ALIAS proto tcp from any to { 192.168.0.0/16, 172.16.0.0/12, 10.0.0.0/8 } port {$pf_nat_ports}\n";
 				}
 			}
 			if (!empty($squid_conf['defined_ip_proxy_off'])) {
@@ -2117,7 +2113,7 @@ function squid_generate_rules($type) {
 				}
 				/* Handle PPPOE case */
 				if (($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) || (function_exists("is_pppoe_server_enabled") && is_pppoe_server_enabled())) {
-					$rules .= "no rdr on $PPPOE_ALIAS proto tcp from { $exempt_ip } to any port {$pf_rule_port}\n";
+					$rules .= "no rdr on $PPPOE_ALIAS proto tcp from { $exempt_ip } to any port {$pf_nat_ports}\n";
 				}
 			}
 			if (!empty($squid_conf['defined_ip_proxy_off_dest'])) {
@@ -2139,33 +2135,33 @@ function squid_generate_rules($type) {
 				}
 				/* Handle PPPOE case */
 				if (($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) || (function_exists("is_pppoe_server_enabled") && is_pppoe_server_enabled())) {
-					$rules .= "no rdr on $PPPOE_ALIAS proto tcp from any to { $exempt_dest } port {$pf_rule_port}\n";
+					$rules .= "no rdr on $PPPOE_ALIAS proto tcp from any to { $exempt_dest } port {$pf_nat_ports}\n";
 				}
 			}
 			foreach ($transparent_ifaces as $t_iface) {
-				$pf_transparent_rule_port = (in_array($t_iface, $ssl_ifaces) ? "{80,443}" : "80");
-				$rules .= "rdr on $t_iface proto tcp from any to !($t_iface) port 80 -> 127.0.0.1 port {$port}\n";
+				$rules .= "rdr pass on $t_iface proto tcp from any to !($t_iface) port 80 -> 127.0.0.1 port {$port}\n";
 				if (in_array($t_iface, $ssl_ifaces)) {
-					$rules .= "rdr on $t_iface proto tcp from any to !($t_iface) port 443 -> 127.0.0.1 port {$ssl_port}\n";
+					$rules .= "rdr pass on $t_iface proto tcp from any to !($t_iface) port 443 -> 127.0.0.1 port {$ssl_port}\n";
 				}
 			}
 			/* Handle PPPOE case */
 			if (($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) || (function_exists("is_pppoe_server_enabled") && is_pppoe_server_enabled())) {
-				$rules .= "rdr on $PPPOE_ALIAS proto tcp from any to !127.0.0.1 port {$pf_rule_port} -> 127.0.0.1 port {$port}\n";
+				$rules .= "rdr pass on $PPPOE_ALIAS proto tcp from any to !($PPPOE_ALIAS) port 80 -> 127.0.0.1 port {$port}\n";
+				if ($squid_conf['ssl_proxy'] == "on") {
+					$rules .= "rdr pass on $t_iface proto tcp from any to !($PPPOE_ALIAS) port 443 -> 127.0.0.1 port {$ssl_port}\n";
+				}
 			}
 			$rules .= "\n";
 			break;
 		case 'filter':
 		case 'rule':
-			foreach ($transparent_ifaces as $iface) {
-				$pf_transparent_rule_port = (in_array($iface, $ssl_ifaces) ? "{80,443,{$port},{$ssl_port}}" : "{80,{$port}}");
+			foreach ($proxy_ifaces as $iface) {
 				$rules .= "# Setup squid pass rules for proxy\n";
-				$rules .= "pass in quick on $iface proto tcp from any to !($iface) port {$pf_transparent_rule_port} flags S/SA keep state\n";
-				// $rules .= "pass in quick on $iface proto tcp from any to !($iface) port {$port} flags S/SA keep state\n";
+				$rules .= "pass in quick on $iface proto tcp from any to !127.0.0.1 port {$pf_rule_ports} flags S/SA keep state\n";
 				$rules .= "\n";
 			}
 			if ($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) {
-				$rules .= "pass in quick on $PPPOE_ALIAS proto tcp from any to !127.0.0.1 port {$port} flags S/SA keep state\n";
+				$rules .= "pass in quick on $PPPOE_ALIAS proto tcp from any to !127.0.0.1 port {$pf_rule_ports} flags S/SA keep state\n";
 			}
 			break;
 		default:

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
@@ -2071,13 +2071,6 @@ function squid_generate_rules($type) {
 	$port = ($squid_conf['proxy_port'] ? $squid_conf['proxy_port'] : 3128);
 	$ssl_port = ($squid_conf['ssl_proxy_port'] ? $squid_conf['ssl_proxy_port'] : 3129);
 
-	$fw_aliases = filter_generate_aliases();
-	if (strstr($fw_aliases, "PPPoE =")) {
-		$PPPOE_ALIAS = "\$PPPoE";
-	} else {
-		$PPPOE_ALIAS = "\$pppoe";
-	}
-
 	// define ports based on transparent options and ssl filtering
 	$pf_nat_ports = ($squid_conf['ssl_proxy'] == "on" ? "{80,443}" : "80");
 	$pf_rule_ports = "{{$port},{$ssl_port}}";
@@ -2091,7 +2084,7 @@ function squid_generate_rules($type) {
 				}
 				/* Handle PPPOE case */
 				if (($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) || (function_exists("is_pppoe_server_enabled") && is_pppoe_server_enabled())) {
-					$rules .= "no rdr on $PPPOE_ALIAS proto tcp from any to { 192.168.0.0/16, 172.16.0.0/12, 10.0.0.0/8 } port {$pf_nat_ports}\n";
+					$rules .= "no rdr on $pppoe proto tcp from any to { 192.168.0.0/16, 172.16.0.0/12, 10.0.0.0/8 } port {$pf_nat_ports}\n";
 				}
 			}
 			if (!empty($squid_conf['defined_ip_proxy_off'])) {
@@ -2113,7 +2106,7 @@ function squid_generate_rules($type) {
 				}
 				/* Handle PPPOE case */
 				if (($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) || (function_exists("is_pppoe_server_enabled") && is_pppoe_server_enabled())) {
-					$rules .= "no rdr on $PPPOE_ALIAS proto tcp from { $exempt_ip } to any port {$pf_nat_ports}\n";
+					$rules .= "no rdr on $pppoe proto tcp from { $exempt_ip } to any port {$pf_nat_ports}\n";
 				}
 			}
 			if (!empty($squid_conf['defined_ip_proxy_off_dest'])) {
@@ -2135,7 +2128,7 @@ function squid_generate_rules($type) {
 				}
 				/* Handle PPPOE case */
 				if (($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) || (function_exists("is_pppoe_server_enabled") && is_pppoe_server_enabled())) {
-					$rules .= "no rdr on $PPPOE_ALIAS proto tcp from any to { $exempt_dest } port {$pf_nat_ports}\n";
+					$rules .= "no rdr on $pppoe proto tcp from any to { $exempt_dest } port {$pf_nat_ports}\n";
 				}
 			}
 			foreach ($transparent_ifaces as $t_iface) {
@@ -2146,9 +2139,9 @@ function squid_generate_rules($type) {
 			}
 			/* Handle PPPOE case */
 			if (($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) || (function_exists("is_pppoe_server_enabled") && is_pppoe_server_enabled())) {
-				$rules .= "rdr pass on $PPPOE_ALIAS proto tcp from any to !($PPPOE_ALIAS) port 80 -> 127.0.0.1 port {$port}\n";
+				$rules .= "rdr pass on $pppoe proto tcp from any to {$config['pppoe']['localip']} port 80 -> 127.0.0.1 port {$port}\n";
 				if ($squid_conf['ssl_proxy'] == "on") {
-					$rules .= "rdr pass on $t_iface proto tcp from any to !($PPPOE_ALIAS) port 443 -> 127.0.0.1 port {$ssl_port}\n";
+					$rules .= "rdr pass on $pppoe proto tcp from any to {$config['pppoe']['localip']} port 443 -> 127.0.0.1 port {$ssl_port}\n";
 				}
 			}
 			$rules .= "\n";
@@ -2161,7 +2154,7 @@ function squid_generate_rules($type) {
 				$rules .= "\n";
 			}
 			if ($config['pppoe']['mode'] == "server" && $config['pppoe']['localip']) {
-				$rules .= "pass in quick on $PPPOE_ALIAS proto tcp from any to ($PPPOE_ALIAS) port {$pf_rule_ports} flags S/SA keep state\n";
+				$rules .= "pass in quick on $pppoe proto tcp from any to {$config['pppoe']['localip']} port {$pf_rule_ports} flags S/SA keep state\n";
 			}
 			break;
 		default:


### PR DESCRIPTION
**Do NOT merge now, this is for discussion ATM.**

OK, guys... so, reading the code, it appears to me the current firewall rules generated by Squid do not make particularly good sense. So I've come up with this:
- use ```rdr pass``` to pass traffic when we have transparent proxy enabled and are doing NAT
- when non-transparent (```case 'rule':```) we should pass the traffic _to the configured proxy ports only_, and the transparent proxy ports/interfaces really have nothing to do with those rules, so no idea why's the code referencing them at all
- finally, the PPPoE cases - no clue about this, no way to test, never used. Regardless, the current code there appears to be complete nonsense.

For a quick idea, here's a comparison of rules generated by the old and new code. with a really simple setup
-  ```LAN = igb0_vlan10``` being a non-transparent interface
-  ```WLAN = igb0_vlan88``` being set up as transparent interface with SSL/MITM
- proxy ports default 3128/3129
- RFC1918 excluded from proxying

**Old rules**
```
no rdr on igb0_vlan88 inet proto tcp from any to 192.168.0.0/16 port = http
no rdr on igb0_vlan88 inet proto tcp from any to 192.168.0.0/16 port = https
no rdr on igb0_vlan88 inet proto tcp from any to 172.16.0.0/12 port = http
no rdr on igb0_vlan88 inet proto tcp from any to 172.16.0.0/12 port = https
no rdr on igb0_vlan88 inet proto tcp from any to 10.0.0.0/8 port = http
no rdr on igb0_vlan88 inet proto tcp from any to 10.0.0.0/8 port = https

rdr on igb0_vlan88 inet proto tcp from any to ! (igb0_vlan88) port = http -> 127.0.0.1 port 3128
rdr on igb0_vlan88 inet proto tcp from any to ! (igb0_vlan88) port = https -> 127.0.0.1 port 3129

pass in quick on igb0_vlan88 proto tcp from any to ! (igb0_vlan88) port = http flags S/SA keep state
pass in quick on igb0_vlan88 proto tcp from any to ! (igb0_vlan88) port = https flags S/SA keep state
pass in quick on igb0_vlan88 proto tcp from any to ! (igb0_vlan88) port = 3128 flags S/SA keep state
pass in quick on igb0_vlan88 proto tcp from any to ! (igb0_vlan88) port = 3129 flags S/SA keep state
```

**New rules**
```
no rdr on igb0_vlan88 inet proto tcp from any to 192.168.0.0/16 port = http
no rdr on igb0_vlan88 inet proto tcp from any to 192.168.0.0/16 port = https
no rdr on igb0_vlan88 inet proto tcp from any to 172.16.0.0/12 port = http
no rdr on igb0_vlan88 inet proto tcp from any to 172.16.0.0/12 port = https
no rdr on igb0_vlan88 inet proto tcp from any to 10.0.0.0/8 port = http
no rdr on igb0_vlan88 inet proto tcp from any to 10.0.0.0/8 port = https

rdr pass on igb0_vlan88 inet proto tcp from any to ! (igb0_vlan88) port = http -> 127.0.0.1 port 3128
rdr pass on igb0_vlan88 inet proto tcp from any to ! (igb0_vlan88) port = https -> 127.0.0.1 port 3129

pass in quick on igb0_vlan10 proto tcp from any to (igb0_vlan10) port = 3128 flags S/SA keep state
pass in quick on igb0_vlan88 proto tcp from any to (igb0_vlan88) port = 3128 flags S/SA keep state
pass in quick on lo0 proto tcp from any to (lo0) port = 3128 flags S/SA keep state
pass in quick on igb0_vlan10 proto tcp from any to (igb0_vlan10) port = 3129 flags S/SA keep state
pass in quick on igb0_vlan88 proto tcp from any to (igb0_vlan88) port = 3129 flags S/SA keep state
pass in quick on lo0 proto tcp from any to (lo0) port = 3129 flags S/SA keep state
```

Also added some comments to the individual changes below.