### PR TITLE
pfSense-pkg-net-snmp: Fix services

### DIFF
--- a/net-mgmt/pfSense-pkg-net-snmp/Makefile
+++ b/net-mgmt/pfSense-pkg-net-snmp/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-net-snmp
 PORTVERSION=	0.1.2
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-net-snmp/files/usr/local/pkg/net-snmp.xml
+++ b/net-mgmt/pfSense-pkg-net-snmp/files/usr/local/pkg/net-snmp.xml
@@ -49,7 +49,7 @@
 	<service>
 		<name>net-snmptrapd</name>
 		<rcfile>net-snmptrapd.sh</rcfile>
-		<executable>snmpdtrapd</executable>
+		<executable>snmptrapd</executable>
 		<description><![CDATA[NET-SNMP Trap Listening Daemon]]></description>
 	</service>
 	<tabs>


### PR DESCRIPTION
- ~~Service name must not use hyphens to not get conflicted with [pfSenseHelpers.js](https://github.com/pfsense/pfsense/blob/master/src/usr/local/www/js/pfSenseHelpers.js#L658-L659)~~
- Fix a typo in `snmptrapd` executable name
- Bump PORTREVISION