### PR TITLE
Suricata improvements

### DIFF
--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -2516,6 +2516,7 @@ function suricata_modify_sid_content(&$rule_map, $sid_mods, $log_results = FALSE
 						$rule_map[1][$k2]['rule'] = preg_replace($from, $to, $v['rule'], -1, $count);
 						if ($count > 0) {
 							$rule_map[1][$k2]['managed'] = 1;
+							$rule_map[1][$k2]['modified'] = 1;
 							$sids[1][$k2] = 'modify';
 							$modifiedcount++;
 						}
@@ -2530,6 +2531,7 @@ function suricata_modify_sid_content(&$rule_map, $sid_mods, $log_results = FALSE
 						$rule_map[1][$sid]['rule'] = preg_replace($from, $to, $rule_map[1][$sid]['rule'], -1, $count);
 						if ($count > 0) {
 							$rule_map[1][$sid]['managed'] = 1;
+							$rule_map[1][$sid]['modified'] = 1;
 							$sids[1][$sid] = 'modify';
 							$modifiedcount++;
 						}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -1909,7 +1909,7 @@ function suricata_parse_sidconf_file($sidconf_file,$split_lines=TRUE) {
 	/*                    file to process         */
 	/*                                            */
 	/*  $split_lines ==> determines whether lines */
-	/*                   should be splitted at    */
+	/*                   should be split at       */
 	/*                   commas into multiple     */
 	/*                   sid modification	      */
 	/*                                            */
@@ -2511,12 +2511,27 @@ function suricata_modify_sid_content(&$rule_map, $sid_mods, $log_results = FALSE
 	// Walk the SID mod tokens and decode each one
 	foreach ($sid_mods as $tok) {
 		$matches = array();
-		if (preg_match('/(([\da-z-_*]+,)*([\da-z-_*]+))\s+"(.+)"\s+"(.*)"/', $tok, $matches)) {
+		if (preg_match('/((?<sid_category_list> (?<sid_category_plus_comma>[\da-z-_*]+,)* (?<last_sid_cageory>[\da-z-_*]+)) \s+)? "(?<from>.*)" \s+ "(?<to>.*)"/x', $tok, $matches)) {
+			// If a valid config token is found. A valid token is:
+			// An optional group of a comma separated list(sid_category_list) of SIDs(numbers) or categories(lowercase chars,numbers,- or _) plus whitespaces followed by
+			// a search term(from) framed by double quotes followed
+			// whitespaces followed by
+			// a replacement(to) framed by double quotes
+
 			$tokencounter++;
-			$sidlist = explode(",", $matches[1]);
-			$from = '/' . preg_quote($matches[4], '/') . '/';
-			$to = $matches[5];
+			$from = '/' . preg_quote($matches['from'], '/') . '/';
+			$to = $matches['to'];
 			$count = 0;
+
+			if ($matches['sid_category_list'] == "") {
+				// If the sidlist is empty it's the same as a wildcard, therefore create a list with just one wildcard item
+				$sidlist = array("*");
+			}
+			else {
+				// Otherwise split the list
+				$sidlist = explode(",", $matches['sid_category_list']);
+			}
+
 
 			// Walk over all sids
 			foreach ($sidlist as $sid) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -2511,40 +2511,42 @@ function suricata_modify_sid_content(&$rule_map, $sid_mods, $log_results = FALSE
 	// Walk the SID mod tokens and decode each one
 	foreach ($sid_mods as $tok) {
 		$matches = array();
-		if (preg_match('/([\d+|,|\*]*)\s+"(.+)"\s+"(.*)"/', $tok, $matches)) {
+		if (preg_match('/(([\da-z-_*]+,)*([\da-z-_*]+))\s+"(.+)"\s+"(.*)"/', $tok, $matches)) {
 			$tokencounter++;
 			$sidlist = explode(",", $matches[1]);
-			$from = '/' . preg_quote($matches[2], '/') . '/';
-			$to = $matches[3];
+			$from = '/' . preg_quote($matches[4], '/') . '/';
+			$to = $matches[5];
 			$count = 0;
 
-			// Now walk the provided rule map and make the modifications
-			if ($matches[1] == "*") {
-				// If wildcard '*' provided for SID, then check them all
-				if (is_array($rule_map)) {
-					foreach ($rule_map[1] as $k2 => $v) {
-						$modcount++;
-						$rule_map[1][$k2]['rule'] = preg_replace($from, $to, $v['rule'], -1, $count);
-						if ($count > 0) {
-							$rule_map[1][$k2]['managed'] = 1;
-							$rule_map[1][$k2]['modified'] = 1;
-							$sids[1][$k2] = 'modify';
-							$modifiedcount++;
-						}
+			// Walk over all sids
+			foreach ($sidlist as $sid) {
+				if (isset($rule_map[1][$sid])) {
+					// If sid is present change modify it
+					$modcount++;
+					$rule_map[1][$sid]['rule'] = preg_replace($from, $to, $rule_map[1][$sid]['rule'], -1, $count);
+					if ($count > 0) {
+						$rule_map[1][$sid]['managed'] = 1;
+						$rule_map[1][$sid]['modified'] = 1;
+						$sids[1][$sid] = 'modify';
+						$modifiedcount++;
 					}
 				}
-			}
-			else {
-				// Otherwise just check the provided SIDs
-				foreach ($sidlist as $sid) {
-					if (isset($rule_map[1][$sid])) {
-						$modcount++;
-						$rule_map[1][$sid]['rule'] = preg_replace($from, $to, $rule_map[1][$sid]['rule'], -1, $count);
-						if ($count > 0) {
-							$rule_map[1][$sid]['managed'] = 1;
-							$rule_map[1][$sid]['modified'] = 1;
-							$sids[1][$sid] = 'modify';
-							$modifiedcount++;
+				else {
+					// Otherwise it's a wildcard or category modification
+					if (is_array($rule_map)) {
+						// If rule_map is an array walk over it to find all rules which need be be modified
+						foreach ($rule_map[1] as $k2 => $v) {
+							if ($sid == "*" || $v['category'] == $sid) {
+								// If a wildcard changed is handled or the category is matching the rule needs to get modified
+								$modcount++;
+								$rule_map[1][$k2]['rule'] = preg_replace($from, $to, $v['rule'], -1, $count);
+								if ($count > 0) {
+									$rule_map[1][$k2]['managed'] = 1;
+									$rule_map[1][$k2]['modified'] = 1;
+									$sids[1][$k2] = 'modify';
+									$modifiedcount++;
+								}
+							}
 						}
 					}
 				}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -2510,8 +2510,8 @@ function suricata_modify_sid_content(&$rule_map, $sid_mods, $log_results = FALSE
 			// Now walk the provided rule map and make the modifications
 			if ($matches[1] == "*") {
 				// If wildcard '*' provided for SID, then check them all
-				foreach ($rule_map[1] as $rulem) {
-					foreach ($rulem as $k2 => $v) {
+				if (is_array($rule_map)) {
+					foreach ($rule_map[1] as $k2 => $v) {
 						$modcount++;
 						$rule_map[1][$k2]['rule'] = preg_replace($from, $to, $v['rule'], -1, $count);
 						if ($count > 0) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -1896,7 +1896,7 @@ function suricata_load_vrt_policy($policy, $mode='alert', $all_rules=null) {
 	return $vrt_policy_rules;
 }
 
-function suricata_parse_sidconf_file($sidconf_file) {
+function suricata_parse_sidconf_file($sidconf_file,$split_lines=TRUE) {
 
 	/**********************************************/
 	/* This function loads and processes the file */
@@ -1907,6 +1907,11 @@ function suricata_parse_sidconf_file($sidconf_file) {
 	/*                                            */
 	/*  $sidconf_file ==> full path and name of   */
 	/*                    file to process         */
+	/*                                            */
+	/*  $split_lines ==> determines whether lines */
+	/*                   should be splitted at    */
+	/*                   commas into multiple     */
+	/*                   sid modification	      */
 	/*                                            */
 	/*        Returns ==> an array containing     */
 	/*                    SID modifier tokens     */
@@ -1941,11 +1946,17 @@ function suricata_parse_sidconf_file($sidconf_file) {
 		// Trim leading and trailing spaces plus newline and any carriage returns
 		$buf = trim($line[0], ' \r\n');
 
-		// Now split the SID mod arguments at the commas, if more than one
-		// per line, and add to our $sid_mods array.
-		$line = explode(",", $buf);
-		foreach ($line as $ent) {
-			$sid_mods[] = trim($ent);
+		if ($split_lines) {
+			// If split mode split the SID mod arguments at the commas, if more than one
+			// per line, and add to our $sid_mods array.
+			$line = explode(",", $buf);
+			foreach ($line as $ent) {
+				$sid_mods[] = trim($ent);
+			}
+		}
+		else{
+			//Otherwise add 1 line as 1 modification to the $sid_mods array
+			$sid_mods[] = $buf;
 		}
 	}
 
@@ -2687,7 +2698,7 @@ function suricata_process_modifysid(&$rule_map, $suricatacfg, $log_results = FAL
 		log_error(gettext("[Suricata] Error - unable to open 'modify_sid_file' \"{$suricatacfg['modify_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 		return;
 	} else {
-		$sid_mods = suricata_parse_sidconf_file("{$suricata_sidmods_dir}{$suricatacfg['modify_sid_file']}");
+		$sid_mods = suricata_parse_sidconf_file("{$suricata_sidmods_dir}{$suricatacfg['modify_sid_file']}",FALSE);
 	}
 
 	if (!empty($sid_mods)) {

--- a/security/pfSense-pkg-suricata/files/var/db/suricata/sidmods/modifysid-sample.conf
+++ b/security/pfSense-pkg-suricata/files/var/db/suricata/sidmods/modifysid-sample.conf
@@ -1,7 +1,7 @@
 # example modifysid.conf
 #
 # formatting is simple
-# <sid or sid list> "what I'm replacing" "what I'm replacing it with"
+# <sid, category, list of sids&categories> "what I'm replacing" "what I'm replacing it with"
 #
 # Note that this will only work with GID:1 rules, simply because modifying
 # GID:3 SO stub rules would not actually affect the rule.
@@ -19,5 +19,13 @@
 # "HTTP_PORTS" "HTTPS_PORTS"
 
 # multiple sids can be specified as noted below:
-# 302,429,1821 "\$EXTERNAL_NET" "\$HOME_NET"
+# 302,429,1821 "$EXTERNAL_NET" "$HOME_NET"
 
+# modify all signatures in a category. Example: replace "$EXTERNAL_NETS" with "any" to be alerts on insider threats as well
+# emerging-scan "$EXTERNAL_NET" "any"
+
+# modify all signatures in multiple categories
+# emerging-scan,emerging-sql "$EXTERNAL_NET" "any"
+
+# modify all signatures for a category and specific SIDs from other categories
+# emerging-sql,2100691,2009817 "$EXTERNAL_NET" "any"


### PR DESCRIPTION
This are some improvements  for the suricata SID content mgmt.

It resolves 2 bugs in the SID content mgmt:

- Only the last SID in a list get modified
- Modification to all SIDs not working. Neither via the wildcard '*' nor with just the search term and replacement as showed in the example config.

Additionally it adds support to modify all signatures from a certain category
