### PR TITLE
Fix for Bug #7345: nanobsd upgrades still fail bacause of lacking resolv.conf

### DIFF
--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-upgrade
-PORTVERSION=	0.20
+PORTVERSION=	0.21
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-upgrade/files/pfSense-upgrade
+++ b/sysutils/pfSense-upgrade/files/pfSense-upgrade
@@ -708,6 +708,8 @@ setup_nanobsd_env() {
 
 	# Make sure resolv.conf is present, otherwise upgrade may fail (bug #6557)
 	local _resolv_conf=$(readlink -f /etc/resolv.conf)
+	_exec "unlink ${chroot_dir}/etc/resolv.conf" \
+		"Removing resolv.conf symlink from upgrade partition" mute ignore_result
 	_exec "cp -f ${_resolv_conf} ${chroot_dir}/etc/resolv.conf" \
 		"Copying resolv.conf to upgrade partition" mute ignore_result
 


### PR DESCRIPTION
Tested on my own box running NanoBSD 2.3.2_1 without dnsmasq or unbound enabled.  This patch allowed for a successful update to 2.3.3_1.