### PR TITLE
Fix registration of alert-pf blocking plugin to honor Suricata 3.2.x format

### DIFF
--- a/security/suricata/files/patch-alert-pf.diff
+++ b/security/suricata/files/patch-alert-pf.diff
@@ -1,6 +1,6 @@
-diff -ruN ../suricata-3.0.orig/src/Makefile.am ./src/Makefile.am
---- ../suricata-3.0.orig/src/Makefile.am	2016-03-04 08:12:34.000000000 -0500
-+++ ./src/Makefile.am	2016-01-06 19:44:31.000000000 -0500
+diff -ruN /tmp/suricata-3.2.1.orig/src/Makefile.am ./src/Makefile.am
+--- /tmp/suricata-3.2.1.orig/src/Makefile.am	2017-02-15 02:54:12.000000000 -0500
++++ ./src/Makefile.am	2017-04-06 19:17:45.000000000 -0400
 @@ -9,6 +9,7 @@
  suricata_SOURCES = \
  alert-debuglog.c alert-debuglog.h \
@@ -9,19 +9,48 @@ diff -ruN ../suricata-3.0.orig/src/Makefile.am ./src/Makefile.am
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
  alert-unified2-alert.c alert-unified2-alert.h \
-diff -ruN ../suricata-3.0.orig/src/Makefile.in ./src/Makefile.in
---- ../suricata-3.0.orig/src/Makefile.in	2016-03-04 08:12:52.000000000 -0500
-+++ ./src/Makefile.in	2016-01-06 19:48:45.000000000 -0500
-@@ -99,7 +99,7 @@
+diff -ruN /tmp/suricata-3.2.1.orig/src/Makefile.in ./src/Makefile.in
+--- /tmp/suricata-3.2.1.orig/src/Makefile.in	2017-02-15 02:54:31.000000000 -0500
++++ ./src/Makefile.in	2017-04-06 19:25:15.000000000 -0400
+@@ -94,10 +94,11 @@
+ @DEBUG_TRUE@am__append_1 = -ggdb -O0
+ subdir = src
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+-am__aclocal_m4_deps = $(top_srcdir)/m4/libprelude.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
++am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_compile_flag.m4 \
++	$(top_srcdir)/m4/libprelude.m4 $(top_srcdir)/m4/libtool.m4 \
++	$(top_srcdir)/m4/ltoptions.m4 $(top_srcdir)/m4/ltsugar.m4 \
++	$(top_srcdir)/m4/ltversion.m4 $(top_srcdir)/m4/lt~obsolete.m4 \
++	$(top_srcdir)/configure.ac
+ am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
+ 	$(ACLOCAL_M4)
+ DIST_COMMON = $(srcdir)/Makefile.am $(noinst_HEADERS) \
+@@ -109,9 +110,10 @@
  am__installdirs = "$(DESTDIR)$(bindir)"
  PROGRAMS = $(bin_PROGRAMS)
  am_suricata_OBJECTS = alert-debuglog.$(OBJEXT) alert-fastlog.$(OBJEXT) \
 -	alert-prelude.$(OBJEXT) alert-syslog.$(OBJEXT) \
-+	alert-prelude.$(OBJEXT) alert-syslog.$(OBJEXT) alert-pf.$(OBJEXT) \
- 	alert-unified2-alert.$(OBJEXT) app-layer.$(OBJEXT) \
- 	app-layer-dcerpc.$(OBJEXT) app-layer-dcerpc-udp.$(OBJEXT) \
- 	app-layer-detect-proto.$(OBJEXT) \
-@@ -555,6 +555,7 @@
+-	alert-unified2-alert.$(OBJEXT) app-layer.$(OBJEXT) \
+-	app-layer-dcerpc.$(OBJEXT) app-layer-dcerpc-udp.$(OBJEXT) \
++	alert-pf.$(OBJEXT) alert-prelude.$(OBJEXT) \
++	alert-syslog.$(OBJEXT) alert-unified2-alert.$(OBJEXT) \
++	app-layer.$(OBJEXT) app-layer-dcerpc.$(OBJEXT) \
++	app-layer-dcerpc-udp.$(OBJEXT) \
+ 	app-layer-detect-proto.$(OBJEXT) app-layer-dnp3.$(OBJEXT) \
+ 	app-layer-dnp3-objects.$(OBJEXT) \
+ 	app-layer-dns-common.$(OBJEXT) app-layer-dns-tcp.$(OBJEXT) \
+@@ -577,7 +579,6 @@
+ psdir = @psdir@
+ pyexecdir = @pyexecdir@
+ pythondir = @pythondir@
+-runstatedir = @runstatedir@
+ sbindir = @sbindir@
+ sharedstatedir = @sharedstatedir@
+ srcdir = @srcdir@
+@@ -597,6 +598,7 @@
  suricata_SOURCES = \
  alert-debuglog.c alert-debuglog.h \
  alert-fastlog.c alert-fastlog.h \
@@ -29,7 +58,7 @@ diff -ruN ../suricata-3.0.orig/src/Makefile.in ./src/Makefile.in
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
  alert-unified2-alert.c alert-unified2-alert.h \
-@@ -1099,6 +1100,7 @@
+@@ -1162,6 +1164,7 @@
  
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/alert-debuglog.Po@am__quote@
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/alert-fastlog.Po@am__quote@
@@ -37,10 +66,10 @@ diff -ruN ../suricata-3.0.orig/src/Makefile.in ./src/Makefile.in
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/alert-prelude.Po@am__quote@
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/alert-syslog.Po@am__quote@
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/alert-unified2-alert.Po@am__quote@
-diff -ruN ../suricata-3.0.orig/src/alert-pf.c ./src/alert-pf.c
---- ../suricata-3.0.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/alert-pf.c	2015-11-04 22:48:45.000000000 -0500
-@@ -0,0 +1,1072 @@
+diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
+--- /tmp/suricata-3.2.1.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
++++ ./src/alert-pf.c	2017-04-27 12:40:00.000000000 -0400
+@@ -0,0 +1,1055 @@
 +/* Copyright (C) 2007-2014 Open Information Security Foundation
 + *
 + * You can copy, redistribute or modify this Program under the terms of
@@ -59,7 +88,7 @@ diff -ruN ../suricata-3.0.orig/src/alert-pf.c ./src/alert-pf.c
 + *
 + * Portions of this module are based on previous works of the following:
 + *
-+ * Copyright (c) 2016  Bill Meeks
++ * Copyright (c) 2017  Bill Meeks
 + * Copyright (c) 2012  Ermal Luci
 + * Copyright (c) 2006  Antonio Benojar <zz.stalker@gmail.com>
 + * Copyright (c) 2005  Antonio Benojar <zz.stalker@gmail.com>
@@ -154,42 +183,25 @@ diff -ruN ../suricata-3.0.orig/src/alert-pf.c ./src/alert-pf.c
 +
 +enum spblock { BLOCK_SRC, BLOCK_DST, BLOCK_BOTH };
 +
-+TmEcode AlertPf (ThreadVars *, Packet *, void *, PacketQueue *, PacketQueue *);
-+TmEcode AlertPfIPv4(ThreadVars *, Packet *, void *, PacketQueue *, PacketQueue *);
-+TmEcode AlertPfIPv6(ThreadVars *, Packet *, void *, PacketQueue *, PacketQueue *);
 +TmEcode AlertPfThreadInit(ThreadVars *, void *, void **);
 +TmEcode AlertPfThreadDeinit(ThreadVars *, void *);
 +void AlertPfExitPrintStats(ThreadVars *, void *);
 +static void AlertPfDeInitCtx(OutputCtx *);
 +
-+void TmModuleAlertPfRegister (void) {
-+    tmm_modules[TMM_ALERTPF].name = MODULE_NAME;
-+    tmm_modules[TMM_ALERTPF].ThreadInit = AlertPfThreadInit;
-+    tmm_modules[TMM_ALERTPF].Func = AlertPf;
-+    tmm_modules[TMM_ALERTPF].ThreadExitPrintStats = AlertPfExitPrintStats;
-+    tmm_modules[TMM_ALERTPF].ThreadDeinit = AlertPfThreadDeinit;
-+    tmm_modules[TMM_ALERTPF].RegisterTests = NULL;
-+    tmm_modules[TMM_ALERTPF].cap_flags = 0;
++int AlertPfCondition(ThreadVars *tv, const Packet *p);
++int AlertPf(ThreadVars *tv, void *data, const Packet *p);
 +
-+    OutputRegisterModule(MODULE_NAME, "alert-pf", AlertPfInitCtx);
++void AlertPfRegister(void)
++{
++    OutputRegisterPacketModule(LOGGER_ALERT_PF, MODULE_NAME, "alert-pf",
++        AlertPfInitCtx, AlertPf, AlertPfCondition,
++        AlertPfThreadInit, AlertPfThreadDeinit,
++        AlertPfExitPrintStats);
 +}
 +
-+void TmModuleAlertPfIPv4Register (void) {
-+    tmm_modules[TMM_ALERTPF4].name = "AlertPfIPv4";
-+    tmm_modules[TMM_ALERTPF4].ThreadInit = AlertPfThreadInit;
-+    tmm_modules[TMM_ALERTPF4].Func = AlertPfIPv4;
-+    tmm_modules[TMM_ALERTPF4].ThreadExitPrintStats = AlertPfExitPrintStats;
-+    tmm_modules[TMM_ALERTPF4].ThreadDeinit = AlertPfThreadDeinit;
-+    tmm_modules[TMM_ALERTPF4].RegisterTests = NULL;
-+}
-+
-+void TmModuleAlertPfIPv6Register (void) {
-+    tmm_modules[TMM_ALERTPF6].name = "AlertPfIPv6";
-+    tmm_modules[TMM_ALERTPF6].ThreadInit = AlertPfThreadInit;
-+    tmm_modules[TMM_ALERTPF6].Func = AlertPfIPv6;
-+    tmm_modules[TMM_ALERTPF6].ThreadExitPrintStats = AlertPfExitPrintStats;
-+    tmm_modules[TMM_ALERTPF6].ThreadDeinit = AlertPfThreadDeinit;
-+    tmm_modules[TMM_ALERTPF6].RegisterTests = NULL;
++int AlertPfCondition(ThreadVars *tv, const Packet *p)
++{
++    return (p->alerts.cnt ? TRUE : FALSE);
 +}
 +
 +/**
@@ -896,7 +908,7 @@ diff -ruN ../suricata-3.0.orig/src/alert-pf.c ./src/alert-pf.c
 +/** \brief This processes an IPv4 alert and inserts the appropriate
 + * block if the IP address is not on the Pass List.
 + */
-+TmEcode AlertPfIPv4(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, PacketQueue *postpq)
++TmEcode AlertPfIPv4(ThreadVars *tv, void *data, Packet *p)
 +{
 +    AlertPfThread *apft = (AlertPfThread *)data;
 +    int i;
@@ -999,7 +1011,7 @@ diff -ruN ../suricata-3.0.orig/src/alert-pf.c ./src/alert-pf.c
 +/** \brief This processes an IPv6 alert and inserts the appropriate
 + * block if the IP address is not on the Pass List.
 + */
-+TmEcode AlertPfIPv6(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, PacketQueue *postpq)
++TmEcode AlertPfIPv6(ThreadVars *tv, void *data, Packet *p)
 +{
 +    AlertPfThread *apft = (AlertPfThread *)data;
 +    int i;
@@ -1102,21 +1114,21 @@ diff -ruN ../suricata-3.0.orig/src/alert-pf.c ./src/alert-pf.c
 +/** \brief This processes an IP alert and routes it to the
 + * appropriate handler.
 + */
-+TmEcode AlertPf (ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, PacketQueue *postpq)
++int AlertPf (ThreadVars *tv, void *data, const Packet *p)
 +{
 +    if (PKT_IS_IPV4(p)) {
-+        return AlertPfIPv4(tv, p, data, pq, postpq);
++        return AlertPfIPv4(tv, data, p);
 +    } else if (PKT_IS_IPV6(p)) {
-+        return AlertPfIPv6(tv, p, data, pq, postpq);
++        return AlertPfIPv6(tv, data, p);
 +    }
 +
 +    return TM_ECODE_OK;
 +}
 +
-diff -ruN ../suricata-3.0.orig/src/alert-pf.h ./src/alert-pf.h
---- ../suricata-3.0.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/alert-pf.h	2015-11-04 22:52:05.000000000 -0500
-@@ -0,0 +1,61 @@
+diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.h ./src/alert-pf.h
+--- /tmp/suricata-3.2.1.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
++++ ./src/alert-pf.h	2017-04-27 12:41:14.000000000 -0400
+@@ -0,0 +1,59 @@
 +/* Copyright (C) 2007-2010 Open Information Security Foundation
 + *
 + * You can copy, redistribute or modify this Program under the terms of
@@ -1135,7 +1147,7 @@ diff -ruN ../suricata-3.0.orig/src/alert-pf.h ./src/alert-pf.h
 + *
 + * Portions of this module are based on previous works of the following:
 + *
-+ * Copyright (c) 2016  Bill Meeks
++ * Copyright (c) 2017  Bill Meeks
 + * Copyright (c) 2012  Ermal Luci
 + * Copyright (c) 2006  Antonio Benojar <zz.stalker@gmail.com>
 + * Copyright (c) 2005  Antonio Benojar <zz.stalker@gmail.com>
@@ -1171,58 +1183,39 @@ diff -ruN ../suricata-3.0.orig/src/alert-pf.h ./src/alert-pf.h
 +	struct type *sle_next;	/* next element */			\
 +}
 +
-+void TmModuleAlertPfRegister (void);
-+void TmModuleAlertPfIPv4Register (void);
-+void TmModuleAlertPfIPv6Register (void);
++void AlertPfRegister (void);
 +OutputCtx *AlertPfInitCtx(ConfNode *);
 +
 +#endif /* __ALERT_PF_H__ */
 +
-diff -ruN ../suricata-3.0.orig/src/suricata.c ./src/suricata.c
---- ../suricata-3.0.orig/src/suricata.c	2016-03-04 08:12:34.000000000 -0500
-+++ ./src/suricata.c	2016-01-06 19:40:34.000000000 -0500
-@@ -170,5 +170,6 @@
- #include "util-mpm-hs.h"
- #include "util-storage.h"
+diff -ruN /tmp/suricata-3.2.1.orig/src/output.c ./src/output.c
+--- /tmp/suricata-3.2.1.orig/src/output.c	2017-02-15 02:54:12.000000000 -0500
++++ ./src/output.c	2017-04-27 12:47:28.000000000 -0400
+@@ -45,6 +45,7 @@
+ #include "alert-debuglog.h"
+ #include "alert-prelude.h"
+ #include "alert-syslog.h"
 +#include "alert-pf.h"
- #include "host-storage.h"
-
- #include "util-lua.h"
-@@ -806,6 +807,10 @@
-     /* managers */
-     TmModuleFlowManagerRegister();
-     TmModuleFlowRecyclerRegister();
+ #include "output-json-alert.h"
+ #include "output-json-flow.h"
+ #include "output-json-netflow.h"
+@@ -1049,6 +1050,8 @@
+     AlertPreludeRegister();
+     /* syslog log */
+     AlertSyslogRegister();
 +    /* alert pf */
-+    TmModuleAlertPfRegister();
-+    TmModuleAlertPfIPv4Register();
-+    TmModuleAlertPfIPv6Register();
-     /* nfq */
-     TmModuleReceiveNFQRegister();
-     TmModuleVerdictNFQRegister();
-diff -ruN ../suricata-3.0.orig/src/tm-modules.c ./src/tm-modules.c
---- ../suricata-3.0.orig/src/tm-modules.c	2016-03-04 08:12:34.000000000 -0500
-+++ ./src/tm-modules.c	2016-01-06 19:52:55.000000000 -0500
-@@ -219,6 +219,9 @@
-         CASE_CODE (TMM_DECODEERFFILE);
-         CASE_CODE (TMM_RECEIVEERFDAG);
-         CASE_CODE (TMM_DECODEERFDAG);
-+        CASE_CODE (TMM_ALERTPF);
-+        CASE_CODE (TMM_ALERTPF4);
-+        CASE_CODE (TMM_ALERTPF6);
-         CASE_CODE (TMM_RECEIVEMPIPE);
-         CASE_CODE (TMM_DECODEMPIPE);
-         CASE_CODE (TMM_RECEIVENAPATECH);
-diff -ruN ../suricata-3.0.orig/src/tm-threads-common.h ./src/tm-threads-common.h
---- ../suricata-3.0.orig/src/tm-threads-common.h	2016-03-04 08:12:34.000000000 -0500
-+++ ./src/tm-threads-common.h	2016-01-06 19:53:59.000000000 -0500
-@@ -58,6 +58,9 @@
-     TMM_DECODEMPIPE,
-     TMM_RECEIVENAPATECH,
-     TMM_DECODENAPATECH,
-+    TMM_ALERTPF,
-+    TMM_ALERTPF4,
-+    TMM_ALERTPF6,
-     TMM_STATSLOGGER,
-     TMM_RECEIVENFLOG,
-     TMM_DECODENFLOG,
-
++    AlertPfRegister();
+     /* unified2 log */
+     Unified2AlertRegister();
+     /* drop log */
+diff -ruN /tmp/suricata-3.2.1.orig/src/suricata-common.h ./src/suricata-common.h
+--- /tmp/suricata-3.2.1.orig/src/suricata-common.h	2017-02-15 02:54:12.000000000 -0500
++++ ./src/suricata-common.h	2017-04-27 12:42:02.000000000 -0400
+@@ -375,6 +375,7 @@
+     LOGGER_PRELUDE,
+     LOGGER_PCAP,
+     LOGGER_JSON_DNP3,
++    LOGGER_ALERT_PF,
+     LOGGER_SIZE,
+ } LoggerId;
+ 


### PR DESCRIPTION
This update patches the _alert-pf_ custom blocking plugin for pfSense so that it properly registers itself as an Output Packet Module.