### PR TITLE
pfSense-pkg-suricata: Suricata eve flow patch

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	3.2.3
-PORTREVISION=   1
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	3.2.3
+PORTREVISION=   1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -445,6 +445,10 @@ if ($suricatacfg['eve_log_smtp'] == 'on') {
 	$eve_out_types .= "\n            md5: [subject]";
 }
 
+if ($suricatacfg['eve_log_flow'] == 'on') {
+	$eve_out_types .= "\n        - flow";
+}
+
 if ($suricatacfg['eve_log_drop'] == 'on' && $suricatacfg['ips_mode'] == "ips_mode_inline") {
 	$eve_out_types .= "\n        - drop:";
 	$eve_out_types .= "\n            alerts: yes";

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -289,6 +289,10 @@ foreach ($rule as &$r) {
 		$pconfig['eve_log_smtp'] = "on";
 		$updated_cfg = true;
 	}
+	if (!isset($pconfig['eve_log_flow'])) {
+		$pconfig['eve_log_flow'] = "off";
+		$updated_cfg = true;
+	}    
 	if (!isset($pconfig['eve_log_drop'])) {
 		$pconfig['eve_log_drop'] = "on";
 		$updated_cfg = true;

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -163,6 +163,8 @@ if (empty($pconfig['eve_log_ssh']))
 	$pconfig['eve_log_ssh'] = "on";
 if (empty($pconfig['eve_log_smtp']))
 	$pconfig['eve_log_smtp'] = "on";
+if (empty($pconfig['eve_log_flow']))
+	$pconfig['eve_log_flow'] = "off";
 if (empty($pconfig['eve_log_drop'])) {
 	$pconfig['eve_log_drop'] = "on";
 }
@@ -330,6 +332,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['eve_log_files'] == "on") { $natent['eve_log_files'] = 'on'; }else{ $natent['eve_log_files'] = 'off'; }
 		if ($_POST['eve_log_ssh'] == "on") { $natent['eve_log_ssh'] = 'on'; }else{ $natent['eve_log_ssh'] = 'off'; }
 		if ($_POST['eve_log_smtp'] == "on") { $natent['eve_log_smtp'] = 'on'; }else{ $natent['eve_log_smtp'] = 'off'; }
+		if ($_POST['eve_log_flow'] == "on") { $natent['eve_log_flow'] = 'on'; }else{ $natent['eve_log_flow'] = 'off'; }
 		if ($_POST['eve_log_drop'] == "on") { $natent['eve_log_drop'] = 'on'; }else{ $natent['eve_log_drop'] = 'off'; }
 		if ($_POST['delayed_detect'] == "on") { $natent['delayed_detect'] = 'on'; }else{ $natent['delayed_detect'] = 'off'; }
 		if ($_POST['intf_promisc_mode'] == "on") { $natent['intf_promisc_mode'] = 'on'; }else{ $natent['intf_promisc_mode'] = 'off'; }
@@ -853,6 +856,14 @@ $group->add(new Form_Checkbox(
 ));
 
 $group->add(new Form_Checkbox(
+	'eve_log_flow',
+	'Flows',
+	'Flows',
+	$pconfig['eve_log_flow'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
 	'eve_log_drop',
 	'Dropped Traffic',
 	'Dropped Traffic',
@@ -1280,6 +1291,7 @@ events.push(function(){
 		disableInput('eve_log_files', disable);
 		disableInput('eve_log_ssh', disable);
 		disableInput('eve_log_smtp', disable);
+		disableInput('eve_log_flow', disable);
 		disableInput('eve_log_drop', disable);
 	}
 


### PR DESCRIPTION
Suricata can (also) log flow info in EVE, which can be used when analysing with an ELK stack. This change enables this in the interface editor as well as creates the corresponding `YAML`. 

Since enabling this option potentially generates larg(er) log files, including packet capture, the option is disabled by default. 