### PR TITLE
Make the HAproxy-devel widget settings panel open

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/Makefile
+++ b/net/pfSense-pkg-haproxy-devel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-haproxy-devel
 PORTVERSION=	0.52
-PORTREVISION=	7
+PORTREVISION=	8
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/widgets/widgets/haproxy.widget.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/widgets/widgets/haproxy.widget.php
@@ -263,7 +263,7 @@ if ($getupdatestatus) {
 			getURL(url+"?"+pars, getstatusgetupdate);
 	}
 </script>
-<div id="widget-haproxy_panel-footer" class="panel-footer collapse">
+<div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 <form action="/widgets/widgets/haproxy.widget.php" method="post" name="iform" id="iform">
 	<table>
 	<tr><td>


### PR DESCRIPTION
The id for the settings panel-footer changed its format a bit to support multiple copies of a widget on the dashboard.