### PR TITLE
Snort 2.9.9.0_3 -- Bug Fix for custom blocking module

### DIFF
--- a/security/snort/Makefile
+++ b/security/snort/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=	snort
 PORTVERSION=	2.9.9.0
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	security
 MASTER_SITES=	https://snort.org/downloads/snort/ \
 		http://www.talosintel.com/downloads/ \

--- a/security/snort/files/patch-spoink-integration.diff
+++ b/security/snort/files/patch-spoink-integration.diff
@@ -42,8 +42,8 @@ diff -urN snort-2.9.9.0.orig/src/output-plugins/Makefile.in ./src/output-plugins
  
 diff -urN snort-2.9.9.0.orig/src/output-plugins/spo_pf.c ./src/output-plugins/spo_pf.c
 --- snort-2.9.9.0.orig/src/output-plugins/spo_pf.c	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/output-plugins/spo_pf.c	2017-08-17 17:36:14.000000000 -0400
-@@ -0,0 +1,758 @@
++++ ./src/output-plugins/spo_pf.c	2017-08-21 18:28:36.000000000 -0400
+@@ -0,0 +1,764 @@
 +/*
 +* Copyright (c) 2017  Bill Meeks
 +* Copyright (c) 2012  Ermal Luci
@@ -227,6 +227,12 @@ diff -urN snort-2.9.9.0.orig/src/output-plugins/spo_pf.c ./src/output-plugins/sp
 +    }
 +
 +    DEBUG_WRAP(DebugMessage(DEBUG_LOG, "spoink block'n!!\n"););
++
++	// Test for valid IP header in packet and
++	// ignore packets with no valid IP information
++	// since we need IP addresses to block.
++	if (!IsIP(p))
++		return;
 +
 +    switch (data->block) {
 +    case SPOINK_BLOCK_DST:


### PR DESCRIPTION
## Snort 2.9.9.0_3
This update corrects a bug in the custom blocking plugin for the Snort binary.  Failure to validate that the IP header information in an alerting packet is valid before attempting to insert the IP addressess into the "snort2c" table could cause Signal 11 faults in the Snort binary.  Certain alerts, particularly from the ARP Spoofing detection preprocessor, may not contain valid IP header information.  The IP header information is now validated before attempting to insert the addresses into the "snort2c" table.  Alert packets with empty or invalid IP header information are now ignored by the blocking plugin since it could not do anything useful with them anyway.