### PR TITLE
pfSense-pkg-snort-3.2.9.5 - GUI Package Update to v3.2.9.5

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-snort
-PORTVERSION=	3.2.9.4
+PORTVERSION=	3.2.9.5
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
@@ -928,6 +928,21 @@ preprocessor appid: \
 
 EOD;
 
+/* def ARP Spoof preprocessor */
+$arpspoof_preproc = "# ARP Spoof preprocessor #\n";
+if ($snortcfg['arp_unicast_detection'] == 'on') {
+	$arpspoof_preproc .= "preprocessor arpspoof: -unicast\n";
+}
+else {
+	$arpspoof_preproc .= "preprocessor arpspoof\n";
+}
+if (is_array($snortcfg['arp_spoof_engine']['item']) && count($snortcfg['arp_spoof_engine']['item']) > 0) {
+	foreach ($snortcfg['arp_spoof_engine']['item'] as $f => $v) {
+		$arpspoof_preproc .= "preprocessor arpspoof_detect_host: ";
+		$arpspoof_preproc .= $v['ip_addr'] . " " . str_replace('-', ':', $v['mac_addr']) . "\n";
+	}
+}
+
 /***************************************/
 /* end of preprocessor string var code */
 /***************************************/
@@ -963,10 +978,10 @@ $snort_preproc_libs = array(
 );
 $snort_preproc = array (
 	"perform_stat", "other_preprocs", "ftp_preprocessor", "smtp_preprocessor", "ssl_preproc", "sip_preproc", "gtp_preproc", "ssh_preproc", "sf_portscan", 
-	"dce_rpc_2", "dns_preprocessor", "sensitive_data", "pop_preproc", "imap_preproc", "dnp3_preproc", "modbus_preproc", "reputation_preproc", "appid_preproc"
+	"dce_rpc_2", "dns_preprocessor", "sensitive_data", "pop_preproc", "imap_preproc", "dnp3_preproc", "modbus_preproc", "reputation_preproc", "appid_preproc", "arpspoof_preproc"
 );
 $default_disabled_preprocs = array(
-	"sf_portscan", "gtp_preproc", "sensitive_data", "dnp3_preproc", "modbus_preproc", "reputation_preproc", "perform_stat", "appid_preproc"
+	"sf_portscan", "gtp_preproc", "sensitive_data", "dnp3_preproc", "modbus_preproc", "reputation_preproc", "perform_stat", "appid_preproc", "arpspoof_preproc"
 );
 $snort_preprocessors = "";
 foreach ($snort_preproc as $preproc) {

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
@@ -77,7 +77,7 @@ conf_mount_rw();
 @rename("{$snortdir}/generators-sample", "{$snortdir}/generators");
 @rename("{$snortdir}/reference.config-sample", "{$snortdir}/reference.config");
 @rename("{$snortdir}/gen-msg.map-sample", "{$snortdir}/gen-msg.map");
-//@rename("{$snortdir}/attribute_table.dtd-sample", "{$snortdir}/attribute_table.dtd");
+@rename("{$snortdir}/attribute_table.dtd-sample", "{$snortdir}/attribute_table.dtd");
 
 /* fix up the preprocessor rules filenames from a PBI package install */
 $preproc_rules = array("decoder.rules", "preprocessor.rules", "sensitive-data.rules");

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -150,6 +150,9 @@ if (is_dir("{$snortdir}/signatures")) {
 if (is_dir("{$snortdir}/preproc_rules")) {
 	rmdir_recursive("{$snortdir}/preproc_rules");
 }
+if (is_dir("usr/local/lib/snort_dynamicrules")) {
+	rmdir_recursive("usr/local/lib/snort_dynamicrules");
+}
 unlink_if_exists("{$snortdir}/*.md5");
 unlink_if_exists("{$snortdir}/*.conf");
 unlink_if_exists("{$snortdir}/*.map");

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -147,10 +147,15 @@ if (is_dir("{$snortdir}/rules")) {
 if (is_dir("{$snortdir}/signatures")) {
 	rmdir_recursive("{$snortdir}/signatures");
 }
+if (is_dir("{$snortdir}/preproc_rules")) {
+	rmdir_recursive("{$snortdir}/preproc_rules");
+}
 unlink_if_exists("{$snortdir}/*.md5");
 unlink_if_exists("{$snortdir}/*.conf");
 unlink_if_exists("{$snortdir}/*.map");
 unlink_if_exists("{$snortdir}/*.config");
+unlink_if_exists("{$snortdir}/attribute_table.dtd");
+
 if (is_array($config['installedpackages']['snortglobal']['rule']) && count($config['installedpackages']['snortglobal']['rule']) > 0) {
 	foreach ($config['installedpackages']['snortglobal']['rule'] as $snortcfg) {
 		$if_real = get_real_interface($snortcfg['interface']);

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -150,8 +150,8 @@ if (is_dir("{$snortdir}/signatures")) {
 if (is_dir("{$snortdir}/preproc_rules")) {
 	rmdir_recursive("{$snortdir}/preproc_rules");
 }
-if (is_dir("usr/local/lib/snort_dynamicrules")) {
-	rmdir_recursive("usr/local/lib/snort_dynamicrules");
+if (is_dir("/usr/local/lib/snort_dynamicrules")) {
+	rmdir_recursive("/usr/local/lib/snort_dynamicrules");
 }
 unlink_if_exists("{$snortdir}/*.md5");
 unlink_if_exists("{$snortdir}/*.conf");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -373,7 +373,7 @@ if ($_POST['clear']) {
 if ($_POST['download']) {
 	$save_date = date("Y-m-d-H-i-s");
 	$file_name = "snort_logs_{$save_date}_{$if_real}.tar.gz";
-	exec("cd {$snortlogdir}/snort_{$if_real}{$snort_uuid} && /usr/bin/tar -czf {$g['tmp_path']}/{$file_name} *");
+	exec("cd {$snortlogdir}/snort_{$if_real}{$snort_uuid} && /usr/bin/tar -czf {$g['tmp_path']}/{$file_name} alert*");
 
 	if (file_exists("{$g['tmp_path']}/{$file_name}")) {
 		ob_start(); //important or other posts will fail

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -694,59 +694,64 @@ if (file_exists("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/alert")) {
 			$alert_priority = $fields[12];
 			/* Protocol */
 			$alert_proto = $fields[5];
+
 			/* IP SRC */
 			$alert_ip_src = $fields[6];
+			if (!empty($alert_ip_src)) {
+				/* Add zero-width space as soft-break opportunity after each colon if we have an IPv6 address */
+				$alert_ip_src = str_replace(":", ":&#8203;", $alert_ip_src);
 
-			/* Add zero-width space as soft-break opportunity after each colon if we have an IPv6 address */
-			$alert_ip_src = str_replace(":", ":&#8203;", $alert_ip_src);
+				/* Add Reverse DNS lookup icons */
+				$alert_ip_src .= '<br/>';
+				$alert_ip_src .= '<i class="fa fa-search icon-pointer" onclick="javascript:resolve_with_ajax(\'' . $fields[6] . '\');" title="' . gettext("Click to resolve") . '" alt="Reverse Resolve with DNS"></i>';
 
-			/* Add Reverse DNS lookup icons */
-			$alert_ip_src .= '<br/>';
-			$alert_ip_src .= '<i class="fa fa-search icon-pointer" onclick="javascript:resolve_with_ajax(\'' . $fields[6] . '\');" title="' . gettext("Click to resolve") . '" alt="Reverse Resolve with DNS"></i>';
+				/* Add icons for auto-adding to Suppress List if appropriate */
+				if (!snort_is_alert_globally_suppressed($supplist, $fields[1], $fields[2]) && 
+				    !isset($supplist[$fields[1]][$fields[2]]['by_src'][$fields[6]])) {
 
-			/* Add icons for auto-adding to Suppress List if appropriate */
-			if (!snort_is_alert_globally_suppressed($supplist, $fields[1], $fields[2]) && 
-			    !isset($supplist[$fields[1]][$fields[2]]['by_src'][$fields[6]])) {
-
-				$alert_ip_src .= "&nbsp;&nbsp;<i class=\"fa fa-plus-square-o icon-pointer\" title=\"" . gettext('Add this alert to the Suppress List and track by_src IP') . '"';
-				$alert_ip_src .= " onClick=\"encRuleSig('{$fields[1]}','{$fields[2]}','{$fields[6]}','{$alert_descr}');$('#mode').val('addsuppress_srcip');$('#formalert').submit();\"></i>";
+					$alert_ip_src .= "&nbsp;&nbsp;<i class=\"fa fa-plus-square-o icon-pointer\" title=\"" . gettext('Add this alert to the Suppress List and track by_src IP') . '"';
+					$alert_ip_src .= " onClick=\"encRuleSig('{$fields[1]}','{$fields[2]}','{$fields[6]}','{$alert_descr}');$('#mode').val('addsuppress_srcip');$('#formalert').submit();\"></i>";
+				}
+				elseif (isset($supplist[$fields[1]][$fields[2]]['by_src'][$fields[6]])) {
+					$alert_ip_src .= '&nbsp;&nbsp;<i class="fa fa-info-circle"';
+					$alert_ip_src .= ' title="' . gettext("This alert track by_src IP is already in the Suppress List") . '"></i>';	
+				}
+				/* Add icon for auto-removing from Blocked Table if required */
+				if (isset($tmpblocked[$fields[6]])) {
+					$alert_ip_src .= "&nbsp;&nbsp;<i class=\"fa fa-times icon-pointer text-danger\" onClick=\"$('#ip').val('{$fields[6]}');$('#mode').val('todelete');$('#formalert').submit();\"";
+					$alert_ip_src .= ' title="' . gettext("Remove host from Blocked Table") . '"></i>';
+				}
 			}
-			elseif (isset($supplist[$fields[1]][$fields[2]]['by_src'][$fields[6]])) {
-				$alert_ip_src .= '&nbsp;&nbsp;<i class="fa fa-info-circle"';
-				$alert_ip_src .= ' title="' . gettext("This alert track by_src IP is already in the Suppress List") . '"></i>';	
-			}
-			/* Add icon for auto-removing from Blocked Table if required */
-			if (isset($tmpblocked[$fields[6]])) {
-				$alert_ip_src .= "&nbsp;&nbsp;<i class=\"fa fa-times icon-pointer text-danger\" onClick=\"$('#ip').val('{$fields[6]}');$('#mode').val('todelete');$('#formalert').submit();\"";
-				$alert_ip_src .= ' title="' . gettext("Remove host from Blocked Table") . '"></i>';
-			}
+
 			/* IP SRC Port */
 			$alert_src_p = $fields[7];
 
 			/* IP Destination */
 			$alert_ip_dst = $fields[8];
 
-			/* Add zero-width space as soft-break opportunity after each colon if we have an IPv6 address */
-			$alert_ip_dst = str_replace(":", ":&#8203;", $alert_ip_dst);
+			if (!empty($alert_ip_dst)) {
+				/* Add zero-width space as soft-break opportunity after each colon if we have an IPv6 address */
+				$alert_ip_dst = str_replace(":", ":&#8203;", $alert_ip_dst);
 
-			/* Add Reverse DNS lookup icons */
-			$alert_ip_dst .= "<br/>";
-			$alert_ip_dst .= '<i class="fa fa-search icon-pointer" onclick="javascript:resolve_with_ajax(\'' . $fields[8] . '\');" title="' . gettext("Click to resolve") . '" alt="Reverse Resolve with DNS"></i>';
+				/* Add Reverse DNS lookup icons */
+				$alert_ip_dst .= "<br/>";
+				$alert_ip_dst .= '<i class="fa fa-search icon-pointer" onclick="javascript:resolve_with_ajax(\'' . $fields[8] . '\');" title="' . gettext("Click to resolve") . '" alt="Reverse Resolve with DNS"></i>';
 
-			/* Add icons for auto-adding to Suppress List if appropriate */
-			if (!snort_is_alert_globally_suppressed($supplist, $fields[1], $fields[2]) && 
-			    !isset($supplist[$fields[1]][$fields[2]]['by_dst'][$fields[8]])) {
-				$alert_ip_dst .= "&nbsp;&nbsp;<i class=\"fa fa-plus-square-o icon-pointer\" onClick=\"encRuleSig('{$fields[1]}','{$fields[2]}','{$fields[8]}','{$alert_descr}');$('#mode').val('addsuppress_dstip');$('#formalert').submit();\"";
-				$alert_ip_dst .= ' title="' . gettext("Add this alert to the Suppress List and track by_dst IP") . '"></i>';	
-			}
-			elseif (isset($supplist[$fields[1]][$fields[2]]['by_dst'][$fields[8]])) {
-				$alert_ip_dst .= '&nbsp;&nbsp;<i class="fa fa-info-circle"';
-				$alert_ip_dst .= ' title="' . gettext("This alert track by_dst IP is already in the Suppress List") . '"></i>';	
-			}
-			/* Add icon for auto-removing from Blocked Table if required */
-			if (isset($tmpblocked[$fields[8]])) {
-				$alert_ip_dst .= "&nbsp;&nbsp;<i name=\"todelete[]\" class=\"fa fa-times icon-pointer text-danger\" onClick=\"$('#ip').val('{$fields[8]}');$('#mode').val('todelete');$('#formalert').submit();\" ";
-				$alert_ip_dst .= ' title="' . gettext("Remove host from Blocked Table") . '"></i>';
+				/* Add icons for auto-adding to Suppress List if appropriate */
+				if (!snort_is_alert_globally_suppressed($supplist, $fields[1], $fields[2]) && 
+				    !isset($supplist[$fields[1]][$fields[2]]['by_dst'][$fields[8]])) {
+					$alert_ip_dst .= "&nbsp;&nbsp;<i class=\"fa fa-plus-square-o icon-pointer\" onClick=\"encRuleSig('{$fields[1]}','{$fields[2]}','{$fields[8]}','{$alert_descr}');$('#mode').val('addsuppress_dstip');$('#formalert').submit();\"";
+					$alert_ip_dst .= ' title="' . gettext("Add this alert to the Suppress List and track by_dst IP") . '"></i>';	
+				}
+				elseif (isset($supplist[$fields[1]][$fields[2]]['by_dst'][$fields[8]])) {
+					$alert_ip_dst .= '&nbsp;&nbsp;<i class="fa fa-info-circle"';
+					$alert_ip_dst .= ' title="' . gettext("This alert track by_dst IP is already in the Suppress List") . '"></i>';	
+				}
+				/* Add icon for auto-removing from Blocked Table if required */
+				if (isset($tmpblocked[$fields[8]])) {
+					$alert_ip_dst .= "&nbsp;&nbsp;<i name=\"todelete[]\" class=\"fa fa-times icon-pointer text-danger\" onClick=\"$('#ip').val('{$fields[8]}');$('#mode').val('todelete');$('#formalert').submit();\" ";
+					$alert_ip_dst .= ' title="' . gettext("Remove host from Blocked Table") . '"></i>';
+				}
 			}
 
 			/* IP DST Port */

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -697,6 +697,9 @@ if (file_exists("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/alert")) {
 			/* IP SRC */
 			$alert_ip_src = $fields[6];
 
+			/* Add zero-width space as soft-break opportunity after each colon if we have an IPv6 address */
+			$alert_ip_src = str_replace(":", ":&#8203;", $alert_ip_src);
+
 			/* Add Reverse DNS lookup icons */
 			$alert_ip_src .= '<br/>';
 			$alert_ip_src .= '<i class="fa fa-search icon-pointer" onclick="javascript:resolve_with_ajax(\'' . $fields[6] . '\');" title="' . gettext("Click to resolve") . '" alt="Reverse Resolve with DNS"></i>';
@@ -722,6 +725,9 @@ if (file_exists("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/alert")) {
 
 			/* IP Destination */
 			$alert_ip_dst = $fields[8];
+
+			/* Add zero-width space as soft-break opportunity after each colon if we have an IPv6 address */
+			$alert_ip_dst = str_replace(":", ":&#8203;", $alert_ip_dst);
 
 			/* Add Reverse DNS lookup icons */
 			$alert_ip_dst .= "<br/>";

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_blocked.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_blocked.php
@@ -110,7 +110,7 @@ if ($_POST['download'])
 				header("Cache-Control: private, must-revalidate");
 			}
 			header("Content-Type: application/octet-stream");
-			header("Content-length: filesize=" . filesize("{$g['tmp_path']}/{$file_name}"));
+			header("Content-length: " . filesize("{$g['tmp_path']}/{$file_name}"));
 			header("Content-disposition: attachment; filename=" . $file_name);
 			ob_end_clean(); //important or other post will fail
 			readfile("{$g['tmp_path']}/{$file_name}");
@@ -119,8 +119,8 @@ if ($_POST['download'])
 			unlink_if_exists("{$g['tmp_path']}/{$file_name}");
 			rmdir_recursive("{$g['tmp_path']}/snort_blocked");
 
-			header("Location: /snort/snort_blocked.php");
-			exit;
+//			header("Location: /snort/snort_blocked.php");
+//			exit;
 		} else
 			$savemsg = gettext("An error occurred while creating archive");
 	} else
@@ -183,7 +183,7 @@ $group->add(new Form_Button(
 	'Download',
 	null,
 	'fa-download'
-))->removeClass('btn-default')->addClass('btn-success btn-sm')
+))->removeClass('btn-default')->addClass('btn-success btn-sm')->setAttribute('title', gettext('Download interface log files as a gzip archive'))
   ->setHelp('All blocked hosts will be saved');
 
 $group->add(new Form_Button(
@@ -191,7 +191,7 @@ $group->add(new Form_Button(
 	'Clear',
 	null,
 	'fa-trash'
-))->removeClass('btn-default')->addClass('btn-danger btn-sm')
+))->removeClass('btn-default')->addClass('btn-danger btn-sm')->setAttribute('title', gettext('Clear all blocked hosts log files'))
   ->setHelp('All blocked hosts will be removed');
 
 $section->add($group);

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
@@ -278,14 +278,18 @@ $section->addInput(new Form_StaticText(
 	'OpenAppID Version',
 	$openappid_ver
 ));
-$section->addInput(new Form_Checkbox(
+$group = new Form_Group('Enable RULES OpenAppID');
+$group->add(new Form_Checkbox(
         'openappid_rules_detectors',
         'Enable RULES OpenAppID',
         'Click to enable download of APPID Open rules',
         $pconfig['openappid_rules_detectors'] == 'on' ? true:false,
         'on'
 ));
-
+$group->setHelp('Note - the AppID Open Rules file is maintained by a volunteer contributor.  The file is hosted at a University in Brazil that employs Geo-IP protection for their network.  ' . 
+'Snort users in some countries may experience issues downloading the rules package because of the Geo-IP blocking used by the hosting web site.  The URL for the file ' . 
+'is <a href="' . SNORT_OPENAPPID_RULES_URL . SNORT_OPENAPPID_RULES_FILENAME . '" target="_blank">' . SNORT_OPENAPPID_RULES_URL . SNORT_OPENAPPID_RULES_FILENAME . '</a>.');
+$section->add($group);
 $form->add($section);
 
 $section = new Form_Section('Rules Update Settings');

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
@@ -1628,7 +1628,7 @@ print_callout('<p>' . gettext("Rules may be dependent on enbled preprocessors!  
 									<th style="width:35%;"><?=gettext("MAC Address")?></th>
 									<th style="width:35%;"><?=gettext("IP Address")?></th>
 									<th>
-										<a href="#" data-toggle="modal" data-target="#arp_spoof_addr_pair" data-eng_id="<?=$arp_spoof_engine_next_id;?>" class="btn btn-sm btn-success" role="button" title="<?=gettext("Add a new server configuration")?>">
+										<a href="#" data-toggle="modal" data-target="#arp_spoof_addr_pair" data-eng_id="<?=$arp_spoof_engine_next_id;?>" class="btn btn-sm btn-success" role="button" title="<?=gettext("Add a new address pair entry")?>">
 											<i class="fa fa-plus icon-embed-btn"></i>
 											<?=gettext(' Add');?>
 										</a>
@@ -1641,8 +1641,8 @@ print_callout('<p>' . gettext("Rules may be dependent on enbled preprocessors!  
 									<td><?=gettext($v['mac_addr'])?></td>
 									<td><?=gettext($v['ip_addr'])?></td>
 									<td>
-										<a href="#" data-toggle="modal" data-target="#arp_spoof_addr_pair" data-eng_id="<?=$f;?>" data-arp_spoof_mac="<?=$v['mac_addr'];?>" data-arp_spoof_ip="<?=$v['ip_addr'];?>" class="fa fa-pencil icon-primary" title="<?=gettext("Edit this entry")?>"></a>
-										<a href="#" class="fa fa-trash icon-primary no-confirm" onclick="del_eng('del_arp_spoof_engine', '<?=$f;?>');" title="<?=gettext("Delete this entry")?>"></a>
+										<a href="#" data-toggle="modal" data-target="#arp_spoof_addr_pair" data-eng_id="<?=$f;?>" data-arp_spoof_mac="<?=$v['mac_addr'];?>" data-arp_spoof_ip="<?=$v['ip_addr'];?>" class="fa fa-pencil icon-primary" title="<?=gettext("Edit this address pair entry")?>"></a>
+										<a href="#" class="fa fa-trash icon-primary no-confirm" onclick="del_eng('del_arp_spoof_engine', '<?=$f;?>');" title="<?=gettext("Delete this adress pair entry")?>"></a>
 									</td>
 								</tr>
 							<?php endforeach; ?>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
@@ -54,6 +54,8 @@ if (!is_array($config['installedpackages']['snortglobal']['rule'][$id]['ftp_serv
 	$config['installedpackages']['snortglobal']['rule'][$id]['ftp_server_engine']['item'] = array();
 if (!is_array($config['installedpackages']['snortglobal']['rule'][$id]['ftp_client_engine']['item']))
 	$config['installedpackages']['snortglobal']['rule'][$id]['ftp_client_engine']['item'] = array();
+if (!is_array($config['installedpackages']['snortglobal']['rule'][$id]['arp_spoof_engine']['item']))
+	$config['installedpackages']['snortglobal']['rule'][$id]['arp_spoof_engine']['item'] = array();
 
 $a_nat = &$config['installedpackages']['snortglobal']['rule'];
 
@@ -65,6 +67,7 @@ $stream5_tcp_engine_next_id = count($a_nat[$id]['stream5_tcp_engine']['item']);
 $http_inspect_engine_next_id = count($a_nat[$id]['http_inspect_engine']['item']);
 $ftp_server_engine_next_id = count($a_nat[$id]['ftp_server_engine']['item']);
 $ftp_client_engine_next_id = count($a_nat[$id]['ftp_client_engine']['item']);
+$arp_spoof_engine_next_id = count($a_nat[$id]['arp_spoof_engine']['item']);
 
 $pconfig = array();
 if (isset($id) && isset($a_nat[$id])) {
@@ -81,6 +84,8 @@ if (isset($id) && isset($a_nat[$id])) {
 		$pconfig['ftp_server_engine']['item'] = array();
 	if (!is_array($pconfig['ftp_client_engine']['item']))
 		$pconfig['ftp_client_engine']['item'] = array();
+	if (!is_array($pconfig['arp_spoof_engine']['item']))
+		$pconfig['arp_spoof_engine']['item'] = array();
 
 	/************************************************************/
 	/* To keep new users from shooting themselves in the foot   */
@@ -263,7 +268,38 @@ if ($_GET['act'] == "import" && isset($_GET['varname']) && !empty($_GET['varvalu
 	$pconfig[$_GET['varname']] = htmlspecialchars($_GET['varvalue']);
 }
 
-// Handle deleting of any of the multiple configuration engines
+// Handle saving of ARP Spoofing MAC-to-IP address pairs
+if ($_POST['arp_spoof_save']) {
+
+	// Validate IP and MAC address values first
+	if (filter_var($_POST['arp_spoof_ip_addr'], FILTER_VALIDATE_IP) && 
+	   filter_var($_POST['arp_spoof_mac_addr'], FILTER_VALIDATE_MAC)) {
+		// Set new or updated ARP Spoof engine values
+		$engine = array();
+		$engine['ip_addr'] = $_POST['arp_spoof_ip_addr'];
+		$engine['mac_addr'] = $_POST['arp_spoof_mac_addr'];
+
+		// See if editing an existing entry or adding a new one
+		if (isset($_POST['eng_id']) && isset($a_nat[$id]['arp_spoof_engine']['item'][$_POST['eng_id']])) {
+			$a_nat[$id]['arp_spoof_engine']['item'][$_POST['eng_id']] = $engine;
+		}
+		else {
+			$a_nat[$id]['arp_spoof_engine']['item'][] = $engine;
+		}
+
+		// Save the updates to the Snort configuration
+		write_config("Snort pkg: Updated ARP Spoofing engine address pairs for {$a_nat[$id]['interface']}.");
+		header("Location: snort_preprocessors.php?id=$id#preproc_arp_spoof_row");
+		exit;
+	}
+	else {
+		$input_errors[] = gettext("The IP address or MAC address failed to validate!  Change was discarded.");
+	}
+}
+
+// Handle deleting of any of the multiple configuration engines.
+// jQuery code is called dynamically from the page to set flags
+// to indicate which multiple configuration engine to delete.
 if ($_POST['del_http_inspect']) {
 	if (isset($_POST['eng_id']) && isset($id) && isset($a_nat[$id])) {
 		unset($a_nat[$id]['http_inspect_engine']['item'][$_POST['eng_id']]);
@@ -301,6 +337,14 @@ elseif ($_POST['del_ftp_server']) {
 		unset($a_nat[$id]['ftp_server_engine']['item'][$_POST['eng_id']]);
 		write_config("Snort pkg: deleted ftp_server engine for {$a_nat[$id]['interface']}.");
 		header("Location: snort_preprocessors.php?id=$id#ftp_telnet_row");
+		exit;
+	}
+}
+elseif ($_POST['del_arp_spoof_engine']) {
+	if (isset($_POST['eng_id']) && isset($id) && isset($a_nat[$id])) {
+		unset($a_nat[$id]['arp_spoof_engine']['item'][$_POST['eng_id']]);
+		write_config("Snort pkg: deleted ARP spoof host address pair for {$a_nat[$id]['interface']}.");
+		header("Location: snort_preprocessors.php?id=$id#preproc_arp_spoof_row");
 		exit;
 	}
 }
@@ -538,7 +582,6 @@ if ($_POST['save']) {
 		$natent['smtp_log_rcpt_to'] = $_POST['smtp_log_rcpt_to'] ? 'on' : 'off';
 		$natent['smtp_log_filename'] = $_POST['smtp_log_filename'] ? 'on' : 'off';
 		$natent['smtp_log_email_hdrs'] = $_POST['smtp_log_email_hdrs'] ? 'on' : 'off';
-
 		$natent['sf_portscan'] = $_POST['sf_portscan'] ? 'on' : 'off';
 		$natent['dce_rpc_2'] = $_POST['dce_rpc_2'] ? 'on' : 'off';
 		$natent['dns_preprocessor'] = $_POST['dns_preprocessor'] ? 'on' : 'off';
@@ -563,6 +606,8 @@ if ($_POST['save']) {
 		$natent['stream5_track_icmp'] = $_POST['stream5_track_icmp'] ? 'on' : 'off';
 		$natent['appid_preproc'] = $_POST['appid_preproc'] ? 'on' : 'off';
 		$natent['sf_appid_statslog'] = $_POST['sf_appid_statslog'] ? 'on' : 'off';
+		$natent['arpspoof_preproc'] = $_POST['arpspoof_preproc'] ? 'on' : 'off';
+		$natent['arp_unicast_detection'] = $_POST['arp_unicast_detection'] ? 'on' : 'off';
 
 		if (isset($id) && isset($a_nat[$id])) {
 			$a_nat[$id] = $natent;
@@ -1520,7 +1565,7 @@ print_callout('<p>' . gettext("Rules may be dependent on enbled preprocessors!  
 	$section->addInput(new Form_Select(
 		'sdf_alert_data_type',
 		'Inspect For',
-		explode(',', $pconfig['sdf_alert_data_type']),
+		explode(',', (string)$pconfig['sdf_alert_data_type']),
 		array( 'Credit Card' => 'Credit Card', 'Email Addresses' => 'Email Addresses', 'U.S. Phone Numbers' => 'U.S. Phone Numbers', 'U.S. Social Security Numbers' => 'U.S. Social Security Numbers' ),
 		true
 	))->setHelp('Choose which types of sensitive data to detect.  Use CTRL + Click for multiple selections.');
@@ -1542,6 +1587,78 @@ print_callout('<p>' . gettext("Rules may be dependent on enbled preprocessors!  
 	));
 	print($section);
 	//----- END Sensitive Data settings -----
+
+	//----- START ARP Spoof Detection settings -----
+?>
+	<div class="panel panel-default" id="preproc_arp_spoof_row">
+		<div class="panel-heading">
+			<h2 class="panel-title">ARP Spoof Detection<span class="widget-heading-icon"><a data-toggle="collapse" href="#preproc_arp_panel-body"><i class="fa fa-plus-circle"></i></a></span></h2>
+		</div>
+	<?php if ($pconfig['arp_preproc'] == 'on') : ?>
+		<div id="preproc_arp_panel-body" class="panel-body collapse in">
+	<?php else : ?>
+		<div id="preproc_arp_panel-body" class="panel-body collapse out">
+	<?php endif ?>
+<?php
+			$group = new Form_Group('Enable ARP Spoof Detection');
+			$group->add(new Form_Checkbox(
+				'arpspoof_preproc',
+				'Enable ARP Spoof Detection',
+				'Detects ARP attacks and inconsistent Ethernet to IP mapping.  Default is Not Checked.',
+				$pconfig['arpspoof_preproc'] == 'on' ? true:false,
+				'on'
+			));
+			print($group);
+			$group = new Form_Group('Enable Unicast ARP Checks');
+			$group->add(new Form_Checkbox(
+				'arp_unicast_detection',
+				'Enable Unicast ARP Checks',
+				'Checks for unicast ARP requests.  Default is Not Checked.',
+				$pconfig['arp_unicast_detection'] == 'on' ? true:false,
+				'on'
+			));
+			print($group);
+?>
+			<!--  Populate MAC-to-IP Address pairs table  -->
+			<div class="form-group">
+				<label class="col-sm-2 control-label">
+					<?=gettext("MAC-to-IP Address Pairings"); ?>
+				</label>
+				<div class="col-sm-10">
+					<div class="table-responsive">
+						<table class="table table-striped table-hover table-condensed">
+							<thead>
+								<tr>
+									<th style="width:35%;"><?=gettext("MAC Address")?></th>
+									<th style="width:35%;"><?=gettext("IP Address")?></th>
+									<th>
+										<a href="#" data-toggle="modal" data-target="#arp_spoof_addr_pair" data-eng_id="<?=$arp_spoof_engine_next_id;?>" class="btn btn-sm btn-success" role="button" title="<?=gettext("Add a new server configuration")?>">
+											<i class="fa fa-plus icon-embed-btn"></i>
+											<?=gettext(' Add');?>
+										</a>
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+							<?php foreach ($a_nat[$id]['arp_spoof_engine']['item'] as $f => $v): ?>
+								<tr>
+									<td><?=gettext($v['mac_addr'])?></td>
+									<td><?=gettext($v['ip_addr'])?></td>
+									<td>
+										<a href="#" data-toggle="modal" data-target="#arp_spoof_addr_pair" data-eng_id="<?=$f;?>" data-arp_spoof_mac="<?=$v['mac_addr'];?>" data-arp_spoof_ip="<?=$v['ip_addr'];?>" class="fa fa-pencil icon-primary" title="<?=gettext("Edit this entry")?>"></a>
+										<a href="#" class="fa fa-trash icon-primary no-confirm" onclick="del_eng('del_arp_spoof_engine', '<?=$f;?>');" title="<?=gettext("Delete this entry")?>"></a>
+									</td>
+								</tr>
+							<?php endforeach; ?>
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+<?php
+	//----- END ARP Spoof Detection settings -----
 
 	//----- START POP3 Decoder settings -----
 	if ($pconfig['pop_preproc']=="on") {
@@ -1901,6 +2018,44 @@ $modal->addInput(new Form_StaticText(
 		gettext('all of the rules shown have been auto-disabled because they require one or more of the preprocessors that have been disabled.') . '</span>'
 ));
 print($modal);
+
+
+// Add ARP Spoofing MAC-IP address entry modal pop-up
+$modal = new Modal('Add/Edit MAC-to-IP Address Pair', 'arp_spoof_addr_pair', true);
+$modal->addInput(new Form_Input(
+	'arp_spoof_mac_addr',
+	'MAC Address',
+	''
+))->setHelp('Enter MAC address of host.');
+$modal->addInput(new Form_IpAddress(
+	'arp_spoof_ip_addr',
+	'IP Address',
+	'',
+	BOTH
+))->setHelp('Enter IP address of host.');
+$btnsave = new Form_Button(
+	'arp_spoof_save',
+	'Save',
+	null,
+	'fa-save'
+);
+$btncancel = new Form_Button(
+	'arp_spoof_cancel',
+	'Cancel'
+);
+$btnsave->addClass('btn-primary')->addClass('btn-default')->setAttribute('title', 'Save changes and return to Preprocessors tab');
+$btncancel->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-warning');
+$btncancel->setAttribute('data-dismiss', 'modal');
+$btncancel->setAttribute('title', 'Cancel changes and return to Preprocessors tab');
+
+$modal->addInput(new Form_StaticText(
+	null,
+	$btnsave . $btncancel
+));
+
+
+
+print($modal);
 ?>
 
 </form>
@@ -2026,6 +2181,13 @@ print_callout('<p>' . gettext("Remember to save your changes before you exit thi
 		}
 	}
 
+	function arp_spoof_enable_change() {
+		// Hide ARP Spoofing Detection section if preprocessor is disabled
+		if (!($('#arp_preproc').prop('checked'))) {
+			$('#preproc_arp_panel-body').collapse('toggle');
+		}
+	}
+
 	function pop_enable_change() {
 		// Hide POP3 section if preprocessor is disabled
 		if (!($('#pop_preproc').prop('checked'))) {
@@ -2064,6 +2226,7 @@ print_callout('<p>' . gettext("Remember to save your changes before you exit thi
 		}
 
 		ftp_telnet_enable_change();
+		arp_spoof_enable_change();
 	}
 
 	function selectAlias(targetVar) {
@@ -2091,7 +2254,7 @@ print_callout('<p>' . gettext("Remember to save your changes before you exit thi
 	function del_eng(eng, engid) {
 		$('#eng_id').val(engid);
 		if (confirm('Are you sure you want to delete this entry?')) {
-			$('#iform').append('<input type="hidden" name=eng value="1">').submit();
+			$('#iform').append('<input type="hidden" id="' + eng + '" name="' + eng + '" value="1">').submit();
 		}
 	}
 
@@ -2115,9 +2278,11 @@ print_callout('<p>' . gettext("Remember to save your changes before you exit thi
 		});
 	}
 
+
+
 events.push(function(){
 
-	// ---------- Autocomplete --------------------------------------------------------------------
+	// ---------- Autocomplete --------------------------------------------
 
 	var addressarray = <?= json_encode(get_alias_list(array("host", "network", "openvpn"))) ?>;
 
@@ -2129,7 +2294,7 @@ events.push(function(){
 		source: addressarray
 	});
 
-	// ---------- Click handlers -------------------------------------------------------
+	// ---------- Click handlers ------------------------------------------
 
 	$('#host_attribute_table').click(function() {
 		host_attribute_table_enable_change();
@@ -2181,6 +2346,13 @@ events.push(function(){
 
 	$('#rulesviewer').on('shown.bs.modal', function() {
 		getFileContents();
+	});
+
+	// Open ARP Spoofing address pairs Modal and init its data fields
+	$('#arp_spoof_addr_pair').on('show.bs.modal', function(e) {
+		$('#eng_id').val($(e.relatedTarget).data('eng_id'));
+		$('#arp_spoof_ip_addr').val($(e.relatedTarget).data('arp_spoof_ip'));
+		$('#arp_spoof_mac_addr').val($(e.relatedTarget).data('arp_spoof_mac'));
 	});
 
 	// Set initial state of form controls

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
@@ -1594,11 +1594,7 @@ print_callout('<p>' . gettext("Rules may be dependent on enbled preprocessors!  
 		<div class="panel-heading">
 			<h2 class="panel-title">ARP Spoof Detection<span class="widget-heading-icon"><a data-toggle="collapse" href="#preproc_arp_panel-body"><i class="fa fa-plus-circle"></i></a></span></h2>
 		</div>
-	<?php if ($pconfig['arp_preproc'] == 'on') : ?>
 		<div id="preproc_arp_panel-body" class="panel-body collapse in">
-	<?php else : ?>
-		<div id="preproc_arp_panel-body" class="panel-body collapse out">
-	<?php endif ?>
 <?php
 			$group = new Form_Group('Enable ARP Spoof Detection');
 			$group->add(new Form_Checkbox(
@@ -2183,7 +2179,7 @@ print_callout('<p>' . gettext("Remember to save your changes before you exit thi
 
 	function arp_spoof_enable_change() {
 		// Hide ARP Spoofing Detection section if preprocessor is disabled
-		if (!($('#arp_preproc').prop('checked'))) {
+		if (!($('#arpspoof_preproc').prop('checked'))) {
 			$('#preproc_arp_panel-body').collapse('toggle');
 		}
 	}
@@ -2330,6 +2326,10 @@ events.push(function(){
 
 	$('#sensitive_data').click(function() {
 		sensitive_data_enable_change();
+	});
+
+	$('#arpspoof_preproc').click(function() {
+		arp_spoof_enable_change();
 	});
 
 	$('#pop_preproc').click(function() {


### PR DESCRIPTION
## Snort GUI Package v3.2.9.5
This updates the _pfSense-pkg-snort_ GUI package to version 3.2.9.5.  One new feature and several reported bug fixes are included in this update.

**New Features**
1. The ARP Spoofing preprocessor is now exposed in the GUI as a configurable option on the PREPROCESSORS tab.  Settings are available for toggling the enabled state of the preprocessor and for enabling detection of unicast ARP requests.  A multi-entry table is provided that allows for entry of MAC address-to-IP address pairs to be monitor for ARP spoofing incidents.  New MAC/IP address pairs can be added to the table and existing MAC/IP pairs can be edited or deleted from the table.

**Bug Fixes**
1. Fix display of IPv6 addresses so they wrap correctly when displayed in the SRC IP and DST IP columns on the ALERTS tab.

2. Fix the DOWNLOAD button on the ALERTS and BLOCKS tabs so that they work.  Also fix the ALERTS download so that it only includes alert logs and not all log files in the directory.

3. Restore the installation of the _attribute_table.dtd_ validation file to the Snort conf directory.

4. Do not show Reverse DNS Lookup and Track-by-IP icons on the ALERTS tab for alert entries that do not contain an IP Header and thus no IP addresses (usually from alerts generated by the ARP Spoof preprocessor).

5. Improve package uninstall procedure by manually cleaning up files created or altered by the GUI code.  The default _pkg_ uninstall code does not remove files modified by others.

6. Remove the shared object rules files when uninstalling the package.  This should fix errors during package upgrades when older versions of these files still exist.

7.  Add a warning to the OpenAppID rules file download section on the GLOBAL SETTINGS tab about Geo-IP blocking at the volunteer hosting web site.  This hosting block may impact users in some countries when they attempt to enable the OpenAppID rules download.  (NOTE - this is for the rules only.  The OpenAppID detectors are maintained by the Snort VRT and should always download and install.  However, the detectors need the rules in order to be fully functional.)
