### PR TITLE
Suricata redis support

### DIFF
--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -340,8 +340,8 @@ if ($suricatacfg['enable_eve_log'] == 'on')
 else
 	$enable_eve_log = "no";
 
-if ($suricatacfg['eve_output_type'] == 'syslog')
-	$eve_output_type = "syslog";
+if (!empty($suricatacfg['eve_output_type']))
+	$eve_output_type = $suricatacfg['eve_output_type'];
 else
 	$eve_output_type = "file";
 
@@ -354,6 +354,23 @@ if (!empty($suricatacfg['eve_systemlog_priority']))
 	$eve_systemlog_priority = $suricatacfg['eve_systemlog_priority'];
 else
 	$eve_systemlog_priority = "info";
+
+// EVE REDIS output settings
+if (!empty($suricatacfg['eve_redis_server']))
+	$eve_redis_output = "\n        server: ". $suricatacfg['eve_redis_server'];
+else
+	$eve_redis_output = "\n        server: 127.0.0.1";
+
+if (!empty($suricatacfg['eve_redis_port']))
+	$eve_redis_output .= "\n        port: " . $suricatacfg['eve_redis_port'];
+
+if (!empty($suricatacfg['eve_redis_mode']))
+	$eve_redis_output .= "\n        mode: " . $suricatacfg['eve_redis_mode'];
+
+if (!empty($suricatacfg['eve_redis_key']))
+	$eve_redis_output .= "\n        key: \"" . $suricatacfg['eve_redis_key'] ."\"";
+
+
 
 // EVE log output included information
 $eve_out_types = "";

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -121,6 +121,7 @@ outputs:
   - eve-log:
       enabled: {$enable_eve_log}
       type: {$eve_output_type}
+      redis: {$eve_redis_output}
       filename: eve.json
       identity: "suricata"
       facility: {$eve_systemlog_facility}

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -265,6 +265,15 @@ if (isset($_POST["save"]) && !$input_errors) {
 	if (!empty($_POST['inspect_recursion_limit']) && !is_numeric($_POST['inspect_recursion_limit']))
 		$input_errors[] = gettext("The value for Inspect Recursion Limit can either be blank or contain only digits evaluating to an integer greater than or equal to 0.");
 
+	if (!empty($_POST['eve_redis_server']) && !is_ipaddr($_POST['eve_redis_server']))
+		$input_errors[] = gettext("The value for 'EVE REDIS Server' must be an IP address.");
+
+	if (!empty($_POST['eve_redis_port']) && !is_port($_POST['eve_redis_port']))
+		$input_errors[] = gettext("The value for 'EVE REDIS Server' must have a valid TCP port.");
+
+	if (!empty($_POST['eve_redis_key']) && !preg_match('/^[A-Za-z0-9]+$/',$_POST['eve_redis_key']))
+		$input_errors[] = gettext("The value for 'EVE REDIS Key' must be alphanumeric.");
+
 	// if no errors write to suricata.yaml
 	if (!$input_errors) {
 		$natent = $a_rule[$id];
@@ -772,7 +781,7 @@ $section->addInput(new Form_Select(
 
 $section->addInput(new Form_Input(
 	'eve_redis_key',
-	'Key',
+	'EVE REDIS Key',
 	'text',
 	$pconfig['eve_redis_key']
 ))->setHelp('Enter the REDIS Key');


### PR DESCRIPTION
Enabling EVE redis output support for suricata. The additional overhead, due to the needed "hiredis" library , is quite small.
Why?
This provides an elegant way to ship eve output towards an ELK stack using redis as a buffer. This method even supports large events which can't be transported trough syslog. For example alerts with packet dump.

Note that the RLIST mode which can be selected in the Webgui is not officially supported yet.
I've just introduced this option to suricata. A PR for it is pending [here](https://github.com/inliniac/suricata/pull/2724).