### PR TITLE
pfSense-pkg-net-snmp: Add option to not let snmptrapd become a subagent

### DIFF
--- a/net-mgmt/pfSense-pkg-net-snmp/Makefile
+++ b/net-mgmt/pfSense-pkg-net-snmp/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-net-snmp
 PORTVERSION=	0.1.2
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-net-snmp/files/usr/local/pkg/net-snmp.inc
+++ b/net-mgmt/pfSense-pkg-net-snmp/files/usr/local/pkg/net-snmp.inc
@@ -617,6 +617,7 @@ function netsnmp_resync_snmptrapd() {
 	}
 
 	$snmptrapd_config = "";
+	$snmptrapd_daemon_options = "";
 
 	/* The protocol and interface binding for snmptrapd works the same as snmpd */
 	$agentaddresses = array();
@@ -791,6 +792,11 @@ function netsnmp_resync_snmptrapd() {
 			$snmptrapd_config .= "forward {$forward['destination']} " . implode(',', $agentaddresses) . "\n";
 		}
 	}
+
+	if ($nsettings['snmptrapd_subagent']) {
+		$snmptrapd_daemon_options .= "-X ";
+	}
+
 	/* Dump custom options into the configuration as-is */
 	if (!empty($nsettings['custom_options'])) {
 		$snmptrapd_config .= "{$nsettings['custom_options']}\n";
@@ -813,7 +819,7 @@ sleep 1
 
 /usr/local/sbin/snmptrapd -p /var/run/snmptrapd.pid \
 			-M /usr/share/snmp/mibs/:/usr/local/share/snmp/mibs \
-			-C \
+			-C {$snmptrapd_daemon_options} \
 			-c {$snmptrapd_config_file}
 EOF;
 	write_rcfile(array(

--- a/net-mgmt/pfSense-pkg-net-snmp/files/usr/local/pkg/net-snmptrapd.xml
+++ b/net-mgmt/pfSense-pkg-net-snmp/files/usr/local/pkg/net-snmptrapd.xml
@@ -174,6 +174,12 @@
 			</options>
 		</field>
 		<field>
+			<fielddescr>Sub-Agent</fielddescr>
+			<fieldname>snmptrapd_subagent</fieldname>
+			<description>Enable to not become a subagent.</description>
+			<type>checkbox</type>
+		</field>
+		<field>
 			<fielddescr>Custom Options</fielddescr>
 			<fieldname>custom_options</fieldname>
 			<description>


### PR DESCRIPTION
- Bump PORTREVISION