### PR TITLE
Update BIND to point to correct Log location

### DIFF
--- a/dns/pfSense-pkg-bind9/files/usr/local/pkg/pkg_bind.inc
+++ b/dns/pfSense-pkg-bind9/files/usr/local/pkg/pkg_bind.inc
@@ -23,7 +23,7 @@ global $shortcuts;
 
 $shortcuts['bind'] = array();
 $shortcuts['bind']['main'] = "pkg_edit.php?xml=bind.xml";
-$shortcuts['bind']['log'] = "diag_logs_resolver.php";
+$shortcuts['bind']['log'] = "status_logs.php?logfile=resolver";
 $shortcuts['bind']['status'] = "status_services.php";
 $shortcuts['bind']['service'] = "named";
 


### PR DESCRIPTION
Updated BIND Log location:
From:  diag_logs_resolver.php
To:      status_logs.php?logfile=resolver

Bug Report: https://redmine.pfsense.org/issues/7431