### PR TITLE
NRPE: Allowing user to define custom shell commands

### DIFF
--- a/net-mgmt/pfSense-pkg-nrpe/Makefile
+++ b/net-mgmt/pfSense-pkg-nrpe/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-nrpe
-PORTVERSION=	2.3.1
+PORTVERSION=	2.3.2
 PORTREVISION=	2
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty

--- a/net-mgmt/pfSense-pkg-nrpe/files/usr/local/pkg/nrpe2.inc
+++ b/net-mgmt/pfSense-pkg-nrpe/files/usr/local/pkg/nrpe2.inc
@@ -208,7 +208,7 @@ function nrpe2_custom_php_service() {
 function nrpe2_get_commands() {
 	$nagios_check_path = NRPE_BASE . "/libexec/nagios";
 	$commands = glob("{$nagios_check_path}/check_*");
-	$cmdarr = array();
+	$cmdarr = array(array("command" => "/bin/tcsh -c "));
 	foreach ($commands as $cmd) {
 		$cmdarr[]["command"] = basename($cmd);
 	}
@@ -230,5 +230,3 @@ function nrpe2_custom_php_validation_command($post, &$input_errors) {
 		}
 	}
 }
-
-?>

--- a/net-mgmt/pfSense-pkg-nrpe/files/usr/local/pkg/nrpe2.inc
+++ b/net-mgmt/pfSense-pkg-nrpe/files/usr/local/pkg/nrpe2.inc
@@ -156,11 +156,10 @@ function nrpe2_custom_php_write_config() {
 		$ccmd = !empty($cmd['critical']) ? "-c {$cmd['critical']}" : "";
 
 		$path_to_command = "{$nagios_check_path}/{$cmd['command']}";
-		$is_custom_shell_command = ($cmd['command'] === 'Custom shell command');
 		if (is_executable($path_to_command)) {
 			$cmds[] = "command[{$cmd['name']}]={$sudo}{$path_to_command} {$wcmd} {$ccmd} {$cmd['extra']}\n";
 		}
-		else if ($is_custom_shell_command) {
+		else if ($cmd['command'] === 'Custom shell command') {
 			$cmds[] = "command[{$cmd['name']}]={$sudo}{$cmd['extra']}\n";
 		}
 	}

--- a/net-mgmt/pfSense-pkg-nrpe/files/usr/local/pkg/nrpe2.inc
+++ b/net-mgmt/pfSense-pkg-nrpe/files/usr/local/pkg/nrpe2.inc
@@ -154,8 +154,14 @@ function nrpe2_custom_php_write_config() {
 		$sudo = (isset($cmd['sudo']) && is_executable($sudo_bin)) ? "{$sudo_bin} " : "";
 		$wcmd = !empty($cmd['warning']) ? "-w {$cmd['warning']}" : "";
 		$ccmd = !empty($cmd['critical']) ? "-c {$cmd['critical']}" : "";
-		if (is_executable("{$nagios_check_path}/{$cmd['command']}")) {
-			$cmds[] = "command[{$cmd['name']}]={$sudo}{$nagios_check_path}/{$cmd['command']} {$wcmd} {$ccmd} {$cmd['extra']}\n";
+
+		$path_to_command = "{$nagios_check_path}/{$cmd['command']}";
+		$is_absolute_path_command = (strpos($cmd['command'], '/') === 0); 
+		if ($is_absolute_path_command) {
+			$path_to_command = $cmd['command'];
+		}
+		if (is_executable($path_to_command) || $is_absolute_path_command) {
+			$cmds[] = "command[{$cmd['name']}]={$sudo}{$path_to_command} {$wcmd} {$ccmd} {$cmd['extra']}\n";
 		}
 	}
 	$commands = implode($cmds);
@@ -208,7 +214,9 @@ function nrpe2_custom_php_service() {
 function nrpe2_get_commands() {
 	$nagios_check_path = NRPE_BASE . "/libexec/nagios";
 	$commands = glob("{$nagios_check_path}/check_*");
-	$cmdarr = array(array("command" => "/bin/tcsh -c "));
+	$cmdarr = array(
+		array("command" => '/bin/tcsh -c')
+	);
 	foreach ($commands as $cmd) {
 		$cmdarr[]["command"] = basename($cmd);
 	}
@@ -230,3 +238,5 @@ function nrpe2_custom_php_validation_command($post, &$input_errors) {
 		}
 	}
 }
+
+?>

--- a/net-mgmt/pfSense-pkg-nrpe/files/usr/local/pkg/nrpe2.inc
+++ b/net-mgmt/pfSense-pkg-nrpe/files/usr/local/pkg/nrpe2.inc
@@ -157,11 +157,11 @@ function nrpe2_custom_php_write_config() {
 
 		$path_to_command = "{$nagios_check_path}/{$cmd['command']}";
 		$is_custom_shell_command = ($cmd['command'] === 'Custom shell command');
-		if ($is_custom_shell_command) {
-			$path_to_command = '';
-		}
-		if (is_executable($path_to_command) || $is_custom_shell_command) {
+		if (is_executable($path_to_command)) {
 			$cmds[] = "command[{$cmd['name']}]={$sudo}{$path_to_command} {$wcmd} {$ccmd} {$cmd['extra']}\n";
+		}
+		else if ($is_custom_shell_command) {
+			$cmds[] = "command[{$cmd['name']}]={$sudo}{$cmd['extra']}\n";
 		}
 	}
 	$commands = implode($cmds);

--- a/net-mgmt/pfSense-pkg-nrpe/files/usr/local/pkg/nrpe2.inc
+++ b/net-mgmt/pfSense-pkg-nrpe/files/usr/local/pkg/nrpe2.inc
@@ -156,11 +156,11 @@ function nrpe2_custom_php_write_config() {
 		$ccmd = !empty($cmd['critical']) ? "-c {$cmd['critical']}" : "";
 
 		$path_to_command = "{$nagios_check_path}/{$cmd['command']}";
-		$is_absolute_path_command = (strpos($cmd['command'], '/') === 0); 
-		if ($is_absolute_path_command) {
-			$path_to_command = $cmd['command'];
+		$is_custom_shell_command = ($cmd['command'] === 'Custom shell command');
+		if ($is_custom_shell_command) {
+			$path_to_command = '';
 		}
-		if (is_executable($path_to_command) || $is_absolute_path_command) {
+		if (is_executable($path_to_command) || $is_custom_shell_command) {
 			$cmds[] = "command[{$cmd['name']}]={$sudo}{$path_to_command} {$wcmd} {$ccmd} {$cmd['extra']}\n";
 		}
 	}
@@ -215,7 +215,7 @@ function nrpe2_get_commands() {
 	$nagios_check_path = NRPE_BASE . "/libexec/nagios";
 	$commands = glob("{$nagios_check_path}/check_*");
 	$cmdarr = array(
-		array("command" => '/bin/tcsh -c')
+		array("command" => 'Custom shell command')
 	);
 	foreach ($commands as $cmd) {
 		$cmdarr[]["command"] = basename($cmd);


### PR DESCRIPTION
Hello,

Currently there's no way of easily extending the monitoring within PFSense, if it's not exposed by an existing check_* or via SNMP it's very difficult to be able to check from external monitoring like Nagios. 

If the user has the ability to inject a shell command that gets dropped into the nrpe.conf then you can define new checks pretty easily by adding commands like  `/bin/tcsh -c 'grep ok /path/to/the/statefile/here && exit 0'` into the GUI. It's not exactly the easiest thing for people to do, but it does at least add a seam for extension.

Feedback welcome!

Thanks,
Rob