### PR TITLE
Make haproxy-devel widget settings open

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/Makefile
+++ b/net/pfSense-pkg-haproxy-devel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-haproxy-devel
 PORTVERSION=	0.52
-PORTREVISION=	7
+PORTREVISION=	8
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/widgets/widgets/haproxy.widget.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/widgets/widgets/haproxy.widget.php
@@ -263,7 +263,7 @@ if ($getupdatestatus) {
 			getURL(url+"?"+pars, getstatusgetupdate);
 	}
 </script>
-<div id="widget-haproxy_panel-footer" class="panel-footer collapse">
+<div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
 <form action="/widgets/widgets/haproxy.widget.php" method="post" name="iform" id="iform">
 	<table>
 	<tr><td>


### PR DESCRIPTION
pfSense 2.4 supports potentially multiple copies of a widget on the dashboard. For this, the widget name is no longer just like "haproxy", but is "haproxy-0" (and could be "haproxy-1" etc in future, if haproxy wanted to allow multiple copies).

Make haproxy-devel use the passed-in value of $widgetname to generate the id of the widget panel footer. That works in both 2.3.* and 2.4.