### PR TITLE
pfSense-pkg-apcupsd: Pull in apcupsd-3.14.14_2

### DIFF
--- a/sysutils/apcupsd/Makefile
+++ b/sysutils/apcupsd/Makefile
@@ -3,14 +3,15 @@
 
 PORTNAME=	apcupsd
 PORTVERSION=	3.14.14
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	sysutils
 MASTER_SITES=	SF/${PORTNAME}/${PORTNAME}%20-%20Stable/${PORTVERSION}
 
-MAINTAINER=	ports@FreeBSD.org
+MAINTAINER=	dbaio@FreeBSD.org
 COMMENT=	Set of programs for controlling APC UPS
 
 LICENSE=	GPLv2
+LICENSE_FILE=	${WRKSRC}/COPYING
 
 USES=		gmake
 GNU_CONFIGURE=	yes
@@ -26,54 +27,55 @@ CONFIGURE_ENV+=	LD="${CXX}" \
 USE_RC_SUBR=	apcupsd
 SUB_FILES=	pkg-message
 
-OPTIONS_DEFINE=	APCSMART_DRV APCDUMB_DRV CLIENT_ONLY CGI PCNET_DRV USB_DRV \
-		SNMP_DRV SNMP_DRV_OLD TCP_WRAPPERS TEST_DRV GAPCMON \
-		DOCS MODBUS
-OPTIONS_DEFAULT=	APCSMART_DRV APCDUMB_DRV PCNET_DRV SNMP_DRV USB_DRV \
-		TCP_WRAPPERS MODBUS
+OPTIONS_DEFINE=	APCDUMB_DRV APCSMART_DRV CGI CLIENT_ONLY DOCS GAPCMON MODBUS \
+		MODBUS_USB PCNET_DRV SHUTDOWN_POWEROFF SNMP_DRV SNMP_DRV_OLD \
+		TCP_WRAPPERS TEST_DRV USB_DRV
+OPTIONS_DEFAULT=	APCDUMB_DRV APCSMART_DRV MODBUS MODBUS_USB PCNET_DRV \
+		SNMP_DRV TCP_WRAPPERS USB_DRV
 OPTIONS_SUB=	yes
 
-APCSMART_DRV_DESC=	APC SmartUPS serial driver support
 APCDUMB_DRV_DESC=	Dumb UPS driver support
-CLIENT_ONLY_DESC=	Only NIS client (no network server or drivers)
+APCSMART_DRV_DESC=	APC SmartUPS serial driver support
 CGI_DESC=		Build CGI programs to show status
+CLIENT_ONLY_DESC=	Only NIS client (no network server or drivers)
+GAPCMON_DESC=		Build GTK GUI front-end
+MODBUS_DESC=		MODBUS driver support
+MODBUS_USB_DESC=	MODBUS USB driver support
 PCNET_DRV_DESC=		PowerChute Network Shutdown driver support
-USB_DRV_DESC=		USB driver support
+SHUTDOWN_POWEROFF_DESC=	Shutdown behavior with Halt and Power off
 SNMP_DRV_DESC=		SNMP driver support
 SNMP_DRV_OLD_DESC=	Old SNMP driver support
 TCP_WRAPPERS_DESC=	${LIBWRAP_DESC}
 TEST_DRV_DESC=		Test driver support
-GAPCMON_DESC=		Build GTK GUI front-end
-MODBUS_DESC=		MODBUS driver support
+USB_DRV_DESC=		USB driver support
 
-#PORTDOCS=	${PORTNAME}.pdf
-
-APCSMART_DRV_CONFIGURE_ENABLE=	apcsmart
 APCDUMB_DRV_CONFIGURE_ENABLE=	dumb
-CLIENT_ONLY_CONFIGURE_ON=	--enable-net \
-				--disable-apcsmart --disable-dumb --disable-usb \
-				--disable-snmp --disable-test --disable-pcnet
+APCSMART_DRV_CONFIGURE_ENABLE=	apcsmart
 CGI_CONFIGURE_ENABLE=		cgi
 CGI_CONFIGURE_ON=		--with-cgi-bin=${ETCDIR}/cgi
 CGI_LIB_DEPENDS=		libgd.so:graphics/gd
+CLIENT_ONLY_CONFIGURE_ON=	--enable-net \
+				--disable-apcsmart --disable-dumb --disable-usb \
+				--disable-snmp --disable-test --disable-pcnet
 GAPCMON_CONFIGURE_ENABLE=	gapcmon
 GAPCMON_USES=			pkgconfig
 GAPCMON_USE=			GNOME=gconf2
 GAPCMON_CONFLICTS=		gapcmon-[0-9]*
-PCNET_DRV_CONFIGURE_ENABLE=	pcnet
-USB_DRV_CONFIGURE_ENABLE=	usb
-SNMP_DRV_CONFIGURE_ENABLE=	snmp
 MODBUS_CONFIGURE_ENABLE=	modbus
+MODBUS_USB_CONFIGURE_ENABLE=	modbus-usb
+PCNET_DRV_CONFIGURE_ENABLE=	pcnet
+SNMP_DRV_CONFIGURE_ENABLE=	snmp
 SNMP_DRV_OLD_CONFIGURE_ENABLE=	net-snmp
 SNMP_DRV_OLD_LIB_DEPENDS=	libnetsnmp.so:net-mgmt/net-snmp
 TCP_WRAPPERS_CONFIGURE_WITH=	libwrap=yes
 TEST_DRV_CONFIGURE_ENABLE=	test
-
-#CONFIGURE_ARGS+=	--with-libwrap=yes
-#CONFIGURE_ENV+=		LIBS="-lcurses -lmenu"
-#PLIST_SUB+=		POWERFL=""
+USB_DRV_CONFIGURE_ENABLE=	usb
 
 .include <bsd.port.options.mk>
+
+post-patch-SHUTDOWN_POWEROFF-on:
+	${REINPLACE_CMD} -e 's|-h now|-p now|' \
+		${WRKSRC}/platforms/freebsd/apccontrol.in
 
 pre-configure:
 .if ${PORT_OPTIONS:MCLIENT_ONLY} && ( ${PORT_OPTIONS:MAPCSMART_DRV} || \

--- a/sysutils/apcupsd/files/apcupsd.in
+++ b/sysutils/apcupsd/files/apcupsd.in
@@ -11,24 +11,73 @@
 #
 # apcupsd_enable (bool):	Set to "NO" by default.
 #				Set it to "YES" to enable apcupsd.
-# apcupsd_args (str):		Custom additional arguments to be passed
-#				to apcupsd (default empty).
+# apcupsd_flags (str):		Custom additional arguments to be passed
+#				to apcupsd (default --kill-on-powerfail).
+# apcupsd_configs (str):	A list of configs to run multiple instances.
 #
 
 . /etc/rc.subr
 
-name="apcupsd"
+name=apcupsd
 rcvar=apcupsd_enable
 
 load_rc_config $name
 
 : ${apcupsd_enable="NO"}
 : ${apcupsd_flags="--kill-on-powerfail"}
-: ${apcupsd_pidfile="/var/run/apcupsd.pid"}
-: ${apcupsd_lockfile="/var/spool/lock/apcupsd.lock"}
 
-pidfile="/var/run/apcupsd.pid"
-required_files="%%ETCDIR%%/apcupsd.conf"
-command="%%PREFIX%%/sbin/apcupsd"
+pidfile=/var/run/${name}.pid
+required_files="${apcupsd_configs:-%%ETCDIR%%/apcupsd.conf}"
+command=%%PREFIX%%/sbin/${name}
+restart_cmd=${name}_restart_cmd
 
-run_rc_command "$1"
+apcupsd_precmd()
+{
+	config=$1
+
+	dn="`/usr/bin/dirname ${pidfile}`"
+	if [ -n "${config}" ]; then
+		# Specific config
+		base="`/usr/bin/basename ${config} .conf`"
+		pidfile="${dn}/${base}.pid"
+		command_args="-f ${config} -P ${pidfile}"
+	else
+		# Default config
+		command_args=""
+	fi
+}
+
+apcupsd_restart_cmd()
+{
+	if [ -n "${apcupsd_configs}" ]; then
+		# One or more named configs
+		for config in ${apcupsd_configs}; do
+			apcupsd_precmd ${config}
+			run_rc_command stop
+		done
+		for config in ${apcupsd_configs}; do
+			apcupsd_precmd ${config}
+			run_rc_command start
+		done
+	else
+		# Default config
+		apcupsd_precmd
+		run_rc_command stop
+		run_rc_command start
+	fi
+}
+
+if [ "$1" = restart ]; then
+	apcupsd_precmd
+	run_rc_command $1
+elif [ -n "${apcupsd_configs}" ]; then
+	# One or more named configs
+	for config in ${apcupsd_configs}; do
+		apcupsd_precmd ${config}
+		run_rc_command $1
+	done
+else
+	# Default config
+	apcupsd_precmd
+	run_rc_command $1
+fi

--- a/sysutils/apcupsd/files/patch-platforms_etc_Makefile
+++ b/sysutils/apcupsd/files/patch-platforms_etc_Makefile
@@ -1,11 +1,21 @@
 --- platforms/etc/Makefile.orig	2014-04-09 22:15:34 UTC
 +++ platforms/etc/Makefile
-@@ -8,7 +8,7 @@ all-uninstall: uninstall-etc
+@@ -8,12 +8,12 @@ all-uninstall: uninstall-etc
  
  install-etc:
  	$(call MKDIR,$(sysconfdir))
 -	$(call INSTNEW,644,apcupsd.conf,$(sysconfdir))
+-	$(call INSTORIG,744,changeme,$(sysconfdir))
+-	$(call INSTORIG,744,commfailure,$(sysconfdir))
+-	$(call INSTORIG,744,commok,$(sysconfdir))
+-	$(call INSTORIG,744,offbattery,$(sysconfdir))
+-	$(call INSTORIG,744,onbattery,$(sysconfdir))
 +	$(call INSTDATA,644,apcupsd.conf,$(sysconfdir)/apcupsd.conf.sample)
- 	$(call INSTORIG,744,changeme,$(sysconfdir))
- 	$(call INSTORIG,744,commfailure,$(sysconfdir))
- 	$(call INSTORIG,744,commok,$(sysconfdir))
++	$(call INSTDATA,744,changeme,$(sysconfdir)/changeme.sample)
++	$(call INSTDATA,744,commfailure,$(sysconfdir)/commfailure.sample)
++	$(call INSTDATA,744,commok,$(sysconfdir)/commok.sample)
++	$(call INSTDATA,744,offbattery,$(sysconfdir)/offbattery.sample)
++	$(call INSTDATA,744,onbattery,$(sysconfdir)/onbattery.sample)
+ 
+ uninstall-etc:
+ 

--- a/sysutils/apcupsd/files/pkg-message.in
+++ b/sysutils/apcupsd/files/pkg-message.in
@@ -1,26 +1,23 @@
 **********************************************************************
-Read the manual
+Read the manual:
+  http://www.apcupsd.org/manual/manual.html
+  http://www.apcupsd.org/manual/manual.pdf
 
-  %%DOCSDIR%%/apcupsd.pdf
-
-to do site specific configuration assigenments! Especially have a
-detailed look into the chapter describing the shutdown procedure.
-
-Sample files are installed in %%ETCDIR%%. These files
-must be copied and/or configured for a proper working apcupsd.
+Sample files and scripts are installed in %%ETCDIR%%.
 You need to modify %%ETCDIR%%/apcupsd.conf as follows:
 
   For serial cable: DEVICE /dev/cuadX (or /dev/cuaaX for [45.]x)
   For USB cable: DEVICE (yes, leave it blank after DEVICE)
 
-NOTE that for USB cable you must comment out the line
+NOTE that for USB cable you need uhid support.
 
-  device         uhid            # "Human Interface Devices"
+To	compile	this driver into the kernel, place the following line in your
+kernel configuration file:
+  device uhid
 
-in your kernel configuration file and recompile the kernel.
-Your keyboard and mouse will still work.
-
-WARNING USB support on FreeBSD is still considered BETA!
+Alternatively, to load the driver as a module at boot time, place the
+following line in loader.conf(5):
+  uhid_load="YES"
 
 Add apcupsd_enable=YES to your /etc/rc.conf[.local] to have apcupsd
 starting up at boot time.

--- a/sysutils/apcupsd/pkg-plist
+++ b/sysutils/apcupsd/pkg-plist
@@ -4,11 +4,11 @@ sbin/apctest
 sbin/smtp
 @sample %%ETCDIR%%/apcupsd.conf.sample
 %%ETCDIR%%/apccontrol
-%%ETCDIR%%/changeme
-%%ETCDIR%%/commfailure
-%%ETCDIR%%/commok
-%%ETCDIR%%/onbattery
-%%ETCDIR%%/offbattery
+@sample %%ETCDIR%%/changeme.sample
+@sample %%ETCDIR%%/commfailure.sample
+@sample %%ETCDIR%%/commok.sample
+@sample %%ETCDIR%%/onbattery.sample
+@sample %%ETCDIR%%/offbattery.sample
 %%CGI%%@sample %%ETCDIR%%/apcupsd.css.sample
 %%CGI%%@sample %%ETCDIR%%/hosts.conf.sample
 %%CGI%%@sample %%ETCDIR%%/multimon.conf.sample

--- a/sysutils/pfSense-pkg-apcupsd/Makefile
+++ b/sysutils/pfSense-pkg-apcupsd/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-apcupsd
 PORTVERSION=	0.3.9
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty


### PR DESCRIPTION
My primary motivation for pulling in the rev 2 package of apcupsd-3.14.14 is the MODBUS USB driver option (I just cherry-picked f7e0540ed53e2225730aa36ddd00b037ad38e369). I wasn't sure if the pfSense-pkg-apcupsd port revision also needed to be bumped up to trigger a rebuild of the package with the updated apcupsd dependency.

CC: @dbaio