### PR TITLE
net/pfSense-pkg-freeradius3: Revert broken change that breaks configuration

### DIFF
--- a/net/pfSense-pkg-freeradius3/Makefile
+++ b/net/pfSense-pkg-freeradius3/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-freeradius3
-PORTVERSION=	0.14
+PORTVERSION=	0.15
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-freeradius3/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius3/files/usr/local/pkg/freeradius.inc
@@ -3255,7 +3255,7 @@ function freeradius_plainmacauth_resync() {
 function freeradius_policyd_resync() {
 	$conf = <<<EOD
 pfs_rewrite_calling_station_id {
-	if (&Calling-Station-Id && (&Calling-Station-Id =~ /^\${policy.mac-addr-regexp}\$/i)) {
+	if (&Calling-Station-Id && (&Calling-Station-Id =~ /^${policy.mac-addr-regexp}\$/i)) {
 		update request {
 			&Calling-Station-Id := "%{tolower:%{1}-%{2}-%{3}-%{4}-%{5}-%{6}}"
 		}

--- a/net/pfSense-pkg-freeradius3/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius3/files/usr/local/pkg/freeradius.inc
@@ -3255,7 +3255,7 @@ function freeradius_plainmacauth_resync() {
 function freeradius_policyd_resync() {
 	$conf = <<<EOD
 pfs_rewrite_calling_station_id {
-	if (&Calling-Station-Id && (&Calling-Station-Id =~ /^${policy.mac-addr-regexp}\$/i)) {
+	if (&Calling-Station-Id && (&Calling-Station-Id =~ /^${policy.mac-addr-regexp}$/i)) {
 		update request {
 			&Calling-Station-Id := "%{tolower:%{1}-%{2}-%{3}-%{4}-%{5}-%{6}}"
 		}


### PR DESCRIPTION
Not sure what was the change supposed to fix but the escaping in heredoc breaks the thing altogether.

```
# radiusd -X
/usr/local/etc/raddb/policy.d/pfs_custom_policies[2]: Reference "${policy.mac-addr-regexp}" not found
/usr/local/etc/raddb/policy.d/pfs_custom_policies[2]: Parse error expanding ${...} in condition
Errors reading or parsing /usr/local/etc/raddb/radiusd.conf
```
@jim-p Perhaps make use of the example here: https://wiki.freeradius.org/guide/mac-auth#plain-mac-auth_raddb-policy-conf ?
