### PR TITLE
Acme, fix moving certificates, showing detail fields

### DIFF
--- a/security/pfSense-pkg-acme/Makefile
+++ b/security/pfSense-pkg-acme/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-acme
-PORTVERSION=	0.1.14
+PORTVERSION=	0.1.15
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_htmllist.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_htmllist.inc
@@ -148,11 +148,6 @@ class HtmlList
 	}
 
 	function acme_htmllist($rowvalues, $items, $editstate=false, $itemdetails=null) {
-		
-		//echo "TEST<br/>TEST<br/>TEST<br/>TEST<br/>";
-		//print_r($items);
-		//print_r($itemdetails);
-		
 		$tablename = $this->tablename;
 		global $g, $counter;
 		$result = "";
@@ -258,17 +253,19 @@ class HtmlList
 		</td>";
 				$result .= "</tr>";
 					if (isset($itemdetails)) {
+						$displayviewstyle = $editstate ? "hidden" : "";
+						$displayeditstyle = $editstate ? "" : "hidden";
 						$colspan = count($items);
 						$result .= "<tr id='tr_viewdetail_$counter'>";
 						$result .= <<<EOT
 							<td>
-							<div id="htmltable_{$tablename}_{$counter}_details_off" style="position:relative;float:right;width:11px;height:11px;">
+							<div class='$displayviewstyle' id="htmltable_{$tablename}_{$counter}_details_off" style="position:relative;float:right;width:11px;height:11px;">
 							<a onclick="htmltable_toggle_details('{$tablename}','{$counter}','htmltable_{$tablename}_{$counter}_details')">
 EOT
 							. acmeicon('expand','Expand advanced server settings') . '</a></div></td>';
 						$result .= "<td colspan='$colspan'>";
 						$itemnr = 0;
-						$result .= "<div id='htmltable_{$tablename}_{$counter}_details_view'>";
+						$result .= "<div id='htmltable_{$tablename}_{$counter}_details_view' class='$displayviewstyle'>";
 						$leftitem = true;
 						foreach($itemdetails as $item) {
 							$itemname = $item['name'];
@@ -298,7 +295,7 @@ EOT
 							$result .= "</div>";
 						}
 						$result .= "</div>";
-						$result .= "<div id='htmltable_{$tablename}_{$counter}_details_edit' class='hidden'>";
+						$result .= "<div id='htmltable_{$tablename}_{$counter}_details_edit' class='$displayeditstyle'>";
 						$result .= "<table class='table table-hover table-striped table-condensed' style='border-collapse:collapse' border='1' cellspacing='0' >";
 						foreach($itemdetails as $item) {
 							$itemname = $item['name'];

--- a/security/pfSense-pkg-acme/files/usr/local/www/acme/acme_certificates.php
+++ b/security/pfSense-pkg-acme/files/usr/local/www/acme/acme_certificates.php
@@ -105,10 +105,9 @@ if ($_POST) {
 		unset($delbtn, $delbtnp2, $movebtn, $movebtnp2, $togglebtn, $togglebtnp2);
 		foreach ($_POST as $pn => $pd) {
 			if (preg_match("/move_(.+)/", $pn, $matches)) {
-				$movebtn = $matches[1];
+				$movebtn = substr($pd, 5);
 			}
 		}
-		//
 		
 		/* move selected p1 entries before this */
 		if (isset($movebtn) && is_array($_POST['rule']) && count($_POST['rule'])) {
@@ -368,7 +367,8 @@ events.push(function() {
 	});
 	
 	$('[id^=Xmove_]').click(function (event) {
-		$('#' + event.target.id.slice(1)).click();
+		buttonid = event.target.id.slice(1);
+		$("[id='" + buttonid + "']").click();
 		return false;
 	});
 	$('[id^=Xmove_]').css('cursor', 'pointer');

--- a/security/pfSense-pkg-acme/files/usr/local/www/acme/acme_certificates_edit.php
+++ b/security/pfSense-pkg-acme/files/usr/local/www/acme/acme_certificates_edit.php
@@ -407,6 +407,7 @@ print $form;
 	totalrows =  <?php echo $counter; ?>;
 	
 	function table_domains_listitem_change(tableId, fieldId, rowNr, field) {
+		d = document;
 		if (fieldId === "toggle_details") {
 			fieldId = "method";
 			field = d.getElementById(tableId+fieldId+rowNr);
@@ -442,6 +443,7 @@ events.push(function() {
 		updatevisibility();
 	});
 	*/
+	$('[id^=table_domainsmethod]').change();
 	updatevisibility();
 });
 //]]>


### PR DESCRIPTION
fix moving certificates with anchor for certificates with a name containing a dot
https://redmine.pfsense.org/issues/7342#note-5

show extra 'detail' fields when tables are drawn in 'edit mode' for a new certificate
https://redmine.pfsense.org/issues/7237