### PR TITLE
Add new package SNMPTT (SNMP Trap Translator)

### DIFF
--- a/GIDs
+++ b/GIDs
@@ -836,7 +836,7 @@ chronyd:*:849:
 # free: 892
 # free: 893
 # free: 894
-# free: 895
+snmptt:*:895:
 istat:*:896:
 znc:*:897:
 ufdb:*:898:

--- a/UIDs
+++ b/UIDs
@@ -841,7 +841,7 @@ chronyd:*:849:849::0:0:chronyd user:/nonexistent:/usr/sbin/nologin
 # free: 892
 # free: 893
 # free: 894
-# free: 895
+snmptt:*:895:895::0:0:SNMPTT User:/var/spool/snmptt:/usr/sbin/nologin
 istat:*:896:896::0:0:istatserver user:/nonexistent:/usr/sbin/nologin
 znc:*:897:897::0:0:ZNC User:/nonexistent:/usr/sbin/nologin
 ufdb:*:898:898::0:0:ufdb user:/nonexistent:/usr/sbin/nologin

--- a/net-mgmt/pfSense-pkg-snmptt/Makefile
+++ b/net-mgmt/pfSense-pkg-snmptt/Makefile
@@ -1,0 +1,45 @@
+# $FreeBSD$
+
+PORTNAME=	pfSense-pkg-snmptt
+PORTVERSION=	0.1.8
+CATEGORIES=	net-mgmt
+MASTER_SITES=	# empty
+DISTFILES=	# empty
+EXTRACT_ONLY=	# empty
+
+MAINTAINER=	coreteam@pfsense.org
+COMMENT=	pfSense package snmptt
+
+LICENSE=	APACHE20
+
+RUN_DEPENDS=	${LOCALBASE}/sbin/snmptt:net-mgmt/snmptt
+
+NO_BUILD=	yes
+NO_MTREE=	yes
+
+SUB_FILES=	pkg-install pkg-deinstall
+SUB_LIST=	PORTNAME=${PORTNAME}
+
+do-extract:
+	${MKDIR} ${WRKSRC}
+
+do-install:
+	${MKDIR} ${STAGEDIR}${PREFIX}/pkg
+	${MKDIR} ${STAGEDIR}/etc/inc/priv
+	${MKDIR} ${STAGEDIR}${DATADIR}
+	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/snmptt.xml \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/snmptt_conf.xml \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/snmptt.inc \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/snmptt.ini.php \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/snmptt.priv.inc \
+		${STAGEDIR}/etc/inc/priv
+	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \
+		${STAGEDIR}${DATADIR}
+	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
+		${STAGEDIR}${DATADIR}/info.xml
+
+.include <bsd.port.mk>

--- a/net-mgmt/pfSense-pkg-snmptt/Makefile
+++ b/net-mgmt/pfSense-pkg-snmptt/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-snmptt
-PORTVERSION=	0.1.8
+PORTVERSION=	1.0.0
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-snmptt/Makefile
+++ b/net-mgmt/pfSense-pkg-snmptt/Makefile
@@ -12,7 +12,7 @@ COMMENT=	pfSense package snmptt
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	${LOCALBASE}/sbin/snmptt:net-mgmt/snmptt
+RUN_DEPENDS=	snmptt>=1.4_1:net-mgmt/snmptt
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/net-mgmt/pfSense-pkg-snmptt/files/etc/inc/priv/snmptt.priv.inc
+++ b/net-mgmt/pfSense-pkg-snmptt/files/etc/inc/priv/snmptt.priv.inc
@@ -1,0 +1,31 @@
+<?php
+/*
+ * snmptt.priv.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2017 Rubicon Communications, LLC (Netgate)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+global $priv_list;
+
+$priv_list['page-services-snmptt'] = array();
+$priv_list['page-services-snmptt']['name'] = "WebCfg - Services: SNMPTT package";
+$priv_list['page-services-snmptt']['descr'] = "Allow access to SNMPTT package GUI";
+
+$priv_list['page-services-snmptt']['match'] = array();
+$priv_list['page-services-snmptt']['match'][] = "pkg_edit.php?xml=snmptt.xml*";
+
+?>

--- a/net-mgmt/pfSense-pkg-snmptt/files/etc/inc/priv/snmptt.priv.inc
+++ b/net-mgmt/pfSense-pkg-snmptt/files/etc/inc/priv/snmptt.priv.inc
@@ -27,5 +27,6 @@ $priv_list['page-services-snmptt']['descr'] = "Allow access to SNMPTT package GU
 
 $priv_list['page-services-snmptt']['match'] = array();
 $priv_list['page-services-snmptt']['match'][] = "pkg_edit.php?xml=snmptt.xml*";
+$priv_list['page-services-snmptt']['match'][] = "pkg_edit.php?xml=snmptt_conf.xml*";
 
 ?>

--- a/net-mgmt/pfSense-pkg-snmptt/files/pkg-deinstall.in
+++ b/net-mgmt/pfSense-pkg-snmptt/files/pkg-deinstall.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/local/bin/php -f /etc/rc.packages %%PORTNAME%% ${2}

--- a/net-mgmt/pfSense-pkg-snmptt/files/pkg-install.in
+++ b/net-mgmt/pfSense-pkg-snmptt/files/pkg-install.in
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "${2}" != "POST-INSTALL" ]; then
+	exit 0
+fi
+
+/usr/local/bin/php -f /etc/rc.packages %%PORTNAME%% ${2}

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
@@ -1,0 +1,158 @@
+<?php
+/*
+ * snmptt.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2017 Rubicon Communications, LLC (Netgate)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once("util.inc");
+require_once("functions.inc");
+require_once("pkg-utils.inc");
+require_once("globals.inc");
+
+function php_install_snmptt() {
+	sync_package_snmptt();
+}
+
+function php_deinstall_snmptt() {
+	global $config, $g;
+
+	define('SNMPTT_BASE', '/usr/local');
+
+	unlink_if_exists(SNMPTT_BASE . "/etc/rc.d/snmptt.sh");
+}
+
+function validate_input_snmptt($post, &$input_errors) {
+
+	if (isset($post['snmpttenabled'])) {
+		/*
+		if ($post['onbatterydelay'] != '' && !is_numericint($post['onbatterydelay'])) {
+			$input_errors[] = 'OnBattery Delay is not numeric.';
+		}
+
+		if ($post['batterylevel'] != '' && !is_numericint($post['batterylevel'])) {
+			$input_errors[] = 'Battery Level is not numeric.';
+		}
+		*/
+	}
+}
+
+function sync_package_snmptt() {
+	global $config, $g;
+
+	conf_mount_rw();
+
+	if (is_service_running('snmptt') && !file_exists("{$g['tmp_path']}/.rc.start_packages.running")) {
+		log_error("Stopping service snmptt");
+		stop_service('snmptt');
+	}
+
+	define('SNMPTT_BASE', '/usr/local');
+
+	if (is_array($config['installedpackages']['snmptt'])) {
+		$snmptt_config = $config['installedpackages']['snmptt']['config'][0];
+		if ($snmptt_config['snmpttenabled'] == "on") {
+			$snmptt_system_name = $snmptt_config['snmptt_system_name'];
+			$mode = $snmptt_config['mode'];
+			$multiple_event = $snmptt_config['multiple_event'];
+			$dns_enable = $snmptt_config['dns_enable'];
+			$strip_domain = $snmptt_config['strip_domain'];
+
+			$strip_domain_list = base64_decode($snmptt_config['strip_domain_list']);
+			$strip_domain_list = preg_replace("~\r\n~", "\n", $strip_domain_list);
+
+			$resolve_value_ip_addresses = $snmptt_config['resolve_value_ip_addresses'];
+			$net_snmp_perl_enable = $snmptt_config['net_snmp_perl_enable'];
+			$net_snmp_perl_cache_enable = $snmptt_config['net_snmp_perl_cache_enable'];
+			$net_snmp_perl_best_guess = $snmptt_config['net_snmp_perl_best_guess'];
+			$translate_log_trap_oid = $snmptt_config['translate_log_trap_oid'];
+			$translate_value_oids = $snmptt_config['translate_value_oids'];
+			$translate_enterprise_oid_format = $snmptt_config['translate_enterprise_oid_format'];
+			$translate_trap_oid_format = $snmptt_config['translate_trap_oid_format'];
+			$translate_varname_oid_format = $snmptt_config['translate_varname_oid_format'];
+			$translate_integers = $snmptt_config['translate_integers'];
+			$wildcard_expansion_separator = $snmptt_config['wildcard_expansion_separator'];
+			$allow_unsafe_regex = $snmptt_config['allow_unsafe_regex'];
+			$remove_backslash_from_quotes = $snmptt_config['remove_backslash_from_quotes'];
+			$dynamic_nodes = $snmptt_config['dynamic_nodes'];
+			$description_mode = $snmptt_config['description_mode'];
+			$description_clean = $snmptt_config['description_clean'];
+			$threads_enable = $snmptt_config['threads_enable'];
+			$threads_max = $snmptt_config['threads_max'];
+			$date_format = $snmptt_config['date_format'];
+			$time_format = $snmptt_config['time_format'];
+			$date_time_format = $snmptt_config['date_time_format'];
+			$sleep = $snmptt_config['sleep'];
+			$use_trap_time = $snmptt_config['use_trap_time'];
+			$keep_unlogged_traps = $snmptt_config['keep_unlogged_traps'];
+			$duplicate_trap_window = $snmptt_config['duplicate_trap_window'];
+			$stdout_enable = $snmptt_config['stdout_enable'];
+			$log_enable = $snmptt_config['log_enable'];
+			$log_file = $snmptt_config['log_file'];
+			$log_system_enable = $snmptt_config['log_system_enable'];
+			$log_system_file = $snmptt_config['log_system_file'];
+			$unknown_trap_log_enable = $snmptt_config['unknown_trap_log_enable'];
+			$unknown_trap_log_file = $snmptt_config['unknown_trap_log_file'];
+			$statistics_interval = $snmptt_config['statistics_interval'];
+			$syslog_enable = $snmptt_config['syslog_enable'];
+			$syslog_facility = $snmptt_config['syslog_facility'];
+			$syslog_level = $snmptt_config['syslog_level'];
+			$syslog_system_enable = $snmptt_config['syslog_system_enable'];
+			$syslog_system_facility = $snmptt_config['syslog_system_facility'];
+			$syslog_system_level = $snmptt_config['syslog_system_level'];
+
+			include("/usr/local/pkg/snmptt.ini.php");
+			file_put_contents(SNMPTT_BASE . "/etc/snmp/snmptt.ini", $snmpttini, LOCK_EX);
+
+			if (is_array($config['installedpackages']['snmpttconf'])) {
+				$snmpttconf_config = $config['installedpackages']['snmpttconf']['config'][0];
+				$snmptt_configfile = base64_decode($snmpttconf_config['snmptt_configfile']);
+				$snmptt_configfile = preg_replace("~\r\n~", "\n", $snmptt_configfile);
+				file_put_contents(SNMPTT_BASE . "/etc/snmp/snmptt.conf", $snmptt_configfile, LOCK_EX);
+			}
+
+		}
+	}
+
+	// RC FILE
+	$snmptt_rcfile="/usr/local/etc/rc.d/snmptt.sh";
+	if (is_array($snmptt_config) && $snmptt_config['snmpttenabled']=="on") {
+
+		$snmptt_start = "echo \"Starting SNMPTT Daemon...\"\n";
+		$snmptt_start .= "	/usr/local/bin/perl /usr/local/sbin/snmptt --daemon > /dev/null 2>&1 \n";
+
+		$snmptt_stop = "echo \"Stopping SNMPTT Daemon...\"\n";
+		$snmptt_stop .= "	kill `cat /var/run/snmptt/snmptt.pid`";
+
+		/* write out rc.d start/stop file */
+		write_rcfile(array(
+			"file" => "snmptt.sh",
+			"start" => "$snmptt_start",
+			"stop" => "$snmptt_stop"
+			)
+		);
+
+		if (!file_exists("{$g['tmp_path']}/.rc.start_packages.running")) {
+			log_error("Starting service snmptt");
+			start_service("snmptt");
+		}
+	}
+
+	conf_mount_ro();
+}
+
+?>

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
@@ -50,6 +50,10 @@ function validate_input_snmptt($post, &$input_errors) {
 			$input_errors[] = "'Statistics Interval' value is not numeric.";
 		}
 
+		if (preg_match("/\"/", $post['wildcard_expansion_separator'])) {
+			$input_errors[] = "Double quotes not allowed in 'Wildcard Expansion Separator' field.";
+		}
+
 	}
 }
 

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
@@ -133,10 +133,19 @@ function sync_package_snmptt() {
 	if (is_array($snmptt_config) && $snmptt_config['snmpttenabled']=="on") {
 
 		$snmptt_start = "echo \"Starting SNMPTT Daemon...\"\n";
+		$snmptt_start .= "	if [ -f /var/run/snmptt/snmptt.pid ]; then \n";
+		$snmptt_start .= "		echo \"Already running\" \n";
+		$snmptt_start .= "		exit 1 \n";
+		$snmptt_start .= "	fi \n";
 		$snmptt_start .= "	/usr/local/bin/perl /usr/local/sbin/snmptt --daemon > /dev/null 2>&1 \n";
 
 		$snmptt_stop = "echo \"Stopping SNMPTT Daemon...\"\n";
-		$snmptt_stop .= "	kill `cat /var/run/snmptt/snmptt.pid`";
+		$snmptt_stop .= "	if [ ! -f /var/run/snmptt/snmptt.pid ]; then \n";
+		$snmptt_stop .= "			kill `pgrep -anf 'snmptt --daemon'` \n";
+		$snmptt_stop .= "	else \n";
+		$snmptt_stop .= "			kill `cat /var/run/snmptt/snmptt.pid` \n";
+		$snmptt_stop .= "	fi \n";
+		$snmptt_stop .= "	/bin/sleep 2 \n";
 
 		/* write out rc.d start/stop file */
 		write_rcfile(array(

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
@@ -91,6 +91,12 @@ function sync_package_snmptt() {
 	if (is_array($snmptt_config) && $snmptt_config['snmpttenabled']=="on") {
 
 		$snmptt_start = "echo \"Starting SNMPTT Daemon...\"\n";
+		$snmptt_start .= "	for DIR in log run spool; do\n";
+		$snmptt_start .= "		if [ ! -d /var/\$DIR/snmptt ]; then\n";
+		$snmptt_start .= "			mkdir /var/\$DIR/snmptt\n";
+		$snmptt_start .= "			chown snmptt:snmptt /var/\$DIR/snmptt\n";
+		$snmptt_start .= "		fi\n";
+		$snmptt_start .= "	done\n";
 		$snmptt_start .= "	if [ -f /var/run/snmptt/snmptt.pid ]; then\n";
 		$snmptt_start .= "		echo \"Already running\"\n";
 		$snmptt_start .= "		exit 1\n";

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
@@ -38,10 +38,6 @@ function validate_input_snmptt($post, &$input_errors) {
 			$input_errors[] = "'SNMPTT System Name' is not a valid hostname.";
 		}
 
-		if (!preg_match("/^\".+\"$/", $post['wildcard_expansion_separator'])) {
-			$input_errors[] = "'Wildcard Expansion Separator' must be within quotes and can contain 1 or more characters.";
-		}
-
 		if (!is_numericint($post['threads_max'])) {
 			$input_errors[] = "'Threads Max' value is not numeric.";
 		}
@@ -72,6 +68,11 @@ function sync_package_snmptt() {
 		if ($snmptt_config['snmpttenabled'] == "on") {
 			$strip_domain_list = base64_decode($snmptt_config['strip_domain_list']);
 			$strip_domain_list = preg_replace("~\r\n~", "\n", $strip_domain_list);
+			if (!empty($snmptt_config['wildcard_expansion_separator'])) {
+				$wildcard_expansion_separator = $snmptt_config['wildcard_expansion_separator'];
+			} else {
+				$wildcard_expansion_separator = " ";
+			}
 			include("/usr/local/pkg/snmptt.ini.php");
 			file_put_contents(SNMPTT_BASE . "/etc/snmp/snmptt.ini", $snmpttini, LOCK_EX);
 

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
@@ -27,8 +27,6 @@ require_once("globals.inc");
 define('SNMPTT_BASE', '/usr/local');
 
 function php_deinstall_snmptt() {
-	global $config, $g;
-
 	unlink_if_exists(SNMPTT_BASE . "/etc/rc.d/snmptt.sh");
 }
 
@@ -86,9 +84,9 @@ function sync_package_snmptt() {
 		}
 	}
 
-	// RC FILE
-	$snmptt_rcfile="/usr/local/etc/rc.d/snmptt.sh";
-	if (is_array($snmptt_config) && $snmptt_config['snmpttenabled']=="on") {
+	if (is_array($snmptt_config) && $snmptt_config['snmpttenabled']=="on" && $snmptt_config['mode'] == "daemon") {
+		// RC FILE
+		$snmptt_rcfile="/usr/local/etc/rc.d/snmptt.sh";
 
 		$snmptt_start = "echo \"Starting SNMPTT Daemon...\"\n";
 		$snmptt_start .= "	for DIR in log run spool; do\n";
@@ -123,6 +121,8 @@ function sync_package_snmptt() {
 			log_error("Starting service snmptt");
 			start_service("snmptt");
 		}
+	} else {
+		unlink_if_exists(SNMPTT_BASE . "/etc/rc.d/snmptt.sh");
 	}
 
 	conf_mount_ro();

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
@@ -39,15 +39,27 @@ function php_deinstall_snmptt() {
 function validate_input_snmptt($post, &$input_errors) {
 
 	if (isset($post['snmpttenabled'])) {
-		/*
-		if ($post['onbatterydelay'] != '' && !is_numericint($post['onbatterydelay'])) {
-			$input_errors[] = 'OnBattery Delay is not numeric.';
+
+		if (!empty($post['snmptt_system_name']) && !is_hostname($post['snmptt_system_name'])) {
+			$input_errors[] = "'SNMPTT System Name' is not a valid hostname.";
 		}
 
-		if ($post['batterylevel'] != '' && !is_numericint($post['batterylevel'])) {
-			$input_errors[] = 'Battery Level is not numeric.';
+		if (!preg_match("/^\".+\"$/", $post['wildcard_expansion_separator'])) {
+			$input_errors[] = "'Wildcard Expansion Separator' must be within quotes and can contain 1 or more characters.";
 		}
-		*/
+
+		if (!is_numericint($post['threads_max'])) {
+			$input_errors[] = "'Threads Max' value is not numeric.";
+		}
+
+		if (!is_numericint($post['sleep'])) {
+			$input_errors[] = "'Sleep' value is not numeric.";
+		}
+
+		if (!is_numericint($post['statistics_interval'])) {
+			$input_errors[] = "'Statistics Interval' value is not numeric.";
+		}
+
 	}
 }
 

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
@@ -24,14 +24,10 @@ require_once("functions.inc");
 require_once("pkg-utils.inc");
 require_once("globals.inc");
 
-function php_install_snmptt() {
-	sync_package_snmptt();
-}
+define('SNMPTT_BASE', '/usr/local');
 
 function php_deinstall_snmptt() {
 	global $config, $g;
-
-	define('SNMPTT_BASE', '/usr/local');
 
 	unlink_if_exists(SNMPTT_BASE . "/etc/rc.d/snmptt.sh");
 }
@@ -73,60 +69,11 @@ function sync_package_snmptt() {
 		stop_service('snmptt');
 	}
 
-	define('SNMPTT_BASE', '/usr/local');
-
 	if (is_array($config['installedpackages']['snmptt'])) {
 		$snmptt_config = $config['installedpackages']['snmptt']['config'][0];
 		if ($snmptt_config['snmpttenabled'] == "on") {
-			$snmptt_system_name = $snmptt_config['snmptt_system_name'];
-			$mode = $snmptt_config['mode'];
-			$multiple_event = $snmptt_config['multiple_event'];
-			$dns_enable = $snmptt_config['dns_enable'];
-			$strip_domain = $snmptt_config['strip_domain'];
-
 			$strip_domain_list = base64_decode($snmptt_config['strip_domain_list']);
 			$strip_domain_list = preg_replace("~\r\n~", "\n", $strip_domain_list);
-
-			$resolve_value_ip_addresses = $snmptt_config['resolve_value_ip_addresses'];
-			$net_snmp_perl_enable = $snmptt_config['net_snmp_perl_enable'];
-			$net_snmp_perl_cache_enable = $snmptt_config['net_snmp_perl_cache_enable'];
-			$net_snmp_perl_best_guess = $snmptt_config['net_snmp_perl_best_guess'];
-			$translate_log_trap_oid = $snmptt_config['translate_log_trap_oid'];
-			$translate_value_oids = $snmptt_config['translate_value_oids'];
-			$translate_enterprise_oid_format = $snmptt_config['translate_enterprise_oid_format'];
-			$translate_trap_oid_format = $snmptt_config['translate_trap_oid_format'];
-			$translate_varname_oid_format = $snmptt_config['translate_varname_oid_format'];
-			$translate_integers = $snmptt_config['translate_integers'];
-			$wildcard_expansion_separator = $snmptt_config['wildcard_expansion_separator'];
-			$allow_unsafe_regex = $snmptt_config['allow_unsafe_regex'];
-			$remove_backslash_from_quotes = $snmptt_config['remove_backslash_from_quotes'];
-			$dynamic_nodes = $snmptt_config['dynamic_nodes'];
-			$description_mode = $snmptt_config['description_mode'];
-			$description_clean = $snmptt_config['description_clean'];
-			$threads_enable = $snmptt_config['threads_enable'];
-			$threads_max = $snmptt_config['threads_max'];
-			$date_format = $snmptt_config['date_format'];
-			$time_format = $snmptt_config['time_format'];
-			$date_time_format = $snmptt_config['date_time_format'];
-			$sleep = $snmptt_config['sleep'];
-			$use_trap_time = $snmptt_config['use_trap_time'];
-			$keep_unlogged_traps = $snmptt_config['keep_unlogged_traps'];
-			$duplicate_trap_window = $snmptt_config['duplicate_trap_window'];
-			$stdout_enable = $snmptt_config['stdout_enable'];
-			$log_enable = $snmptt_config['log_enable'];
-			$log_file = $snmptt_config['log_file'];
-			$log_system_enable = $snmptt_config['log_system_enable'];
-			$log_system_file = $snmptt_config['log_system_file'];
-			$unknown_trap_log_enable = $snmptt_config['unknown_trap_log_enable'];
-			$unknown_trap_log_file = $snmptt_config['unknown_trap_log_file'];
-			$statistics_interval = $snmptt_config['statistics_interval'];
-			$syslog_enable = $snmptt_config['syslog_enable'];
-			$syslog_facility = $snmptt_config['syslog_facility'];
-			$syslog_level = $snmptt_config['syslog_level'];
-			$syslog_system_enable = $snmptt_config['syslog_system_enable'];
-			$syslog_system_facility = $snmptt_config['syslog_system_facility'];
-			$syslog_system_level = $snmptt_config['syslog_system_level'];
-
 			include("/usr/local/pkg/snmptt.ini.php");
 			file_put_contents(SNMPTT_BASE . "/etc/snmp/snmptt.ini", $snmpttini, LOCK_EX);
 
@@ -136,7 +83,6 @@ function sync_package_snmptt() {
 				$snmptt_configfile = preg_replace("~\r\n~", "\n", $snmptt_configfile);
 				file_put_contents(SNMPTT_BASE . "/etc/snmp/snmptt.conf", $snmptt_configfile, LOCK_EX);
 			}
-
 		}
 	}
 
@@ -145,19 +91,19 @@ function sync_package_snmptt() {
 	if (is_array($snmptt_config) && $snmptt_config['snmpttenabled']=="on") {
 
 		$snmptt_start = "echo \"Starting SNMPTT Daemon...\"\n";
-		$snmptt_start .= "	if [ -f /var/run/snmptt/snmptt.pid ]; then \n";
-		$snmptt_start .= "		echo \"Already running\" \n";
-		$snmptt_start .= "		exit 1 \n";
-		$snmptt_start .= "	fi \n";
-		$snmptt_start .= "	/usr/local/bin/perl /usr/local/sbin/snmptt --daemon > /dev/null 2>&1 \n";
+		$snmptt_start .= "	if [ -f /var/run/snmptt/snmptt.pid ]; then\n";
+		$snmptt_start .= "		echo \"Already running\"\n";
+		$snmptt_start .= "		exit 1\n";
+		$snmptt_start .= "	fi\n";
+		$snmptt_start .= "	/usr/local/bin/perl /usr/local/sbin/snmptt --daemon > /dev/null 2>&1\n";
 
 		$snmptt_stop = "echo \"Stopping SNMPTT Daemon...\"\n";
-		$snmptt_stop .= "	if [ ! -f /var/run/snmptt/snmptt.pid ]; then \n";
-		$snmptt_stop .= "			kill `pgrep -anf 'snmptt --daemon'` \n";
-		$snmptt_stop .= "	else \n";
-		$snmptt_stop .= "			kill `cat /var/run/snmptt/snmptt.pid` \n";
-		$snmptt_stop .= "	fi \n";
-		$snmptt_stop .= "	/bin/sleep 2 \n";
+		$snmptt_stop .= "	if [ ! -f /var/run/snmptt/snmptt.pid ]; then\n";
+		$snmptt_stop .= "			kill `pgrep -anf 'snmptt --daemon'`\n";
+		$snmptt_stop .= "	else\n";
+		$snmptt_stop .= "			kill `cat /var/run/snmptt/snmptt.pid`\n";
+		$snmptt_stop .= "	fi\n";
+		$snmptt_stop .= "	/bin/sleep 2\n";
 
 		/* write out rc.d start/stop file */
 		write_rcfile(array(

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
@@ -24,10 +24,8 @@ require_once("functions.inc");
 require_once("pkg-utils.inc");
 require_once("globals.inc");
 
-define('SNMPTT_BASE', '/usr/local');
-
 function php_deinstall_snmptt() {
-	unlink_if_exists(SNMPTT_BASE . "/etc/rc.d/snmptt.sh");
+	unlink_if_exists("/usr/local/etc/rc.d/snmptt.sh");
 }
 
 function validate_input_snmptt($post, &$input_errors) {
@@ -78,13 +76,13 @@ function sync_package_snmptt() {
 				$wildcard_expansion_separator = " ";
 			}
 			include("/usr/local/pkg/snmptt.ini.php");
-			file_put_contents(SNMPTT_BASE . "/etc/snmp/snmptt.ini", $snmpttini, LOCK_EX);
+			file_put_contents("/usr/local/etc/snmp/snmptt.ini", $snmpttini, LOCK_EX);
 
 			if (is_array($config['installedpackages']['snmpttconf'])) {
 				$snmpttconf_config = $config['installedpackages']['snmpttconf']['config'][0];
 				$snmptt_configfile = base64_decode($snmpttconf_config['snmptt_configfile']);
 				$snmptt_configfile = preg_replace("~\r\n~", "\n", $snmptt_configfile);
-				file_put_contents(SNMPTT_BASE . "/etc/snmp/snmptt.conf", $snmptt_configfile, LOCK_EX);
+				file_put_contents("/usr/local/etc/snmp/snmptt.conf", $snmptt_configfile, LOCK_EX);
 			}
 		}
 	}
@@ -127,7 +125,7 @@ function sync_package_snmptt() {
 			start_service("snmptt");
 		}
 	} else {
-		unlink_if_exists(SNMPTT_BASE . "/etc/rc.d/snmptt.sh");
+		unlink_if_exists("/usr/local/etc/rc.d/snmptt.sh");
 	}
 
 	conf_mount_ro();

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.inc
@@ -58,8 +58,6 @@ function validate_input_snmptt($post, &$input_errors) {
 function sync_package_snmptt() {
 	global $config, $g;
 
-	conf_mount_rw();
-
 	if (is_service_running('snmptt') && !file_exists("{$g['tmp_path']}/.rc.start_packages.running")) {
 		log_error("Stopping service snmptt");
 		stop_service('snmptt');
@@ -128,7 +126,6 @@ function sync_package_snmptt() {
 		unlink_if_exists("/usr/local/etc/rc.d/snmptt.sh");
 	}
 
-	conf_mount_ro();
 }
 
 ?>

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.ini.php
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.ini.php
@@ -31,13 +31,13 @@ $snmpttini =<<<EOF
 [General]
 # Name of this system for \$H variable.  If blank, system name will be the computer's
 # hostname via Sys::Hostname.
-snmptt_system_name = {$snmptt_system_name} 
+snmptt_system_name = {$snmptt_config['snmptt_system_name']} 
 
 # Set to either 'standalone' or 'daemon'
 # standalone: snmptt called from snmptrapd.conf
 # daemon: snmptrapd.conf calls snmptthandler
 # Ignored by Windows.  See documentation
-mode = {$mode} 
+mode = {$snmptt_config['mode']} 
 
 # Set to 1 to allow multiple trap definitions to be executed for the same trap.
 # Set to 0 to have it stop after the first match.
@@ -47,7 +47,7 @@ mode = {$mode}
 # 	into consideration the NODES list.  Therefore, if there is a matching trap, but
 #	the NODES list prevents it from being considered a match, the wildcard entry will
 #	only be used if there are no other exact matches.
-multiple_event = {$multiple_event}
+multiple_event = {$snmptt_config['multiple_event']}
 
 # SNMPTRAPD passes the IP address of device sending the trap, and the IP address of the
 # actual SNMP agent.  These addresses could differ if the trap was sent on behalf of another
@@ -59,7 +59,7 @@ multiple_event = {$multiple_event}
 # will then be used for comparing.
 # Set to 0 to disable DNS resolution
 # Set to 1 to enable DNS resolution
-dns_enable = {$dns_enable}
+dns_enable = {$snmptt_config['dns_enable']}
 
 # Set to 0 to enable the use of FQDN (Fully Qualified Domain Names).  If a host name is
 # passed to SNMPTT that contains a domain name, it will not be altered in any way by
@@ -68,7 +68,7 @@ dns_enable = {$dns_enable}
 # example, server01.domain.com would be changed to server01
 # Set to 2 to have SNMPTT strip the domain name from the host name passed to it
 # based on the list of domains in strip_domain_list
-strip_domain = {$strip_domain}
+strip_domain = {$snmptt_config['strip_domain']}
 
 # List of domain names that should be stripped when strip_domain is set to 2.
 # List can contain one or more domains.  For example, if the FQDN of a host is
@@ -84,7 +84,7 @@ END
 # Set to 1 to enable resolving ip address to host names
 # Note: net_snmp_perl_enable *must* be enabled.  The strip_domain settings influence the
 # format of the resolved host name.  DNS must be enabled (dns_enable)
-resolve_value_ip_addresses = {$resolve_value_ip_addresses}
+resolve_value_ip_addresses = {$snmptt_config['resolve_value_ip_addresses']}
 
 # Set to 1 to enable the use of the Perl module from the UCD-SNMP / NET-SNMP package.
 # This is required for \$v variable substitution to work, and also for some other options
@@ -92,14 +92,14 @@ resolve_value_ip_addresses = {$resolve_value_ip_addresses}
 # Set to 0 to disable the use of the Perl module from the UCD-SNMP / NET-SNMP package.
 # Note: Enabling this with stand-alone mode can cause SNMPTT to run very slowly due to
 #       the loading of the MIBS at startup.
-net_snmp_perl_enable = {$net_snmp_perl_enable}
+net_snmp_perl_enable = {$snmptt_config['net_snmp_perl_enable']}
 
 # Set to 1 to enable caching of OID and ENUM translations when net_snmp_perl_enable is 
 # enabled.  Enabling this should result in faster translations.
 # Set to 0 to disable caching.
 # Note: Restart SNMPTT after updating the MIB files for Net-SNMP, otherwise the cache may
 # contain inaccurate data.  Defaults to 1.
-net_snmp_perl_cache_enable = {$net_snmp_perl_cache_enable}
+net_snmp_perl_cache_enable = {$snmptt_config['net_snmp_perl_cache_enable']}
 
 # This sets the best_guess parameter used by the UCD-SNMP / NET-SNMP Perl module for 
 # translating symbolic nams to OIDs and vice versa.
@@ -109,7 +109,7 @@ net_snmp_perl_cache_enable = {$net_snmp_perl_cache_enable}
 # UCD-SNMP and Net-SNMP 5.0.8 and previous may not be able to translate certain formats of
 # symbolic names such as RFC1213-MIB::sysDescr.  Net-SNMP 5.0.9 or patch 722075 will allow
 # all possibilities to be translated.  See the FAQ section in the README for more info
-net_snmp_perl_best_guess = {$net_snmp_perl_best_guess}
+net_snmp_perl_best_guess = {$snmptt_config['net_snmp_perl_best_guess']}
 
 # Configures how the OID of the received trap is handled when outputting to a log file /
 # database.  It does NOT apply to the \$O variable.
@@ -124,7 +124,7 @@ net_snmp_perl_best_guess = {$net_snmp_perl_best_guess}
 #       -net_snmp_perl_enable *must* be enabled
 #       -If using database logging, ensure the trapoid column is large enough to hold the
 #        entire line
-translate_log_trap_oid = {$translate_log_trap_oid}
+translate_log_trap_oid = {$snmptt_config['translate_log_trap_oid']}
 
 # Configures how OIDs contained in the VALUE of the variable bindings are handled.
 # This only applies to the values for \$n, \$+n, \$-n, \$vn, \$+*, \$-*.  For substitutions
@@ -138,22 +138,22 @@ translate_log_trap_oid = {$translate_log_trap_oid}
 # For example, if the value contained: 'A UPS Alarm (.1.3.6.1.4.1.534.1.7.12) has cleared.',
 # it could be translated to: 'A UPS Alarm (UPS-MIB::BuildingAlarm) has cleared.'
 # Note: net_snmp_perl_enable *must* be enabled
-translate_value_oids = {$translate_value_oids}
+translate_value_oids = {$snmptt_config['translate_value_oids']}
 
 # Configures how the symbolic enterprise OID will be displayed for \$E.
 # Set to 1, 2, 3 or 4.  See translate_value_oids options 1,2,3 and 4. 
 # Note: net_snmp_perl_enable *must* be enabled
-translate_enterprise_oid_format = {$translate_enterprise_oid_format}
+translate_enterprise_oid_format = {$snmptt_config['translate_enterprise_oid_format']}
 
 # Configures how the symbolic trap OID will be displayed for \$O.
 # Set to 1, 2, 3 or 4.  See translate_value_oids options 1,2,3 and 4. 
 # Note: net_snmp_perl_enable *must* be enabled
-translate_trap_oid_format = {$translate_trap_oid_format}
+translate_trap_oid_format = {$snmptt_config['translate_trap_oid_format']}
 
 # Configures how the symbolic trap OID will be displayed for \$v, \$-n, \$+n, \$-* and \$+*.
 # Set to 1, 2, 3 or 4.  See translate_value_oids options 1,2,3 and 4. 
 # Note: net_snmp_perl_enable *must* be enabled
-translate_varname_oid_format = {$translate_varname_oid_format}
+translate_varname_oid_format = {$snmptt_config['translate_varname_oid_format']}
 
 # Set to 0 to disable converting INTEGER values to enumeration tags as defined in the 
 # MIB files
@@ -161,7 +161,7 @@ translate_varname_oid_format = {$translate_varname_oid_format}
 # MIB files
 # Example: moverDoorState:open instead of moverDoorState:2
 # Note: net_snmp_perl_enable *must* be enabled
-translate_integers = {$translate_integers}
+translate_integers = {$snmptt_config['translate_integers']}
 
 # Allows you to set the MIBS environment variable used by SNMPTT
 # Leave blank or comment out to have the systems enviroment settings used
@@ -172,7 +172,7 @@ translate_integers = {$translate_integers}
 # Set what is used to separate variables when wildcards are expanded on the FORMAT /
 # EXEC line.  Defaults to a space.  Value MUST be within quotes.  Can contain 1 or 
 # more characters
-wildcard_expansion_separator = {$wildcard_expansion_separator}
+wildcard_expansion_separator = {$snmptt_config['wildcard_expansion_separator']}
 
 # Set to 1 to allow unsafe REGEX code to be executed.
 # Set to 0 to prevent unsafe REGEX code from being executed (default).
@@ -186,12 +186,12 @@ wildcard_expansion_separator = {$wildcard_expansion_separator}
 # This is considered unsafe because the contents of the regular expression 
 # (right) is executed (eval) by Perl which *could contain unsafe code*.
 # BE SURE THAT THE SNMPTT CONFIGURATION FILES ARE SECURE!
-allow_unsafe_regex = {$allow_unsafe_regex}
+allow_unsafe_regex = {$snmptt_config['allow_unsafe_regex']}
 
 # Set to 1 to have the backslash (escape) removed from quotes passed from
 # snmptrapd.  For example, \" would be changed to just "
 # Set to 0 to disable
-remove_backslash_from_quotes = {$remove_backslash_from_quotes}
+remove_backslash_from_quotes = {$snmptt_config['remove_backslash_from_quotes']}
 
 # Set to 1 to have NODES files loaded each time a trap is processed.
 # Set to 0 to have all NODES files loaded when the snmptt.conf files are loaded.
@@ -200,7 +200,7 @@ remove_backslash_from_quotes = {$remove_backslash_from_quotes}
 # NODES files.  This will allow the NODES file to be modified while SNMPTT is 
 # running but can result in many file reads depending on the number of traps
 # received.  Defaults to 0
-dynamic_nodes = {$dynamic_nodes}
+dynamic_nodes = {$snmptt_config['dynamic_nodes']}
 
 # This option allows you to use the \$D substitution variable to include the
 # description text from the SNMPTT.CONF or MIB files.
@@ -214,11 +214,11 @@ dynamic_nodes = {$dynamic_nodes}
 #  module save_descriptions variable.  Enabling this option can greatly 
 #  increase the amount of memory used by the Net-SNMP SNMP Perl module, which 
 #  will result in an increase of memory usage by SNMPTT.
-description_mode = {$description_mode}
+description_mode = {$snmptt_config['description_mode']}
 
 # Set to 1 to remove any white space at the start of each line from the MIB
 # or SNMPTT.CONF description when description_mode is set to 1 or 2.
-description_clean = {$description_clean}
+description_clean = {$snmptt_config['description_clean']}
 
 # Warning: Experimental.  Not recommended for production environments.
 #          When threads are enabled, SNMPTT may quit unexpectedly.
@@ -227,28 +227,28 @@ description_clean = {$description_clean}
 # traps.  See also threads_max.
 # Set to 0 to disable threads (ithreads).
 # Defaults to 0
-threads_enable = {$threads_enable}
+threads_enable = {$snmptt_config['threads_enable']}
 
 # Warning: Experimental.  Not recommended for production environments.
 #          When threads are enabled, SNMPTT may quit unexpectedly.
 # This option allows you to set the maximum number of threads that will 
 # execute at once.  Defaults to 10
-threads_max = {$threads_max}
+threads_max = {$snmptt_config['threads_max']}
 
 # The date format for \$x in strftime() format.  If not defined, defaults 
 # to %a %b %e %Y.
-date_format = {$date_format}
+date_format = {$snmptt_config['date_format']}
 
 # The time format for \$X in strftime() format.  If not defined, defaults 
 # to %H:%M:%S.
-time_format = {$time_format}
+time_format = {$snmptt_config['time_format']}
 
 # The date time format in strftime() format for the date/time when logging 
 # to standard output, snmptt log files (log_file) and the unknown log file 
 # (unknown_trap_log_file).  Defaults to localtime().  For SQL, see 
 # date_time_format_sql.
 # Example:  %a %b %e %Y %H:%M:%S
-date_time_format = {$date_time_format}
+date_time_format = {$snmptt_config['date_time_format']}
 
 [DaemonMode]
 # Set to 1 to have snmptt fork to the background when run in daemon mode
@@ -275,12 +275,12 @@ pid_file = /var/run/snmptt/snmptt.pid
 spool_directory = /var/spool/snmptt/
 
 # Amount of time in seconds to sleep between processing spool files
-sleep = {$sleep}
+sleep = {$snmptt_config['sleep']}
 
 # Set to 1 to have SNMPTT use the time that the trap was processed by SNMPTTHANDLER
 # Set to 0 to have SNMPTT use the time the trap was processed.  Note:  Using 0 can
 # result in the time being off by the number of seconds used for 'sleep'
-use_trap_time = {$use_trap_time}
+use_trap_time = {$snmptt_config['use_trap_time']}
 
 # Set to 0 to have SNMPTT erase the spooled trap file after it attempts to process
 # the trap even if it did not successfully log the trap to any of the log systems.
@@ -291,7 +291,7 @@ use_trap_time = {$use_trap_time}
 # enabled and only one fails, the other log system will continuously be logged to
 # until ALL of the log systems function.
 # The recommended setting is 1 with only one log system enabled.
-keep_unlogged_traps = {$keep_unlogged_traps}
+keep_unlogged_traps = {$snmptt_config['keep_unlogged_traps']}
 
 # How often duplicate traps will be processed.  An MD5 hash of all incoming traps
 # is stored in memory and is used to check for duplicates.  All variables except for
@@ -304,27 +304,27 @@ keep_unlogged_traps = {$keep_unlogged_traps}
 # 5 minutes = 300
 # 10 minutes = 600
 # 15 minutes = 900
-duplicate_trap_window = {$duplicate_trap_window}
+duplicate_trap_window = {$snmptt_config['duplicate_trap_window']}
 
 [Logging]
 # Set to 1 to enable messages to be sent to standard output, or 0 to disable.
 # Would normally be disabled unless you are piping this program to another
-stdout_enable = {$stdout_enable}
+stdout_enable = {$snmptt_config['stdout_enable']}
 
 # Set to 1 to enable text logging of *TRAPS*.  Make sure you specify a log_file 
 # location
-log_enable = {$log_enable}
+log_enable = {$snmptt_config['log_enable']}
 
 # Log file location.  The COMPLETE path and filename.  Ex: '/var/log/snmptt/snmptt.log'
-log_file = {$log_file}
+log_file = {$snmptt_config['log_file']}
 
 # Set to 1 to enable text logging of *SNMPTT system errors*.  Make sure you 
 # specify a log_system_file location
-log_system_enable = {$log_system_enable}
+log_system_enable = {$snmptt_config['log_system_enable']}
 
 # Log file location.  The COMPLETE path and filename.  
 # Ex: '/var/log/snmptt/snmpttsystem.log'
-log_system_file = {$log_system_file} 
+log_system_file = {$snmptt_config['log_system_file']} 
 
 # Set to 1 to enable logging of unknown traps.  This should normally be left off
 # as the file could grow large quickly.  Used primarily for troubleshooting.  If
@@ -333,27 +333,27 @@ log_system_file = {$log_system_file}
 # simply missing from the snmptt.conf file.
 # Unknown traps can be logged either a text file, a SQL table or both.
 # See SQL section to define a SQL table to log unknown traps to.
-unknown_trap_log_enable = {$unknown_trap_log_enable}
+unknown_trap_log_enable = {$snmptt_config['unknown_trap_log_enable']}
 
 # Unknown trap log file location.  The COMPLETE path and filename.  
 # Ex: '/var/log/snmptt/snmpttunknown.log'
 # Leave blank to disable logging to text file if logging to SQL is enabled
 # for unknown traps
-unknown_trap_log_file = {$unknown_trap_log_file}
+unknown_trap_log_file = {$snmptt_config['unknown_trap_log_file']}
 
 # How often in seconds statistics should be logged to syslog or the event log.
 # Set to 0 to disable
 # 1 hour = 216000
 # 12 hours = 2592000
 # 24 hours = 5184000
-statistics_interval = {$statistics_interval}
+statistics_interval = {$snmptt_config['statistics_interval']}
 
 # Set to 1 to enable logging of *TRAPS* to syslog.  If you do not have the Sys::Syslog
 # module then disable this.  Windows users should disable this.
-syslog_enable = {$syslog_enable}
+syslog_enable = {$snmptt_config['syslog_enable']}
 
 # Syslog facility to use for logging of *TRAPS*.  For example: 'local0'
-syslog_facility = {$syslog_facility}
+syslog_facility = {$snmptt_config['syslog_facility']}
 
 # Set the syslog level for *TRAPS* based on the severity level of the trap
 # as defined in the snmptt.conf file.  Values must be one per line between 
@@ -378,18 +378,18 @@ END
 
 # Syslog default level to use for logging of *TRAPS*.  For example: warning
 # Valid values: emerg, alert, crit, err, warning, notice, info, debug 
-syslog_level = {$syslog_level}
+syslog_level = {$snmptt_config['syslog_level']}
 
 # Set to 1 to enable logging of *SNMPTT system errors* to syslog.  If you do not have the 
 # Sys::Syslog module then disable this.  Windows users should disable this.
-syslog_system_enable = {$syslog_system_enable}
+syslog_system_enable = {$snmptt_config['syslog_system_enable']}
 
 # Syslog facility to use for logging of *SNMPTT system errors*.  For example: 'local0'
-syslog_system_facility = {$syslog_system_facility} 
+syslog_system_facility = {$snmptt_config['syslog_system_facility']} 
 
 # Syslog level to use for logging of *SNMPTT system errors*..  For example: 'warning'
 # Valid values: emerg, alert, crit, err, warning, notice, info, debug 
-syslog_system_level = {$syslog_system_level}
+syslog_system_level = {$snmptt_config['syslog_system_level']}
 
 [SQL]
 # Determines if the enterprise column contains the numeric OID or symbolic OID

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.ini.php
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.ini.php
@@ -172,7 +172,7 @@ translate_integers = {$snmptt_config['translate_integers']}
 # Set what is used to separate variables when wildcards are expanded on the FORMAT /
 # EXEC line.  Defaults to a space.  Value MUST be within quotes.  Can contain 1 or 
 # more characters
-wildcard_expansion_separator = {$snmptt_config['wildcard_expansion_separator']}
+wildcard_expansion_separator = "{$wildcard_expansion_separator}"
 
 # Set to 1 to allow unsafe REGEX code to be executed.
 # Set to 0 to prevent unsafe REGEX code from being executed (default).

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.ini.php
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.ini.php
@@ -1,0 +1,651 @@
+<?php
+
+/*
+ * snmptt.ini.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2017 Rubicon Communications, LLC (Netgate)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Create snmptt.ini.php 
+$snmpttini =<<<EOF
+#
+# SNMPTT v1.4 Configuration File
+#
+# Linux / Unix
+#
+
+[General]
+# Name of this system for \$H variable.  If blank, system name will be the computer's
+# hostname via Sys::Hostname.
+snmptt_system_name = {$snmptt_system_name} 
+
+# Set to either 'standalone' or 'daemon'
+# standalone: snmptt called from snmptrapd.conf
+# daemon: snmptrapd.conf calls snmptthandler
+# Ignored by Windows.  See documentation
+mode = {$mode} 
+
+# Set to 1 to allow multiple trap definitions to be executed for the same trap.
+# Set to 0 to have it stop after the first match.
+# This option should normally be set to 1.  See the section 'SNMPTT.CONF Configuration 
+# file Notes' in the SNMPTT documentation for more information.
+# Note: Wildcard matches are only matched if there are NO exact matches.  This takes
+# 	into consideration the NODES list.  Therefore, if there is a matching trap, but
+#	the NODES list prevents it from being considered a match, the wildcard entry will
+#	only be used if there are no other exact matches.
+multiple_event = {$multiple_event}
+
+# SNMPTRAPD passes the IP address of device sending the trap, and the IP address of the
+# actual SNMP agent.  These addresses could differ if the trap was sent on behalf of another
+# device (relay, proxy etc).
+# If DNS is enabled, the agent IP address is converted to a host name using a DNS lookup
+# (which includes the local hosts file, depending on how the OS is configured).  This name
+# will be used for: NODES entry matches, hostname field in logged traps (file / database), 
+# and the \$A variable.  Host names on the NODES line will be resolved and the IP address 
+# will then be used for comparing.
+# Set to 0 to disable DNS resolution
+# Set to 1 to enable DNS resolution
+dns_enable = {$dns_enable}
+
+# Set to 0 to enable the use of FQDN (Fully Qualified Domain Names).  If a host name is
+# passed to SNMPTT that contains a domain name, it will not be altered in any way by
+# SNMPTT.  This also affects resolve_value_ip_addresses.
+# Set to 1 to have SNMPTT strip the domain name from the host name passed to it.  For 
+# example, server01.domain.com would be changed to server01
+# Set to 2 to have SNMPTT strip the domain name from the host name passed to it
+# based on the list of domains in strip_domain_list
+strip_domain = {$strip_domain}
+
+# List of domain names that should be stripped when strip_domain is set to 2.
+# List can contain one or more domains.  For example, if the FQDN of a host is
+# server01.city.domain.com and the list contains domain.com, the 'host' will be
+# set as server01.city.
+strip_domain_list = <<END
+{$strip_domain_list}
+END
+
+# Configures how IP addresses contained in the VALUE of the variable bindings are handled.
+# This only applies to the values for \$n, \$+n, \$-n, \$vn, \$+*, \$-*.
+# Set to 0 to disable resolving ip address to host names
+# Set to 1 to enable resolving ip address to host names
+# Note: net_snmp_perl_enable *must* be enabled.  The strip_domain settings influence the
+# format of the resolved host name.  DNS must be enabled (dns_enable)
+resolve_value_ip_addresses = {$resolve_value_ip_addresses}
+
+# Set to 1 to enable the use of the Perl module from the UCD-SNMP / NET-SNMP package.
+# This is required for \$v variable substitution to work, and also for some other options
+# that are enabled in this .ini file.
+# Set to 0 to disable the use of the Perl module from the UCD-SNMP / NET-SNMP package.
+# Note: Enabling this with stand-alone mode can cause SNMPTT to run very slowly due to
+#       the loading of the MIBS at startup.
+net_snmp_perl_enable = {$net_snmp_perl_enable}
+
+# Set to 1 to enable caching of OID and ENUM translations when net_snmp_perl_enable is 
+# enabled.  Enabling this should result in faster translations.
+# Set to 0 to disable caching.
+# Note: Restart SNMPTT after updating the MIB files for Net-SNMP, otherwise the cache may
+# contain inaccurate data.  Defaults to 1.
+net_snmp_perl_cache_enable = {$net_snmp_perl_cache_enable}
+
+# This sets the best_guess parameter used by the UCD-SNMP / NET-SNMP Perl module for 
+# translating symbolic nams to OIDs and vice versa.
+# For UCD-SNMP, and Net-SNMP 5.0.8 and previous versions, set this value to 0.
+# For Net-SNMP 5.0.9, or any Net-SNMP with patch 722075 applied, set this value to 2.
+# A value of 2 is equivalent to -IR on Net-SNMP command line utilities.
+# UCD-SNMP and Net-SNMP 5.0.8 and previous may not be able to translate certain formats of
+# symbolic names such as RFC1213-MIB::sysDescr.  Net-SNMP 5.0.9 or patch 722075 will allow
+# all possibilities to be translated.  See the FAQ section in the README for more info
+net_snmp_perl_best_guess = {$net_snmp_perl_best_guess}
+
+# Configures how the OID of the received trap is handled when outputting to a log file /
+# database.  It does NOT apply to the \$O variable.
+# Set to 0 to use the default of numerical OID
+# Set to 1 to translate the trap OID to short text (symbolic form) (eg: linkUp)
+# Set to 2 to translate the trap OID to short text with module name (eg: IF-MIB::linkUp)
+# Set to 3 to translate the trap OID to long text (eg: iso...snmpTraps.linkUp)
+# Set to 4 to translate the trap OID to long text with module name (eg: 
+# IF-MIB::iso...snmpTraps.linkUp)
+# Note: -The output of the long format will vary depending on the version of Net-SNMP you
+#        are using.
+#       -net_snmp_perl_enable *must* be enabled
+#       -If using database logging, ensure the trapoid column is large enough to hold the
+#        entire line
+translate_log_trap_oid = {$translate_log_trap_oid}
+
+# Configures how OIDs contained in the VALUE of the variable bindings are handled.
+# This only applies to the values for \$n, \$+n, \$-n, \$vn, \$+*, \$-*.  For substitutions
+# that include variable NAMES (\$+n etc), only the variable VALUE is affected.
+# Set to 0 to disable translating OID values to text (symbolic form)
+# Set to 1 to translate OID values to short text (symbolic form) (eg: BuildingAlarm)
+# Set to 2 to translate OID values to short text with module name (eg: UPS-MIB::BuildingAlarm)
+# Set to 3 to translate OID values to long text (eg: iso...upsAlarm.BuildingAlarm)
+# Set to 4 to translate OID values to long text with module name (eg: 
+# UPS-MIB::iso...upsAlarm.BuildingAlarm)
+# For example, if the value contained: 'A UPS Alarm (.1.3.6.1.4.1.534.1.7.12) has cleared.',
+# it could be translated to: 'A UPS Alarm (UPS-MIB::BuildingAlarm) has cleared.'
+# Note: net_snmp_perl_enable *must* be enabled
+translate_value_oids = {$translate_value_oids}
+
+# Configures how the symbolic enterprise OID will be displayed for \$E.
+# Set to 1, 2, 3 or 4.  See translate_value_oids options 1,2,3 and 4. 
+# Note: net_snmp_perl_enable *must* be enabled
+translate_enterprise_oid_format = {$translate_enterprise_oid_format}
+
+# Configures how the symbolic trap OID will be displayed for \$O.
+# Set to 1, 2, 3 or 4.  See translate_value_oids options 1,2,3 and 4. 
+# Note: net_snmp_perl_enable *must* be enabled
+translate_trap_oid_format = {$translate_trap_oid_format}
+
+# Configures how the symbolic trap OID will be displayed for \$v, \$-n, \$+n, \$-* and \$+*.
+# Set to 1, 2, 3 or 4.  See translate_value_oids options 1,2,3 and 4. 
+# Note: net_snmp_perl_enable *must* be enabled
+translate_varname_oid_format = {$translate_varname_oid_format}
+
+# Set to 0 to disable converting INTEGER values to enumeration tags as defined in the 
+# MIB files
+# Set to 1 to enable converting INTEGER values to enumeration tags as defined in the 
+# MIB files
+# Example: moverDoorState:open instead of moverDoorState:2
+# Note: net_snmp_perl_enable *must* be enabled
+translate_integers = {$translate_integers}
+
+# Allows you to set the MIBS environment variable used by SNMPTT
+# Leave blank or comment out to have the systems enviroment settings used
+# To have all MIBS processed, set to ALL
+# See the snmp.conf manual page for more info
+#mibs_environment = ALL
+
+# Set what is used to separate variables when wildcards are expanded on the FORMAT /
+# EXEC line.  Defaults to a space.  Value MUST be within quotes.  Can contain 1 or 
+# more characters
+wildcard_expansion_separator = {$wildcard_expansion_separator}
+
+# Set to 1 to allow unsafe REGEX code to be executed.
+# Set to 0 to prevent unsafe REGEX code from being executed (default).
+# Enabling unsafe REGEX code will allow variable interopolation and the use of the e
+# modifier to allow statements such as substitution with captures such
+# as:            (one (two) three)(five \$1 six)
+# which outputs: five two six
+# or:            (one (two) three)("five ".length(\$1)." six")e
+# which outputs: five 3 six
+#
+# This is considered unsafe because the contents of the regular expression 
+# (right) is executed (eval) by Perl which *could contain unsafe code*.
+# BE SURE THAT THE SNMPTT CONFIGURATION FILES ARE SECURE!
+allow_unsafe_regex = {$allow_unsafe_regex}
+
+# Set to 1 to have the backslash (escape) removed from quotes passed from
+# snmptrapd.  For example, \" would be changed to just "
+# Set to 0 to disable
+remove_backslash_from_quotes = {$remove_backslash_from_quotes}
+
+# Set to 1 to have NODES files loaded each time a trap is processed.
+# Set to 0 to have all NODES files loaded when the snmptt.conf files are loaded.
+# If NODES files are used (files that contain lists of NODES), then setting to 1
+# will cause the list to be loaded each time an EVENT is processed that uses
+# NODES files.  This will allow the NODES file to be modified while SNMPTT is 
+# running but can result in many file reads depending on the number of traps
+# received.  Defaults to 0
+dynamic_nodes = {$dynamic_nodes}
+
+# This option allows you to use the \$D substitution variable to include the
+# description text from the SNMPTT.CONF or MIB files.
+# Set to 0 to disable the \$D substitution variable.  If \$D is used, nothing
+#  will be outputted.
+# Set to 1 to enable the \$D substitution variable and have it use the
+#  descriptions stored in the SNMPTT .conf files.  Enabling this option can
+#  greatly increase the amount of memory used by SNMPTT.
+# Set to 2 to enable the \$D substitution variable and have it use the
+#  description from the MIB files.  This enables the UCD-SNMP / NET-SNMP Perl 
+#  module save_descriptions variable.  Enabling this option can greatly 
+#  increase the amount of memory used by the Net-SNMP SNMP Perl module, which 
+#  will result in an increase of memory usage by SNMPTT.
+description_mode = {$description_mode}
+
+# Set to 1 to remove any white space at the start of each line from the MIB
+# or SNMPTT.CONF description when description_mode is set to 1 or 2.
+description_clean = {$description_clean}
+
+# Warning: Experimental.  Not recommended for production environments.
+#          When threads are enabled, SNMPTT may quit unexpectedly.
+# Set to 1 to enable threads (ithreads) in Perl 5.6.0 or higher.  If enabled,
+# EXEC will launch in a thread to allow SNMPTT to continue processing other
+# traps.  See also threads_max.
+# Set to 0 to disable threads (ithreads).
+# Defaults to 0
+threads_enable = {$threads_enable}
+
+# Warning: Experimental.  Not recommended for production environments.
+#          When threads are enabled, SNMPTT may quit unexpectedly.
+# This option allows you to set the maximum number of threads that will 
+# execute at once.  Defaults to 10
+threads_max = {$threads_max}
+
+# The date format for \$x in strftime() format.  If not defined, defaults 
+# to %a %b %e %Y.
+date_format = {$date_format}
+
+# The time format for \$X in strftime() format.  If not defined, defaults 
+# to %H:%M:%S.
+time_format = {$time_format}
+
+# The date time format in strftime() format for the date/time when logging 
+# to standard output, snmptt log files (log_file) and the unknown log file 
+# (unknown_trap_log_file).  Defaults to localtime().  For SQL, see 
+# date_time_format_sql.
+# Example:  %a %b %e %Y %H:%M:%S
+date_time_format = {$date_time_format}
+
+[DaemonMode]
+# Set to 1 to have snmptt fork to the background when run in daemon mode
+# Ignored by Windows.  See documentation
+daemon_fork = 1
+
+# Set to the numerical user id (eg: 500) or textual user id (eg: snmptt)
+# that snmptt should change to when running in daemon mode.  Leave blank
+# to disable.  The user used should have read/write access to all log
+# files, the spool folder, and read access to the configuration files.
+# Only use this if you are starting snmptt as root.
+# A second (child) process will be started as the daemon_uid user so
+# there will be two snmptt processes running.  The first process will 
+# continue to run as the user that ran snmptt (root), waiting for the
+# child to quit.  After the child quits, the parent process will remove 
+# the snmptt.pid file and exit. 
+daemon_uid = snmptt
+
+# Complete path of file to store process ID when running in daemon mode.
+pid_file = /var/run/snmptt/snmptt.pid
+
+# Directory to read received traps from.  Ex: /var/spool/snmptt/
+# Don't forget the trailing slash!
+spool_directory = /var/spool/snmptt/
+
+# Amount of time in seconds to sleep between processing spool files
+sleep = {$sleep}
+
+# Set to 1 to have SNMPTT use the time that the trap was processed by SNMPTTHANDLER
+# Set to 0 to have SNMPTT use the time the trap was processed.  Note:  Using 0 can
+# result in the time being off by the number of seconds used for 'sleep'
+use_trap_time = {$use_trap_time}
+
+# Set to 0 to have SNMPTT erase the spooled trap file after it attempts to process
+# the trap even if it did not successfully log the trap to any of the log systems.
+# Set to 1 to have SNMPTT erase the spooled trap file only after it successfully
+# logs to at least ONE log system.
+# Set to 2 to have SNMPTT erase the spooled trap file only after it successfully
+# logs to ALL of the enabled log systems.  Warning:  If multiple log systems are
+# enabled and only one fails, the other log system will continuously be logged to
+# until ALL of the log systems function.
+# The recommended setting is 1 with only one log system enabled.
+keep_unlogged_traps = {$keep_unlogged_traps}
+
+# How often duplicate traps will be processed.  An MD5 hash of all incoming traps
+# is stored in memory and is used to check for duplicates.  All variables except for
+# the uptime variable are used when calculating the MD5.  The larger this variable,
+# the more memory snmptt will require.
+# Note:  In most cases it may be a good idea to enable this but sometimes it can have a 
+#        negative effect.  For example, if you are trying to troubleshoot a wireless device
+#        that keeps losing it's connection you may want to disable this so that you see
+#        all the associations and disassociations.
+# 5 minutes = 300
+# 10 minutes = 600
+# 15 minutes = 900
+duplicate_trap_window = {$duplicate_trap_window}
+
+[Logging]
+# Set to 1 to enable messages to be sent to standard output, or 0 to disable.
+# Would normally be disabled unless you are piping this program to another
+stdout_enable = {$stdout_enable}
+
+# Set to 1 to enable text logging of *TRAPS*.  Make sure you specify a log_file 
+# location
+log_enable = {$log_enable}
+
+# Log file location.  The COMPLETE path and filename.  Ex: '/var/log/snmptt/snmptt.log'
+log_file = {$log_file}
+
+# Set to 1 to enable text logging of *SNMPTT system errors*.  Make sure you 
+# specify a log_system_file location
+log_system_enable = {$log_system_enable}
+
+# Log file location.  The COMPLETE path and filename.  
+# Ex: '/var/log/snmptt/snmpttsystem.log'
+log_system_file = {$log_system_file} 
+
+# Set to 1 to enable logging of unknown traps.  This should normally be left off
+# as the file could grow large quickly.  Used primarily for troubleshooting.  If
+# you have defined a trap in snmptt.conf, but it is not executing, enable this to
+# see if it is being considered an unknown trap due to an incorrect entry or 
+# simply missing from the snmptt.conf file.
+# Unknown traps can be logged either a text file, a SQL table or both.
+# See SQL section to define a SQL table to log unknown traps to.
+unknown_trap_log_enable = {$unknown_trap_log_enable}
+
+# Unknown trap log file location.  The COMPLETE path and filename.  
+# Ex: '/var/log/snmptt/snmpttunknown.log'
+# Leave blank to disable logging to text file if logging to SQL is enabled
+# for unknown traps
+unknown_trap_log_file = {$unknown_trap_log_file}
+
+# How often in seconds statistics should be logged to syslog or the event log.
+# Set to 0 to disable
+# 1 hour = 216000
+# 12 hours = 2592000
+# 24 hours = 5184000
+statistics_interval = {$statistics_interval}
+
+# Set to 1 to enable logging of *TRAPS* to syslog.  If you do not have the Sys::Syslog
+# module then disable this.  Windows users should disable this.
+syslog_enable = {$syslog_enable}
+
+# Syslog facility to use for logging of *TRAPS*.  For example: 'local0'
+syslog_facility = {$syslog_facility}
+
+# Set the syslog level for *TRAPS* based on the severity level of the trap
+# as defined in the snmptt.conf file.  Values must be one per line between 
+# the syslog_level_* and END lines, and are not case sensitive.  For example:
+#   Warning
+#   Critical
+# Duplicate definitions will use the definition with the higher severity.
+syslog_level_debug = <<END
+END
+syslog_level_info = <<END
+END
+syslog_level_notice = <<END
+END
+syslog_level_warning = <<END
+END
+syslog_level_err = <<END
+END
+syslog_level_crit = <<END
+END
+syslog_level_alert = <<END
+END
+
+# Syslog default level to use for logging of *TRAPS*.  For example: warning
+# Valid values: emerg, alert, crit, err, warning, notice, info, debug 
+syslog_level = {$syslog_level}
+
+# Set to 1 to enable logging of *SNMPTT system errors* to syslog.  If you do not have the 
+# Sys::Syslog module then disable this.  Windows users should disable this.
+syslog_system_enable = {$syslog_system_enable}
+
+# Syslog facility to use for logging of *SNMPTT system errors*.  For example: 'local0'
+syslog_system_facility = {$syslog_system_facility} 
+
+# Syslog level to use for logging of *SNMPTT system errors*..  For example: 'warning'
+# Valid values: emerg, alert, crit, err, warning, notice, info, debug 
+syslog_system_level = {$syslog_system_level}
+
+[SQL]
+# Determines if the enterprise column contains the numeric OID or symbolic OID
+# Set to 0 for numeric OID
+# Set to 1 for symbolic OID
+# Uses translate_enterprise_oid_format to determine format
+# Note: net_snmp_perl_enable *must* be enabled
+db_translate_enterprise = 0
+
+# FORMAT line to use for unknown traps.  If not defined, defaults to \$-*.
+db_unknown_trap_format = '\$-*'
+
+# List of custom SQL column names and values for the table of received traps
+# (defined by *_table below).  The format is
+#   column name
+#   value
+#
+# For example:
+#
+#   binding_count
+#   \$#
+#   uptime2
+#   The agent has been up for \$T.
+sql_custom_columns = <<END
+END
+
+# List of custom SQL column names and values for the table of unknown traps
+# (defined by *_table_unknown below).  See sql_custom_columns for the format.
+sql_custom_columns_unknown = <<END
+END
+
+# MySQL: Set to 1 to enable logging to a MySQL database via DBI (Linux / Windows)
+# This requires DBI:: and DBD::mysql
+mysql_dbi_enable = 0
+
+# MySQL: Hostname of database server (optional - default localhost)
+mysql_dbi_host = localhost
+
+# MySQL: Port number of database server (optional - default 3306)
+mysql_dbi_port = 3306
+
+# MySQL: Database to use
+mysql_dbi_database = snmptt
+
+# MySQL: Table to use
+mysql_dbi_table = snmptt
+
+# MySQL: Table to use for unknown traps
+# Leave blank to disable logging of unknown traps to MySQL
+# Note: unknown_trap_log_enable must be enabled.
+mysql_dbi_table_unknown = snmptt_unknown
+
+# MySQL: Table to use for statistics
+# Note: statistics_interval must be set.  See also stat_time_format_sql.
+#mysql_dbi_table_statistics = snmptt_statistics
+mysql_dbi_table_statistics = 
+
+# MySQL: Username to use
+mysql_dbi_username = snmpttuser
+
+# MySQL: Password to use
+mysql_dbi_password = password
+
+# MySQL: Whether or not to 'ping' the database before attempting an INSERT
+# to ensure the connection is still valid.  If *any* error is generate by 
+# the ping such as 'Unable to connect to database', it will attempt to 
+# re-create the database connection.
+# Set to 0 to disable
+# Set to 1 to enable
+# Note:  This has no effect on mysql_ping_interval.
+mysql_ping_on_insert = 1
+
+# MySQL: How often in seconds the database should be 'pinged' to ensure the
+# connection is still valid.  If *any* error is generate by the ping such as 
+# 'Unable to connect to database', it will attempt to re-create the database
+# connection.  Set to 0 to disable pinging.
+# Note:  This has no effect on mysql_ping_on_insert.
+# disabled = 0
+# 5 minutes = 300
+# 15 minutes = 900
+# 30 minutes = 1800
+mysql_ping_interval = 300
+
+# PostgreSQL: Set to 1 to enable logging to a PostgreSQL database via DBI (Linux / Windows)
+# This requires DBI:: and DBD::PgPP
+postgresql_dbi_enable = 0
+
+# Set to 0 to use the DBD::PgPP module
+# Set to 1 to use the DBD::Pg module
+postgresql_dbi_module = 0
+
+# Set to 0 to disable host and port network support
+# Set to 1 to enable host and port network support
+# If set to 1, ensure PostgreSQL is configured to allow connections via TCPIP by setting 
+# tcpip_socket = true in the \$PGDATA/postgresql.conf file, and adding the ip address of 
+# the SNMPTT server to \$PGDATApg_hba.conf.  The common location for the config files for
+# RPM installations of PostgreSQL is /var/lib/pgsql/data.  
+postgresql_dbi_hostport_enable = 0
+
+# PostgreSQL: Hostname of database server (optional - default localhost)
+postgresql_dbi_host = localhost
+
+# PostgreSQL: Port number of database server (optional - default 5432)
+postgresql_dbi_port = 5432
+
+# PostgreSQL: Database to use
+postgresql_dbi_database = snmptt
+
+# PostgreSQL: Table to use for unknown traps
+# Leave blank to disable logging of unknown traps to PostgreSQL
+# Note: unknown_trap_log_enable must be enabled.
+postgresql_dbi_table_unknown = snmptt_unknown
+
+# PostgreSQL: Table to use for statistics
+# Note: statistics_interval must be set.  See also stat_time_format_sql.
+#postgresql_dbi_table_statistics = snmptt_statistics
+postgresql_dbi_table_statistics = 
+
+# PostgreSQL: Table to use
+postgresql_dbi_table = snmptt
+
+# PostgreSQL: Username to use
+postgresql_dbi_username = snmpttuser
+
+# PostgreSQL: Password to use
+postgresql_dbi_password = password
+
+# PostgreSQL: Whether or not to 'ping' the database before attempting an INSERT
+# to ensure the connection is still valid.  If *any* error is generate by 
+# the ping such as 'Unable to connect to database', it will attempt to 
+# re-create the database connection.
+# Set to 0 to disable
+# Set to 1 to enable
+# Note:  This has no effect on postgresqll_ping_interval.
+postgresql_ping_on_insert = 1
+
+# PostgreSQL: How often in seconds the database should be 'pinged' to ensure the
+# connection is still valid.  If *any* error is generate by the ping such as 
+# 'Unable to connect to database', it will attempt to re-create the database
+# connection.  Set to 0 to disable pinging.
+# Note:  This has no effect on postgresql_ping_on_insert.
+# disabled = 0
+# 5 minutes = 300
+# 15 minutes = 900
+# 30 minutes = 1800
+postgresql_ping_interval = 300
+
+# ODBC: Set to 1 to enable logging to a database via ODBC using DBD::ODBC.  
+# This requires both DBI:: and DBD::ODBC
+dbd_odbc_enable = 0
+
+# DBD:ODBC: Database to use
+dbd_odbc_dsn = snmptt
+
+# DBD:ODBC: Table to use
+dbd_odbc_table = snmptt
+
+# DBD:ODBC: Table to use for unknown traps
+# Leave blank to disable logging of unknown traps to DBD:ODBC
+# Note: unknown_trap_log_enable must be enabled.
+dbd_odbc_table_unknown = snmptt_unknown
+
+# DBD:ODBC: Table to use for statistics
+# Note: statistics_interval must be set.  See also stat_time_format_sql.
+#dbd_odbc_table_statistics = snmptt_statistics
+dbd_odbc_table_statistics = 
+
+# DBD:ODBC: Username to use
+dbd_odbc_username = snmptt
+
+# DBD:DBC:: Password to use
+dbd_odbc_password = password
+
+
+# DBD:ODBC: Whether or not to 'ping' the database before attempting an INSERT
+# to ensure the connection is still valid.  If *any* error is generate by 
+# the ping such as 'Unable to connect to database', it will attempt to 
+# re-create the database connection.
+# Set to 0 to disable
+# Set to 1 to enable
+# Note:  This has no effect on dbd_odbc_ping_interval.
+dbd_odbc_ping_on_insert = 1
+
+# DBD:ODBC:: How often in seconds the database should be 'pinged' to ensure the
+# connection is still valid.  If *any* error is generate by the ping such as 
+# 'Unable to connect to database', it will attempt to re-create the database
+# connection.  Set to 0 to disable pinging.
+# Note:  This has no effect on dbd_odbc_ping_on_insert.
+# disabled = 0
+# 5 minutes = 300
+# 15 minutes = 900
+# 30 minutes = 1800
+dbd_odbc_ping_interval = 300
+
+# The date time format for the traptime column in SQL.  Defaults to 
+# localtime().  When a date/time field is used in SQL, this should
+# be changed to follow a standard that is supported by the SQL server.
+# Example:  For a MySQL DATETIME, use %Y-%m-%d %H:%M:%S.
+#date_time_format_sql = 
+
+# The date time format for the stat_time column in SQL.  Defaults to 
+# localtime().  When a date/time field is used in SQL, this should
+# be changed to follow a standard that is supported by the SQL server.
+# Example:  For a MySQL DATETIME, use %Y-%m-%d %H:%M:%S.
+#stat_time_format_sql = 
+
+[Exec]
+
+# Set to 1 to allow EXEC statements to execute.  Should normally be left on unless you
+# want to temporarily disable all EXEC commands
+exec_enable = 1
+
+# Set to 1 to allow PREEXEC statements to execute.  Should normally be left on unless you
+# want to temporarily disable all PREEXEC commands
+pre_exec_enable = 1
+
+# If defined, the following command will be executed for ALL unknown traps.  Passed to the
+# command will be all standard and enterprise variables, similar to unknown_trap_log_file
+# but without the newlines.
+unknown_trap_exec = 
+
+# FORMAT line that is passed to the unknown_trap_exec command.  If not defined, it
+# defaults to what is described in the unknown_trap_exec setting.  The following
+# would be *similar* to the default described in the unknown_trap_exec setting
+# (all on one line):
+# \$x !! \$X: Unknown trap (\$o) received from \$A at: Value 0: \$A Value 1: \$aR 
+# Value 2: \$T Value 3: \$o Value 4: \$aA Value 5: \$C Value 6: \$e Ent Values: \$+*
+unknown_trap_exec_format = 
+
+# Set to 1 to escape wildards (* and ?) in EXEC, PREEXEC and the unknown_trap_exec
+# commands.  Enable this to prevent the shell from expanding the wildcard 
+# characters.  The default is 1.
+exec_escape = 1
+
+[Debugging]
+# 0 - do not output messages
+# 1 - output some basic messages
+# 2 - out all messages
+DEBUGGING = 0
+
+# Debugging file - SNMPTT
+# Location of debugging output file.  Leave blank to default to STDOUT (good for
+# standalone mode, or daemon mode without forking)
+DEBUGGING_FILE = 
+# DEBUGGING_FILE = /var/log/snmptt/snmptt.debug
+
+# Debugging file - SNMPTTHANDLER
+# Location of debugging output file.  Leave blank to default to STDOUT
+DEBUGGING_FILE_HANDLER = 
+# DEBUGGING_FILE_HANDLER = /var/log/snmptt/snmptthandler.debug
+
+[TrapFiles]
+# A list of snmptt.conf files (this is NOT the snmptrapd.conf file).  The COMPLETE path 
+# and filename.  Ex: '/usr/local/etc/snmp/snmptt.conf'
+snmptt_conf_files = <<END
+/usr/local/etc/snmp/snmptt.conf
+END
+EOF;
+?>

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.xml
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.xml
@@ -32,7 +32,7 @@
 	<addedit_string>SNMPTT has been created/modified.</addedit_string>
 	<delete_string>SNMPTT has been deleted.</delete_string>
 	<menu>
-		<name>SNMPTT</name>
+		<name>SNMP Trap Translator (SNMPTT)</name>
 		<section>Services</section>
 		<url>/pkg_edit.php?xml=snmptt.xml</url>
 	</menu>
@@ -54,7 +54,7 @@
 			<active />
 		</tab>
 		<tab>
-			<text>SNMPTT.CONF</text>
+			<text>snmptt.conf</text>
 			<url>/pkg_edit.php?xml=snmptt_conf.xml</url>
 		</tab>
 	</tabs>
@@ -81,7 +81,6 @@
 			<default_value></default_value>
 			<type>input</type>
 			<size>50</size>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Operation Mode</fielddescr>
@@ -98,7 +97,6 @@
 				<option><name>standalone</name><value>standalone</value></option>
 				<option><name>daemon</name><value>daemon</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Multiple Event</fielddescr>
@@ -115,7 +113,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>DNS Enable</fielddescr>
@@ -132,7 +129,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Strip Domain</fielddescr>
@@ -155,7 +151,6 @@
 				<option><name>1</name><value>1</value></option>
 				<option><name>2</name><value>2</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Strip Domain List</fielddescr>
@@ -181,7 +176,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Net SNMP Perl Enable</fielddescr>
@@ -200,7 +194,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Net SNMP Perl Cache Enable</fielddescr>
@@ -218,7 +211,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Net SNMP Perl Best Guess</fielddescr>
@@ -241,7 +233,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Translate Log Trap OID</fielddescr>
@@ -265,7 +256,6 @@
 				<option><name>3</name><value>3</value></option>
 				<option><name>4</name><value>4</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Translate Value OIDs</fielddescr>
@@ -289,7 +279,6 @@
 				<option><name>3</name><value>3</value></option>
 				<option><name>4</name><value>4</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Translate Enterprise OID Format</fielddescr>
@@ -308,7 +297,6 @@
 				<option><name>3</name><value>3</value></option>
 				<option><name>4</name><value>4</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Translate Trap OID Format</fielddescr>
@@ -327,7 +315,6 @@
 				<option><name>3</name><value>3</value></option>
 				<option><name>4</name><value>4</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Translate Variable Name OID Format</fielddescr>
@@ -346,7 +333,6 @@
 				<option><name>3</name><value>3</value></option>
 				<option><name>4</name><value>4</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Translate Integers</fielddescr>
@@ -363,7 +349,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Wildcard Expansion Separator</fielddescr>
@@ -394,7 +379,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Remove Backslash From Quotes</fielddescr>
@@ -411,7 +395,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Dynamic Nodes</fielddescr>
@@ -428,7 +411,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Description Mode</fielddescr>
@@ -456,7 +438,6 @@
 				<option><name>1</name><value>1</value></option>
 				<option><name>2</name><value>2</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Description Clean</fielddescr>
@@ -473,7 +454,6 @@
 				<option><name>1</name><value>1</value></option>
 				<option><name>2</name><value>2</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Threads Enable</fielddescr>
@@ -490,7 +470,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Threads Max</fielddescr>
@@ -504,7 +483,6 @@
 			<default_value>10</default_value>
 			<type>input</type>
 			<size>3</size>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Date Format</fielddescr>
@@ -568,7 +546,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Keep Unlogged Traps</fielddescr>
@@ -593,7 +570,6 @@
 				<option><name>1</name><value>1</value></option>
 				<option><name>2</name><value>2</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Duplicate Trap Window</fielddescr>
@@ -618,7 +594,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Log Enable</fielddescr>
@@ -630,7 +605,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Log File</fielddescr>
@@ -650,7 +624,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Log System File</fielddescr>
@@ -670,7 +643,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Unknown Trap Log File</fielddescr>
@@ -687,7 +659,6 @@
 			<default_value>0</default_value>
 			<type>input</type>
 			<size>3</size>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Syslog Enable</fielddescr>
@@ -699,7 +670,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Syslog Facility</fielddescr>
@@ -727,7 +697,6 @@
 				<option><name>0</name><value>0</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Syslog System Facility</fielddescr>

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.xml
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.xml
@@ -87,8 +87,8 @@
 			<fieldname>mode</fieldname>
 			<description>
 				<![CDATA[
-					standalone: snmptt called from snmptrapd.conf<br/>
-					daemon: snmptrapd.conf calls snmptthandle<br/>
+					standalone: <b>/usr/local/sbin/snmptt</b> called from snmptrapd.conf<br/>
+					daemon: <b>/usr/local/sbin/snmptthandler --ini=/usr/local/etc/snmp/snmptt.ini</b> called from snmptrapd.conf<br/>
 				]]>
 			</description>
 			<type>select</type>

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.xml
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.xml
@@ -94,62 +94,39 @@
 			<type>select</type>
 			<default_value>standalone</default_value>
 			<options>
-				<option><name>standalone</name><value>standalone</value></option>
-				<option><name>daemon</name><value>daemon</value></option>
+				<option><name>Standalone</name><value>standalone</value></option>
+				<option><name>Daemon</name><value>daemon</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Multiple Event</fielddescr>
 			<fieldname>multiple_event</fieldname>
-			<description>
-				<![CDATA[
-					Set to 1 to allow multiple trap definitions to be executed for the same trap.<br/>
-					Set to 0 to have it stop after the first match.<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>1</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Stop after the first match (0)</name><value>0</value></option>
+				<option><name>Allow multiple trap definitions (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>DNS Enable</fielddescr>
 			<fieldname>dns_enable</fieldname>
-			<description>
-				<![CDATA[
-					Set to 0 to disable DNS resolution.<br/>
-					Set to 1 to enable DNS resolution.<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>0</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Disable DNS resolution (0)</name><value>0</value></option>
+				<option><name>Enable DNS resolution (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Strip Domain</fielddescr>
 			<fieldname>strip_domain</fieldname>
-			<description>
-				<![CDATA[
-					Set to 0 to enable the use of FQDN (Fully Qualified Domain Names). If a host name is<br/>
-					passed to SNMPTT that contains a domain name, it will not be altered in any way by<br/>
-					SNMPTT. This also affects resolve_value_ip_addresses.<br/>
-					Set to 1 to have SNMPTT strip the domain name from the host name passed to it. For<br/>
-					example, server01.domain.com would be changed to server01<br/>
-					Set to 2 to have SNMPTT strip the domain name from the host name passed to it<br/>
-					based on the list of domains in strip_domain_list.<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>0</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
-				<option><name>2</name><value>2</value></option>
+				<option><name>Use Fully Qualified Domain Names (0)</name><value>0</value></option>
+				<option><name>Remove all domain names (1)</name><value>1</value></option>
+				<option><name>Remove domain names from strip_domain_list (2)</name><value>2</value></option>
 			</options>
 		</field>
 		<field>
@@ -159,195 +136,124 @@
 			<type>textarea</type>
 			<rows>5</rows>
 			<cols>50</cols>
+			<description>
+				<![CDATA[
+					List of domain names that should be stripped when strip_domain is set to 2.<br/>
+					<b>Note: Put each entry on a separate line.</b><br/>
+				]]>
+			</description>
 			<description>List of domain names that should be stripped when strip_domain is set to 2.</description>
 		</field>
 		<field>
 			<fielddescr>Resolve Value IP Addresses</fielddescr>
 			<fieldname>resolve_value_ip_addresses</fieldname>
-			<description>
-				<![CDATA[
-					Set to 0 to disable resolving ip address to host names.<br/>
-					Set to 1 to enable resolving ip address to host names.<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>0</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Do not resolve the IP address (0)</name><value>0</value></option>
+				<option><name>Resolve the IP address (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Net SNMP Perl Enable</fielddescr>
 			<fieldname>net_snmp_perl_enable</fieldname>
-			<description>
-				<![CDATA[
-					Set to 1 to enable the use of the Perl module from the UCD-SNMP / NET-SNMP package.<br/>
-					This is required for $v variable substitution to work, and also for some other options<br/>
-					that are enabled in this .ini file.<br/>
-					Set to 0 to disable the use of the Perl module from the UCD-SNMP / NET-SNMP package.<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>1</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Do not use NET-SNMP Perl module (0)</name><value>0</value></option>
+				<option><name>Use NET-SNMP Perl module (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Net SNMP Perl Cache Enable</fielddescr>
 			<fieldname>net_snmp_perl_cache_enable</fieldname>
-			<description>
-				<![CDATA[
-					Set to 1 to enable caching of OID and ENUM translations when net_snmp_perl_enable is<br/>
-					enabled.  Enabling this should result in faster translations.<br/>
-					Set to 0 to disable caching.<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>1</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Do not enable translation cache for NET-SNMP Perl module (0)</name><value>0</value></option>
+				<option><name>Enable translation cache for NET-SNMP Perl module (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Net SNMP Perl Best Guess</fielddescr>
 			<fieldname>net_snmp_perl_best_guess</fieldname>
-			<description>
-				<![CDATA[
-					This sets the best_guess parameter used by the UCD-SNMP / NET-SNMP Perl module for<br/>
-					translating symbolic nams to OIDs and vice versa.<br/>
-					For UCD-SNMP, and Net-SNMP 5.0.8 and previous versions, set this value to 0.<br/>
-					For Net-SNMP 5.0.9, or any Net-SNMP with patch 722075 applied, set this value to 2.<br/>
-					A value of 2 is equivalent to -IR on Net-SNMP command line utilities.<br/>
-					UCD-SNMP and Net-SNMP 5.0.8 and previous may not be able to translate certain formats of<br/>
-					symbolic names such as RFC1213-MIB::sysDescr. Net-SNMP 5.0.9 or patch 722075 will allow<br/>
-					all possibilities to be translated.<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>0</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Parameter for Net-SNMP 5.0.8 and previous versions (0)</name><value>0</value></option>
+				<option><name>Parameter for Net-SNMP 5.0.9 or later (2)</name><value>2</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Translate Log Trap OID</fielddescr>
 			<fieldname>translate_log_trap_oid</fieldname>
-			<description>
-				<![CDATA[
-					Set to 0 to use the default of numerical OID<br/>
-					Set to 1 to translate the trap OID to short text (symbolic form) (eg: linkUp)<br/>
-					Set to 2 to translate the trap OID to short text with module name (eg: IF-MIB::linkUp)<br/>
-					Set to 3 to translate the trap OID to long text (eg: iso...snmpTraps.linkUp)<br/>
-					Set to 4 to translate the trap OID to long text with module name (eg:<br/>
-					IF-MIB::iso...snmpTraps.linkUp)<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>2</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
-				<option><name>2</name><value>2</value></option>
-				<option><name>3</name><value>3</value></option>
-				<option><name>4</name><value>4</value></option>
+				<option><name>Disable translation (0)</name><value>0</value></option>
+				<option><name>Translate to short text (1)</name><value>1</value></option>
+				<option><name>Translate to short text with module name (2)</name><value>2</value></option>
+				<option><name>Translate to long text (3)</name><value>3</value></option>
+				<option><name>Translate to long text with module name (4)</name><value>4</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Translate Value OIDs</fielddescr>
 			<fieldname>translate_value_oids</fieldname>
-			<description>
-				<![CDATA[
-					Set to 0 to disable translating OID values to text (symbolic form)<br/>
-					Set to 1 to translate OID values to short text (symbolic form) (eg: BuildingAlarm)<br/>
-					Set to 2 to translate OID values to short text with module name (eg: UPS-MIB::BuildingAlarm)<br/>
-					Set to 3 to translate OID values to long text (eg: iso...upsAlarm.BuildingAlarm)<br/>
-					Set to 4 to translate OID values to long text with module name (eg:<br/>
-					UPS-MIB::iso...upsAlarm.BuildingAlarm)<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>1</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
-				<option><name>2</name><value>2</value></option>
-				<option><name>3</name><value>3</value></option>
-				<option><name>4</name><value>4</value></option>
+				<option><name>Disable translation (0)</name><value>0</value></option>
+				<option><name>Translate to short text (1)</name><value>1</value></option>
+				<option><name>Translate to short text with module name (2)</name><value>2</value></option>
+				<option><name>Translate to long text (3)</name><value>3</value></option>
+				<option><name>Translate to long text with module name (4)</name><value>4</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Translate Enterprise OID Format</fielddescr>
 			<fieldname>translate_enterprise_oid_format</fieldname>
-			<description>
-				<![CDATA[
-					Configures how the symbolic enterprise OID will be displayed for $E.<br/>
-					Set to 1, 2, 3 or 4.  See translate_value_oids options 1,2,3 and 4.<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>1</default_value>
 			<options>
-				<option><name>1</name><value>1</value></option>
-				<option><name>2</name><value>2</value></option>
-				<option><name>3</name><value>3</value></option>
-				<option><name>4</name><value>4</value></option>
+				<option><name>Translate to short text (1)</name><value>1</value></option>
+				<option><name>Translate to short text with module name (2)</name><value>2</value></option>
+				<option><name>Translate to long text (3)</name><value>3</value></option>
+				<option><name>Translate to long text with module name (4)</name><value>4</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Translate Trap OID Format</fielddescr>
 			<fieldname>translate_trap_oid_format</fieldname>
-			<description>
-				<![CDATA[
-					Configures how the symbolic trap OID will be displayed for $O.<br/>
-					Set to 1, 2, 3 or 4.  See translate_value_oids options 1,2,3 and 4.<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>1</default_value>
 			<options>
-				<option><name>1</name><value>1</value></option>
-				<option><name>2</name><value>2</value></option>
-				<option><name>3</name><value>3</value></option>
-				<option><name>4</name><value>4</value></option>
+				<option><name>Translate to short text (1)</name><value>1</value></option>
+				<option><name>Translate to short text with module name (2)</name><value>2</value></option>
+				<option><name>Translate to long text (3)</name><value>3</value></option>
+				<option><name>Translate to long text with module name (4)</name><value>4</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Translate Variable Name OID Format</fielddescr>
 			<fieldname>translate_varname_oid_format</fieldname>
-			<description>
-				<![CDATA[
-					Configures how the symbolic trap OID will be displayed for $v, $-n, $+n, $-* and $+*.<br/>
-					Set to 1, 2, 3 or 4.  See translate_value_oids options 1,2,3 and 4.<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>1</default_value>
 			<options>
-				<option><name>1</name><value>1</value></option>
-				<option><name>2</name><value>2</value></option>
-				<option><name>3</name><value>3</value></option>
-				<option><name>4</name><value>4</value></option>
+				<option><name>Translate to short text (1)</name><value>1</value></option>
+				<option><name>Translate to short text with module name (2)</name><value>2</value></option>
+				<option><name>Translate to long text (3)</name><value>3</value></option>
+				<option><name>Translate to long text with module name (4)</name><value>4</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Translate Integers</fielddescr>
 			<fieldname>translate_integers</fieldname>
-			<description>
-				<![CDATA[
-					Set to 0 to disable converting INTEGER values to enumeration tags as defined in the MIB files.<br/>
-					Set to 1 to enable converting INTEGER values to enumeration tags as defined in the MIB files.<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>1</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Disable converting INTEGER (0)</name><value>0</value></option>
+				<option><name>Enable converting INTEGER (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
@@ -356,7 +262,7 @@
 			<description>
 				<![CDATA[
 					Set what is used to separate variables when wildcards are expanded on the FORMAT / EXEC line.<br/>
-					Defaults to a space.  Value MUST be within quotes. Can contain 1 or more characters.<br/>
+					Defaults to a space.  Value MUST be within double quotes. Can contain 1 or more characters.<br/>
 				]]>
 			</description>
 			<default_value>" "</default_value>
@@ -367,108 +273,64 @@
 		<field>
 			<fielddescr>Allow Unsafe Regex</fielddescr>
 			<fieldname>allow_unsafe_regex</fieldname>
-			<description>
-				<![CDATA[
-					Set to 1 to allow unsafe REGEX code to be executed.<br/>
-					Set to 0 to prevent unsafe REGEX code from being executed (default).<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>0</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Allow unsafe REGEX (0)</name><value>0</value></option>
+				<option><name>Block unsafe REGEX (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Remove Backslash From Quotes</fielddescr>
 			<fieldname>remove_backslash_from_quotes</fieldname>
-			<description>
-				<![CDATA[
-					Set to 1 to have the backslash (escape) removed from quotes passed from<br/>
-					snmptrapd. For example, \" would be changed to just " Set to 0 to disable.<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>0</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Do not Remove Backslash (0)</name><value>0</value></option>
+				<option><name>Remove Backslash (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Dynamic Nodes</fielddescr>
 			<fieldname>dynamic_nodes</fieldname>
-			<description>
-				<![CDATA[
-					Set to 1 to have NODES files loaded each time a trap is processed.<br/>
-					Set to 0 to have all NODES files loaded when the snmptt.conf files are loaded.<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>0</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Load NODES files once (0)</name><value>0</value></option>
+				<option><name>Load NODES files in every call (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Description Mode</fielddescr>
 			<fieldname>description_mode</fieldname>
-			<description>
-				<![CDATA[
-					This option allows you to use the $D substitution variable to include the<br/>
-					description text from the SNMPTT.CONF or MIB files.<br/>
-					Set to 0 to disable the $D substitution variable.  If $D is used, nothing<br/>
-					will be outputted.<br/>
-					Set to 1 to enable the $D substitution variable and have it use the<br/>
-					descriptions stored in the SNMPTT .conf files.  Enabling this option can<br/>
-					greatly increase the amount of memory used by SNMPTT.<br/>
-					Set to 2 to enable the $D substitution variable and have it use the<br/>
-					description from the MIB files.  This enables the UCD-SNMP / NET-SNMP Perl<br/>
-					module save_descriptions variable.  Enabling this option can greatly<br/>
-					increase the amount of memory used by the Net-SNMP SNMP Perl module, which<br/>
-					will result in an increase of memory usage by SNMPTT.<br/>
-				]]>
-			</description>
+			<description>Enabling this option can greatly increase the amount of memory used by SNMPTT.</description>
 			<type>select</type>
 			<default_value>0</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
-				<option><name>2</name><value>2</value></option>
+				<option><name>Disable the $D substitution variable (0)</name><value>0</value></option>
+				<option><name>Enable the $D substitution variable with SNMPTT.conf (1)</name><value>1</value></option>
+				<option><name>Enable the $D substitution variable with MIB files (2)</name><value>2</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Description Clean</fielddescr>
 			<fieldname>description_clean</fieldname>
-			<description>
-				<![CDATA[
-					Set to 1 to remove any white space at the start of each line from the MIB<br/>
-					or SNMPTT.CONF description when description_mode is set to 1 or 2.<br/>
-				]]>
-			</description>
+			<description>Used when description_mode is enabled.</description>
 			<type>select</type>
 			<default_value>1</default_value>
 			<options>
-				<option><name>1</name><value>1</value></option>
-				<option><name>2</name><value>2</value></option>
+				<option><name>Do not remove white space at the start of each line from the MIB (0)</name><value>0</value></option>
+				<option><name>Remove white space at the start of each line from the MIB (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Threads Enable</fielddescr>
 			<fieldname>threads_enable</fieldname>
-			<description>
-				<![CDATA[
-					Set to 1 to enable threads (ithreads) in Perl 5.6.0 or higher.<br/>
-					Set to 0 to disable threads (ithreads).<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>0</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Disable threads (0)</name><value>0</value></option>
+				<option><name>Enable threads (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
@@ -533,42 +395,22 @@
 		<field>
 			<fielddescr>Use Trap Time</fielddescr>
 			<fieldname>use_trap_time</fieldname>
-			<description>
-				<![CDATA[
-					Set to 1 to have SNMPTT use the time that the trap was processed by SNMPTTHANDLER<br/>
-					Set to 0 to have SNMPTT use the time the trap was processed.  Note:  Using 0 can<br/>
-					result in the time being off by the number of seconds used for 'sleep'<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>1</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Use time from SNMPTT (0)</name><value>0</value></option>
+				<option><name>Use time from SNMPTTHANDLER (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Keep Unlogged Traps</fielddescr>
 			<fieldname>keep_unlogged_traps</fieldname>
-			<description>
-				<![CDATA[
-					Set to 0 to have SNMPTT erase the spooled trap file after it attempts to process<br/>
-					the trap even if it did not successfully log the trap to any of the log systems.<br/>
-					Set to 1 to have SNMPTT erase the spooled trap file only after it successfully<br/>
-					logs to at least ONE log system.<br/>
-					Set to 2 to have SNMPTT erase the spooled trap file only after it successfully<br/>
-					logs to ALL of the enabled log systems.  Warning:  If multiple log systems are<br/>
-					enabled and only one fails, the other log system will continuously be logged to<br/>
-					until ALL of the log systems function.<br/>
-					The recommended setting is 1 with only one log system enabled.<br/>
-				]]>
-			</description>
 			<type>select</type>
 			<default_value>1</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
-				<option><name>2</name><value>2</value></option>
+				<option><name>Erase spooler in every process (0)</name><value>0</value></option>
+				<option><name>Erase spooler if it logs to at least one log system (1)</name><value>1</value></option>
+				<option><name>Erase spooler if it logs to all log system (2)</name><value>2</value></option>
 			</options>
 		</field>
 		<field>
@@ -587,23 +429,21 @@
 		<field>
 			<fielddescr>Stdout Enable</fielddescr>
 			<fieldname>stdout_enable</fieldname>
-			<description>Set to 1 to enable messages to be sent to standard output, or 0 to disable.</description>
 			<type>select</type>
 			<default_value>0</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Disable logging messages to standard output (0)</name><value>0</value></option>
+				<option><name>Enable logging messages to standard output (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Log Enable</fielddescr>
 			<fieldname>log_enable</fieldname>
-			<description>Set to 1 to enable text logging of TRAPS.</description>
 			<type>select</type>
 			<default_value>1</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Disable logging (0)</name><value>0</value></option>
+				<option><name>Enable logging (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
@@ -617,12 +457,11 @@
 		<field>
 			<fielddescr>Log System Enable</fielddescr>
 			<fieldname>log_system_enable</fieldname>
-			<description>Set to 1 to enable text logging of SNMPTT system errors.</description>
 			<type>select</type>
 			<default_value>1</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Disable logging of SNMPTT system errors (0)</name><value>0</value></option>
+				<option><name>Enable logging of SNMPTT system errors (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
@@ -636,12 +475,11 @@
 		<field>
 			<fielddescr>Unknown Trap Log Enable</fielddescr>
 			<fieldname>unknown_trap_log_enable</fieldname>
-			<description>Set to 1 to enable logging of unknown traps.</description>
 			<type>select</type>
 			<default_value>1</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Disable logging of unknown traps (0)</name><value>0</value></option>
+				<option><name>Enable logging of unknown traps (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
@@ -663,12 +501,11 @@
 		<field>
 			<fielddescr>Syslog Enable</fielddescr>
 			<fieldname>syslog_enable</fieldname>
-			<description>Set to 1 to enable logging of TRAPS to syslog.</description>
 			<type>select</type>
 			<default_value>0</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Disable logging to syslog (0)</name><value>0</value></option>
+				<option><name>Enable logging to syslog (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>
@@ -690,12 +527,11 @@
 		<field>
 			<fielddescr>Syslog System Enable</fielddescr>
 			<fieldname>syslog_system_enable</fieldname>
-			<description>Set to 1 to enable logging of SNMPTT system errors to syslog.</description>
 			<type>select</type>
 			<default_value>1</default_value>
 			<options>
-				<option><name>0</name><value>0</value></option>
-				<option><name>1</name><value>1</value></option>
+				<option><name>Disable logging of SNMPTT system errors to syslog (0)</name><value>0</value></option>
+				<option><name>Enable logging of SNMPTT system errors to syslog (1)</name><value>1</value></option>
 			</options>
 		</field>
 		<field>

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.xml
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.xml
@@ -142,7 +142,6 @@
 					<b>Note: Put each entry on a separate line.</b><br/>
 				]]>
 			</description>
-			<description>List of domain names that should be stripped when strip_domain is set to 2.</description>
 		</field>
 		<field>
 			<fielddescr>Resolve Value IP Addresses</fielddescr>

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.xml
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.xml
@@ -261,13 +261,12 @@
 			<description>
 				<![CDATA[
 					Set what is used to separate variables when wildcards are expanded on the FORMAT / EXEC line.<br/>
-					Defaults to a space.  Value MUST be within double quotes. Can contain 1 or more characters.<br/>
+					Defaults to a space. Can contain 1 or more characters.<br/>
 				]]>
 			</description>
-			<default_value>" "</default_value>
+			<default_value> </default_value>
 			<type>input</type>
 			<size>50</size>
-			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Allow Unsafe Regex</fielddescr>

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.xml
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.xml
@@ -41,6 +41,11 @@
 		<rcfile>snmptt.sh</rcfile>
 		<executable>snmptt</executable>
 		<description>SNMPTT Daemon</description>
+		<custom_php_service_status_command>
+			<![CDATA[
+				""; $output=""; exec("/bin/pgrep -anf snmptt", $output, $retval); $rc=(intval($retval) == 0)
+			]]>
+		</custom_php_service_status_command>
 	</service>
 	<tabs>
 		<tab>

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.xml
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt.xml
@@ -1,0 +1,756 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
+<packagegui>
+	<copyright>
+	<![CDATA[
+/*
+ * snmptt.xml
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2017 Rubicon Communications, LLC (Netgate)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+	]]>
+	</copyright>
+	<name>snmptt</name>
+	<title>Services: SNMPTT</title>
+	<category>Monitoring</category>
+	<include_file>/usr/local/pkg/snmptt.inc</include_file>
+	<addedit_string>SNMPTT has been created/modified.</addedit_string>
+	<delete_string>SNMPTT has been deleted.</delete_string>
+	<menu>
+		<name>SNMPTT</name>
+		<section>Services</section>
+		<url>/pkg_edit.php?xml=snmptt.xml</url>
+	</menu>
+	<service>
+		<name>snmptt</name>
+		<rcfile>snmptt.sh</rcfile>
+		<executable>snmptt</executable>
+		<description>SNMPTT Daemon</description>
+	</service>
+	<tabs>
+		<tab>
+			<text>General</text>
+			<url>/pkg_edit.php?xml=snmptt.xml</url>
+			<active />
+		</tab>
+		<tab>
+			<text>SNMPTT.CONF</text>
+			<url>/pkg_edit.php?xml=snmptt_conf.xml</url>
+		</tab>
+	</tabs>
+	<fields>
+		<field>
+			<name>General Settings</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>Enable</fielddescr>
+			<fieldname>snmpttenabled</fieldname>
+			<description>Enable SNMPTT service.</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>SNMPTT System Name</fielddescr>
+			<fieldname>snmptt_system_name</fieldname>
+			<description>
+				<![CDATA[
+					Name of this system for $H variable.  If blank, system name will be the computer's<br/>
+					hostname via Sys::Hostname.<br/>
+				]]>
+			</description>
+			<default_value></default_value>
+			<type>input</type>
+			<size>50</size>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Operation Mode</fielddescr>
+			<fieldname>mode</fieldname>
+			<description>
+				<![CDATA[
+					standalone: snmptt called from snmptrapd.conf<br/>
+					daemon: snmptrapd.conf calls snmptthandle<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>standalone</default_value>
+			<options>
+				<option><name>standalone</name><value>standalone</value></option>
+				<option><name>daemon</name><value>daemon</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Multiple Event</fielddescr>
+			<fieldname>multiple_event</fieldname>
+			<description>
+				<![CDATA[
+					Set to 1 to allow multiple trap definitions to be executed for the same trap.<br/>
+					Set to 0 to have it stop after the first match.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>1</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>DNS Enable</fielddescr>
+			<fieldname>dns_enable</fieldname>
+			<description>
+				<![CDATA[
+					Set to 0 to disable DNS resolution.<br/>
+					Set to 1 to enable DNS resolution.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>0</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Strip Domain</fielddescr>
+			<fieldname>strip_domain</fieldname>
+			<description>
+				<![CDATA[
+					Set to 0 to enable the use of FQDN (Fully Qualified Domain Names). If a host name is<br/>
+					passed to SNMPTT that contains a domain name, it will not be altered in any way by<br/>
+					SNMPTT. This also affects resolve_value_ip_addresses.<br/>
+					Set to 1 to have SNMPTT strip the domain name from the host name passed to it. For<br/>
+					example, server01.domain.com would be changed to server01<br/>
+					Set to 2 to have SNMPTT strip the domain name from the host name passed to it<br/>
+					based on the list of domains in strip_domain_list.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>0</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+				<option><name>2</name><value>2</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Strip Domain List</fielddescr>
+			<fieldname>strip_domain_list</fieldname>
+			<encoding>base64</encoding>
+			<type>textarea</type>
+			<rows>5</rows>
+			<cols>50</cols>
+			<description>List of domain names that should be stripped when strip_domain is set to 2.</description>
+		</field>
+		<field>
+			<fielddescr>Resolve Value IP Addresses</fielddescr>
+			<fieldname>resolve_value_ip_addresses</fieldname>
+			<description>
+				<![CDATA[
+					Set to 0 to disable resolving ip address to host names.<br/>
+					Set to 1 to enable resolving ip address to host names.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>0</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Net SNMP Perl Enable</fielddescr>
+			<fieldname>net_snmp_perl_enable</fieldname>
+			<description>
+				<![CDATA[
+					Set to 1 to enable the use of the Perl module from the UCD-SNMP / NET-SNMP package.<br/>
+					This is required for $v variable substitution to work, and also for some other options<br/>
+					that are enabled in this .ini file.<br/>
+					Set to 0 to disable the use of the Perl module from the UCD-SNMP / NET-SNMP package.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>1</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Net SNMP Perl Cache Enable</fielddescr>
+			<fieldname>net_snmp_perl_cache_enable</fieldname>
+			<description>
+				<![CDATA[
+					Set to 1 to enable caching of OID and ENUM translations when net_snmp_perl_enable is<br/>
+					enabled.  Enabling this should result in faster translations.<br/>
+					Set to 0 to disable caching.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>1</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Net SNMP Perl Best Guess</fielddescr>
+			<fieldname>net_snmp_perl_best_guess</fieldname>
+			<description>
+				<![CDATA[
+					This sets the best_guess parameter used by the UCD-SNMP / NET-SNMP Perl module for<br/>
+					translating symbolic nams to OIDs and vice versa.<br/>
+					For UCD-SNMP, and Net-SNMP 5.0.8 and previous versions, set this value to 0.<br/>
+					For Net-SNMP 5.0.9, or any Net-SNMP with patch 722075 applied, set this value to 2.<br/>
+					A value of 2 is equivalent to -IR on Net-SNMP command line utilities.<br/>
+					UCD-SNMP and Net-SNMP 5.0.8 and previous may not be able to translate certain formats of<br/>
+					symbolic names such as RFC1213-MIB::sysDescr. Net-SNMP 5.0.9 or patch 722075 will allow<br/>
+					all possibilities to be translated.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>0</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Translate Log Trap OID</fielddescr>
+			<fieldname>translate_log_trap_oid</fieldname>
+			<description>
+				<![CDATA[
+					Set to 0 to use the default of numerical OID<br/>
+					Set to 1 to translate the trap OID to short text (symbolic form) (eg: linkUp)<br/>
+					Set to 2 to translate the trap OID to short text with module name (eg: IF-MIB::linkUp)<br/>
+					Set to 3 to translate the trap OID to long text (eg: iso...snmpTraps.linkUp)<br/>
+					Set to 4 to translate the trap OID to long text with module name (eg:<br/>
+					IF-MIB::iso...snmpTraps.linkUp)<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>2</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+				<option><name>2</name><value>2</value></option>
+				<option><name>3</name><value>3</value></option>
+				<option><name>4</name><value>4</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Translate Value OIDs</fielddescr>
+			<fieldname>translate_value_oids</fieldname>
+			<description>
+				<![CDATA[
+					Set to 0 to disable translating OID values to text (symbolic form)<br/>
+					Set to 1 to translate OID values to short text (symbolic form) (eg: BuildingAlarm)<br/>
+					Set to 2 to translate OID values to short text with module name (eg: UPS-MIB::BuildingAlarm)<br/>
+					Set to 3 to translate OID values to long text (eg: iso...upsAlarm.BuildingAlarm)<br/>
+					Set to 4 to translate OID values to long text with module name (eg:<br/>
+					UPS-MIB::iso...upsAlarm.BuildingAlarm)<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>1</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+				<option><name>2</name><value>2</value></option>
+				<option><name>3</name><value>3</value></option>
+				<option><name>4</name><value>4</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Translate Enterprise OID Format</fielddescr>
+			<fieldname>translate_enterprise_oid_format</fieldname>
+			<description>
+				<![CDATA[
+					Configures how the symbolic enterprise OID will be displayed for $E.<br/>
+					Set to 1, 2, 3 or 4.  See translate_value_oids options 1,2,3 and 4.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>1</default_value>
+			<options>
+				<option><name>1</name><value>1</value></option>
+				<option><name>2</name><value>2</value></option>
+				<option><name>3</name><value>3</value></option>
+				<option><name>4</name><value>4</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Translate Trap OID Format</fielddescr>
+			<fieldname>translate_trap_oid_format</fieldname>
+			<description>
+				<![CDATA[
+					Configures how the symbolic trap OID will be displayed for $O.<br/>
+					Set to 1, 2, 3 or 4.  See translate_value_oids options 1,2,3 and 4.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>1</default_value>
+			<options>
+				<option><name>1</name><value>1</value></option>
+				<option><name>2</name><value>2</value></option>
+				<option><name>3</name><value>3</value></option>
+				<option><name>4</name><value>4</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Translate Variable Name OID Format</fielddescr>
+			<fieldname>translate_varname_oid_format</fieldname>
+			<description>
+				<![CDATA[
+					Configures how the symbolic trap OID will be displayed for $v, $-n, $+n, $-* and $+*.<br/>
+					Set to 1, 2, 3 or 4.  See translate_value_oids options 1,2,3 and 4.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>1</default_value>
+			<options>
+				<option><name>1</name><value>1</value></option>
+				<option><name>2</name><value>2</value></option>
+				<option><name>3</name><value>3</value></option>
+				<option><name>4</name><value>4</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Translate Integers</fielddescr>
+			<fieldname>translate_integers</fieldname>
+			<description>
+				<![CDATA[
+					Set to 0 to disable converting INTEGER values to enumeration tags as defined in the MIB files.<br/>
+					Set to 1 to enable converting INTEGER values to enumeration tags as defined in the MIB files.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>1</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Wildcard Expansion Separator</fielddescr>
+			<fieldname>wildcard_expansion_separator</fieldname>
+			<description>
+				<![CDATA[
+					Set what is used to separate variables when wildcards are expanded on the FORMAT / EXEC line.<br/>
+					Defaults to a space.  Value MUST be within quotes. Can contain 1 or more characters.<br/>
+				]]>
+			</description>
+			<default_value>" "</default_value>
+			<type>input</type>
+			<size>50</size>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Allow Unsafe Regex</fielddescr>
+			<fieldname>allow_unsafe_regex</fieldname>
+			<description>
+				<![CDATA[
+					Set to 1 to allow unsafe REGEX code to be executed.<br/>
+					Set to 0 to prevent unsafe REGEX code from being executed (default).<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>0</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Remove Backslash From Quotes</fielddescr>
+			<fieldname>remove_backslash_from_quotes</fieldname>
+			<description>
+				<![CDATA[
+					Set to 1 to have the backslash (escape) removed from quotes passed from<br/>
+					snmptrapd. For example, \" would be changed to just " Set to 0 to disable.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>0</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Dynamic Nodes</fielddescr>
+			<fieldname>dynamic_nodes</fieldname>
+			<description>
+				<![CDATA[
+					Set to 1 to have NODES files loaded each time a trap is processed.<br/>
+					Set to 0 to have all NODES files loaded when the snmptt.conf files are loaded.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>0</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Description Mode</fielddescr>
+			<fieldname>description_mode</fieldname>
+			<description>
+				<![CDATA[
+					This option allows you to use the $D substitution variable to include the<br/>
+					description text from the SNMPTT.CONF or MIB files.<br/>
+					Set to 0 to disable the $D substitution variable.  If $D is used, nothing<br/>
+					will be outputted.<br/>
+					Set to 1 to enable the $D substitution variable and have it use the<br/>
+					descriptions stored in the SNMPTT .conf files.  Enabling this option can<br/>
+					greatly increase the amount of memory used by SNMPTT.<br/>
+					Set to 2 to enable the $D substitution variable and have it use the<br/>
+					description from the MIB files.  This enables the UCD-SNMP / NET-SNMP Perl<br/>
+					module save_descriptions variable.  Enabling this option can greatly<br/>
+					increase the amount of memory used by the Net-SNMP SNMP Perl module, which<br/>
+					will result in an increase of memory usage by SNMPTT.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>0</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+				<option><name>2</name><value>2</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Description Clean</fielddescr>
+			<fieldname>description_clean</fieldname>
+			<description>
+				<![CDATA[
+					Set to 1 to remove any white space at the start of each line from the MIB<br/>
+					or SNMPTT.CONF description when description_mode is set to 1 or 2.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>1</default_value>
+			<options>
+				<option><name>1</name><value>1</value></option>
+				<option><name>2</name><value>2</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Threads Enable</fielddescr>
+			<fieldname>threads_enable</fieldname>
+			<description>
+				<![CDATA[
+					Set to 1 to enable threads (ithreads) in Perl 5.6.0 or higher.<br/>
+					Set to 0 to disable threads (ithreads).<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>0</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Threads Max</fielddescr>
+			<fieldname>threads_max</fieldname>
+			<description>
+				<![CDATA[
+					This option allows you to set the maximum number of threads that will<br/>
+					execute at once.  Defaults to 10<br/>
+				]]>
+			</description>
+			<default_value>10</default_value>
+			<type>input</type>
+			<size>3</size>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Date Format</fielddescr>
+			<fieldname>date_format</fieldname>
+			<description>The date format for $x in strftime() format.</description>
+			<default_value>%a %b %e %Y</default_value>
+			<type>input</type>
+			<size>20</size>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Time Format</fielddescr>
+			<fieldname>time_format</fieldname>
+			<description>The time format for $X in strftime() format.</description>
+			<default_value>%H:%M:%S</default_value>
+			<type>input</type>
+			<size>20</size>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Date Time Format</fielddescr>
+			<fieldname>date_time_format</fieldname>
+			<description>
+				<![CDATA[
+					The date time format in strftime() format for the date/time when logging<br/>
+					to standard output, snmptt log files (log_file) and the unknown log file<br/>
+					(unknown_trap_log_file). Defaults to localtime().<br/>
+				]]>
+			</description>
+			<default_value>%a %b %e %Y %H:%M:%S</default_value>
+			<type>input</type>
+			<size>20</size>
+			<required>true</required>
+		</field>
+		<field>
+			<name>Daemon Mode</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>Sleep</fielddescr>
+			<fieldname>sleep</fieldname>
+			<description>Amount of time in seconds to sleep between processing spool files.</description>
+			<default_value>5</default_value>
+			<type>input</type>
+			<size>3</size>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Use Trap Time</fielddescr>
+			<fieldname>use_trap_time</fieldname>
+			<description>
+				<![CDATA[
+					Set to 1 to have SNMPTT use the time that the trap was processed by SNMPTTHANDLER<br/>
+					Set to 0 to have SNMPTT use the time the trap was processed.  Note:  Using 0 can<br/>
+					result in the time being off by the number of seconds used for 'sleep'<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>1</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Keep Unlogged Traps</fielddescr>
+			<fieldname>keep_unlogged_traps</fieldname>
+			<description>
+				<![CDATA[
+					Set to 0 to have SNMPTT erase the spooled trap file after it attempts to process<br/>
+					the trap even if it did not successfully log the trap to any of the log systems.<br/>
+					Set to 1 to have SNMPTT erase the spooled trap file only after it successfully<br/>
+					logs to at least ONE log system.<br/>
+					Set to 2 to have SNMPTT erase the spooled trap file only after it successfully<br/>
+					logs to ALL of the enabled log systems.  Warning:  If multiple log systems are<br/>
+					enabled and only one fails, the other log system will continuously be logged to<br/>
+					until ALL of the log systems function.<br/>
+					The recommended setting is 1 with only one log system enabled.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>1</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+				<option><name>2</name><value>2</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Duplicate Trap Window</fielddescr>
+			<fieldname>duplicate_trap_window</fieldname>
+			<description>How often in seconds duplicate traps will be processed.</description>
+			<default_value>0</default_value>
+			<type>input</type>
+			<size>3</size>
+			<required>true</required>
+		</field>
+		<field>
+			<name>Logging</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>Stdout Enable</fielddescr>
+			<fieldname>stdout_enable</fieldname>
+			<description>Set to 1 to enable messages to be sent to standard output, or 0 to disable.</description>
+			<type>select</type>
+			<default_value>0</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Log Enable</fielddescr>
+			<fieldname>log_enable</fieldname>
+			<description>Set to 1 to enable text logging of TRAPS.</description>
+			<type>select</type>
+			<default_value>1</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Log File</fielddescr>
+			<fieldname>log_file</fieldname>
+			<description>Log file location. The COMPLETE path and filename.</description>
+			<default_value>/var/log/snmptt/snmptt.log</default_value>
+			<type>input</type>
+			<size>150</size>
+		</field>
+		<field>
+			<fielddescr>Log System Enable</fielddescr>
+			<fieldname>log_system_enable</fieldname>
+			<description>Set to 1 to enable text logging of SNMPTT system errors.</description>
+			<type>select</type>
+			<default_value>1</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Log System File</fielddescr>
+			<fieldname>log_system_file</fieldname>
+			<description>Log file location. The COMPLETE path and filename.</description>
+			<default_value>/var/log/snmptt/snmpttsystem.log</default_value>
+			<type>input</type>
+			<size>150</size>
+		</field>
+		<field>
+			<fielddescr>Unknown Trap Log Enable</fielddescr>
+			<fieldname>unknown_trap_log_enable</fieldname>
+			<description>Set to 1 to enable logging of unknown traps.</description>
+			<type>select</type>
+			<default_value>1</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Unknown Trap Log File</fielddescr>
+			<fieldname>unknown_trap_log_file</fieldname>
+			<description>Log file location. The COMPLETE path and filename.</description>
+			<default_value>/var/log/snmptt/snmpttunknown.log</default_value>
+			<type>input</type>
+			<size>150</size>
+		</field>
+		<field>
+			<fielddescr>Statistics Interval</fielddescr>
+			<fieldname>statistics_interval</fieldname>
+			<description>How often in seconds statistics should be logged to syslog or the event log.</description>
+			<default_value>0</default_value>
+			<type>input</type>
+			<size>3</size>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Syslog Enable</fielddescr>
+			<fieldname>syslog_enable</fieldname>
+			<description>Set to 1 to enable logging of TRAPS to syslog.</description>
+			<type>select</type>
+			<default_value>0</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Syslog Facility</fielddescr>
+			<fieldname>syslog_facility</fieldname>
+			<description>Syslog facility to use for logging of TRAPS.</description>
+			<default_value>local0</default_value>
+			<type>input</type>
+			<size>60</size>
+		</field>
+		<field>
+			<fielddescr>Syslog Level</fielddescr>
+			<fieldname>syslog_level</fieldname>
+			<description>Syslog default level to use for logging of TRAPS.</description>
+			<default_value>warning</default_value>
+			<type>input</type>
+			<size>60</size>
+		</field>
+		<field>
+			<fielddescr>Syslog System Enable</fielddescr>
+			<fieldname>syslog_system_enable</fieldname>
+			<description>Set to 1 to enable logging of SNMPTT system errors to syslog.</description>
+			<type>select</type>
+			<default_value>1</default_value>
+			<options>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Syslog System Facility</fielddescr>
+			<fieldname>syslog_system_facility</fieldname>
+			<description>Syslog facility to use for logging of SNMPTT system errors.</description>
+			<default_value>local0</default_value>
+			<type>input</type>
+			<size>60</size>
+		</field>
+		<field>
+			<fielddescr>Syslog System Level</fielddescr>
+			<fieldname>syslog_system_level</fieldname>
+			<description>Syslog level to use for logging of SNMPTT system errors.</description>
+			<default_value>warning</default_value>
+			<type>input</type>
+			<size>60</size>
+		</field>
+	</fields>
+	<custom_php_install_command>
+		sync_package_snmptt();
+	</custom_php_install_command>
+	<custom_php_validation_command>
+		validate_input_snmptt($_POST, $input_errors);
+	</custom_php_validation_command>
+	<custom_php_resync_config_command>
+		sync_package_snmptt();
+	</custom_php_resync_config_command>
+	<custom_php_deinstall_command>
+		php_deinstall_snmptt();
+	</custom_php_deinstall_command>
+</packagegui>

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt_conf.xml
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt_conf.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
+<packagegui>
+	<copyright>
+	<![CDATA[
+/*
+ * snmptt_conf.xml
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2017 Rubicon Communications, LLC (Netgate)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+	]]>
+	</copyright>
+	<name>snmptt_conf</name>
+	<title>Services: SNMPTT</title>
+	<include_file>/usr/local/pkg/snmptt.inc</include_file>
+	<tabs>
+		<tab>
+			<text>General</text>
+			<url>/pkg_edit.php?xml=snmptt.xml</url>
+		</tab>
+		<tab>
+			<text>SNMPTT.CONF</text>
+			<url>/pkg_edit.php?xml=snmptt_conf.xml</url>
+			<active />
+		</tab>
+	</tabs>
+	<fields>
+		<field>
+			<name>SNMPTT.CONF</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>SNMPTT.CONF</fielddescr>
+			<fieldname>snmptt_configfile</fieldname>
+			<encoding>base64</encoding>
+			<type>textarea</type>
+			<rows>20</rows>
+			<cols>80</cols>
+			<description>
+				<![CDATA[
+					Zabbix example:<br/>
+					<br/>
+					#<br/>
+					#<br/>
+					#<br/>
+					EVENT general .* "General event" Normal<br/>
+					FORMAT ZBXTRAP $aA $ar $+*<br/>
+					<br/>
+					<a href="http://snmptt.sourceforge.net/docs/snmptt.shtml#SNMPTT.CONF-Configuration-file-format"> More info here.</a><br/>                
+				]]>
+			</description>
+			<required>true</required>
+		</field>
+	</fields>
+	<custom_php_resync_config_command>
+		sync_package_snmptt();
+	</custom_php_resync_config_command>
+</packagegui>

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt_conf.xml
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/pkg/snmptt_conf.xml
@@ -34,7 +34,7 @@
 			<url>/pkg_edit.php?xml=snmptt.xml</url>
 		</tab>
 		<tab>
-			<text>SNMPTT.CONF</text>
+			<text>snmptt.conf</text>
 			<url>/pkg_edit.php?xml=snmptt_conf.xml</url>
 			<active />
 		</tab>
@@ -45,7 +45,7 @@
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>SNMPTT.CONF</fielddescr>
+			<fielddescr>snmptt.conf</fielddescr>
 			<fieldname>snmptt_configfile</fieldname>
 			<encoding>base64</encoding>
 			<type>textarea</type>

--- a/net-mgmt/pfSense-pkg-snmptt/files/usr/local/share/pfSense-pkg-snmptt/info.xml
+++ b/net-mgmt/pfSense-pkg-snmptt/files/usr/local/share/pfSense-pkg-snmptt/info.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<pfsensepkgs>
+	<package>
+		<name>snmptt</name>
+		<internalname>snmptt</internalname>
+		<descr>SNMPTT (SNMP Trap Translator) is an SNMP trap handler written in Perl for use with the Net-SNMP / UCD-SNMP snmptrapd program.</descr>
+		<website>http://snmptt.sourceforge.net</website>
+		<version>%%PKGVERSION%%</version>
+		<configurationfile>snmptt.xml</configurationfile>
+	</package>
+</pfsensepkgs>

--- a/net-mgmt/pfSense-pkg-snmptt/pkg-descr
+++ b/net-mgmt/pfSense-pkg-snmptt/pkg-descr
@@ -1,0 +1,4 @@
+SNMPTT (SNMP Trap Translator) is an SNMP trap handler written in Perl
+for use with the Net-SNMP. Easy to setup and use.
+
+WWW: http://www.snmptt.org/

--- a/net-mgmt/pfSense-pkg-snmptt/pkg-plist
+++ b/net-mgmt/pfSense-pkg-snmptt/pkg-plist
@@ -1,0 +1,7 @@
+pkg/snmptt.xml
+pkg/snmptt.inc
+pkg/snmptt.ini.php
+pkg/snmptt_conf.xml
+/etc/inc/priv/snmptt.priv.inc
+%%DATADIR%%/info.xml
+@dir /etc/inc/priv

--- a/net-mgmt/snmptt/Makefile
+++ b/net-mgmt/snmptt/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	snmptt
 PORTVERSION=	1.4
+PORTREVISION=	1
 CATEGORIES=	net-mgmt
 MASTER_SITES=	SF/${PORTNAME}/${PORTNAME}/${PORTNAME}_${PORTVERSION}
 DISTNAME=	${PORTNAME}_${PORTVERSION}
@@ -9,20 +10,23 @@ DISTNAME=	${PORTNAME}_${PORTVERSION}
 MAINTAINER=	nistor@snickers.org
 COMMENT=	SNMP trap handler/translator/swiss-army-knife
 
-NO_BUILD=	yes
 LICENSE=	GPLv2
-
-USES=		perl5 shebangfix tar:tgz
-USE_RC_SUBR=	snmptt
+LICENSE_FILE=	${WRKSRC}/COPYING
 
 RUN_DEPENDS=	net-snmp>=0:net-mgmt/net-snmp \
-		p5-Config-IniFiles>=0:devel/p5-Config-IniFiles \
-		p5-Text-Balanced>=0:textproc/p5-Text-Balanced \
-		p5-Text-ParseWords>=0:textproc/p5-Text-ParseWords \
-		p5-Time-HiRes>=0:devel/p5-Time-HiRes
+		p5-Config-IniFiles>=0:devel/p5-Config-IniFiles
 
-DOCS=		faqs.html index.html layout1.css snmptt.html \
+NO_BUILD=	yes
+NO_ARCH=	yes
+USES=		perl5 shebangfix tar:tgz
+USE_RC_SUBR=	snmptt
+SUB_LIST=	PERL=${PERL}
+
+PORTDOCS=	faqs.html index.html layout1.css snmptt.html \
 		snmpttconvert.html snmpttconvertmib.html
+
+USERS=	snmptt
+GROUPS=	snmptt
 
 OPTIONS_DEFINE=	DOCS
 
@@ -31,19 +35,24 @@ SCRIPTS=	snmptt snmptt-net-snmp-test snmpttconvert \
 
 SHEBANG_FILES=	${SCRIPTS}
 
+post-patch:
+	${REINPLACE_CMD} -e "s|/var/run|/var/run/${PORTNAME}|" \
+	-e "s|/etc|${PREFIX}/etc|" ${WRKSRC}/snmptt.ini
 
 do-install:
-.for _SCRIPT in ${SCRIPTS}
-	@${INSTALL_SCRIPT} ${WRKSRC}/${_SCRIPT} ${STAGEDIR}${PREFIX}/sbin
-.endfor
-
+	cd ${WRKSRC} && ${INSTALL_SCRIPT} ${SCRIPTS} ${STAGEDIR}${PREFIX}/sbin
 	${MKDIR} ${STAGEDIR}${PREFIX}/etc/snmp
 	${INSTALL_DATA} ${WRKSRC}/snmptt.ini ${STAGEDIR}${PREFIX}/etc/snmp/snmptt.ini.sample
-	${INSTALL_DATA} ${WRKSRC}/examples/snmptt.conf.generic ${STAGEDIR}${PREFIX}/etc/snmp/snmptt.conf.generic.sample
+	${INSTALL_DATA} ${WRKSRC}/examples/snmptt.conf.generic \
+		${STAGEDIR}${PREFIX}/etc/snmp/snmptt.conf.generic.sample
+	${INSTALL_DATA} ${FILESDIR}/newsyslog-snmptt.conf \
+		${STAGEDIR}${PREFIX}/etc/snmp/newsyslog-snmptt.conf.sample
+	@${MKDIR} ${STAGEDIR}/var/log/${PORTNAME}
+	@${MKDIR} ${STAGEDIR}/var/run/${PORTNAME}
+	@${MKDIR} ${STAGEDIR}/var/spool/${PORTNAME}
 
-	${MKDIR} ${STAGEDIR}${DOCSDIR}
-.for _DOC in ${DOCS}
-	${INSTALL_MAN} ${WRKSRC}/docs/${_DOC} ${STAGEDIR}${DOCSDIR}
-.endfor
+do-install-DOCS-on:
+	@${MKDIR} ${STAGEDIR}${DOCSDIR}
+	cd ${WRKSRC}/docs && ${INSTALL_DATA} ${PORTDOCS} ${STAGEDIR}${DOCSDIR}
 
 .include <bsd.port.mk>

--- a/net-mgmt/snmptt/files/newsyslog-snmptt.conf
+++ b/net-mgmt/snmptt/files/newsyslog-snmptt.conf
@@ -1,0 +1,10 @@
+# configuration file for newsyslog for snmptt
+#
+# see newsyslog.conf(5) for details
+#
+# logfilename          [owner:group]    mode count size when  flags [/pid_file] [sig_num]
+/var/log/snmptt/snmptt.debug	snmptt:snmptt	644	3	1024	*	JC	/var/run/snmptt/snmptt.pid
+/var/log/snmptt/snmptt.log	snmptt:snmptt	644	3	*	$W6D0	JC
+/var/log/snmptt/snmptthandler.debug	snmptt:snmptt	644	3	1024	*	JC
+/var/log/snmptt/snmpttunknown.log	snmptt:snmptt	644	3	1024	*	JC
+/var/log/snmptt/snmpttsystem.log	snmptt:snmptt	644	3	1024	*	JC

--- a/net-mgmt/snmptt/files/snmptt.in
+++ b/net-mgmt/snmptt/files/snmptt.in
@@ -9,36 +9,27 @@
 #
 # Add the following lines to /etc/rc.conf to enable snmptt:
 #
-# snmptt_enable="YES"
-# snmptt_flags="<set as needed>"
-#
-# See snmptt documentation for flags.
+# snmptt_enable:    Set to NO by default. Set it to YES to enable it.
+# snmptt_user:      The user account snmptt runs as what
+#                   you want it to be. It uses 'snmptt' user by
+#                   default.
+# snmptt_flags:     See snmptt documentation for flags.
 #
 
 . /etc/rc.subr
 
 name=snmptt
-rcvar=snmptt_enable
+rcvar=${name}_enable
 
 command=%%PREFIX%%/sbin/${name}
-command_args=">/dev/null --daemon"
-pidfile=/var/run/${name}.pid
-# XXX: Makes assumptions about the interpreter path and version. However,
-# USE_PERL5 should guarantee that this path is valid. In any event, we
-# don't sed-ify the #! operators.
-procname=/usr/bin/perl
-required_files=%%PREFIX%%/etc/snmp/${name}.ini
-
-# set defaults
-
-snmptt_enable=${snmptt_enable:-"NO"}
-
-stop_postcmd=stop_postcmd
-
-stop_postcmd()
-{
-  rm -f $pidfile
-}
+command_args="--daemon > /dev/null 2>&1"
+command_interpreter=%%PERL%%
 
 load_rc_config ${name}
+
+: ${snmptt_enable:="NO"}
+: ${snmptt_user:="snmptt"}
+
+required_files=%%PREFIX%%/etc/snmp/${name}.ini
+
 run_rc_command "$1"

--- a/net-mgmt/snmptt/pkg-plist
+++ b/net-mgmt/snmptt/pkg-plist
@@ -1,3 +1,4 @@
+@sample etc/snmp/newsyslog-snmptt.conf.sample etc/newsyslog.conf.d/snmptt.conf
 @sample etc/snmp/snmptt.conf.generic.sample
 @sample etc/snmp/snmptt.ini.sample
 sbin/snmptt
@@ -5,9 +6,7 @@ sbin/snmptt-net-snmp-test
 sbin/snmpttconvert
 sbin/snmpttconvertmib
 sbin/snmptthandler
-%%DOCSDIR%%/faqs.html
-%%DOCSDIR%%/index.html
-%%DOCSDIR%%/layout1.css
-%%DOCSDIR%%/snmptt.html
-%%DOCSDIR%%/snmpttconvert.html
-%%DOCSDIR%%/snmpttconvertmib.html
+%%PORTDOCS%%@dir %%DOCSDIR%%
+@dir(snmptt,snmptt,775) /var/log/snmptt
+@dir(snmptt,snmptt,775) /var/run/snmptt
+@dir(snmptt,snmptt,700) /var/spool/snmptt


### PR DESCRIPTION
> SNMPTT (SNMP Trap Translator) is an SNMP trap handler written in Perl
> for use with the Net-SNMP. Easy to setup and use.

It was mostly used select fields to follow the configuration file pattern, with values "0,1", "0,1,2", "0,1,2,3,4" and "1,2,3,4".

There is more information about the `custom_php_service_status_command` [here](https://gist.github.com/dbaio/d0c5d4f10ca0a6edcc68c3e3702e41e4).

Accepting suggestions in this approach, I couldn't find another package using this custom command.

Cherry picked [this commit](https://github.com/pfsense/FreeBSD-ports/commit/88f5effabf75eff1653c682275a24874f18e0cae).

Thank you.
