### PR TITLE
pfSense-pkg-snort-3.2.9.3 -- Update for Snort 2.9.9.0 binary and GUI bug fixes

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-snort
-PORTVERSION=	3.2.9.2
-PORTREVISION=	16
+PORTVERSION=	3.2.9.3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2016 Bill Meeks
+ * Copyright (c) 2013-2017 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,7 +40,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 	if (!empty($snortver))
 		define("SNORT_BIN_VERSION", $snortver);
 	else
-		define("SNORT_BIN_VERSION", "2.9.8.3");
+		define("SNORT_BIN_VERSION", "2.9.9.0");
 }
 if (!defined("SNORT_SID_MODS_PATH"))
 	define('SNORT_SID_MODS_PATH', "{$g['vardb_path']}/snort/sidmods/");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -385,13 +385,15 @@ if ($_POST['download']) {
 			header("Cache-Control: private, must-revalidate");
 		}
 		header("Content-Type: application/octet-stream");
-		header("Content-length: " . filesize("{$g['tmp_path']}/{$file_name}"));
-		header("Content-disposition: attachment; filename = {$file_name}");
+		header("Content-length: filesize=" . filesize("{$g['tmp_path']}/{$file_name}"));
+		header("Content-disposition: attachment; filename=" . $file_name);
 		ob_end_clean(); //important or other post will fail
 		readfile("{$g['tmp_path']}/{$file_name}");
 
 		// Clean up the temp file
 		unlink_if_exists("{$g['tmp_path']}/{$file_name}");
+		header("Location: /snort/snort_alerts.php?instance={$instanceid}");
+		exit;
 	}
 	else
 		$savemsg = gettext("An error occurred while creating archive");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_barnyard.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_barnyard.php
@@ -6,7 +6,7 @@
  * Copyright (c) 2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>
  * Copyright (c) 2008-2009 Robert Zelaya
- * Copyright (c) 2014-2016 Bill Meeks
+ * Copyright (c) 2014-2017 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -221,7 +221,9 @@ if ($_POST['save']) {
 }
 
 $if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']);
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Barnyard2 Settings"), gettext("{$if_friendly}"));
+if (empty($if_friendly)) {
+	$if_friendly = "None";
+}$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Barnyard2 Settings"), gettext("{$if_friendly}"));
 include_once("head.inc");
 
 /* Display Alert message */

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_blocked.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_blocked.php
@@ -110,14 +110,17 @@ if ($_POST['download'])
 				header("Cache-Control: private, must-revalidate");
 			}
 			header("Content-Type: application/octet-stream");
-			header("Content-length: " . filesize("{$g['tmp_path']}/{$file_name}"));
-			header("Content-disposition: attachment; filename = {$file_name}");
+			header("Content-length: filesize=" . filesize("{$g['tmp_path']}/{$file_name}"));
+			header("Content-disposition: attachment; filename=" . $file_name);
 			ob_end_clean(); //important or other post will fail
 			readfile("{$g['tmp_path']}/{$file_name}");
 
 			// Clean up the temp files and directory
 			unlink_if_exists("{$g['tmp_path']}/{$file_name}");
 			rmdir_recursive("{$g['tmp_path']}/snort_blocked");
+
+			header("Location: /snort/snort_blocked.php");
+			exit;
 		} else
 			$savemsg = gettext("An error occurred while creating archive");
 	} else

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_define_servers.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_define_servers.php
@@ -6,7 +6,7 @@
  * Copyright (c) 2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2008-2009 Robert Zelaya.
- * Copyright (c) 2014-2016 Bill Meeks
+ * Copyright (c) 2014-2017 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -155,7 +155,9 @@ if ($_POST['save']) {
 }
 
 $if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']);
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Interface Servers and Ports Variables - {$if_friendly}"));
+if (empty($if_friendly)) {
+	$if_friendly = "None";
+}$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Interface Servers and Ports Variables - {$if_friendly}"));
 include("head.inc");
 
 /* Display Alert message */

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interface_logs.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interface_logs.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2014-2016 Bill Meeks
+ * Copyright (c) 2014-2017 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -76,7 +76,9 @@ if ($_POST['action'] == 'load') {
 }
 
 $if_friendly = convert_friendly_interface_to_friendly_descr($a_instance[$id]['interface']);
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Interface Logs"), gettext("{$if_friendly}"));
+if (empty($if_friendly)) {
+	$if_friendly = "None";
+}$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Interface Logs"), gettext("{$if_friendly}"));
 include("head.inc");
 
 if ($input_errors) {

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
@@ -467,6 +467,9 @@ function snort_get_config_lists($lists) {
 }
 
 $if_friendly = convert_friendly_interface_to_friendly_descr($a_rule[$id]['interface']);
+if (empty($if_friendly)) {
+	$if_friendly = "None";
+}
 $pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Edit Interface"), gettext("{$if_friendly}"));
 include("head.inc");
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ip_reputation.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ip_reputation.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2014-2016 Bill Meeks
+ * Copyright (c) 2014-2017 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -198,7 +198,9 @@ if ($_POST['save']) {
 }
 
 $if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']);
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("IP Reputation Preprocessor"), gettext("{$if_friendly}"));
+if (empty($if_friendly)) {
+	$if_friendly = "None";
+}$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("IP Reputation Preprocessor"), gettext("{$if_friendly}"));
 include("head.inc");
 
 /* Display Alert message */

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
@@ -6,7 +6,7 @@
  * Copyright (c) 2011-2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2008-2009 Robert Zelaya
- * Copyright (c) 2013-2016 Bill Meeks
+ * Copyright (c) 2013-2017 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -654,6 +654,9 @@ if ($_POST['btn_edit_hat']) {
 if ($pconfig['host_attribute_table'] == 'on' && empty($pconfig['host_attribute_data']))
 	$input_errors[] = gettext("The Host Attribute Table option is enabled, but no Host Attribute data has been loaded.  Data may be entered manually or imported from a suitable file.");
 
+if (empty($if_friendly)) {
+	$if_friendly = "None";
+}
 $pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Preprocessors and Flow"), gettext("{$if_friendly}"));
 include("head.inc");
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2004-2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2008-2009 Robert Zelaya
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2017 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -511,7 +511,9 @@ elseif ($_POST['apply']) {
 }
 
 $if_friendly = convert_friendly_interface_to_friendly_descr($a_rule[$id]['interface']);
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Rules"), gettext("{$if_friendly}"));
+if (empty($if_friendly)) {
+	$if_friendly = "None";
+}$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Rules"), gettext("{$if_friendly}"));
 include("head.inc");
 
 // Display error messages if we have any

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009 Robert Zelaya
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2017 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -251,6 +251,9 @@ if ($a_nat[$id]['autoflowbitrules'] == 'on') {
 }
 
 $if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']);
+if (empty($if_friendly)) {
+	$if_friendly = "None";
+}
 $pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Categories"), gettext("{$if_friendly}"));
 include_once("head.inc");
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2017 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -123,10 +123,11 @@ if (isset($_POST['sidlist_action']) && isset($_POST['sidlist_fname'])) {
 					header("Cache-Control: private, must-revalidate");
 				}
 				header("Content-Type: application/octet-stream");
-				header("Content-length: " . filesize($file));
-				header("Content-disposition: attachment; filename = " . basename($file));
+				header("Content-length: filesize=" . filesize($file));
+				header("Content-disposition: attachment; filename=" . basename($file));
 				ob_end_clean(); //important or other post will fail
 				readfile($file);
+				exit;
 			}
 			else
 				$savemsg = gettext("Unable to locate the file specified!");
@@ -220,13 +221,14 @@ if (isset($_POST['sidlist_dnload_all'])) {
 			header("Cache-Control: private, must-revalidate");
 		}
 		header("Content-Type: application/octet-stream");
-		header("Content-length: " . filesize("{$g['tmp_path']}/{$file_name}"));
-		header("Content-disposition: attachment; filename = {$file_name}");
+		header("Content-length: filesize=" . filesize("{$g['tmp_path']}/{$file_name}"));
+		header("Content-disposition: attachment; filename=" . $file_name);
 		ob_end_clean(); //important or other post will fail
 		readfile("{$g['tmp_path']}/{$file_name}");
 
 		// Clean up the temp file
 		unlink_if_exists("{$g['tmp_path']}/{$file_name}");
+		exit;
 	}
 	else
 		$savemsg = gettext("An error occurred while creating the gzip archive!");


### PR DESCRIPTION
This update for the Snort GUI package implements support for the latest 2.9.9.0 version of the Snort binary.  Release Note for Snort 2.9.9.0 can be found here:  [https://www.snort.org/downloads/snort/release_notes_2.9.9.0.txt](url)

**GUI Package New Features:**
None

**GUI Package Bug Fixes:**

1.  When using the download buttons on the ALERTS, BLOCKED and SID MGT tabs, the downloaded files either have HTML appended to them (if downloading individual files) or when downloading a gzip archive it shows as corrupt on Windows.

2.  Redmine Bug #7555, translation data shown in breadcrumb link when no interfaces are defined for Snort and one of the interface settings tabs is selected.
