### PR TITLE
Adding support for Google Authenticator

### DIFF
--- a/net/pfSense-pkg-freeradius2/Makefile
+++ b/net/pfSense-pkg-freeradius2/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-freeradius2
-PORTVERSION=	1.7.8
+PORTVERSION=	1.7.9
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-freeradius2/Makefile
+++ b/net/pfSense-pkg-freeradius2/Makefile
@@ -13,8 +13,9 @@ COMMENT=	pfSense package freeradius2
 LICENSE=	APACHE20
 
 RUN_DEPENDS=	${LOCALBASE}/sbin/radiusd:net/freeradius2 \
-		${LOCALBASE}/bin/bash:shells/bash \
-		${LOCALBASE}/bin/python2.7:lang/python27
+		${LOCALBASE}/bin/bash:shells/bash 
+
+USES=		python2.7
 
 NO_BUILD=	yes
 NO_MTREE=	yes
@@ -58,7 +59,7 @@ do-install:
 		${STAGEDIR}${DATADIR}
 	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/googleauth \
 		${STAGEDIR}/usr/local/etc/raddb/modules
-	${INSTALL_DATA} -m 0755 ${FILESDIR}${PREFIX}/pkg/googleauth.py \
+	${INSTALL_SCRIPT} ${FILESDIR}${PREFIX}/pkg/googleauth.py \
 		${STAGEDIR}/usr/local/etc/raddb/scripts
 	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
 		${STAGEDIR}${DATADIR}/info.xml

--- a/net/pfSense-pkg-freeradius2/Makefile
+++ b/net/pfSense-pkg-freeradius2/Makefile
@@ -15,6 +15,9 @@ LICENSE=	APACHE20
 RUN_DEPENDS=	${LOCALBASE}/sbin/radiusd:net/freeradius2 \
 		${LOCALBASE}/bin/bash:shells/bash
 
+USES=		python2.7+
+USE_PYTHON=	autoplist distutils
+
 NO_BUILD=	yes
 NO_MTREE=	yes
 
@@ -57,7 +60,7 @@ do-install:
 		${STAGEDIR}${DATADIR}
 	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/googleauth \
 		${STAGEDIR}/usr/local/etc/raddb/modules
-	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/googleauth.py \
+	${INSTALL_DATA} -m 0755 ${FILESDIR}${PREFIX}/pkg/googleauth.py \
 		${STAGEDIR}/usr/local/etc/raddb/scripts
 	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
 		${STAGEDIR}${DATADIR}/info.xml

--- a/net/pfSense-pkg-freeradius2/Makefile
+++ b/net/pfSense-pkg-freeradius2/Makefile
@@ -13,10 +13,8 @@ COMMENT=	pfSense package freeradius2
 LICENSE=	APACHE20
 
 RUN_DEPENDS=	${LOCALBASE}/sbin/radiusd:net/freeradius2 \
-		${LOCALBASE}/bin/bash:shells/bash
-
-USES=		python2.7+
-USE_PYTHON=	autoplist distutils
+		${LOCALBASE}/bin/bash:shells/bash \
+		${LOCALBASE}/bin/python2.7:lang/python27
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/net/pfSense-pkg-freeradius2/Makefile
+++ b/net/pfSense-pkg-freeradius2/Makefile
@@ -55,6 +55,10 @@ do-install:
 		${STAGEDIR}${PREFIX}/pkg
 	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \
 		${STAGEDIR}${DATADIR}
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/googleauth \
+		${STAGEDIR}/usr/local/etc/raddb/modules
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/googleauth.py \
+		${STAGEDIR}/usr/local/etc/raddb/scripts
 	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
 		${STAGEDIR}${DATADIR}/info.xml
 

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -538,6 +538,7 @@ function freeradius_users_resync($via_rpc = false) {
 					$varuserspassword = $users['varuserspassword'];
 			}
 
+			$varusersauthmethod = $users['varusersauthmethod']; 
 			$varusersmotpinitsecret = $users['varusersmotpinitsecret'];
 			$varusersmotppin = $users['varusersmotppin'];
 			$varusersmotpoffset = ($users['varusersmotpoffset'] ?: '0');
@@ -626,7 +627,7 @@ function freeradius_users_resync($via_rpc = false) {
 			// end of check if otp is enabled
 			} else {
 				// if otp is enabled we need to set Auth-Type to accept because password will be checked when the otp script gets executed in reply-item list
-				$varuserscheckitem = '"' . $varusersusername . '"' . " Auth-Type = motp";
+				$varuserscheckitem = '"' . $varusersusername . '"' . " Auth-Type = " .  $varusersauthmethod;
 			}
 
 			// Add additional CHECK-ITEMS here. Different formatting in "users" file needed.
@@ -1883,6 +1884,12 @@ authenticate {
 	#  Mobile-One-Time-Password (MOTP) authentication.
 	Auth-Type MOTP {
 		motp
+	}
+
+	#
+	#  Mobile-One-Time-Password (MOTP) authentication.
+	Auth-Type GOOGLEAUTH {
+		googleauth
 	}
 
 	#

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -4040,7 +4040,7 @@ function freeradius_validate_users($post, &$input_errors) {
 	if ($post['varusersmotpenable'] == 'on') {
 		if ($post['varusersauthmethod'] == '') {
 			$input_errors[] = "The 'Authentication method' field may not be empty when 'Enable One-Time-Password for this user' is checked.";
-		} elseif (!preg_match('/^(mOTP|Google-Authenticator)/', $post['varusersauthmethod'])) {
+		} elseif (!preg_match('/^(motp|googleauth)$/', $post['varusersauthmethod'])) {
 			$input_errors[] = "The 'Authentication method' field may only contain 'mOTP' or 'Google-Authenticator' (regex /^(mOTP|Google-Authenticator)/).";
 		}
 	}

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -627,7 +627,7 @@ function freeradius_users_resync($via_rpc = false) {
 			// end of check if otp is enabled
 			} else {
 				// if otp is enabled we need to set Auth-Type to accept because password will be checked when the otp script gets executed in reply-item list
-				$varuserscheckitem = '"' . $varusersusername . '"' . " Auth-Type = " .  $varusersauthmethod;
+				$varuserscheckitem = '"' . $varusersusername . '"' . " Auth-Type = " . '"' .  $varusersauthmethod . '"';
 			}
 
 			// Add additional CHECK-ITEMS here. Different formatting in "users" file needed.

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -627,7 +627,7 @@ function freeradius_users_resync($via_rpc = false) {
 			// end of check if otp is enabled
 			} else {
 				// if otp is enabled we need to set Auth-Type to accept because password will be checked when the otp script gets executed in reply-item list
-				$varuserscheckitem = '"' . $varusersusername . '"' . " Auth-Type = " . '"' .  $varusersauthmethod . '"';
+				$varuserscheckitem = '"' . $varusersusername . '"' . " Auth-Type = " . $varusersauthmethod . '"';
 			}
 
 			// Add additional CHECK-ITEMS here. Different formatting in "users" file needed.

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -627,7 +627,7 @@ function freeradius_users_resync($via_rpc = false) {
 			// end of check if otp is enabled
 			} else {
 				// if otp is enabled we need to set Auth-Type to accept because password will be checked when the otp script gets executed in reply-item list
-				$varuserscheckitem = '"' . $varusersusername . '"' . " Auth-Type = " . $varusersauthmethod . '"';
+				$varuserscheckitem = '"' . $varusersusername . '"' . " Auth-Type = " . $varusersauthmethod;
 			}
 
 			// Add additional CHECK-ITEMS here. Different formatting in "users" file needed.
@@ -649,7 +649,7 @@ function freeradius_users_resync($via_rpc = false) {
 
 			// this is the part for mobile otp
 			if ($users['varusersmotpenable'] == 'on') {
-				$varusersreplyitem .= "MOTP-Method = $varusersauthmethod," . "\n\tMOTP-Init-Secret = $varusersmotpinitsecret," . "\n\tMOTP-PIN = $varusersmotppin," . "\n\tMOTP-Offset = $varusersmotpoffset";
+				$varusersreplyitem .= "MOTP-Init-Secret = $varusersmotpinitsecret," . "\n\tMOTP-PIN = $varusersmotppin," . "\n\tMOTP-Offset = $varusersmotpoffset";
 			} else {
 				$varusersreplyitem .= '';
 			}

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -627,7 +627,12 @@ function freeradius_users_resync($via_rpc = false) {
 			// end of check if otp is enabled
 			} else {
 				// if otp is enabled we need to set Auth-Type to accept because password will be checked when the otp script gets executed in reply-item list
-				$varuserscheckitem = '"' . $varusersusername . '"' . " Auth-Type = " . $varusersauthmethod;
+				// prevent overwrite with '' on package update
+				if ($varusersauthmethod == '') {
+                                        $varuserscheckitem = '"' . $varusersusername . '"' . " Auth-Type = motp";
+                                } else {
+					$varuserscheckitem = '"' . $varusersusername . '"' . " Auth-Type = " . $varusersauthmethod;
+				}
 			}
 
 			// Add additional CHECK-ITEMS here. Different formatting in "users" file needed.

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -4040,8 +4040,8 @@ function freeradius_validate_users($post, &$input_errors) {
 	if ($post['varusersmotpenable'] == 'on') {
 		if ($post['varusersmotpinitsecret'] == '') {
 			$input_errors[] = "The 'Init-Secret' field may not be empty when 'Enable One-Time-Password for this user' is checked.";
-		} elseif (!preg_match('/^[0-9a-f]{16,}$/', $post['varusersmotpinitsecret'])) {
-			$input_errors[] = "The 'Init-Secret' field may only contain 0-9 and a-f (regex /^[0-9a-f]*$/) and must contain at least 16 characters.";
+		} elseif (!preg_match('/^[0-9a-zA-Z]{16,}$/', $post['varusersmotpinitsecret'])) {
+			$input_errors[] = "The 'Init-Secret' field may only contain 0-9, a-z and A-Z (regex /^[0-9a-zA-Z]*$/) and must contain at least 16 characters.";
 		}
 	}
 

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.inc
@@ -649,7 +649,7 @@ function freeradius_users_resync($via_rpc = false) {
 
 			// this is the part for mobile otp
 			if ($users['varusersmotpenable'] == 'on') {
-				$varusersreplyitem .= "MOTP-Init-Secret = $varusersmotpinitsecret," . "\n\tMOTP-PIN = $varusersmotppin," . "\n\tMOTP-Offset = $varusersmotpoffset";
+				$varusersreplyitem .= "MOTP-Method = $varusersauthmethod," . "\n\tMOTP-Init-Secret = $varusersmotpinitsecret," . "\n\tMOTP-PIN = $varusersmotppin," . "\n\tMOTP-Offset = $varusersmotpoffset";
 			} else {
 				$varusersreplyitem .= '';
 			}
@@ -4036,6 +4036,15 @@ function freeradius_validate_users($post, &$input_errors) {
 		$input_errors[] = "The 'Password' field must be left empty when 'Enable One-Time-Password for this user' is checked.";
 	}
 
+	// OTP-Method
+	if ($post['varusersmotpenable'] == 'on') {
+		if ($post['varusersauthmethod'] == '') {
+			$input_errors[] = "The 'Authentication method' field may not be empty when 'Enable One-Time-Password for this user' is checked.";
+		} elseif (!preg_match('/^(mOTP|Google-Authenticator)/', $post['varusersauthmethod'])) {
+			$input_errors[] = "The 'Authentication method' field may only contain 'mOTP' or 'Google-Authenticator' (regex /^(mOTP|Google-Authenticator)/).";
+		}
+	}
+	
 	// Init-Secret
 	if ($post['varusersmotpenable'] == 'on') {
 		if ($post['varusersmotpinitsecret'] == '') {

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.xml
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.xml
@@ -200,14 +200,17 @@
 		<field>
 			<fielddescr>Authentication method</fielddescr>
 			<fieldname>varusersauthmethod</fieldname>
-			<description><![CDATA[Select the authentication method for this user. Default: motp]]>    
+			<description>
+				<![CDATA[
+				Select the authentication method for this user. Default: mOTP
+				]]>
 			</description>
 			<type>select</type>
 			<default_value>motp</default_value>
-				<options>
-				      <option><name>mOTP</name><value>motp</value></option>
-				      <option><name>Google-Authenticator</name><value>googleauth</value></option>              
-				</options>
+			<options>
+			      <option><name>mOTP</name><value>motp</value></option>
+			      <option><name>Google-Authenticator</name><value>googleauth</value></option>              
+			</options>
 		</field>
 		<field>
 			<fielddescr>Init-Secret</fielddescr>

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.xml
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.xml
@@ -205,8 +205,8 @@
 			<type>select</type>
 			<default_value>motp</default_value>
 				<options>
-				      <option><name>Use mOTP</name><value>motp</value></option>
-				      <option><name>Use Google-Authenticator</name><value>googleauth</value></option>              
+				      <option><name>mOTP</name><value>motp</value></option>
+				      <option><name>Google-Authenticator</name><value>googleauth</value></option>              
 				</options>
 		</field>
 		<field>

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.xml
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/freeradius.xml
@@ -195,7 +195,19 @@
 				]]>
 			</sethelp>
 			<type>checkbox</type>
-			<enablefields>varusersmotpinitsecret,varusersmotppin,varusersmotpoffset</enablefields>
+			<enablefields>varusersauthmethod,varusersmotpinitsecret,varusersmotppin,varusersmotpoffset</enablefields>
+		</field>
+		<field>
+			<fielddescr>Authentication method</fielddescr>
+			<fieldname>varusersauthmethod</fieldname>
+			<description><![CDATA[Select the authentication method for this user. Default: motp]]>    
+			</description>
+			<type>select</type>
+			<default_value>motp</default_value>
+				<options>
+				      <option><name>Use mOTP</name><value>motp</value></option>
+				      <option><name>Use Google-Authenticator</name><value>googleauth</value></option>              
+				</options>
 		</field>
 		<field>
 			<fielddescr>Init-Secret</fielddescr>

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/googleauth
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/googleauth
@@ -1,0 +1,4 @@
+exec googleauth {
+      wait = yes
+      program = " /usr/local/etc/raddb/scripts/googleauth.py %{request:User-Name} %{reply:MOTP-Init-Secret} %{reply:MOTP-PIN} %{request:User-Password}"
+}

--- a/net/pfSense-pkg-freeradius2/files/usr/local/pkg/googleauth.py
+++ b/net/pfSense-pkg-freeradius2/files/usr/local/pkg/googleauth.py
@@ -1,0 +1,60 @@
+#!/usr/local/bin/python2.7
+# Copyright: www.brool.com (http://www.brool.com/post/using-google-authenticator-for-your-website/)
+# License: CC0 1.0 Universal License
+
+import sys
+import time
+import struct
+import hmac
+import hashlib
+import base64
+import syslog
+ 
+def authenticate(username, secretkey, pin, code_attempt):
+
+    if code_attempt.startswith(pin,0, len(pin)) == False:
+         syslog.syslog(syslog.LOG_ERR, "freeRADIUS: Google Authenticator - Authentication failed. User: " + username + ", Reason: wrong PIN")
+         return False
+
+    code_attempt = code_attempt[len(pin):]
+    tm = int(time.time() / 30)
+ 
+    secretkey = base64.b32decode(secretkey)
+ 
+    # try 30 seconds behind and ahead as well
+    for ix in [-1, 0, 1]:
+        # convert timestamp to raw bytes
+        b = struct.pack(">q", tm + ix)
+ 
+        # generate HMAC-SHA1 from timestamp based on secret key
+        hm = hmac.HMAC(secretkey, b, hashlib.sha1).digest()
+ 
+        # extract 4 bytes from digest based on LSB
+        offset = ord(hm[-1]) & 0x0F
+        truncatedHash = hm[offset:offset+4]
+ 
+        # get the code from it
+        code = struct.unpack(">L", truncatedHash)[0]
+        code &= 0x7FFFFFFF;
+        code %= 1000000;
+ 
+        if ("%06d" % code) == str(code_attempt):
+            syslog.syslog(syslog.LOG_NOTICE, "freeRADIUS: Google Authenticator - Authentication successful for user: " + username)
+            return True
+
+    syslog.syslog(syslog.LOG_ERR, "freeRADIUS: Google Authenticator - Authentication failed. User: " + username + ", Reason: wrong tokencode")
+    return False
+
+
+# Check the length of the parameters
+if len(sys.argv) != 5:
+        syslog.syslog(syslog.LOG_ERR, "freeRADIUS: Google Authenticator - wrong syntax - USAGE: googleauth.py Username, Secret-Key, PIN, Auth-Attempt")
+        exit(1)
+
+
+auth = authenticate(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+
+if auth == True:
+   exit(0)
+
+exit(1)

--- a/net/pfSense-pkg-freeradius2/pkg-plist
+++ b/net/pfSense-pkg-freeradius2/pkg-plist
@@ -10,5 +10,7 @@ pkg/freeradiusinterfaces.xml
 pkg/freeradiussync.xml
 pkg/freeradiusmodulesldap.xml
 pkg/freeradiusauthorizedmacs.xml
+pkg/googleauth
+pkg/googleauth.py
 %%DATADIR%%/info.xml
 @dir /etc/inc/priv


### PR DESCRIPTION
Gives the possibility for a user to choose between mOTP and Google Authenticator in Freeradius, when using one-time-passwords.