### PR TITLE
Suricata - remove {fbegin,fend}.inc usage

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	3.1.2
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_rules.php
@@ -34,10 +34,6 @@ $pgtitle = "Services: Suricata - Update Rules";
 require_once("head.inc");
 ?>
 
-<body link="#0000CC" vlink="#0000CC" alink="#0000CC">
-
-<?if($pfsense_stable == 'yes'){echo '<p class="pgtitle">' . $pgtitle . '</p>';}?>
-
 <form action="/suricata/suricata_download_updates.php" method="GET">
 
 <table width="100%" border="0" cellpadding="6" cellspacing="0">

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_rules.php
@@ -31,12 +31,11 @@ require_once("/usr/local/pkg/suricata/suricata.inc");
 global $g;
 
 $pgtitle = "Services: Suricata - Update Rules";
-include("head.inc");
+require_once("head.inc");
 ?>
 
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
 
-<?php include("fbegin.inc"); ?>
 <?if($pfsense_stable == 'yes'){echo '<p class="pgtitle">' . $pgtitle . '</p>';}?>
 
 <form action="/suricata/suricata_download_updates.php" method="GET">
@@ -79,9 +78,8 @@ include("head.inc");
 	</tr>
 </table>
 </form>
-<?php include("fend.inc");?>
-</body>
-</html>
+<?php require_once("foot.inc"); ?>
+	
 <?php
 
 $suricata_gui_include = true;


### PR DESCRIPTION
See https://github.com/pfsense/pfsense/pull/3495

@bmeeks8 - Still using the pre-bootstrap tables, not touching that now.