### PR TITLE
pfSense-pkg-suricata-3.2.1

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	3.1.2
-PORTREVISION=	3
+PORTVERSION=	3.2.1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +12,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=3.1.2:security/suricata \
+RUN_DEPENDS=	suricata>=3.2.1:security/suricata \
 		barnyard2:security/barnyard2
 
 NO_BUILD=	yes

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2014 Bill Meeks
+ * Copyright (C) 2017 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,13 +46,10 @@ if (!defined('SURICATA_PKG_VER'))
 $pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
 // Define the PBI base directory
 if (!defined('SURICATA_PBI_BASEDIR')) {
-	if ($pf_version == "2.1" || $pf_version == "2.2")
-		define('SURICATA_PBI_BASEDIR', '/usr/pbi/suricata-' . php_uname("m") . '/');
-	else
-		define('SURICATA_PBI_BASEDIR', '/usr/local/');
+	define('SURICATA_PBI_BASEDIR', '/usr/local/');
 }
 
-// Define the PBI binary wrapper directory
+// Define the suricata binary directory
 if (!defined('SURICATA_PBI_BINDIR'))
 	define('SURICATA_PBI_BINDIR', SURICATA_PBI_BASEDIR . 'bin/');
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -265,10 +265,10 @@ if ($suricatacfg['enable_tracked_files_magic'] == 'on')
 else
 	$json_log_magic = "no";
 
-if ($suricatacfg['enable_tracked_files_md5'] == 'on')
-	$json_log_md5 = "yes";
+if ($suricatacfg['tracked_files_hash'] != 'none')
+	$json_log_hash = "force-hash: [{$suricatacfg['tracked_files_hash']}]";
 else
-	$json_log_md5 = "no";
+	$json_log_hash = "#force-hash: [md5]";
 	
 if ($suricatacfg['enable_file_store'] == 'on') {
 	$file_store_enabled = "yes";
@@ -359,13 +359,15 @@ if (($suricatacfg['eve_log_alerts'] == 'on') && ($suricatacfg['eve_log_alerts_pa
 	
 if (($suricatacfg['eve_log_alerts'] == 'on') && ($suricatacfg['eve_log_alerts_payload'] == 'on')) {
 	$eve_out_types .= "\n        - alert:";
-	$eve_out_types .= "\n            payload: yes # enable dumping payload in Base64";
+	$eve_out_types .= "\n            payload: yes           # enable dumping payload in Base64";
 	$eve_out_types .= "\n            payload-printable: yes # enable dumping payload in printable (lossy) format";
-	$eve_out_types .= "\n            packet: yes # enable dumping of packet (without stream segments)";
-	$eve_out_types .= "\n            http: yes # enable dumping of http fields";
-	$eve_out_types .= "\n            tls: yes # enable dumping of tls fields";
-	$eve_out_types .= "\n            ssh: yes # enable dumping of ssh fields";
-	$eve_out_types .= "\n            smtp: yes # enable dumping of smtp fields";
+	$eve_out_types .= "\n            packet: yes            # enable dumping of packet (without stream segments)";
+	$eve_out_types .= "\n            http: yes              # enable dumping of http fields";
+	$eve_out_types .= "\n            tls: yes               # enable dumping of tls fields";
+	$eve_out_types .= "\n            ssh: yes               # enable dumping of ssh fields";
+	$eve_out_types .= "\n            smtp: yes              # enable dumping of smtp fields";
+	$eve_out_types .= "\n            dnp3: yes              # enable dumping of DNP3 fields";
+	$eve_out_types .= "\n            tagged-packets: yes    # enable logging of tagged packets";
 }
 
 if ($suricatacfg['eve_log_http'] == 'on') {
@@ -376,8 +378,11 @@ if ($suricatacfg['eve_log_http'] == 'on') {
 		$eve_out_types .= "\n            extended: no";
 }
 
-if ($suricatacfg['eve_log_dns'] == 'on')
-	$eve_out_types .= "\n        - dns";
+if ($suricatacfg['eve_log_dns'] == 'on') {
+	$eve_out_types .= "\n        - dns:";
+	$eve_out_types .= "\n            query: yes";
+	$eve_out_types .= "\n            answer: yes";
+}
 
 if ($suricatacfg['eve_log_tls'] == 'on') {
 	$eve_out_types .= "\n        - tls:";
@@ -393,14 +398,27 @@ if ($suricatacfg['eve_log_files'] == 'on') {
 		$eve_out_types .= "\n            force-magic: yes";
 	else
 		$eve_out_types .= "\n            force-magic: no";
-	if ($suricatacfg['enable_tracked_files_md5'] == 'on')
-		$eve_out_types .= "\n            force-md5: yes";
-	else
-		$eve_out_types .= "\n            force-md5: no";
+	if ($suricatacfg['tracked_files_hash'] != 'none') {
+		$eve_out_types .= "\n            force-hash: [{$suricatacfg['tracked_files_hash']}]";
+	}
 }
 
-if ($suricatacfg['eve_log_ssh'] == 'on')
+if ($suricatacfg['eve_log_ssh'] == 'on') {
 	$eve_out_types .= "\n        - ssh";
+}
+
+if ($suricatacfg['eve_log_smtp'] == 'on') {
+	$eve_out_types .= "\n        - smtp:";
+	$eve_out_types .= "\n            extended: yes";
+	$eve_out_types .= "\n            custom: [received, x-mailer, x-originating-ip, relays, reply-to, bcc]";
+	$eve_out_types .= "\n            md5: [subject]";
+}
+
+if ($suricatacfg['eve_log_drop'] == 'on' && $suricatacfg['ips_mode'] == "ips_mode_inline") {
+	$eve_out_types .= "\n        - drop:";
+	$eve_out_types .= "\n            alerts: yes";
+	$eve_out_types .= "\n            flows: all";
+}
 
 // Add interface-specific IP defrag settings
 if (!empty($suricatacfg['frag_memcap']))

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -142,7 +142,7 @@ else
 if (!empty($suricatacfg['mpm_algo']))
 	$mpm_algo = $suricatacfg['mpm_algo'];
 else
-	$mpm_algo = "ac";
+	$mpm_algo = "auto";
 
 if (!empty($suricatacfg['inspect_recursion_limit']) || $suricatacfg['inspect_recursion_limit'] == '0')
 	$inspection_recursion_limit = $suricatacfg['inspect_recursion_limit'];

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -274,9 +274,12 @@ if ($suricatacfg['enable_file_store'] == 'on') {
 	$file_store_enabled = "yes";
 	if (!file_exists("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/file.waldo"))
 		@file_put_contents("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/file.waldo", "");
+	$file_store_waldo = "waldo: file.waldo";
 }
-else
+else {
 	$file_store_enabled = "no";
+	$file_store_waldo = "#waldo: file.waldo";
+}
 
 if ($suricatacfg['enable_pcap_log'] == 'on')
 	$pcap_log_enabled = "yes";

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016 Rubicon Communications, LLC (Netgate)
- * Copyright (C) 2016 Bill Meeks
+ * Copyright (C) 2017 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,7 +51,7 @@ $rule = &$config['installedpackages']['suricata']['rule'];
 $updated_cfg = false;
 log_error("[Suricata] Checking configuration settings version...");
 
-// Check the configuration version to see if XMLRPC Sync should
+// Check the configuration version to see if XMLRPC Sync should be
 // auto-disabled as part of the upgrade due to config format changes.
 if ($config['installedpackages']['suricata']['config'][0]['suricata_config_ver'] < 2 && 
     ($config['installedpackages']['suricatasync']['config'][0]['varsynconchanges'] == 'auto' ||
@@ -285,6 +285,22 @@ foreach ($rule as &$r) {
 		$pconfig['eve_log_ssh'] = "on";
 		$updated_cfg = true;
 	}
+	if (!isset($pconfig['eve_log_smtp'])) {
+		$pconfig['eve_log_smtp'] = "on";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_drop'])) {
+		$pconfig['eve_log_drop'] = "on";
+		$updated_cfg = true;
+	}
+
+	/******************************************************************/
+	/* SHA1 and SHA256 were added as additional hashing options in    */
+	/* Suricata 3.x, so the old binary on/off MD5 hashing parameter   */
+	/* is now one of three string values: NONE, MD5, SHA1 or SHA256.  */
+	/* It has been moved to a new parameter name and the old one is   */
+	/* now deprecated and removed from the config.                    */
+	/******************************************************************/
 	if (!isset($pconfig['tracked_files_hash'])) {
 		if ($pconfig['enabled_tracked_files_md5'] == "on") {
 			$pconfig['tracked_files_hash'] = "md5";
@@ -507,6 +523,17 @@ foreach ($rule as &$r) {
 	/**********************************************************/
 	if (empty($pconfig['ips_mode'])) {
 		$pconfig['ips_mode'] = "ips_mode_legacy";
+		$updated_cfg = true;
+	}
+
+	/**********************************************************/
+	/* Suricata 3.2.1 introduced support for hyperscan as an  */
+	/* option for the multi pattern matcher (MPM) algorithm.  */
+	/* Several older MPM algorithms were also deprecated.     */
+	/**********************************************************/
+	$old_mpm_algos = array('ac-gfbs', 'b2g', 'b2gc', 'b2gm', 'b3g', 'wumanber');
+	if (in_array($pconfig['mpm_algo'], $old_mpm_algos)) {
+		$pconfig['mpm_algo'] = "auto";
 		$updated_cfg = true;
 	}
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -285,6 +285,16 @@ foreach ($rule as &$r) {
 		$pconfig['eve_log_ssh'] = "on";
 		$updated_cfg = true;
 	}
+	if (!isset($pconfig['tracked_files_hash'])) {
+		if ($pconfig['enabled_tracked_files_md5'] == "on") {
+			$pconfig['tracked_files_hash'] = "md5";
+		}
+		else {
+			$pconfig['tracked_files_hash'] = "none";
+		}
+		unset($pconfig['enabled_tracked_files_md5']);
+		$updated_cfg = true;
+	}
 
 	/******************************************************************/
 	/* Remove per interface default log size and retention limits     */ 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2017 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,27 +36,6 @@ require_once("/usr/local/pkg/suricata/suricata.inc");
 require("/usr/local/pkg/suricata/suricata_defs.inc");
 
 global $config, $g, $rebuild_rules, $pkg_interface, $suricata_gui_include;
-
-/****************************************
- * Define any new constants here that   *
- * may not be yet defined in the old    *
- * "suricata_defs.inc" include file     *
- * that might be cached and used by     *
- * the package manager installation     *
- * code.                                *
- *                                      *
- * This is a hack to work around the    *
- * fact the old version of the inc file *
- * is cached and used instead of the    *
- * updated version included with the    *
- * updated GUI package.                 *
- ****************************************/
-if (!defined('SURICATA_PBI_BASEDIR'))
-	define('SURICATA_PBI_BASEDIR', '/usr/pbi/suricata-' . php_uname("m"));
-
-/****************************************
- * End of PHP caching workaround        *
- ****************************************/
 
 // Initialize some common values from defined constants
 $suricatadir = SURICATADIR;
@@ -185,7 +164,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 	/****************************************************************/
 
 	/* Do one-time settings migration for new version configuration */
-	update_status(gettext("Migrating settings to new configuration...") . "\n");
+	update_status(gettext("Migrating settings to new configuration..."));
 	include('/usr/local/pkg/suricata/suricata_migrate_config.php');
 	update_status(gettext(" done.") . "\n");
 	log_error(gettext("[Suricata] Downloading and updating configured rule types."));

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -102,7 +102,7 @@ outputs:
       log-dir: files
       force-magic: {$json_log_magic}
       {$json_log_hash}
-      waldo: file.waldo
+      {$file_store_waldo}
 
   - file-log:
       enabled: {$json_log_enabled}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -144,28 +144,14 @@ threading:
   set-cpu-affinity: no
   detect-thread-ratio: 1.5
 
-mpm-algo: ac
+# Multi pattern algorithm
+# The default mpm-algo value of "auto" will use "hs" if Hyperscan is
+# available, "ac" otherwise.
+mpm-algo: {$mpm_algo}
 
-pattern-matcher:
-  - b2gc:
-      search-algo: B2gSearchBNDMq
-      hash-size: low
-      bf-size: medium
-  - b2gm:
-      search-algo: B2gSearchBNDMq
-      hash-size: low
-      bf-size: medium
-  - b2g:
-      search-algo: B2gSearchBNDMq
-      hash-size: low
-      bf-size: medium
-  - b3g:
-      search-algo: B3gSearchBNDMq
-      hash-size: low
-      bf-size: medium
-  - wumanber:
-      hash-size: low
-      bf-size: medium
+# Single pattern algorithm
+# The default of "auto" will use "hs" if available, otherwise "bm".
+spm-algo: auto
 
 # Defrag settings:
 defrag:

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -142,7 +142,16 @@ detect-engine:
 # Suricata is multi-threaded. Here the threading can be influenced.
 threading:
   set-cpu-affinity: no
-  detect-thread-ratio: 1.5
+  detect-thread-ratio: 1.0
+
+# Luajit has a strange memory requirement, it's 'states' need to be in the
+# first 2G of the process' memory.
+#
+# 'luajit.states' is used to control how many states are preallocated.
+# State use: per detect script: 1 per detect thread. Per output script: 1 per
+# script.
+luajit:
+  states: 128
 
 # Multi pattern algorithm
 # The default mpm-algo value of "auto" will use "hs" if Hyperscan is
@@ -169,6 +178,11 @@ flow:
   prealloc: {$flow_prealloc}
   emergency-recovery: {$flow_emerg_recovery}
   prune-flows: {$flow_prune}
+
+# This option controls the use of vlan ids in the flow (and defrag)
+# hashing.
+vlan:
+  use-for-tracking: true
 
 # Specific timeouts for flows.
 flow-timeouts:

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -101,7 +101,7 @@ outputs:
       enabled: {$file_store_enabled}
       log-dir: files
       force-magic: {$json_log_magic}
-      force-md5: {$json_log_md5}
+      {$json_log_hash}
       waldo: file.waldo
 
   - file-log:
@@ -110,7 +110,7 @@ outputs:
       append: {$json_log_append}
       filetype: regular
       force-magic: {$json_log_magic}
-      force-md5: {$json_log_md5}
+      {$json_log_hash}
 
   - dns-log:
       enabled: {$dns_log_enabled}

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -116,7 +116,7 @@ if (empty($pconfig['max_pending_packets']))
 if (empty($pconfig['detect_eng_profile']))
 	$pconfig['detect_eng_profile'] = "medium";
 if (empty($pconfig['mpm_algo']))
-	$pconfig['mpm_algo'] = "ac";
+	$pconfig['mpm_algo'] = "auto";
 if (empty($pconfig['sgh_mpm_context']))
 	$pconfig['sgh_mpm_context'] = "auto";
 if (empty($pconfig['enable_http_log']))
@@ -849,8 +849,8 @@ $section->addInput(new Form_Select(
 	'mpm_algo',
 	'Pattern Matcher Algorithm',
 	$pconfig['mpm_algo'],
-	array('ac' => 'AC', 'ac-gfbs' => 'AC-GFBS', 'b2g' => 'B2G', 'b2gc' => 'B2GC', 'b2gm' => 'B2GM', 'b3g' => 'B3G', 'wumanber' => 'WUMANBER')
-))->setHelp('Choose a multi-pattern matcher (MPM) algorithm. AC is the default, and is the best choice for almost all systems.	');
+	array('auto' => 'Auto', 'ac' => 'AC', 'ac-bs' => 'AC-BS', 'ac-ks' => 'AC-KS', 'hs' => 'Hyperscan')
+))->setHelp('Choose a multi-pattern matcher (MPM) algorithm. Auto is the default, and is the best choice for almost all systems.  Auto will use hyperscan if available.');
 
 $section->addInput(new Form_Select(
 	'sgh_mpm_context',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2017 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -161,6 +161,11 @@ if (empty($pconfig['eve_log_files']))
 	$pconfig['eve_log_files'] = "on";
 if (empty($pconfig['eve_log_ssh']))
 	$pconfig['eve_log_ssh'] = "on";
+if (empty($pconfig['eve_log_smtp']))
+	$pconfig['eve_log_smtp'] = "on";
+if (empty($pconfig['eve_log_drop'])) {
+	$pconfig['eve_log_drop'] = "on";
+}
 if (empty($pconfig['intf_promisc_mode']))
 	$pconfig['intf_promisc_mode'] = "on";
 
@@ -272,7 +277,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['enable_json_file_log'] == "on") { $natent['enable_json_file_log'] = 'on'; }else{ $natent['enable_json_file_log'] = 'off'; }
 		if ($_POST['append_json_file_log'] == "on") { $natent['append_json_file_log'] = 'on'; }else{ $natent['append_json_file_log'] = 'off'; }
 		if ($_POST['enable_tracked_files_magic'] == "on") { $natent['enable_tracked_files_magic'] = 'on'; }else{ $natent['enable_tracked_files_magic'] = 'off'; }
-		if ($_POST['enable_tracked_files_md5'] == "on") { $natent['enable_tracked_files_md5'] = 'on'; }else{ $natent['enable_tracked_files_md5'] = 'off'; }
+		if ($_POST['tracked_files_hash']) $natent['tracked_files_hash'] = $_POST['tracked_files_hash'];
 		if ($_POST['enable_file_store'] == "on") { $natent['enable_file_store'] = 'on'; }else{ $natent['enable_file_store'] = 'off'; }
 		if ($_POST['enable_eve_log'] == "on") { $natent['enable_eve_log'] = 'on'; }else{ $natent['enable_eve_log'] = 'off'; }
 		if ($_POST['max_pending_packets']) $natent['max_pending_packets'] = $_POST['max_pending_packets']; else unset($natent['max_pending_packets']);
@@ -304,6 +309,8 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['eve_log_tls'] == "on") { $natent['eve_log_tls'] = 'on'; }else{ $natent['eve_log_tls'] = 'off'; }
 		if ($_POST['eve_log_files'] == "on") { $natent['eve_log_files'] = 'on'; }else{ $natent['eve_log_files'] = 'off'; }
 		if ($_POST['eve_log_ssh'] == "on") { $natent['eve_log_ssh'] = 'on'; }else{ $natent['eve_log_ssh'] = 'off'; }
+		if ($_POST['eve_log_smtp'] == "on") { $natent['eve_log_smtp'] = 'on'; }else{ $natent['eve_log_smtp'] = 'off'; }
+		if ($_POST['eve_log_drop'] == "on") { $natent['eve_log_drop'] = 'on'; }else{ $natent['eve_log_drop'] = 'off'; }
 		if ($_POST['delayed_detect'] == "on") { $natent['delayed_detect'] = 'on'; }else{ $natent['delayed_detect'] = 'off'; }
 		if ($_POST['intf_promisc_mode'] == "on") { $natent['intf_promisc_mode'] = 'on'; }else{ $natent['intf_promisc_mode'] = 'off'; }
 		if ($_POST['configpassthru']) $natent['configpassthru'] = base64_encode(str_replace("\r\n", "\n", $_POST['configpassthru'])); else unset($natent['configpassthru']);
@@ -670,13 +677,12 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['enable_tracked_files_magic'] == 'on' ? true:false,
 	'on'
 ));
-$section->addInput(new Form_Checkbox(
-	'enable_tracked_files_md5',
-	'Enable MD5 for Tracked-Files',
-	'Suricata will generate MD5 checksums for all logged Tracked Files. Default is Not Checked.',
-	$pconfig['enable_tracked_files_md5'] == 'on' ? true:false,
-	'on'
-));
+$section->addInput(new Form_Select(
+	'tracked_files_hash',
+	'Tracked-Files Checksum',
+	$pconfig['tracked_files_hash'],
+	array("none" => "None", "md5" => "MD5", "sha1" => "SHA1", "sha256" => "SHA256")
+))->setHelp('Suricata will generate checksums for all logged Tracked Files using the chosen algorithm. Default is None.');
 $section->addInput(new Form_Checkbox(
 	'enable_file_store',
 	'Enable File-Store',
@@ -777,6 +783,22 @@ $group->add(new Form_Checkbox(
 	'SSH Handshakes',
 	'SSH Handshakes',
 	$pconfig['eve_log_ssh'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_smtp',
+	'SMTP Traffic',
+	'SMTP Traffic',
+	$pconfig['eve_log_smtp'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_drop',
+	'Dropped Traffic',
+	'Dropped Traffic',
+	$pconfig['eve_log_drop'] == 'on' ? true:false,
 	'on'
 ));
 
@@ -1073,6 +1095,15 @@ events.push(function(){
 		if ($('#ips_mode').val() == 'ips_mode_inline') {
 			hideCheckbox('blockoffenderskill', true);
 			hideSelect('blockoffendersip', true);
+			if (hide) {
+				$('#eve_log_drop').parent().hide();
+			}
+			else {
+				$('#eve_log_drop').parent().show();
+			}
+		}
+		else {
+			$('#eve_log_drop').parent().hide();
 		}
 	}
 
@@ -1109,7 +1140,7 @@ events.push(function(){
 		var hide = ! $('#enable_json_file_log').prop('checked');
 		hideCheckbox('append_json_file_log', hide);
 		hideCheckbox('enable_tracked_files_magic', hide);
-		hideCheckbox('enable_tracked_files_md5', hide);
+		hideSelect('tracked_files_hash', hide);
 	}
 
 	function toggle_pcap_log() {
@@ -1121,7 +1152,7 @@ events.push(function(){
 	function toggle_eve_log() {
 		var hide = ! $('#enable_eve_log').prop('checked');
 		hideSelect('eve_output_type', hide);
-		hideClass('eve_log_info',hide);
+		hideClass('eve_log_info', hide);
 	}
 
 	function enable_change() {
@@ -1169,7 +1200,7 @@ events.push(function(){
 		disableInput('enable_json_file_log', disable);
 		disableInput('append_json_file_log', disable);
 		disableInput('enable_tracked_files_magic', disable);
-		disableInput('enable_tracked_files_md5', disable);
+		disableInput('tracked_files_hash', disable);
 		disableInput('enable_file_store', disable);
 		disableInput('enable_pcap_log', disable);
 		disableInput('max_pcap_log_size', disable);
@@ -1184,6 +1215,8 @@ events.push(function(){
 		disableInput('eve_log_tls', disable);
 		disableInput('eve_log_files', disable);
 		disableInput('eve_log_ssh', disable);
+		disableInput('eve_log_smtp', disable);
+		disableInput('eve_log_drop', disable);
 	}
 
 	// Call the list viewing page and write what it returns to the modal text area
@@ -1273,11 +1306,13 @@ events.push(function(){
 		if ($('#ips_mode').val() == 'ips_mode_inline') {
 			hideCheckbox('blockoffenderskill', true);
 			hideSelect('blockoffendersip', true);
+			$('#eve_log_drop').parent().show();
 		}
 		else {
 			hideCheckbox('blockoffenderskill', false);
 			hideSelect('blockoffendersip', false);
 			hideClass('passlist', false);
+			$('#eve_log_drop').parent().hide();
 		}
 	});
 


### PR DESCRIPTION
**Suricata 3.2.1**
This updates the Suricata package on pfSense to version 3.2.1.  The underlying Suricata binary is also versioned up to 3.2.1.  Some configuration parameters were changed as a result of the update.

**Release Notes:**
1. Suricata 3.2.1 now supports hyperscan for the pattern matcher algorithm.  Hyperscan is a high-performance regex pattern matching library.  Several older pattern matching algorithms were deprecated.  If your existing Suricata configuration is using any pattern matcher algorithm not shown below, the setting will be migrated to "Auto".  If your existing configuration is "AC", then it will be left at that value and you will need to manually change the _Pattern Matcher_ setting on the INTERFACE SETTINGS tab.  The new valid options for Pattern Matching are:

        Auto   - will use hyperscan when available, else defaults to AC
        AC     - Aho-Corasick (default implementation)
        AC-BS  - Aho-Corasick (reduced memory implementation)
        AC-KS  - Aho-Corasick (Ken Steele variant)
        HS     - Hyperscan (available when built with hyperscan support)

2. Two additional hashing algorithms (SHA1 and SHA256) were added to the Tracked Files option.  The old binary config parameter for switching MD5 hashing of tracked files ON or OFF is changed to a select drop-down with choices of "None", "MD5", "SHA1" and "SHA256".

3. Two new EVE JSON logging options were added for logging SMTP traffic and DROPPED traffic.  These are enabled by default when EVE JSON logging is enabled.  Note that the DROPPED traffic option can consume quite a large amount of disk space on a busy network.  This option logs all packets that are dropped when using inline IPS mode in JSON format.  The DROPPED traffic option is hidden and not used if Legacy Mode is chosen for the IPS Mode.

