### PR TITLE
pfSense-pkg-Telegraf: Fix Wrong Password Written to Telegraf Config File

### DIFF
--- a/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.xml
+++ b/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.xml
@@ -77,7 +77,6 @@
             <fieldname>influx_pass</fieldname>
             <type>password</type>
             <description>Database password if required by InfluxDB config</description>
-			<encoding>base64</encoding>
         </field>
     </fields>
     <custom_php_resync_config_command>


### PR DESCRIPTION
Resolves issue number 7696, where an incorrect influxdb database password is written to the telegraf config file.

https://redmine.pfsense.org/issues/7696