### PR TITLE
pfSense-pkg-LCDproc: add a shutdown/reboot control menu

### DIFF
--- a/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc_client.php
+++ b/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc_client.php
@@ -25,6 +25,7 @@ require_once("config.inc");
 require_once("functions.inc");
 require_once("interfaces.inc");
 require_once("/usr/local/pkg/lcdproc.inc");
+require_once("system.inc");
 
 function get_pfstate() {
 	global $config;
@@ -411,11 +412,7 @@ function send_lcd_commands($lcd, $lcd_cmds) {
 		lcdproc_warn("Failed to interpret lcd commands");
 		return;
 	}
-	while (($cmd_output = fgets($lcd, 8000)) !== false) {
-		if (preg_match("/^huh?/", $cmd_output)) {
-			lcdproc_notice("LCDd output: \"$cmd_output\". Executed \"$lcd_cmd\"");
-		}
-	}
+	get_lcd_messages($lcd);
 	foreach ($lcd_cmds as $lcd_cmd) {
 		if (! fwrite($lcd, "$lcd_cmd\n")) {
 			lcdproc_warn("Connection to LCDd process lost $errstr ($errno)");
@@ -424,6 +421,24 @@ function send_lcd_commands($lcd, $lcd_cmds) {
 		}
 	}
 	return true;
+}
+
+function get_lcd_messages($lcd) {
+	while (($cmd_output = fgets($lcd, 8000)) !== false) {
+		if (preg_match("/^huh?/", $cmd_output)) {
+			lcdproc_notice("LCDd output: \"$cmd_output\". Executed \"$lcd_cmd\"");
+		}
+		if (cmenu_enabled()) {
+			if (preg_match("/^menuevent select r_ask_yes/", $cmd_output)) {
+				lcdproc_notice("init REBOOT!");
+				system_reboot();
+			}
+			if (preg_match("/^menuevent select s_ask_yes/", $cmd_output)) {
+				lcdproc_notice("init SHUTDOWN!");
+				system_halt();
+			}
+		}
+	}
 }
 
 function get_lcdpanel_width() {
@@ -474,6 +489,15 @@ function outputled_enabled_CFontz633() {
 			return false;
 		}
 	}
+}
+
+function cmenu_enabled() {
+	global $config;
+	$lcdproc_config = $config['installedpackages']['lcdproc']['config'][0];
+	$value = $lcdproc_config['controlmenu'];
+	if (is_null($value))
+		return false;
+	return true;
 }
 
 function outputled_carp() {
@@ -868,6 +892,17 @@ function build_interface($lcd) {
 	$lcd_cmds = array();
 	$lcd_cmds[] = "hello";
 	$lcd_cmds[] = "client_set name pfSense";
+
+	/* setup pfsense control menu */
+	if (cmenu_enabled()) {
+		$lcd_cmds[] = 'menu_add_item "" reboot_menu menu "Reboot"';
+		$lcd_cmds[] = 'menu_add_item "reboot_menu" r_ask_no action "No" -next _close_';
+		$lcd_cmds[] = 'menu_add_item "reboot_menu" r_ask_yes action "Yes" -next _quit_';
+
+		$lcd_cmds[] = 'menu_add_item "" shutdown_menu menu "Shutdown"';
+		$lcd_cmds[] = 'menu_add_item "shutdown_menu" s_ask_no action "No" -next _close_';
+		$lcd_cmds[] = 'menu_add_item "shutdown_menu" s_ask_yes action "Yes" -next _quit_';
+	}
 
 	/* process screens to display */
 	if (is_array($lcdproc_screens_config)) {

--- a/sysutils/pfSense-pkg-LCDproc/files/usr/local/www/packages/lcdproc/lcdproc.php
+++ b/sysutils/pfSense-pkg-LCDproc/files/usr/local/www/packages/lcdproc/lcdproc.php
@@ -41,6 +41,7 @@ if (!isset($pconfig['offbrightness']))               $pconfig['offbrightness']  
 if (!isset($pconfig['contrast']))                    $pconfig['contrast']                    = '-1';
 if (!isset($pconfig['backlight']))                   $pconfig['backlight']                   = 'default';
 if (!isset($pconfig['outputleds']))                  $pconfig['outputleds']                  = 'no';
+if (!isset($pconfig['controlmenu']))                 $pconfig['controlmenu']                 = 'no';
 if (!isset($pconfig['mtxorb_type']))                 $pconfig['mtxorb_type']                 = 'lcd'; // specific to Matrix Orbital driver
 if (!isset($pconfig['mtxorb_adjustable_backlight'])) $pconfig['mtxorb_adjustable_backlight'] = true;  // specific to Matrix Orbital driver
 
@@ -66,6 +67,7 @@ if ($_POST) {
 		$lcdproc_config['contrast']                    = $pconfig['contrast'];
 		$lcdproc_config['backlight']                   = $pconfig['backlight'];
 		$lcdproc_config['outputleds']                  = $pconfig['outputleds'];
+		$lcdproc_config['controlmenu']                 = $pconfig['controlmenu'];
 		$lcdproc_config['mtxorb_type']                 = $pconfig['mtxorb_type'];
 		$lcdproc_config['mtxorb_adjustable_backlight'] = $pconfig['mtxorb_adjustable_backlight'];
 				
@@ -334,6 +336,17 @@ $section->addInput(
 	'LED4: Gateway status (green: ok, red: at least one gateway not responding, off: no gateway configured).'
 );
 
+$section->addInput(
+	new Form_Checkbox(
+		'controlmenu', // checkbox name (id)
+		'pfSense control menu', // checkbox label
+		'Enable the pfSense control menu next to LCDproc\'s Options menu.', // checkbox text
+		$pconfig['controlmenu'] // checkbox initial value
+	)
+)->setHelp(
+	'This will only be usefull on display with buttons.<br />' .
+	'Currently you can REBOOT and HALT the system from there.'
+);
 
 $section->addInput(
 	new Form_Select(


### PR DESCRIPTION
add a control menu with the name 'pfsense' next to the 'Options' menu of LCDproc.
Currently there are only two options implemented: Reboot and shutdown, but I think more usefull direct accessible features could be made avalable (i.e. switch wlan on/off for example)
Current structure:
```
Options (original LCDproc)
pfsense
  ->Reboot
    ->No
    ->Yes
  ->Shutdown
    ->No
    ->Yes
```