### PR TITLE
Only check custom networks CIDRs validity when actually using the cus…

### DIFF
--- a/net/pfSense-pkg-ntopng/Makefile
+++ b/net/pfSense-pkg-ntopng/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-ntopng
-PORTVERSION=	0.8.9
+PORTVERSION=	0.8.10
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-ntopng/files/usr/local/pkg/ntopng.inc
+++ b/net/pfSense-pkg-ntopng/files/usr/local/pkg/ntopng.inc
@@ -334,11 +334,13 @@ function ntopng_validate_input($post, &$input_errors) {
 	if ($post['redis_password'] != $post['redis_passwordagain']) {
 		$input_errors[] = "The provided passwords did not match.";
 	}
-	$idx = 0;
-	while (isset($_POST["cidr{$idx}"])) {
-		$cidr = $_POST["cidr" . $idx++];
-		if (!is_subnet($cidr)) {
-			$input_errors[] = "Invalid CIDR in custom local networks list at position {$idx}.";
+	if($_POST["local_networks"] == "custom") {
+		$idx = 0;
+		while (isset($_POST["cidr{$idx}"])) {
+			$cidr = $_POST["cidr" . $idx++];
+			if (!is_subnet($cidr)) {
+				$input_errors[] = "Invalid CIDR in custom local networks list at position {$idx}.";
+			}
 		}
 	}
 	if ($post['Submit'] == "Update GeoIP Data") {


### PR DESCRIPTION
…tom list mode.

My commit fc2f34fb39 contains a mistake, it always checks the CIDR address list, even if it is not actually  using it, causing an empty field to be refused.

This commit addresses this issue. Sorry for my mistake.

Can this fix be "fast tracked"?

Thanks!