### PR TITLE
Enable BGP and OSPFv3

### DIFF
--- a/net/pfSense-pkg-Quagga_OSPF/Makefile
+++ b/net/pfSense-pkg-Quagga_OSPF/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-Quagga_OSPF
-PORTVERSION=	0.6.17
+PORTVERSION=	0.6.18
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-Quagga_OSPF/files/usr/local/bin/quaggactl
+++ b/net/pfSense-pkg-Quagga_OSPF/files/usr/local/bin/quaggactl
@@ -10,6 +10,10 @@ OSPF_CONFIG=${QUAGGA_CONFIG_BASE}/ospfd.conf
 OSPF_PORT=2604
 OSPF_PASSWORD=`/usr/bin/grep '^password ' ${OSPF_CONFIG} | /usr/bin/awk '{print $2};'`
 
+BGP_CONFIG=${QUAGGA_CONFIG_BASE}/bgpd.conf
+BGP_PORT=2605
+BGP_PASSWORD=`/usr/bin/grep '^password ' ${BGP_CONFIG} | /usr/bin/awk '{print $2};'`
+
 daemon_command() {
 	COMMANDS=${2}
 	COMMANDS=${COMMANDS}`echo -e "\n${3}\n"`
@@ -81,4 +85,29 @@ ospf*)
 		daemon_command ${OSPF_PORT} ${OSPF_PASSWORD} "show ip ospf route"
 		;;
 	esac ;;
+bgp6*)
+        if [ "`pgrep bgpd`" = "" ]; then
+                echo "bgpd does not appear to be running"
+                exit 1
+        fi
+        case $2 in
+        rou*)
+                daemon_command ${BGP_PORT} ${BGP_PASSWORD} "show bgp"
+                ;;
+
+        esac ;;
+bgp*)
+	if [ "`pgrep bgpd`" = "" ]; then
+		echo "bgpd does not appear to be running"
+		exit 1
+	fi
+	case $2 in
+	nei*)
+		shift; shift;
+		daemon_command ${BGP_PORT} ${BGP_PASSWORD} "show ip bgp neighbor $*"
+		;;
+		rou*)
+		daemon_command ${BGP_PORT} ${BGP_PASSWORD} "show ip bgp"
+		;;
+        esac ;;
 esac

--- a/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd.inc
+++ b/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd.inc
@@ -78,6 +78,10 @@ function quagga_ospfd_install_conf() {
 	// generate ospfd.conf based on the assistant
 	if (is_array($config['installedpackages']['quaggaospfd']['config'])) {
 		$ospfd_conf = &$config['installedpackages']['quaggaospfd']['config'][0];
+	} elseif (isset($config['installedpackages']['quaggaospfdraw']['config'][0]['ospfd'])  ||
+	    isset($config['installedpackages']['quaggaospfdraw']['config'][0]['ospf6d']) ||
+	    isset($config['installedpackages']['quaggaospfdraw']['config'][0]['bgpd'])) {
+		log_error("Quagga: No assistant generated config for OSPF, but found raw config for one or more daemon");		
 	} else {
 		log_error("Quagga OSPFd: No config data found.");
 		return;
@@ -285,6 +289,32 @@ function quagga_ospfd_install_conf() {
 	fwrite($fd, $zebraconffile);
 	fclose($fd);
 
+	/* Make bgpd config */
+	if (isset($config['installedpackages']['quaggaospfdraw']['config'][0]['bgpd'])
+	    && !empty($config['installedpackages']['quaggaospfdraw']['config'][0]['bgpd'])) {
+		// if there is a raw config specified in the config.xml use that instead of the assisted config
+		$bgpdconffile = str_replace("\r","",base64_decode($config['installedpackages']['quaggaospfdraw']['config'][0]['bgpd']));
+	} else {
+		$bgpdconffile = "";
+	}
+
+	$fd = fopen("{$quagga_config_base}/bgpd.conf", "w");
+	fwrite($fd, $bgpdconffile);
+	fclose($fd);
+
+        /* Make ospf6 config */
+	if (isset($config['installedpackages']['quaggaospfdraw']['config'][0]['ospf6d'])
+	    && !empty($config['installedpackages']['quaggaospfdraw']['config'][0]['ospf6d'])) {
+		// if there is a raw config specified in the config.xml use that instead of the assisted config
+		$ospf6dconffile = str_replace("\r","",base64_decode($config['installedpackages']['quaggaospfdraw']['config'][0]['ospf6d']));
+	} else {
+        	$ospf6dconffile = "";
+	}
+
+	$fd = fopen("{$quagga_config_base}/ospf6d.conf", "w");
+	fwrite($fd, $ospf6dconffile);
+	fclose($fd);
+
 	$carp_ip_status_check = "";
 	if (isset($ospfd_conf['carpstatusvid']) && $ospfd_conf['carpstatusvid'] != "none") {
 		$vip = get_configured_vip($ospfd_conf['carpstatusvid']);
@@ -312,12 +342,24 @@ if [ -e /var/run/quagga/ospfd.pid ]; then
 	/bin/pkill -F /var/run/quagga/ospfd.pid
 	/bin/rm -f /var/run/quagga/ospfd.pid
 fi
+if [ -e /var/run/quagga/ospf6d.pid ]; then
+	# XXX: See Bug #6305 - Quagga 1.x does not like SIGKILL
+	/bin/pkill -F /var/run/quagga/ospf6d.pid
+	/bin/rm -f /var/run/quagga/ospf6d.pid
+fi
+if [ -e /var/run/quagga/bgpd.pid ]; then
+	# XXX: See Bug #6305 - Quagga 1.x does not like SIGKILL
+	/bin/pkill -F /var/run/quagga/bgpd.pid
+	/bin/rm -f /var/run/quagga/bgpd.pid
+fi
 EOF;
 	$rc_file_start = <<<EOF
 /bin/mkdir -p /var/run/quagga
 /bin/mkdir -p /var/log/quagga
 /bin/rm -f /var/run/quagga/zebra.pid
 /bin/rm -f /var/run/quagga/ospfd.pid
+/bin/rm -f /var/run/quagga/ospf6d.pid
+/bin/rm -f /var/run/quagga/bgpd.pid
 
 /usr/sbin/chown -R quagga:quagga {$quagga_config_base}
 /usr/sbin/chown -R quagga:quagga /var/run/quagga
@@ -334,9 +376,22 @@ if /bin/pgrep -q ospfd; then
 	sleep 1
 	/usr/bin/killall -9 ospfd 2>/dev/null
 fi
+if /bin/pgrep -q ospf6d; then
+	/usr/bin/killall ospf6d
+	sleep 1
+	/usr/bin/killall -9 ospf6d 2>/dev/null
+fi
+if /bin/pgrep -q bgpd; then
+	/usr/bin/killall bgpd
+	sleep 1
+	/usr/bin/killall -9 bgpd 2>/dev/null
+fi
 {$carp_ip_status_check}
-/usr/local/sbin/zebra -d -f {$quagga_config_base}/zebra.conf
-/usr/local/sbin/ospfd -d -f {$quagga_config_base}/ospfd.conf
+[ -s {$quagga_config_base}/zebra.conf ] && /usr/local/sbin/zebra -d -f {$quagga_config_base}/zebra.conf
+[ -s {$quagga_config_base}/ospfd.conf ] && /usr/local/sbin/ospfd -d -f {$quagga_config_base}/ospfd.conf
+[ -s {$quagga_config_base}/ospf6d.conf ] && /usr/local/sbin/ospf6d -d -f {$quagga_config_base}/ospf6d.conf
+[ -s {$quagga_config_base}/bgpd.conf ] && /usr/local/sbin/bgpd -d -f {$quagga_config_base}/bgpd.conf
+
 EOF;
 	write_rcfile(array(
 			"file" => "quagga.sh",
@@ -348,7 +403,9 @@ EOF;
 	// Ensure files have correct permissions
 	mwexec("/bin/chmod a+rx /usr/local/etc/rc.d/quagga.sh");
 	mwexec("/bin/chmod u+rw,go-rw {$quagga_config_base}/ospfd.conf");
+	mwexec("/bin/chmod u+rw,go-rw {$quagga_config_base}/ospf6d.conf");
 	mwexec("/bin/chmod u+rw,go-rw {$quagga_config_base}/zebra.conf");
+	mwexec("/bin/chmod u+rw,go-rw {$quagga_config_base}/bgpd.conf");
 
 	// Kick off newly created rc.d script
 	if (isset($ospfd_conf['carpstatusvid']) && $ospfd_conf['carpstatusvid'] != "none") {

--- a/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd.xml
+++ b/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd.xml
@@ -61,6 +61,18 @@
 		<description>OSPF routing daemon</description>
 	</service>
 	<service>
+		<name>Quagga OSPF6d</name>
+		<rcfile>quagga.sh</rcfile>
+		<executable>ospf6d</executable>
+		<description>OSPF6 routing daemon</description>
+	</service>
+	<service>
+		<name>Quagga BGPd</name>
+		<rcfile>quagga.sh</rcfile>
+		<executable>bgpd</executable>
+		<description>BGP routing daemon</description>
+	</service>
+	<service>
 		<name>Quagga Zebra</name>
 		<rcfile>quagga.sh</rcfile>
 		<executable>zebra</executable>

--- a/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd_interfaces.xml
+++ b/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd_interfaces.xml
@@ -71,6 +71,16 @@
 		<executable>ospfd</executable>
 	</service>
 	<service>
+		<name>Quagga OSPF6d</name>
+		<rcfile>quagga.sh</rcfile>
+		<executable>ospf6d</executable>
+	</service>
+	<service>
+		<name>Quagga BGPd</name>
+		<rcfile>quagga.sh</rcfile>
+		<executable>bgpd</executable>
+	</service>
+	<service>
 		<name>Quagga Zebra</name>
 		<rcfile>quagga.sh</rcfile>
 		<executable>zebra</executable>

--- a/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd_raw.xml
+++ b/net/pfSense-pkg-Quagga_OSPF/files/usr/local/pkg/quagga_ospfd_raw.xml
@@ -61,6 +61,16 @@
 		<executable>ospfd</executable>
 	</service>
 	<service>
+		<name>Quagga OSPF6d</name>
+		<rcfile>quagga.sh</rcfile>
+		<executable>ospf6d</executable>
+	</service>
+	<service>
+		<name>Quagga BGPd</name>
+		<rcfile>quagga.sh</rcfile>
+		<executable>bgpd</executable>
+	</service>
+	<service>
 		<name>Quagga Zebra</name>
 		<rcfile>quagga.sh</rcfile>
 		<executable>zebra</executable>
@@ -72,6 +82,34 @@
 			<description>
 				<![CDATA[
 				Note: Once you click "Save" below, the assistant (in the "Global Settings" and "Interface Settings" tabs above) will be overridden with whatever you type here.<br />
+				To get back the assisted config save this form below once with both empty input fields.
+				]]>
+			</description>
+			<type>textarea</type>
+			<encoding>base64</encoding>
+			<rows>30</rows>
+			<cols>65</cols>
+		</field>
+		<field>
+			<fielddescr>ospf6d.conf</fielddescr>
+			<fieldname>ospf6d</fieldname>
+			<description>
+				<![CDATA[
+				Note: Once you click "Save" below, the assistant (in the "Global Settings" and "Interface Settings" tabs above) will be overridden with w$
+				To get back the assisted config save this form below once with both empty input fields.
+				]]>
+			</description>		
+			<type>textarea</type>
+			<encoding>base64</encoding>
+			<rows>30</rows>
+			<cols>65</cols>
+		</field>
+		<field>
+			<fielddescr>bgpd.conf</fielddescr>
+			<fieldname>bgpd</fieldname>
+			<description>
+				<![CDATA[
+				Note: Once you click "Save" below, the assistant (in the "Global Settings" and "Interface Settings" tabs above) will be overridden with w$
 				To get back the assisted config save this form below once with both empty input fields.
 				]]>
 			</description>

--- a/net/pfSense-pkg-Quagga_OSPF/files/usr/local/www/status_ospfd.php
+++ b/net/pfSense-pkg-Quagga_OSPF/files/usr/local/www/status_ospfd.php
@@ -74,7 +74,11 @@ defCmdT("Quagga Zebra Routes", "{$control_script} zebra route");
 defCmdT("Quagga OSPF Interfaces", "{$control_script} ospf interfaces");
 defCmdT("Quagga OSPF CPU Usage", "{$control_script} ospf cpu");
 defCmdT("Quagga OSPF Memory", "{$control_script} ospf mem");
+defCmdT("Quagga BGP Neighbors", "{$control_script} bgp neighbor");
+defCmdT("Quagga BGP Routes", "{$control_script} bgp route");
+defCmdT("Quagga BGP IPv6 Routes", "{$control_script} bgp6 route");
 defCmdT("Quagga ospfd.conf", "/bin/cat {$pkg_homedir}/ospfd.conf");
+defCmdT("Quagga bgpd.conf", "/bin/cat {$pkg_homedir}/bgpd.conf");
 defCmdT("Quagga zebra.conf", "/bin/cat {$pkg_homedir}/zebra.conf");
 
 $tab_array = array();


### PR DESCRIPTION
Allows raw config to be entered to enable the use of BGP and OSPFv3 and provides required support to control the daemons.

For users who require both BGP and OSPF this is the only way of accomplishing this. Also some people who are using Quagga elsewhere in their infrastructure, means that they have only one type of BGP config to manage.

Based on work from this pull request
https://github.com/pfsense/pfsense-packages/pull/1258/files