### PR TITLE
Suricata-4.0.0 Update

### DIFF
--- a/security/suricata/Makefile
+++ b/security/suricata/Makefile
@@ -1,8 +1,8 @@
 # Created by: Patrick Tracanelli <eksffa@freebsdbrasil.com.br>
-# $FreeBSD$
+# $FreeBSD: head/security/suricata/Makefile 447598 2017-08-09 08:15:21Z joneum $
 
 PORTNAME=	suricata
-PORTVERSION=	3.2.3
+PORTVERSION=	4.0.0
 CATEGORIES=	security
 MASTER_SITES=	http://www.openinfosecfoundation.org/download/
 
@@ -110,8 +110,7 @@ REDIS_CONFIGURE_ON=		--enable-hiredis \
 				--with-libhiredis-libraries=${LOCALBASE}/lib
 
 SC_USES=			python
-SC_CONFIGURE_ENV=		ac_cv_path_HAVE_PYTHON_CONFIG=yes
-SC_CONFIGURE_ENV_OFF=		ac_cv_path_HAVE_PYTHON_CONFIG=no
+SC_CONFIGURE_ENABLE=		python
 
 TESTS_CONFIGURE_ENABLE=		unittests
 
@@ -136,8 +135,6 @@ RULES_FILES=	app-layer-events.rules decoder-events.rules dns-events.rules files.
 		tls-events.rules
 LOGS_DIR?=	/var/log/${PORTNAME}
 
-.include <bsd.port.pre.mk>
-
 pre-patch:
 	${CP} ${FILESDIR}/ax_check_compile_flag.m4 ${WRKSRC}/m4
 
@@ -145,19 +142,16 @@ post-install:
 	${MKDIR} ${STAGEDIR}${CONFIG_DIR}
 	${MKDIR} ${STAGEDIR}${RULES_DIR}
 	${MKDIR} ${STAGEDIR}${LOGS_DIR}
-
 .for f in ${CONFIG_FILES}
 	${INSTALL_DATA} ${WRKSRC}/${f} ${STAGEDIR}${CONFIG_DIR}/${f}.sample
 .endfor
-
 .for f in ${RULES_FILES}
 	${INSTALL_DATA} ${WRKSRC}/rules/${f} ${STAGEDIR}${RULES_DIR}/${f}
 .endfor
 
-.if ${PORT_OPTIONS:MSC}
+post-install-SC-on:
 	(cd ${STAGEDIR}${PREFIX} \
 	&& ${PYTHON_CMD} ${PYTHON_LIBDIR}/compileall.py \
 	-d ${PYTHONPREFIX_SITELIBDIR} -f ${PYTHONPREFIX_SITELIBDIR:S;${PREFIX}/;;})
-.endif
 
-.include <bsd.port.post.mk>
+.include <bsd.port.mk>

--- a/security/suricata/distinfo
+++ b/security/suricata/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1499981095
-SHA256 (suricata-3.2.3.tar.gz) = ad800e313ece9b4e4ef11b2bdfe15bd73d3c8e51833bc4466525b8f0d8ac86aa
-SIZE (suricata-3.2.3.tar.gz) = 11760480
+TIMESTAMP = 1501558442
+SHA256 (suricata-4.0.0.tar.gz) = 6b8b183a8409829ca92c71854cc1abed45f04ccfb7f14c08211f4edf571fa577
+SIZE (suricata-4.0.0.tar.gz) = 12252693

--- a/security/suricata/files/patch-alert-pf.diff
+++ b/security/suricata/files/patch-alert-pf.diff
@@ -1,6 +1,6 @@
-diff -ruN /tmp/suricata-3.2.1.orig/src/Makefile.am ./src/Makefile.am
---- /tmp/suricata-3.2.1.orig/src/Makefile.am	2017-02-15 02:54:12.000000000 -0500
-+++ ./src/Makefile.am	2017-04-06 19:17:45.000000000 -0400
+diff -urN suricata-4.0.0.orig/src/Makefile.am suricata-4.0.0/src/Makefile.am
+--- suricata-4.0.0.orig/src/Makefile.am	2017-07-27 03:02:52.000000000 -0400
++++ ./src/Makefile.am	2017-08-14 14:09:48.000000000 -0400
 @@ -9,6 +9,7 @@
  suricata_SOURCES = \
  alert-debuglog.c alert-debuglog.h \
@@ -9,48 +9,18 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/Makefile.am ./src/Makefile.am
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
  alert-unified2-alert.c alert-unified2-alert.h \
-diff -ruN /tmp/suricata-3.2.1.orig/src/Makefile.in ./src/Makefile.in
---- /tmp/suricata-3.2.1.orig/src/Makefile.in	2017-02-15 02:54:31.000000000 -0500
-+++ ./src/Makefile.in	2017-04-06 19:25:15.000000000 -0400
-@@ -94,10 +94,11 @@
- @DEBUG_TRUE@am__append_1 = -ggdb -O0
- subdir = src
- ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
--am__aclocal_m4_deps = $(top_srcdir)/m4/libprelude.m4 \
--	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
--	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
--	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
-+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_compile_flag.m4 \
-+	$(top_srcdir)/m4/libprelude.m4 $(top_srcdir)/m4/libtool.m4 \
-+	$(top_srcdir)/m4/ltoptions.m4 $(top_srcdir)/m4/ltsugar.m4 \
-+	$(top_srcdir)/m4/ltversion.m4 $(top_srcdir)/m4/lt~obsolete.m4 \
-+	$(top_srcdir)/configure.ac
- am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
- 	$(ACLOCAL_M4)
- DIST_COMMON = $(srcdir)/Makefile.am $(noinst_HEADERS) \
-@@ -109,9 +110,10 @@
- am__installdirs = "$(DESTDIR)$(bindir)"
+diff -urN suricata-4.0.0.orig/src/Makefile.in ./src/Makefile.in
+--- suricata-4.0.0.orig/src/Makefile.in	2017-07-27 03:03:09.000000000 -0400
++++ ./src/Makefile.in	2017-08-14 14:15:40.000000000 -0400
+@@ -113,6 +113,7 @@
  PROGRAMS = $(bin_PROGRAMS)
  am_suricata_OBJECTS = alert-debuglog.$(OBJEXT) alert-fastlog.$(OBJEXT) \
--	alert-prelude.$(OBJEXT) alert-syslog.$(OBJEXT) \
--	alert-unified2-alert.$(OBJEXT) app-layer.$(OBJEXT) \
--	app-layer-dcerpc.$(OBJEXT) app-layer-dcerpc-udp.$(OBJEXT) \
-+	alert-pf.$(OBJEXT) alert-prelude.$(OBJEXT) \
-+	alert-syslog.$(OBJEXT) alert-unified2-alert.$(OBJEXT) \
-+	app-layer.$(OBJEXT) app-layer-dcerpc.$(OBJEXT) \
-+	app-layer-dcerpc-udp.$(OBJEXT) \
+ 	alert-prelude.$(OBJEXT) alert-syslog.$(OBJEXT) \
++	alert-pf.$(OBJEXT) \
+ 	alert-unified2-alert.$(OBJEXT) app-layer.$(OBJEXT) \
+ 	app-layer-dcerpc.$(OBJEXT) app-layer-dcerpc-udp.$(OBJEXT) \
  	app-layer-detect-proto.$(OBJEXT) app-layer-dnp3.$(OBJEXT) \
- 	app-layer-dnp3-objects.$(OBJEXT) \
- 	app-layer-dns-common.$(OBJEXT) app-layer-dns-tcp.$(OBJEXT) \
-@@ -577,7 +579,6 @@
- psdir = @psdir@
- pyexecdir = @pyexecdir@
- pythondir = @pythondir@
--runstatedir = @runstatedir@
- sbindir = @sbindir@
- sharedstatedir = @sharedstatedir@
- srcdir = @srcdir@
-@@ -597,6 +598,7 @@
+@@ -627,6 +628,7 @@
  suricata_SOURCES = \
  alert-debuglog.c alert-debuglog.h \
  alert-fastlog.c alert-fastlog.h \
@@ -58,7 +28,7 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/Makefile.in ./src/Makefile.in
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
  alert-unified2-alert.c alert-unified2-alert.h \
-@@ -1162,6 +1164,7 @@
+@@ -1222,6 +1224,7 @@
  
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/alert-debuglog.Po@am__quote@
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/alert-fastlog.Po@am__quote@
@@ -66,11 +36,11 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/Makefile.in ./src/Makefile.in
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/alert-prelude.Po@am__quote@
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/alert-syslog.Po@am__quote@
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/alert-unified2-alert.Po@am__quote@
-diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
---- /tmp/suricata-3.2.1.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/alert-pf.c	2017-04-27 12:40:00.000000000 -0400
-@@ -0,0 +1,1055 @@
-+/* Copyright (C) 2007-2014 Open Information Security Foundation
+diff -urN suricata-4.0.0.orig/src/alert-pf.c ./src/alert-pf.c
+--- suricata-4.0.0.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
++++ ./src/alert-pf.c	2017-08-15 21:31:21.000000000 -0400
+@@ -0,0 +1,1077 @@
++/* Copyright (C) 2007-2017 Open Information Security Foundation
 + *
 + * You can copy, redistribute or modify this Program under the terms of
 + * the GNU General Public License version 2 as published by the Free
@@ -134,10 +104,11 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 + *    # alert-pf blocking plugin
 + *    - alert-pf:
 + *        enabled: yes/no            # "yes" to enable blocking plugin
-+ *        kill-state: yes/no         # "yes" to kill open state table entries associated with blocked IP addresses (default is YES)
++ *        kill-state: yes/no         # "yes" to kill open state table entries associated with blocked IP addresses (default is "yes")
 + *        pass-list: <filename>      # complete path and filename for txt file of single IP addresses or CIDR networks that should never be blocked
 + *        block-ip: src/dst/both     # which IP in packet to block (default is BOTH)
 + *        pf-table: <pf table name>  # name of packet filter firewall table where block IP addresses should be added.  This table must exist!
++ *        block-drops-only: yes/no   # only insert blocks in packet filter firewall for rules having DROP action keyword (default is "no")
 + *
 + */
 +
@@ -176,20 +147,23 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +#include <pthread.h>
 +
 +#define PFDEVICE	"/dev/pf"
-+#define WLMAX		1024
++#define WLMAX		4096
 +#define MODULE_NAME	"AlertPf"
 +#define DEFAULT_LOG_FILENAME "block.log"
 +#define MAX_RTMSG_SIZE 2048
 +
 +enum spblock { BLOCK_SRC, BLOCK_DST, BLOCK_BOTH };
 +
-+TmEcode AlertPfThreadInit(ThreadVars *, void *, void **);
++TmEcode AlertPfThreadInit(ThreadVars *, const void *, void **);
 +TmEcode AlertPfThreadDeinit(ThreadVars *, void *);
 +void AlertPfExitPrintStats(ThreadVars *, void *);
 +static void AlertPfDeInitCtx(OutputCtx *);
 +
 +int AlertPfCondition(ThreadVars *tv, const Packet *p);
 +int AlertPf(ThreadVars *tv, void *data, const Packet *p);
++
++TmEcode AlertPfIPv4(ThreadVars *, void *, const Packet *);
++TmEcode AlertPfIPv6(ThreadVars *, void *, const Packet *);
 +
 +void AlertPfRegister(void)
 +{
@@ -214,6 +188,7 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +    enum spblock block_ip;
 +    SCRadixTree *tree;
 +    LogFileCtx* file_ctx;
++    int block_drops;
 +} AlertPfCtx;
 +
 +/**
@@ -225,6 +200,7 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +} AlertPfThread;
 +
 +SC_ATOMIC_DECLARE(uint64_t, alert_pf_blocks);  /* Atomic counter, to hold block count */
++SC_ATOMIC_DECLARE(uint64_t, alert_pf_alerts);  /* Atomic counter, to hold alerts count */
 +
 +// Used for Interface IP change monitoring thread
 +pthread_t alert_pf_ifmon_thread;
@@ -236,7 +212,7 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +static int AlertPfLoadPassList(char *, AlertPfCtx *);
 +static int AlertPfDeviceInit(void);
 +static int AlertPfTableExists(char *);
-+static int AlertPfBlock(AlertPfThread *, Address *);
++static int AlertPfBlock(AlertPfThread *, const Address *);
 +
 +void *AlertPfMonitorIfaceChanges(void *);
 +
@@ -304,7 +280,7 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 + *  \param *net_addr pointer to IP address to block
 + *  \retval -1 on error, 1 if IP blocked, 0 if already blocked
 + */
-+static int AlertPfBlock(AlertPfThread *data, Address *net_addr) 
++static int AlertPfBlock(AlertPfThread *data, const Address *net_addr) 
 +{ 
 +    struct pfioc_table io; 
 +    struct pfr_table table; 
@@ -611,7 +587,7 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +/**
 + * This initializes the data for a new thread.
 + */
-+TmEcode AlertPfThreadInit(ThreadVars *t, void *initdata, void **data)
++TmEcode AlertPfThreadInit(ThreadVars *t, const void *initdata, void **data)
 +{
 +    AlertPfThread *apft;
 +
@@ -674,18 +650,20 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +        return;
 +    }
 +
-+    uint64_t alerts = SC_ATOMIC_GET(alert_pf_blocks);
-+    if (alerts == 1)
-+        SCLogInfo("alert-pf output inserted %" PRIu64 " IP address block", alerts);
++    uint64_t blocks = SC_ATOMIC_GET(alert_pf_blocks);
++    uint64_t alerts = SC_ATOMIC_GET(alert_pf_alerts);
++    if (blocks == 1)
++        SCLogInfo("alert-pf output inserted %" PRIu64 " IP address block", blocks);
 +    else
-+        SCLogInfo("alert-pf output inserted %" PRIu64 " IP address blocks", alerts);
++        SCLogInfo("alert-pf output inserted %" PRIu64 " IP address blocks", blocks);
 +
-+    if (apft->ctx->file_ctx->alerts == 1)
-+        SCLogInfo("alert-pf output wrote %" PRIu64 " alerts", apft->ctx->file_ctx->alerts);
++    if (alerts == 1)
++        SCLogInfo("alert-pf output processed %" PRIu64 " alert", alerts);
 +    else
-+        SCLogInfo("alert-pf output wrote %" PRIu64 " alerts", apft->ctx->file_ctx->alerts);
++        SCLogInfo("alert-pf output processed %" PRIu64 " alerts", alerts);
 +
 +    SC_ATOMIC_DESTROY(alert_pf_blocks);
++    SC_ATOMIC_DESTROY(alert_pf_alerts);
 +}
 +
 +/** \brief Thread for monitoring firewall interface IP address changes.
@@ -779,6 +757,7 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +    const char *pass_list_name;
 +    const char *kill_state;
 +    const char *block_ip;
++    const char *block_drops;
 +    const char *pf_table;
 +    OutputCtx *output_ctx;
 +
@@ -790,6 +769,7 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +    kill_state = ConfNodeLookupChildValue(conf, "kill-state");
 +    block_ip = ConfNodeLookupChildValue(conf, "block-ip");
 +    pf_table = ConfNodeLookupChildValue(conf, "pf-table");
++    block_drops = ConfNodeLookupChildValue(conf, "block-drops-only");
 +
 +    if (unlikely(pf_table == NULL)) {
 +	SCLogError(SC_ERR_INVALID_ARGUMENT, "alert-pf: No PF table name specified, module init failed.");
@@ -833,6 +813,13 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +    if (kill_state && ConfValIsFalse(kill_state))
 +        ctx->kill_state = 0;
 +
++    ctx->block_drops = 0;
++    if (block_drops == NULL) {
++        SCLogWarning(SC_ERR_INVALID_ARGUMENT, "alert-pf: block-drops-only parameter not recognized, defaulting to 'no'.");
++    }
++    if (block_drops && ConfValIsTrue(block_drops))
++        ctx->block_drops = 1;
++
 +    if (block_ip == NULL) {
 +        SCLogWarning(SC_ERR_INVALID_ARGUMENT, "alert-pf: block-ip parameter not recognized, defaulting to 'both'.");
 +    }
@@ -867,6 +854,7 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +    output_ctx->data = ctx;
 +    output_ctx->DeInit = AlertPfDeInitCtx;
 +    SC_ATOMIC_INIT(alert_pf_blocks);
++    SC_ATOMIC_INIT(alert_pf_alerts);
 +
 +    const char *block;
 +    switch (ctx->block_ip) {
@@ -908,7 +896,7 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +/** \brief This processes an IPv4 alert and inserts the appropriate
 + * block if the IP address is not on the Pass List.
 + */
-+TmEcode AlertPfIPv4(ThreadVars *tv, void *data, Packet *p)
++TmEcode AlertPfIPv4(ThreadVars *tv, void *data, const Packet *p)
 +{
 +    AlertPfThread *apft = (AlertPfThread *)data;
 +    int i;
@@ -934,6 +922,12 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +        if (unlikely(pa->s == NULL)) {
 +            continue;
 +        }
++        SC_ATOMIC_ADD(alert_pf_alerts, 1);
++
++	/* If blocking only DROP rules and alert is not from a DROP rule, ignore it */
++	if (apft->ctx->block_drops && !(PACKET_TEST_ACTION(p, ACTION_DROP))) {
++	    return TM_ECODE_OK;
++	}
 +
 +        switch (apft->ctx->block_ip) {
 +
@@ -948,7 +942,6 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +                                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
 +                                proto, srcip, p->sp);
 +                        fflush(apft->ctx->file_ctx->fp);
-+                        apft->ctx->file_ctx->alerts++;
 +                        SCMutexUnlock(&apft->ctx->file_ctx->fp_mutex);
 +                    }
 +                }
@@ -961,7 +954,6 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +                                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
 +                                proto, dstip, p->dp);
 +                        fflush(apft->ctx->file_ctx->fp);
-+                        apft->ctx->file_ctx->alerts++;
 +                        SCMutexUnlock(&apft->ctx->file_ctx->fp_mutex);
 +                    }
 +                }
@@ -978,7 +970,6 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +                                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
 +                                proto, srcip, p->sp);
 +                        fflush(apft->ctx->file_ctx->fp);
-+                        apft->ctx->file_ctx->alerts++;
 +                        SCMutexUnlock(&apft->ctx->file_ctx->fp_mutex);
 +                    }
 +                }
@@ -995,7 +986,6 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +                                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
 +                                proto, dstip, p->dp);
 +                        fflush(apft->ctx->file_ctx->fp);
-+                        apft->ctx->file_ctx->alerts++;
 +                        SCMutexUnlock(&apft->ctx->file_ctx->fp_mutex);
 +                    }
 +                }
@@ -1011,7 +1001,7 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +/** \brief This processes an IPv6 alert and inserts the appropriate
 + * block if the IP address is not on the Pass List.
 + */
-+TmEcode AlertPfIPv6(ThreadVars *tv, void *data, Packet *p)
++TmEcode AlertPfIPv6(ThreadVars *tv, void *data, const Packet *p)
 +{
 +    AlertPfThread *apft = (AlertPfThread *)data;
 +    int i;
@@ -1037,6 +1027,12 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +        if (unlikely(pa->s == NULL)) {
 +            continue;
 +        }
++        SC_ATOMIC_ADD(alert_pf_alerts, 1);
++
++	/* If blocking only DROP rules and alert is not from a DROP rule, ignore it */
++	if (apft->ctx->block_drops && !(PACKET_TEST_ACTION(p, ACTION_DROP))) {
++	    return TM_ECODE_OK;
++	}
 +
 +        switch (apft->ctx->block_ip) {
 +
@@ -1051,7 +1047,6 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +                                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
 +                                proto, srcip, p->sp);
 +                        fflush(apft->ctx->file_ctx->fp);
-+                        apft->ctx->file_ctx->alerts++;
 +                        SCMutexUnlock(&apft->ctx->file_ctx->fp_mutex);
 +                    }
 +                }
@@ -1064,7 +1059,6 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +                                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
 +                                proto, dstip, p->dp);
 +                        fflush(apft->ctx->file_ctx->fp);
-+                        apft->ctx->file_ctx->alerts++;
 +                        SCMutexUnlock(&apft->ctx->file_ctx->fp_mutex);
 +                    }
 +                }
@@ -1081,7 +1075,6 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +                                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
 +                                proto, srcip, p->sp);
 +                        fflush(apft->ctx->file_ctx->fp);
-+                        apft->ctx->file_ctx->alerts++;
 +                        SCMutexUnlock(&apft->ctx->file_ctx->fp_mutex);
 +                    }
 +                }
@@ -1098,7 +1091,6 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +                                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
 +                                proto, dstip, p->dp);
 +                        fflush(apft->ctx->file_ctx->fp);
-+                        apft->ctx->file_ctx->alerts++;
 +                        SCMutexUnlock(&apft->ctx->file_ctx->fp_mutex);
 +                    }
 +                }
@@ -1125,9 +1117,9 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.c ./src/alert-pf.c
 +    return TM_ECODE_OK;
 +}
 +
-diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.h ./src/alert-pf.h
---- /tmp/suricata-3.2.1.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/alert-pf.h	2017-04-27 12:41:14.000000000 -0400
+diff -urN suricata-4.0.0.orig/src/alert-pf.h ./src/alert-pf.h
+--- suricata-4.0.0.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
++++ ./src/alert-pf.h	2017-04-27 13:11:20.000000000 -0400
 @@ -0,0 +1,59 @@
 +/* Copyright (C) 2007-2010 Open Information Security Foundation
 + *
@@ -1188,9 +1180,9 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/alert-pf.h ./src/alert-pf.h
 +
 +#endif /* __ALERT_PF_H__ */
 +
-diff -ruN /tmp/suricata-3.2.1.orig/src/output.c ./src/output.c
---- /tmp/suricata-3.2.1.orig/src/output.c	2017-02-15 02:54:12.000000000 -0500
-+++ ./src/output.c	2017-04-27 12:47:28.000000000 -0400
+diff -urN suricata-4.0.0.orig/src/output.c ./src/output.c
+--- suricata-4.0.0.orig/src/output.c	2017-07-27 03:02:52.000000000 -0400
++++ ./src/output.c	2017-08-14 14:06:32.000000000 -0400
 @@ -45,6 +45,7 @@
  #include "alert-debuglog.h"
  #include "alert-prelude.h"
@@ -1199,23 +1191,23 @@ diff -ruN /tmp/suricata-3.2.1.orig/src/output.c ./src/output.c
  #include "output-json-alert.h"
  #include "output-json-flow.h"
  #include "output-json-netflow.h"
-@@ -1049,6 +1050,8 @@
+@@ -1039,6 +1040,8 @@
      AlertPreludeRegister();
      /* syslog log */
      AlertSyslogRegister();
-+    /* alert pf */
++    /* alerf pf */
 +    AlertPfRegister();
      /* unified2 log */
      Unified2AlertRegister();
      /* drop log */
-diff -ruN /tmp/suricata-3.2.1.orig/src/suricata-common.h ./src/suricata-common.h
---- /tmp/suricata-3.2.1.orig/src/suricata-common.h	2017-02-15 02:54:12.000000000 -0500
-+++ ./src/suricata-common.h	2017-04-27 12:42:02.000000000 -0400
-@@ -375,6 +375,7 @@
+diff -urN suricata-4.0.0.orig/src/suricata-common.h ./src/suricata-common.h
+--- suricata-4.0.0.orig/src/suricata-common.h	2017-07-27 03:02:52.000000000 -0400
++++ ./src/suricata-common.h	2017-08-14 14:03:05.000000000 -0400
+@@ -410,6 +410,7 @@
+     LOGGER_JSON_STATS,
      LOGGER_PRELUDE,
      LOGGER_PCAP,
-     LOGGER_JSON_DNP3,
 +    LOGGER_ALERT_PF,
+     LOGGER_JSON_DNP3,
+     LOGGER_JSON_VARS,
      LOGGER_SIZE,
- } LoggerId;
- 

--- a/security/suricata/files/patch-alert-pf.diff
+++ b/security/suricata/files/patch-alert-pf.diff
@@ -38,8 +38,8 @@ diff -urN suricata-4.0.0.orig/src/Makefile.in ./src/Makefile.in
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/alert-unified2-alert.Po@am__quote@
 diff -urN suricata-4.0.0.orig/src/alert-pf.c ./src/alert-pf.c
 --- suricata-4.0.0.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/alert-pf.c	2017-08-15 21:31:21.000000000 -0400
-@@ -0,0 +1,1077 @@
++++ ./src/alert-pf.c	2017-08-16 09:12:18.000000000 -0400
+@@ -0,0 +1,1078 @@
 +/* Copyright (C) 2007-2017 Open Information Security Foundation
 + *
 + * You can copy, redistribute or modify this Program under the terms of
@@ -108,7 +108,7 @@ diff -urN suricata-4.0.0.orig/src/alert-pf.c ./src/alert-pf.c
 + *        pass-list: <filename>      # complete path and filename for txt file of single IP addresses or CIDR networks that should never be blocked
 + *        block-ip: src/dst/both     # which IP in packet to block (default is BOTH)
 + *        pf-table: <pf table name>  # name of packet filter firewall table where block IP addresses should be added.  This table must exist!
-+ *        block-drops-only: yes/no   # only insert blocks in packet filter firewall for rules having DROP action keyword (default is "no")
++ *        block-drops-only: yes/no   # only insert blocks in packet filter firewall table for rules having DROP action keyword (default is "no")
 + *
 + */
 +
@@ -870,13 +870,14 @@ diff -urN suricata-4.0.0.orig/src/alert-pf.c ./src/alert-pf.c
 +            block = "both";
 +    }
 +    const char *state = ctx->kill_state ? "on" : "off";
++    const char *drops = ctx->block_drops ? "on" : "off";
 +
 +    if (pthread_create(&alert_pf_ifmon_thread, NULL, AlertPfMonitorIfaceChanges, ctx))
 +	SCLogError(SC_ERR_SYSCALL, "Failed to create Interface IP Address change monitoring thread for 'alert-pf' output plugin.");
 +    else
 +	SCLogInfo("Created firewall interface IP change monitor thread for auto-whitelisting of firewall interface IP addresses.");
 +
-+    SCLogInfo("alert-pf output initialized, pf-table=%s  block-ip=%s  kill-state=%s", ctx->pftable, block, state);
++    SCLogInfo("alert-pf output initialized, pf-table=%s  block-ip=%s  kill-state=%s  block-drops-only=%s", ctx->pftable, block, state, drops);
 +
 +    return output_ctx;
 +}

--- a/security/suricata/files/suricata.in
+++ b/security/suricata/files/suricata.in
@@ -1,5 +1,5 @@
 #!/bin/sh
-# $FreeBSD$
+# $FreeBSD: head/security/suricata/files/suricata.in 443829 2017-06-18 15:06:34Z ultima $
 
 # PROVIDE: suricata
 # REQUIRE: DAEMON


### PR DESCRIPTION
This updates the Suricata binary to version 4.0.0 to match the latest upstream version.

**New Features**
A new configurable parameter has been added to the _alert-pf_ plugin used to insert offending IP addresses into the "snort2c" table in the packet filter of pfSense.  The new parameter is named "block-drops-only" and can be set to 'yes' or 'no' (with 'no' being the default when no setting is specified).  When set to 'yes', this new setting causes the plugin to only insert offending IP addresses into the "snort2c" table when the firing rule signature has a rule action of DROP.  Rules with action ALERT will only cause alerts with no blocks if this new option is set to 'yes'.

The _alert-pf_ plugin's suricata.yaml configuration settings are shown below
```
    # alert-pf blocking plugin
    - alert-pf:
        enabled: yes/no            # "yes" to enable blocking plugin
        kill-state: yes/no         # "yes" to kill open state table entries associated with blocked IP addresses (default is "yes")
        pass-list: <filename>      # complete path and filename for txt file of single IP addresses or CIDR networks that should never be blocked
        block-ip: src/dst/both     # which IP in packet to block (default is BOTH)
        pf-table: <pf table name>  # name of packet filter firewall table where block IP addresses should be added.  This table must exist!
        block-drops-only: yes/no   # only insert blocks in packet filter firewall table for rules having DROP action keyword (default is "no")
```