### PR TITLE
adding extended custom http eve.json fields

### DIFF
--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -375,10 +375,21 @@ if (($suricatacfg['eve_log_alerts'] == 'on') && ($suricatacfg['eve_log_alerts_pa
 
 if ($suricatacfg['eve_log_http'] == 'on') {
 	$eve_out_types .= "\n        - http:";
-	if ($suricatacfg['http_log_extended'] == 'on')
-		$eve_out_types .= "\n            extended: yes";
-	else
-		$eve_out_types .= "\n            extended: no";
+	if ($suricatacfg['http_log_extended'] == 'on') {
+                $eve_out_types .= "\n            extended: yes";
+                $eve_out_types .= "\n            custom: [accept, accept-charset, accept-encoding, accept-language,";
+                $eve_out_types .= "\n                    accept-datetime, authorization, cache-control, cookie, from,";
+                $eve_out_types .= "\n                    max-forwards, origin, pragma, proxy-authorization, range, te, via,";
+                $eve_out_types .= "\n                    x-requested-with, dnt, x-forwarded-proto, accept-range, age,";
+                $eve_out_types .= "\n                    allow, connection, content-encoding, content-language,";
+                $eve_out_types .= "\n                    content-length, content-location, content-md5, content-range,";
+                $eve_out_types .= "\n                    content-type, date, etags, last-modified, link, location,";
+                $eve_out_types .= "\n                    proxy-authenticate, referrer, refresh, retry-after, server,";
+                $eve_out_types .= "\n                    set-cookie, trailer, transfer-encoding, upgrade, vary, warning,";
+                $eve_out_types .= "\n                    www-authenticate, x-flash-version, x-authenticated-user]";
+         } else {
+                $eve_out_types .= "\n            extended: no";
+         }
 }
 
 if ($suricatacfg['eve_log_dns'] == 'on') {


### PR DESCRIPTION
why not adding this fields to the custom fields? maybe needs a suboption at the interface or could stay as it is to extend the http eve.json information as default.