### PR TITLE
pfSense-pkg-LCDproc: Add a link status screen for each interface

### DIFF
--- a/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc_client.php
+++ b/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc_client.php
@@ -550,7 +550,6 @@ function build_interface_link_list() {
 			$entry['status'] = "down";
 		}
 
-
 		if ($ifinfo['pppoelink'] == "up" ||
 		    $ifinfo['pptplink']  == "up" ||
 		    $ifinfo['l2tplink']  == "up") {

--- a/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc_client.php
+++ b/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc_client.php
@@ -533,7 +533,7 @@ function build_interface_link_list() {
 	$result = array();
 	$ifList = get_configured_interface_with_descr();
 
-	foreach($ifList as $ifdescr => $ifname) {	
+	foreach($ifList as $ifdescr => $ifname) {
 
 		// get the interface link infos
 		$ifinfo = get_interface_info($ifdescr);
@@ -541,7 +541,7 @@ function build_interface_link_list() {
 		$entry = array();
 		$entry['name'] = $ifname;
 		$entry['mac'] = $ifinfo['macaddr'];
-	
+
 		if ($ifinfo['status'] == "up" ||
 		    $ifinfo['status'] == "associated") {
 

--- a/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc_client.php
+++ b/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc_client.php
@@ -525,6 +525,52 @@ function outputled_gateway() {
 	return 1;
 }
 
+function build_interface_link_list() {
+	// Returns a dictionary of all the interfaces along with their
+	// link and address information, keyed on the interface description.
+	global $config;
+
+	$result = array();
+	$ifList = get_configured_interface_with_descr();
+
+	foreach($ifList as $ifdescr => $ifname) {	
+
+		// get the interface link infos
+		$ifinfo = get_interface_info($ifdescr);
+
+		$entry = array();
+		$entry['name'] = $ifname;
+		$entry['mac'] = $ifinfo['macaddr'];
+	
+		if ($ifinfo['status'] == "up" ||
+		    $ifinfo['status'] == "associated") {
+
+			$entry['status'] = "up";
+		} else {
+			$entry['status'] = "down";
+		}
+
+
+		if ($ifinfo['pppoelink'] == "up" ||
+		    $ifinfo['pptplink']  == "up" ||
+		    $ifinfo['l2tplink']  == "up") {
+
+			$entry['link'] = sprintf(gettext("Uptime %s"), $ifinfo['ppp_uptime']);
+		} else {
+			$entry['link'] = $ifinfo['media'];
+		}
+
+		$entry['v4addr'] = (empty($ifinfo['ipaddr'])) ?
+			"n/a" : $ifinfo['ipaddr'];
+
+		$entry['v6addr'] = (empty($ifinfo['ipaddrv6'])) ?
+			"n/a" : $ifinfo['ipaddrv6'];
+
+		$result[$ifdescr] = $entry;
+	}
+	return $result;
+}
+
 function build_interface_traffic_stats_list() {
 	// Returns a dictionary of all the interfaces along with their in/out
 	// traffic stats, keyed on the interface name.
@@ -1026,6 +1072,30 @@ function build_interface($lcd) {
 						}
 						$includeSummary = false; // this screen needs all the lines
 						break;
+					case "scr_interfaces_link":
+						$ifLinkList = build_interface_link_list();
+						foreach ($ifLinkList as $ifdescr => $iflink) {
+							$s_name = $name . $ifdescr;
+							$ifname = $iflink['name'] . ":";
+							$lcd_cmds[] = "screen_add $s_name";
+							$lcd_cmds[] = "screen_set $s_name heartbeat off";
+							$lcd_cmds[] = "screen_set $s_name name \"$name.$ifdescr\"";
+							$lcd_cmds[] = "screen_set $s_name duration $refresh_frequency";
+							$lcd_cmds[] = "widget_add $s_name ifname_wdgt string";
+							$lcd_cmds[] = "widget_set $s_name ifname_wdgt 1 1 \"$ifname\"";
+							$lcd_cmds[] = "widget_add $s_name link_wdgt scroller";
+							$lcd_cmds[] = "widget_add $s_name v4l_wdgt string";
+							$lcd_cmds[] = "widget_set $s_name v4l_wdgt 1 2 \"v4:\"";
+							$lcd_cmds[] = "widget_add $s_name v4a_wdgt scroller";
+							$lcd_cmds[] = "widget_add $s_name v6l_wdgt string";
+							$lcd_cmds[] = "widget_set $s_name v6l_wdgt 1 3 \"v6:\"";
+							$lcd_cmds[] = "widget_add $s_name v6a_wdgt scroller";
+							$lcd_cmds[] = "widget_add $s_name macl_wdgt string";
+							$lcd_cmds[] = "widget_set $s_name macl_wdgt 1 4 \"m:\"";
+							$lcd_cmds[] = "widget_add $s_name maca_wdgt scroller";
+							$includeSummary = false; // this screen needs all the lines
+						}
+						break;
 					case "scr_traffic_by_address":
 						$lcd_cmds[] = "screen_add $name";
 						$lcd_cmds[] = "screen_set $name heartbeat off";
@@ -1083,6 +1153,7 @@ function loop_status($lcd) {
 
 		$lcd_cmds = array();
 		$interfaceTrafficList = null;
+		$ifLinkList = null;
 
 		/* initializes the widget counter */
 		$widget_counter = 0;
@@ -1241,6 +1312,37 @@ function loop_status($lcd) {
 					for($i = 0; $i < ($lcdpanel_height - 1) && i < count($interfaceTrafficStrings); $i++) {
 
 						$lcd_cmds[] = "widget_set $name text_wdgt{$i} 1 " . ($i + 2) . " \"{$interfaceTrafficStrings[$i]}\"";
+					}
+					$updateSummary = false;
+					break;
+				case "scr_interfaces_link":
+					// We only want build_interface_link_list() to be
+					// called once per loop, and only if it's needed
+					if ($interfaceLinkList == null)
+						$ifLinkList = build_interface_link_list();
+
+					foreach ($ifLinkList as $ifdescr => $iflink) {
+						$s_name = $name . $ifdescr;
+						$ifname = $iflink['name'] . ":";
+						$l_str = ($iflink['status'] == "down") ? "down" : $iflink['link'];
+
+						$lcd_cmds[] = "widget_set $s_name ifname_wdgt 1 1 \"$ifname\"";
+
+						$lcd_cmds[] = "widget_set $s_name link_wdgt " .
+							(strlen($iflink['name']) + 3) . " 1 " .
+							$lcdpanel_width . " 1 h 4 \"" . $l_str . "\"";
+
+						$lcd_cmds[] = "widget_set $s_name v4a_wdgt 5 2 " .
+							$lcdpanel_width . " 2 h 4 \"" .
+							$iflink['v4addr'] . "\"";
+
+						$lcd_cmds[] = "widget_set $s_name v6a_wdgt 5 3 " .
+							$lcdpanel_width . " 3 h 4 \"" .
+							$iflink['v6addr'] . "\"";
+
+						$lcd_cmds[] = "widget_set $s_name maca_wdgt 4 4 " .
+							$lcdpanel_width . " 4 h 4 \"" .
+							$iflink['mac'] . "\"";
 					}
 					$updateSummary = false;
 					break;

--- a/sysutils/pfSense-pkg-LCDproc/files/usr/local/www/packages/lcdproc/lcdproc_screens.php
+++ b/sysutils/pfSense-pkg-LCDproc/files/usr/local/www/packages/lcdproc/lcdproc_screens.php
@@ -47,6 +47,7 @@ if (!isset($pconfig['scr_traffic_interface']))               $pconfig['scr_traff
 if (!isset($pconfig['scr_top_interfaces_by_bps']))           $pconfig['scr_top_interfaces_by_bps']           = false;
 if (!isset($pconfig['scr_top_interfaces_by_total_bytes']))   $pconfig['scr_top_interfaces_by_total_bytes']   = false;
 if (!isset($pconfig['scr_top_interfaces_by_bytes_today']))   $pconfig['scr_top_interfaces_by_bytes_today']   = false;
+if (!isset($pconfig['scr_interfaces_link']))                 $pconfig['scr_interfaces_link']                 = false;
 if (!isset($pconfig['scr_traffic_by_address']))              $pconfig['scr_traffic_by_address']              = false;
 if (!isset($pconfig['scr_traffic_by_address_if']))           $pconfig['scr_traffic_by_address_if']           = '';
 if (!isset($pconfig['scr_traffic_by_address_sort']))         $pconfig['scr_traffic_by_address_sort']         = 'in';
@@ -82,6 +83,7 @@ if ($_POST) {
 		$lcdproc_screens_config['scr_top_interfaces_by_bps']           = $pconfig['scr_top_interfaces_by_bps'];
 		$lcdproc_screens_config['scr_top_interfaces_by_total_bytes']   = $pconfig['scr_top_interfaces_by_total_bytes'];
 		$lcdproc_screens_config['scr_top_interfaces_by_bytes_today']   = $pconfig['scr_top_interfaces_by_bytes_today'];
+		$lcdproc_screens_config['scr_interfaces_link']                 = $pconfig['scr_interfaces_link'];
 		$lcdproc_screens_config['scr_traffic_by_address']              = $pconfig['scr_traffic_by_address'];
 		$lcdproc_screens_config['scr_traffic_by_address_if']           = $pconfig['scr_traffic_by_address_if'];
 		$lcdproc_screens_config['scr_traffic_by_address_sort']         = $pconfig['scr_traffic_by_address_sort'];
@@ -271,6 +273,23 @@ $section->addInput(
 		$pconfig['scr_top_interfaces_by_bytes_today'] // checkbox initial value
 	)
 )->setHelp('A 4&hyphen;row 20&hyphen;column display size, or higher, is recommended for this screen.');
+
+
+$section->addInput(
+	new Form_Checkbox(
+		'scr_interfaces_link', // checkbox name (id)
+		'Interfaces link status', // checkbox label
+		'Display the interfaces current link status', // checkbox text
+		$pconfig['scr_interfaces_link'] // checkbox initial value
+	)
+)->setHelp(
+	'This will create a seperate status screen for each inferface with four lines each:<br />' .
+	'&lt;IFNAME&gt;: &lt;link status&gt;<br />' .
+	'v4: &lt;ip v4 address&gt;<br />' .
+	'v6: &lt;ip v6 address&gt;<br />' .
+	'm: &lt;mac address&gt;<br />' .
+	'A 4&hyphen;row 20&hyphen;column display size, or higher, is recommended for this screen.'
+);
 
 
 $group = new Form_Group('Addresses by traffic');


### PR DESCRIPTION
The link screen is similar to the 'Interfaces' dashboard widget, displaying ipv4, ipv6, mac and link status for each interface.