### PR TITLE
pfSense-pkg-suricata: Delete rotated `eve.json` log files

### DIFF
--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -81,6 +81,9 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 			log_error(gettext("[Suricata] Deleting any rotated log files for {$value['descr']} ({$if_real})..."));
 			unlink_if_exists("{$suricata_log_dir}/*.log.*");
 
+			log_error(gettext("[Suricata] Deleting any rotated eve log files for {$value['descr']} ({$if_real})..."));
+			unlink_if_exists("{$suricata_log_dir}/*.json.*");
+
 			// Cleanup any rotated pcap logs
 			log_error(gettext("[Suricata] Deleting any rotated pcap log files for {$value['descr']} ({$if_real})..."));
 			unlink_if_exists("{$suricata_log_dir}/log.pcap.*");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -81,8 +81,9 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 			log_error(gettext("[Suricata] Deleting any rotated log files for {$value['descr']} ({$if_real})..."));
 			unlink_if_exists("{$suricata_log_dir}/*.log.*");
 
+			// Cleanup any rotated eve.json logs
 			log_error(gettext("[Suricata] Deleting any rotated eve log files for {$value['descr']} ({$if_real})..."));
-			unlink_if_exists("{$suricata_log_dir}/*.json.*");
+			unlink_if_exists("{$suricata_log_dir}/eve.json.*");
 
 			// Cleanup any rotated pcap logs
 			log_error(gettext("[Suricata] Deleting any rotated pcap log files for {$value['descr']} ({$if_real})..."));


### PR DESCRIPTION
The automatic log removal under `suricata_check_dir_size_limit` currently does not clean-up the `eve.json.*` log. This can lead to a situation where the other rotated logs are cleared but the overall directory size can still grow beyond the hard limit. 

For example, if `eve.json` log retention is set to more than a few days and with `flow` logging enabled: there you can end up with dozens of files that are not cleared in time. 

With this change, that shouldn't happen anymore. 

This change is especially relevant with respect to changes introduced in #383 that result in large `eve.json` files if `flow` is enabled.