### PR TITLE
Restart BIND with SIGTERM, not SIGKILL

### DIFF
--- a/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.inc
+++ b/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.inc
@@ -868,7 +868,7 @@ function bind_write_rcfile() {
 		fi
 EOD;
 	$rc['stop'] = <<<EOD
-		/usr/bin/killall -9 named 2>/dev/null
+		/usr/bin/killall -TERM named 2>/dev/null
 		sleep 2
 EOD;
 	// curly braces in the following <<<EOD are PHP {$variable}, not named.conf text { value; }
@@ -876,7 +876,7 @@ EOD;
 		if [ -z "`/bin/ps auxw | /usr/bin/grep "[n]amed " | /usr/bin/awk '{print $2}'`" ]; then
 			{$BIND_LOCALBASE}/sbin/named {$ip_version} -c /etc/namedb/named.conf -u bind -t /cf/named/
 		else
-			/usr/bin/killall -9 named 2>/dev/null
+			/usr/bin/killall -TERM named 2>/dev/null
 				sleep 3
 			{$BIND_LOCALBASE}/sbin/named {$ip_version} -c /etc/namedb/named.conf -u bind -t /cf/named/
 		fi


### PR DESCRIPTION
BIND does not have a chance to freeze zones and
clean up if it is stopped or restarted with SIGKILL.
SIGTERM is the BIND9 documented way of stopping
named:
https://ftp.isc.org/isc/bind9/cur/9.9/doc/arm/Bv9ARM.ch03.html#signals

SIGKILL is not the right way to stop processes in
rc scripts: http://novosial.org/shell/kill-9/index.html

Discovered this when using dynamic zones and my zones were corrupted every time I made a configuration change (and BIND was restarted by the resync).