### PR TITLE
Bugfix for Bug #7278 Suricata Service - Advanced Configuration Pass-Through not working

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	3.2.1
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -844,4 +844,6 @@ pcap:
 EOD;
 }
 
+$suricata_config_pass_thru = base64_decode($suricatacfg['configpassthru']);
+
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -356,6 +356,9 @@ libhtp:
 coredump:
   max-dump: unlimited
 
+# Suricata user pass through configuration
+{$suricata_config_pass_thru}
+
 EOD;
 
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1054,7 +1054,7 @@ $section = new Form_Section('Arguments here will be automatically inserted into 
 $section->addInput(new Form_Textarea (
 	'configpassthru',
 	'Advanced Configuration Pass-Through',
-	$pconfig['configpassthru']
+	($_POST['configpassthru']?$_POST['configpassthru']:$pconfig['configpassthru'])
 ))->setHelp('Enter any additional configuration parameters to add to the Suricata configuration here, separated by a newline');
 
 $form->add($section);


### PR DESCRIPTION
This fixes the bug [7278 Suricata Service - Advanced Configuration Pass-Through not working](https://redmine.pfsense.org/issues/7278)

Also fixing a form render error: After saving the "Advanced Configuration Pass-Through" is showing base64 encoded text.