### PR TITLE
Allow NS/MX records to have hostnames with pfSense-pkg-bind9

### DIFF
--- a/dns/pfSense-pkg-bind9/Makefile
+++ b/dns/pfSense-pkg-bind9/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-bind
 PORTVERSION=	9.11
-PORTREVISION=	7
+PORTREVISION=	8
 CATEGORIES=	dns net ipv6
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.inc
+++ b/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.inc
@@ -67,9 +67,6 @@ function bind_zone_validate($post, &$input_errors) {
 							$input_errors[] = 'On reverse zones, valid record types are NS or PTR';
 						}
 					}
-					if (preg_match("/(MX|NS)/", $_POST["hosttype$i"])) {
-						$_POST["hostname$i"] = "";
-					}
 					if (!preg_match("/(MX|NS)/", $_POST["hosttype$i"]) && $_POST["hostname$i"] == "") {
 						$input_errors[] = 'Record cannot be empty for '.$_POST["hosttype$i"].' type ';
 					}
@@ -507,7 +504,10 @@ EOD;
 							}
 						}
 						for ($y = 0; $y < sizeof($zone['row']); $y++) {
-							$hostname = (preg_match("/(MX|NS)/", $zone['row'][$y]['hosttype']) ? "@" : $zone['row'][$y]['hostname']);
+							$hostname = $zone['row'][$y]['hostname'];
+							if (preg_match("/(MX|NS)/", $zone['row'][$y]['hosttype']) && $hostname == "") {
+								$hostname = "@";
+							}
 							$hosttype = $zone['row'][$y]['hosttype'];
 							$hostdst = $zone['row'][$y]['hostdst'];
 							if (preg_match("/[a-zA-Z]/", $hostdst) && !preg_match("/(TXT|SPF|AAAA)/", $hosttype)) {


### PR DESCRIPTION
Previously, the BIND package would blank out the hostname field and always use "@" for either MX or NS records. However, this is an arbitrary limitation. If you want to delegate a sub-domain, then you need to be able to provide a NS record with a hostname. Additionally, providing MX records for hosts is a valid record as well.

This patch continues to allow a blank hostname field (automatically replacing with "@"), so this should be backward compatible for existing users.