### PR TITLE
sysutils/pfSense-pkg-Shellcmd: Fix earlyshellcmd special case for pfSense-pkg-System_Patches

### DIFF
--- a/sysutils/pfSense-pkg-Shellcmd/Makefile
+++ b/sysutils/pfSense-pkg-Shellcmd/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-Shellcmd
-PORTVERSION=	1.0.2
-PORTREVISION=	4
+PORTVERSION=	1.0.3
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-Shellcmd/files/usr/local/pkg/shellcmd.inc
+++ b/sysutils/pfSense-pkg-Shellcmd/files/usr/local/pkg/shellcmd.inc
@@ -3,7 +3,7 @@
  * shellcmd.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2017 Rubicon Communications, LLC (Netgate)
  * Copyright (C) 2008 Mark J Crane
  * All rights reserved.
  *
@@ -48,7 +48,7 @@ function shellcmd_delete_php_command() {
 
 		/* First check for a couple of special cases that we do NOT want deleted */
 		$pkg = '';
-		/* pfBlockerNG - function to restore archived aliastables on nanobsd (see pfblockerng.inc) */
+		/* pfBlockerNG - function to restore archived aliastables on systems with /var ramdisk (see pfblockerng.inc) */
 		$pfbcmd = "/usr/local/pkg/pfblockerng/pfblockerng.sh";
 		/* If the entry exists in system config ... */
 		if (in_array($pfbcmd, $a_earlyshellcmd)) {
@@ -67,7 +67,7 @@ function shellcmd_delete_php_command() {
 			}
 		}
 		/* System Patches auto-apply patch feature (see patches.inc) */
-		$spcmd = "/usr/local/bin/php -f /usr/local/bin/apply_patches.php";
+		$spcmd = "/usr/local/bin/php-cgi -f /usr/local/bin/apply_patches.php";
 		if (in_array($spcmd, $a_earlyshellcmd)) {
 			$cntb = 0;
 			foreach ($a_shellcmd_config as $item => $value) {
@@ -191,9 +191,9 @@ function shellcmd_import_config() {
 	if (is_array($config['system']['earlyshellcmd'])) {
 		$earlyshellcmds = &$config['system']['earlyshellcmd'];
 		$pfbcmd = "/usr/local/pkg/pfblockerng/pfblockerng.sh";
-		$spcmd = "/usr/local/bin/php -f /usr/local/bin/apply_patches.php";
+		$spcmd = "/usr/local/bin/php-cgi -f /usr/local/bin/apply_patches.php";
 		foreach ($earlyshellcmds as $earlyshellcmd) {
-			/* pfBlockerNG - function to restore archived aliastables on nanobsd (see pfblockerng.inc) */
+			/* pfBlockerNG - function to restore archived aliastables on on systems with /var ramdisk (see pfblockerng.inc) */
 			if (stristr($earlyshellcmd, "{$pfbcmd}")) {
 				$shellcmd_config[$i]['cmd'] = $earlyshellcmd;
 				$shellcmd_config[$i]['cmdtype'] = "earlyshellcmd";


### PR DESCRIPTION
Also remove references to nanobsd while here.