### PR TITLE
Bug 7616 - Barnyard2 webui configuration updates result in ****** written to the config for the password

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-snort
-PORTVERSION=	3.2.9.3
+PORTVERSION=	3.2.9.4
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_barnyard.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_barnyard.php
@@ -178,7 +178,14 @@ if ($_POST['save']) {
 		if ($_POST['barnyard_dbhost']) $natent['barnyard_dbhost'] = $_POST['barnyard_dbhost']; else unset($natent['barnyard_dbhost']);
 		if ($_POST['barnyard_dbname']) $natent['barnyard_dbname'] = $_POST['barnyard_dbname']; else unset($natent['barnyard_dbname']);
 		if ($_POST['barnyard_dbuser']) $natent['barnyard_dbuser'] = $_POST['barnyard_dbuser']; else unset($natent['barnyard_dbuser']);
-		if ($_POST['barnyard_dbpwd']) $natent['barnyard_dbpwd'] = base64_encode($_POST['barnyard_dbpwd']); else unset($natent['barnyard_dbpwd']);
+
+		// The password field will return '********' if no changes are made and needs to be escaped.
+        if ($_POST['barnyard_dbpwd'] && ($_POST['barnyard_dbpwd'] != DMYPWD)) $natent['barnyard_dbpwd'] = base64_encode($_POST['barnyard_dbpwd']);
+        else
+			// Because of the base64 encoding/decoding, in the case of a valid value that hasn't changed, it needs to be re-encoded to base64.
+            if ($_POST['barnyard_dbpwd'] != DMYPWD) unset($natent['barnyard_dbpwd']);
+            else $natent['barnyard_dbpwd'] = base64_encode($natent['barnyard_dbpwd']);
+		
 		if ($_POST['barnyard_syslog_rhost']) $natent['barnyard_syslog_rhost'] = $_POST['barnyard_syslog_rhost']; else unset($natent['barnyard_syslog_rhost']);
 		if ($_POST['barnyard_syslog_dport']) $natent['barnyard_syslog_dport'] = $_POST['barnyard_syslog_dport']; else $natent['barnyard_syslog_dport'] = '514';
 		if ($_POST['barnyard_syslog_facility']) $natent['barnyard_syslog_facility'] = $_POST['barnyard_syslog_facility']; else $natent['barnyard_syslog_facility'] = 'LOG_USER';

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_barnyard.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_barnyard.php
@@ -180,11 +180,9 @@ if ($_POST['save']) {
 		if ($_POST['barnyard_dbuser']) $natent['barnyard_dbuser'] = $_POST['barnyard_dbuser']; else unset($natent['barnyard_dbuser']);
 
 		// The password field will return '********' if no changes are made and needs to be escaped.
-        if ($_POST['barnyard_dbpwd'] && ($_POST['barnyard_dbpwd'] != DMYPWD)) $natent['barnyard_dbpwd'] = base64_encode($_POST['barnyard_dbpwd']);
-        else
-			// Because of the base64 encoding/decoding, in the case of a valid value that hasn't changed, it needs to be re-encoded to base64.
-            if ($_POST['barnyard_dbpwd'] != DMYPWD) unset($natent['barnyard_dbpwd']);
-            else $natent['barnyard_dbpwd'] = base64_encode($natent['barnyard_dbpwd']);
+		// Because of the base64 encoding/decoding, in the case of a valid value that hasn't changed, it will need to be re-encoded to base64.
+		if ($_POST['barnyard_dbpwd'] && ($_POST['barnyard_dbpwd'] != DMYPWD)) $natent['barnyard_dbpwd'] = base64_encode($_POST['barnyard_dbpwd']); else 
+			if ($_POST['barnyard_dbpwd'] != DMYPWD) unset($natent['barnyard_dbpwd']); else $natent['barnyard_dbpwd'] = base64_encode($natent['barnyard_dbpwd']); 
 		
 		if ($_POST['barnyard_syslog_rhost']) $natent['barnyard_syslog_rhost'] = $_POST['barnyard_syslog_rhost']; else unset($natent['barnyard_syslog_rhost']);
 		if ($_POST['barnyard_syslog_dport']) $natent['barnyard_syslog_dport'] = $_POST['barnyard_syslog_dport']; else $natent['barnyard_syslog_dport'] = '514';


### PR DESCRIPTION
The logic of the password input type will send a hardcoded '********' post value when the value has not been edited which was not handled. The changes are to escape when the DMYPWD constant is being passed in. Another aspect of this is that when the value has not changed, it needs to be re-encoded to base64 since it was decrypted during page load.

This is to address [Bug-7616](https://redmine.pfsense.org/issues/7616).
