### PR TITLE
Corrects SquidGuard sgerror.php page was allowing curl requests on TAG_BLANK_IMG.

### DIFF
--- a/www/pfSense-pkg-squidGuard/Makefile
+++ b/www/pfSense-pkg-squidGuard/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-squidGuard
-PORTVERSION=	1.16.2
+PORTVERSION=	1.16.3
 CATEGORIES=	www
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/www/pfSense-pkg-squidGuard/files/usr/local/www/sgerror.php
+++ b/www/pfSense-pkg-squidGuard/files/usr/local/www/sgerror.php
@@ -198,41 +198,6 @@ function get_about() {
 <?php
 }
 
-function filter_by_image_size($url, $val_size) {
-	// Load URL header
-	$ch = curl_init();
-	curl_setopt($ch, CURLOPT_URL, $url);
-	curl_setopt($ch, CURLOPT_HEADER, 1);
-	curl_setopt($ch, CURLOPT_NOBODY, 1);
-	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-	$hd = curl_exec($ch);
-	curl_close($ch);
-
-	$size = 0;
-	$SKEY = "content-length:";
-	$s_tmp = strtolower($hd);
-	$s_tmp = str_replace("\n", " ", $s_tmp); // replace all "\n"
-	if (strpos($s_tmp, $SKEY) !== false) {
-		$s_tmp = trim(substr($s_tmp, strpos($s_tmp, $SKEY) + strlen($SKEY)));
-		$s_tmp = trim(substr($s_tmp, 0, strpos($s_tmp, " ")));
-		if (is_numeric($s_tmp))
-			$size = intval($s_tmp);
-		else $size = 0;
-	}
-
-	/*
-	 * check url type and content size
-	 * redirect to specified url
-	 */
-	if (($size !== 0) && ($size < $val_size)) {
-		header("HTTP/1.0");
-		header("Location: $url", '', 302);
-	} else {
-		// Returna blank image
-		header("Content-Type: image/gif;");
-		echo GIF_BODY;
-	}
-}
 
 /* ----------------------------------------------------------------------------------------------------------------------
  * Check arguments
@@ -272,17 +237,9 @@ if ($url) {
 		// Output a blank page
 		echo get_page('');
 	} elseif ($url === TAG_BLANK_IMG) {
-		// Output a blank image
-		$msg = trim($msg);
-		if (strpos($msg, "maxlen_") !== false) {
-			$maxlen = intval(trim(str_replace("maxlen_", "", $url)));
-			filter_by_image_size($cl['u'], $maxlen);
-			exit();
-		} else {
-			// Return a blank image
-			header("Content-Type: image/gif;"); // charset=windows-1251");
-			echo GIF_BODY;
-		}
+		// Return a blank image
+		header("Content-Type: image/gif;"); // charset=windows-1251");
+		echo GIF_BODY;
 	} elseif ($err_id !== 0) {
 		// Output an error code
 		$er_msg = strstr($_GET['url'], ' ');


### PR DESCRIPTION
Removing code that was allowing to force the squidguard to make a curl HEAD request when squidguard sgerror.php page was requested to show a TAG_BLANK_IMG with 'u' parameter set to a target url and msg parameter containing 'maxlen_'