### PR TITLE
FreeRADIUS3: Put client shared secret between single quotes to avoid breaking configuration (Bug #7836)

### DIFF
--- a/net/pfSense-pkg-freeradius3/Makefile
+++ b/net/pfSense-pkg-freeradius3/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-freeradius3
-PORTVERSION=	0.15.1
+PORTVERSION=	0.15.2
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-freeradius3/files/usr/local/pkg/freeradius.inc
+++ b/net/pfSense-pkg-freeradius3/files/usr/local/pkg/freeradius.inc
@@ -1004,7 +1004,8 @@ function freeradius_clients_resync($restart_svc = true) {
 	if (!empty($arrclients)) {
 		foreach ($arrclients as $item) {
 			$varclientip = $item['varclientip'];
-			$varclientsharedsecret = $item['varclientsharedsecret'];
+			// Bug #7836: Add single quotes to avoid breaking configuration with certain chars in secret
+			$varclientsharedsecret = "'" . $item['varclientsharedsecret'] . "'";
 			$varclientipversion = $item['varclientipversion'];
 			$varclientshortname = $item['varclientshortname'];
 			$varclientproto = $item['varclientproto'];

--- a/net/pfSense-pkg-freeradius3/files/usr/local/pkg/freeradiusclients.xml
+++ b/net/pfSense-pkg-freeradius3/files/usr/local/pkg/freeradiusclients.xml
@@ -155,7 +155,9 @@
 				<![CDATA[
 				Enter the shared secret of the RADIUS client here. This is the shared secret (password)
 				which the NAS (switch, accesspoint, etc.) needs to communicate with the RADIUS server.
-				<span class="text-info">FreeRADIUS is limited to 31 characters for the shared secret.</span>
+				<span class="text-info">FreeRADIUS is limited to 31 characters for the shared secret.</span><br/>
+				<span class="text-danger">Warning: </span>Single quotes in shared secret must be escaped with a backslash (<code>\'</code>).
+				Backslash must be escaped by using two backslashes (<code>\\</code>).
 				]]>
 			</description>
 			<type>password</type>


### PR DESCRIPTION
https://redmine.pfsense.org/issues/7836