### PR TITLE
shellcmd, dont write the config when no changes where made, it pollutes the config backups

### DIFF
--- a/sysutils/pfSense-pkg-Shellcmd/Makefile
+++ b/sysutils/pfSense-pkg-Shellcmd/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-Shellcmd
 PORTVERSION=	1.0.2
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-Shellcmd/files/usr/local/pkg/shellcmd.inc
+++ b/sysutils/pfSense-pkg-Shellcmd/files/usr/local/pkg/shellcmd.inc
@@ -143,16 +143,19 @@ function shellcmd_sync_package() {
 			$i++;
 		}
 	}
-
-	/* Write the new system configuration to config.xml from scratch when done */
-	unset($config['system']['shellcmd']);
-	$config['system']['shellcmd'] = $a_shellcmd;
-	unset($config['system']['earlyshellcmd']);
-	$config['system']['earlyshellcmd'] = $a_earlyshellcmd;
-	unset($config['system']['afterfilterchangeshellcmd']);
-	$config['system']['afterfilterchangeshellcmd'] = $afterfilterchangeshellcmd;
-	write_config("[shellcmd] Successfully (re)synced shellcmd configuration.");
-
+	if (($config['system']['shellcmd'] != $a_shellcmd) ||
+		($config['system']['earlyshellcmd'] != $a_earlyshellcmd) ||
+		($config['system']['afterfilterchangeshellcmd'] != $afterfilterchangeshellcmd)) {
+		/* Write the new system configuration to config.xml from scratch when done 
+		   but only if something changed */
+		unset($config['system']['shellcmd']);
+		$config['system']['shellcmd'] = $a_shellcmd;
+		unset($config['system']['earlyshellcmd']);
+		$config['system']['earlyshellcmd'] = $a_earlyshellcmd;
+		unset($config['system']['afterfilterchangeshellcmd']);
+		$config['system']['afterfilterchangeshellcmd'] = $afterfilterchangeshellcmd;
+		write_config("[shellcmd] Successfully (re)synced shellcmd configuration.");
+	}
 }
 
 

--- a/sysutils/pfSense-pkg-Shellcmd/files/usr/local/pkg/shellcmd.inc
+++ b/sysutils/pfSense-pkg-Shellcmd/files/usr/local/pkg/shellcmd.inc
@@ -144,8 +144,8 @@ function shellcmd_sync_package() {
 		}
 	}
 	if (($config['system']['shellcmd'] != $a_shellcmd) ||
-		($config['system']['earlyshellcmd'] != $a_earlyshellcmd) ||
-		($config['system']['afterfilterchangeshellcmd'] != $afterfilterchangeshellcmd)) {
+	    ($config['system']['earlyshellcmd'] != $a_earlyshellcmd) ||
+	    ($config['system']['afterfilterchangeshellcmd'] != $afterfilterchangeshellcmd)) {
 		/* Write the new system configuration to config.xml from scratch when done 
 		   but only if something changed */
 		unset($config['system']['shellcmd']);


### PR DESCRIPTION
shellcmd, dont write the config when no changes where made, it pollutes the config backups