### PR TITLE
Squid - Fix ClamAV DB location in widget (Bug #7305), cache digests tweaks

### DIFF
--- a/www/pfSense-pkg-squid/Makefile
+++ b/www/pfSense-pkg-squid/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-squid
 PORTVERSION=	0.4.36
+PORTREVISION=	1
 CATEGORIES=	www
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
@@ -1275,8 +1275,24 @@ function squid_resync_general() {
 	$squid_uid = SQUID_UID;
 	$squid_gid = SQUID_GID;
 
+	/*
+	 * Disable cache digest generation unless we are a sibbling to another proxy.
+	 * This avoids periods when Squid is unresponsive due to digest generation.
+	 */
+	$digest_generation = "off";
+	if (!is_array($config['installedpackages']['squidremote']['config'])) {
+		$config['installedpackages']['squidremote']['config'] = array();
+	}
+	foreach ($config['installedpackages']['squidremote']['config'] as $settings) {
+		if ($settings['enable'] == 'on' && $settings['hierarchy'] == 'sibling') {
+			$digest_generation = "on";
+			break;
+		}
+	}
+
 	$conf .= <<< EOD
 icp_port {$icp_port}
+digest_generation {$digest_generation}
 dns_v4_first {$dns_v4_first}
 pid_filename {$pidfile}
 cache_effective_user {$squid_uid}

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
@@ -712,7 +712,7 @@ function squid_upgrade_config() {
 	/* unset broken antivirus settings */
 	squid_antivirus_upgrade_config();
 
-	write_config();
+	write_config(gettext("Upgraded Squid configuration during package install."));
 }
 
 
@@ -1741,7 +1741,7 @@ function squid_resync_auth() {
 	global $config, $valid_acls;
 	$write_config = 0;
 	if (!is_array($config['installedpackages']['squidauth']['config'])) {
-		$config['installedpackages']['squidauth']['config'][] = array('auth_method'=> "none");
+		$config['installedpackages']['squidauth']['config'][] = array('auth_method' => "none");
 		$write_config++;
 	}
 	$settings = $config['installedpackages']['squidauth']['config'][0];
@@ -1758,7 +1758,7 @@ function squid_resync_auth() {
 	}
 
 	if ($write_config > 0) {
-		write_config();
+		write_config(gettext("Squid authentication method not configured, setting to None explicitly."));
 	}
 
 	$conf = '';

--- a/www/pfSense-pkg-squid/files/usr/local/www/widgets/widgets/squid_antivirus_status.widget.php
+++ b/www/pfSense-pkg-squid/files/usr/local/www/widgets/widgets/squid_antivirus_status.widget.php
@@ -31,7 +31,11 @@ if (file_exists("/usr/local/pkg/squid.inc")) {
 	echo "No squid.inc found. You must have Squid package installed to use this widget.";
 }
 
-define('PATH_CLAMDB', '/var/db/clamav');
+if (isset($config['system']['use_mfs_tmpvar'])) {
+	define('PATH_CLAMDB', '/usr/local/share/clamav-db/');
+} else {
+	define('PATH_CLAMDB', '/var/db/clamav/');
+}
 define('PATH_SQUID', SQUID_BASE . '/bin/squid');
 define('PATH_AVLOG', '/var/log/c-icap/virus.log');
 global $clamd_path, $img;


### PR DESCRIPTION
- Fix the Squid AV widget for systems with /var ramdisk.
- Disable cache digests generation unless we are a sibling to another proxy; avoids pointless periodic Squid freezes which have never been solved upstream.
- Add reason to write_config() calls