### PR TITLE
System Patches ignore unlink of downloaded patch

### DIFF
--- a/sysutils/pfSense-pkg-System_Patches/Makefile
+++ b/sysutils/pfSense-pkg-System_Patches/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-System_Patches
-PORTVERSION=	1.1.5
+PORTVERSION=	1.1.6
 PORTREVISION=	1
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches.inc
+++ b/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches.inc
@@ -93,7 +93,7 @@ function patch_fetch(& $patch) {
 		download_file($url, $temp_filename);
 	}
 	$text = @file_get_contents($temp_filename);
-	unlink($temp_filename);
+	@unlink($temp_filename);
 	if (empty($text)) {
 		return false;
 	} else {

--- a/sysutils/pfSense-pkg-System_Patches/files/usr/local/www/system_patches_edit.php
+++ b/sysutils/pfSense-pkg-System_Patches/files/usr/local/www/system_patches_edit.php
@@ -185,7 +185,7 @@ $section->addInput($patchtext);
 
 $form->add($section);
 
-$section = new Form_Section('Patch Application Behavoir');
+$section = new Form_Section('Patch Application Behavior');
 
 $section->addInput(new Form_Select(
 	'pathstrip',


### PR DESCRIPTION
and a little typo in System Patches Edit.