### PR TITLE
pfSense-pkg-freeradius3: Allow 127.0.0.1 for interface selection

### DIFF
--- a/net/pfSense-pkg-freeradius3/Makefile
+++ b/net/pfSense-pkg-freeradius3/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-freeradius3
-PORTVERSION=	0.8
+PORTVERSION=	0.9
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-freeradius3/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius3/files/usr/local/pkg/freeradius.inc
@@ -4040,7 +4040,7 @@ function freeradius_validate_interfaces($post, &$input_errors) {
 		if ($post['varinterfaceipversion'] == 'ipv6addr' && !is_ipaddrv6($post['varinterfaceip'])) {
 			$input_errors[] = "The 'Interface IP Address' must contain a valid IPv6 address when IPv6 is selected under 'IP Version'.";
 		}
-		if (!is_ipaddr_configured($post['varinterfaceip'])) {
+		if (!is_ipaddr_configured($post['varinterfaceip']) && $post['varinterfaceip'] != "127.0.0.1") {
 			$input_errors[] = "The 'Interface IP Address' must contain a valid, locally configured IP address!";
 		}
 	}


### PR DESCRIPTION
The configuration of using the radius server and a single client on
the loopback device should be allowed.  This allows a secure
method for using OTP tokens on a single firewall.

Signed-off-by: Jason Wessel <jason@wesselworks.com>