### PR TITLE
pfSense-pkg-snort-3.2.9.5_1 -- fix XMLRPC sync to work in both 2.3 and 2.4 pfSense versions

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	3.2.9.5
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2016 Bill Meeks
+ * Copyright (c) 2013-2017 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -3700,12 +3700,18 @@ function snort_sync_on_changes() {
  	}
 }
 
+if(!function_exists('pf_version')) {
+	function pf_version() {
+		return substr(trim(file_get_contents("/etc/version")), 0, 3);
+	}
+}
+
 /* Do the actual XMLRPC sync */
-function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol, $username, $password, $synctimeout = 150, $syncstartsnort) {
+function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol, $username, $password, $synctimeout, $syncstartsnort) {
 	global $config, $g;
 
 	/* Do not attempt a package sync while booting up or installing package */
-	if ($g['booting'] || $g['snort_postinstall']) {
+	if ($g['booting'] || isset($g['snort_postinstall'])) {
 		log_error("[snort] Skipping XMLRPC sync when booting up or during package reinstallation.");
 		return;
 	}
@@ -3715,111 +3721,13 @@ function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol,
 		return;
 	}
 
-	// Take care of IPv6 literal address
-	if (is_ipaddrv6($sync_to_ip)) {
-		$sync_to_ip = "[{$sync_to_ip}]";
-	}
-
-	$url = "{$protocol}://{$sync_to_ip}";
-
-	/*************************************************/
-	/* Send over any auto-SID management files       */
-	/*************************************************/
-	$sid_files = glob(SNORT_SID_MODS_PATH . '*');
-	foreach ($sid_files as $file) {
-		$content = base64_encode(file_get_contents($file));
-		$payload = "@file_put_contents('{$file}', base64_decode('{$content}'));";
-
-		/* assemble xmlrpc payload */
-		$method = 'pfsense.exec_php';
-		$params = array( XML_RPC_encode($password), XML_RPC_encode($payload) );
-	
-		log_error("[snort] Snort XMLRPC sync sending auto-SID conf files to {$url}:{$port}.");
-		$msg = new XML_RPC_Message($method, $params);
-		$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
-		$cli->setCredentials($username, $password);
-		$resp = $cli->send($msg, $synctimeout);
-		$error = "";
-		if(!$resp) {
-			$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
-			log_error($error);
-			file_notice("sync_settings", $error, "Snort Settings Sync", "");
-		} elseif($resp->faultCode()) {
-			$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
-			log_error($error);
-			file_notice("sync_settings", $error, "Snort Settings Sync", "");
-		}
-	}
-
-	if (!empty($sid_files) && $error == "") {
-		log_error("[snort] XMLRPC sync auto-SID conf files success with {$url}:{$port} (pfsense.exec_php).");
-	}
-
-	/*************************************************/
-	/* Send over any IPREP IP List files             */
-	/*************************************************/
-	$sid_files = glob(SNORT_IPREP_PATH . '*');
-	foreach ($sid_files as $file) {
-		$content = base64_encode(file_get_contents($file));
-		$payload = "@file_put_contents('{$file}', base64_decode('{$content}'));";
-
-		/* assemble xmlrpc payload */
-		$method = 'pfsense.exec_php';
-		$params = array( XML_RPC_encode($password), XML_RPC_encode($payload) );
-	
-		log_error("[snort] Snort XMLRPC sync sending IPREP files to {$url}:{$port}.");
-		$msg = new XML_RPC_Message($method, $params);
-		$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
-		$cli->setCredentials($username, $password);
-		$resp = $cli->send($msg, $synctimeout);
-		$error = "";
-		if (!$resp) {
-			$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
-			log_error($error);
-			file_notice("sync_settings", $error, "Snort Settings Sync", "");
-		} elseif ($resp->faultCode()) {
-			$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
-			log_error($error);
-			file_notice("sync_settings", $error, "Snort Settings Sync", "");
-		}
-	}
-
-	if (!empty($sid_files) && $error == "") {
-		log_error("[snort] XMLRPC sync IPREP files success with {$url}:{$port} (pfsense.exec_php).");
-	}
-
-	/**************************************************/
-	/* Send over the <snortglobal> portion of the     */
-	/* config.xml.  $xml will hold section to sync.   */
-	/**************************************************/
+	/*****************************************************/
+	/* Send over the <snortglobal> portion of config.xml */
+	/* $xml will hold the section to sync.               */
+	/*****************************************************/
 	$xml = array();
 	$xml['snortglobal'] = $config['installedpackages']['snortglobal'];
-	/* assemble xmlrpc payload */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($xml)
-	);
-
-	log_error("[snort] Beginning package configuration XMLRPC sync to {$url}:{$port}.");
-	$method = 'pfsense.merge_installedpackages_section_xmlrpc';
-	$msg = new XML_RPC_Message($method, $params);
-	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
-	$cli->setCredentials($username, $password);
-
-	/* send our XMLRPC message and timeout after defined sync timeout value*/
-	$resp = $cli->send($msg, $synctimeout);
-	if (!$resp) {
-		$error = "A communications error occurred while attempting snort XMLRPC sync with {$url}:{$port}.";
-		log_error($error);
-		file_notice("sync_settings", $error, "snort Settings Sync", "");
-	} elseif ($resp->faultCode()) {
-		$error = "An error code was received while attempting snort XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
-		file_notice("sync_settings", $error, "snort Settings Sync", "");
-	} else {
-		log_error("[snort] Package configuration XMLRPC sync successfully completed with {$url}:{$port}.");
-	}
-
+	
 	$downloadrulescmd = "";
 	if ($syncdownloadrules == "yes") {
 		$downloadrulescmd = "log_error(gettext(\"[snort] XMLRPC pkg sync: Update of downloaded rule sets requested...\"));\n";
@@ -3827,8 +3735,12 @@ function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol,
 	}
 	$snortstart = "";
 	if ($syncstartsnort == "ON") {
-		$snortstart = "log_error(gettext(\"[snort] XMLRPC pkg sync: Starting Snort if not running...\"));\n";
-		$snortstart .= "\tsnort_start_all_interfaces(TRUE);\n";
+		$snortstart = "log_error(gettext(\"[snort] XMLRPC pkg sync: Checking Snort status...\"));\n";
+		$snortstart .= "\tif (!is_process_running(\"snort\")) {\n";
+		$snortstart .= "\t\tlog_error(gettext(\"[snort] XMLRPC pkg sync: Snort not running. Sending a start command...\"));\n";
+		$snortstart .= "\t\t\$sh_script = RCFILEPREFIX . \"snort.sh\";\n";
+		$snortstart .= "\t\tmwexec_bg(\"{\$sh_script} start\");\n\t}\n";
+		$snortstart .= "\telse {\n\t\tlog_error(gettext(\"[snort] XMLRPC pkg sync: Snort is running...\"));\n\t}\n";
 	}
 
 	/*************************************************/
@@ -3868,54 +3780,191 @@ EOD;
 	/* to a PHP file in the /tmp directory.          */
 	/*************************************************/
 	$execcmd = "file_put_contents('/tmp/snort_sync_cmds.php', '{$snort_sync_cmd}');";
-
-	/* assemble xmlrpc payload */
-	$method = 'pfsense.exec_php';
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($execcmd)
-	);
 	
-	log_error("[snort] Snort XMLRPC sending reload configuration cmd set as a file to {$url}:{$port}.");
-	$msg = new XML_RPC_Message($method, $params);
-	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
-	$cli->setCredentials($username, $password);
-	$resp = $cli->send($msg, $synctimeout);
-	if (!$resp) {
-		$error = "A communications error occurred while attempting snort XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
-		log_error($error);
-		file_notice("sync_settings", $error, "snort Settings Sync", "");
-	} elseif ($resp->faultCode()) {
-		$error = "An error code was received while attempting snort XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
-		file_notice("sync_settings", $error, "snort Settings Sync", "");
-	} else {
-		log_error("[snort] XMLRPC reload configuration success with {$url}:{$port} (pfsense.exec_php).");
-	}
-
 	/*************************************************/
 	/* Now assemble a command to execute the         */
 	/* previously sent PHP file in the background.   */
 	/*************************************************/
-	$execcmd = "exec(\"/usr/local/bin/php -f '/tmp/snort_sync_cmds.php' > /dev/null 2>&1 &\");";
-	$params2 = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($execcmd)
-	);
-	log_error("[snort] Snort XMLRPC sending {$url}:{$port} cmd to execute configuration reload.");
-	$msg2 = new XML_RPC_Message($method, $params2);
-	$resp = $cli->send($msg2, $synctimeout);
-	if (!$resp) {
-		$error = "A communications error occurred while attempting snort XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
-		log_error($error);
-		file_notice("sync_settings", $error, "snort Settings Sync", "");
-	} elseif ($resp->faultCode()) {
-		$error = "An error code was received while attempting snort XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
-		file_notice("sync_settings", $error, "snort Settings Sync", "");
+	$execcmd2 = "exec(\"/usr/local/bin/php-cgi -f '/tmp/snort_sync_cmds.php' > /dev/null 2>&1 &\");";
+	
+	if (pf_version() >= "2.4") {
+		// xmlrpc cannot encode NULL objects/arrays..
+		foreach($xml as $xmlkey => $xmlvalue) {
+			if (gettype($xmlvalue) == "NULL") {
+				$xml[$xmlkey] = array();
+			}
+		}
+		$synctimeout = intval($synctimeout);
+		$rpc_client = new pfsense_xmlrpc_client();
+		$rpc_client->setConnectionData($sync_to_ip, $port, $username, $password, $protocol);
+		
+		/*************************************************/
+		/* Send over any auto-SID management files       */
+		/*************************************************/
+		$sid_files = glob(SNORT_SID_MODS_PATH . '*');
+		foreach ($sid_files as $file) {
+			$content = base64_encode(file_get_contents($file));
+			$payload = "@file_put_contents('{$file}', base64_decode('{$content}'));";
+			$resp = $rpc_client->xmlrpc_exec_php($payload, $synctimeout);
+		}
+		/*************************************************/
+		/* Send over any IPREP IP List files             */
+		/*************************************************/
+		$iprep_files = glob(SNORT_IPREP_PATH . '*');
+		foreach ($iprep_files as $file) {
+			$content = base64_encode(file_get_contents($file));
+			$payload = "@file_put_contents('{$file}', base64_decode('{$content}'));";
+			$resp = $rpc_client->xmlrpc_exec_php($payload, $synctimeout);
+		}
+		
+		$resp = $rpc_client->xmlrpc_method('merge_installedpackages_section', $xml, $synctimeout);
+		$resp = $rpc_client->xmlrpc_exec_php($execcmd, $synctimeout);
+		$resp = $rpc_client->xmlrpc_exec_php($execcmd2, $synctimeout);
 	} else {
-		log_error("[snort] XMLRPC reload configuration success with {$url}:{$port} (pfsense.exec_php).");
+		// pfSense before 2.4
+		require_once('xmlrpc.inc');
+	
+		// Take care of IPv6 literal address
+		if (is_ipaddrv6($sync_to_ip)) {
+			$sync_to_ip = "[{$sync_to_ip}]";
+		}
+
+		$url = "{$protocol}://{$sync_to_ip}";
+
+		/*************************************************/
+		/* Send over any auto-SID management files       */
+		/*************************************************/
+		$sid_files = glob(SNORT_SID_MODS_PATH . '*');
+		foreach ($sid_files as $file) {
+			$content = base64_encode(file_get_contents($file));
+			$payload = "@file_put_contents('{$file}', base64_decode('{$content}'));";
+
+			/* assemble xmlrpc payload */
+			$method = 'pfsense.exec_php';
+			$params = array( XML_RPC_encode($password), XML_RPC_encode($payload) );
+
+			log_error("[snort] XMLRPC sync sending auto-SID conf files to {$url}:{$port}.");
+			$msg = new XML_RPC_Message($method, $params);
+			$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
+			$cli->setCredentials($username, $password);
+			$resp = $cli->send($msg, $synctimeout);
+			$error = "";
+			if (!$resp) {
+				$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
+				log_error($error);
+				file_notice("sync_settings", $error, "Snort Settings Sync", "");
+			} elseif ($resp->faultCode()) {
+				$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
+				log_error($error);
+				file_notice("sync_settings", $error, "Snort Settings Sync", "");
+			}
+		}
+
+		if (!empty($sid_files) && $error == "") {
+			log_error("[snort] XMLRPC sync auto-SID conf files success with {$url}:{$port} (pfsense.exec_php).");
+		}
+
+		/*************************************************/
+		/* Send over any IPREP IP List files             */
+		/*************************************************/
+		$iprep_files = glob(SNORT_IPREP_PATH . '*');
+		foreach ($iprep_files as $file) {
+			$content = base64_encode(file_get_contents($file));
+			$payload = "@file_put_contents('{$file}', base64_decode('{$content}'));";
+
+			/* assemble xmlrpc payload */
+			$method = 'pfsense.exec_php';
+			$params = array( XML_RPC_encode($password), XML_RPC_encode($payload) );
+
+			log_error("[snort] Snort XMLRPC sync sending IPREP files to {$url}:{$port}.");
+			$msg = new XML_RPC_Message($method, $params);
+			$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
+			$cli->setCredentials($username, $password);
+			$resp = $cli->send($msg, $synctimeout);
+			$error = "";
+			if (!$resp) {
+				$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
+				log_error($error);
+				file_notice("sync_settings", $error, "Snort Settings Sync", "");
+			} elseif ($resp->faultCode()) {
+				$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
+				log_error($error);
+				file_notice("sync_settings", $error, "Snort Settings Sync", "");
+			}
+		}
+
+		if (!empty($iprep_files) && $error == "") {
+			log_error("[snort] XMLRPC sync IPREP files success with {$url}:{$port} (pfsense.exec_php).");
+		}
+
+		/* assemble xmlrpc payload */
+		$params = array(
+			XML_RPC_encode($password),
+			XML_RPC_encode($xml)
+		);
+
+		log_error("[snort] Beginning package configuration XMLRPC sync to {$url}:{$port}.");
+		$method = 'pfsense.merge_installedpackages_section_xmlrpc';
+		$msg = new XML_RPC_Message($method, $params);
+		$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
+		$cli->setCredentials($username, $password);
+
+		/* send our XMLRPC message and timeout after defined sync timeout value*/
+		$resp = $cli->send($msg, $synctimeout);
+		if (!$resp) {
+			$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port}.";
+			log_error($error);
+			file_notice("sync_settings", $error, "Snort Settings Sync", "");
+		} elseif ($resp->faultCode()) {
+			$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+			log_error($error);
+			file_notice("sync_settings", $error, "Snort Settings Sync", "");
+		} else {
+			log_error("[snort] Package configuration XMLRPC sync successfully completed with {$url}:{$port}.");
+		}
+
+		/* assemble xmlrpc payload */
+		$method = 'pfsense.exec_php';
+		$params = array(
+			XML_RPC_encode($password),
+			XML_RPC_encode($execcmd)
+		);
+
+		log_error("[snort] XMLRPC sync sending reload configuration cmd set as a file to {$url}:{$port}.");
+		$msg = new XML_RPC_Message($method, $params);
+		$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
+		$cli->setCredentials($username, $password);
+		$resp = $cli->send($msg, $synctimeout);
+		if (!$resp) {
+			$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
+			log_error($error);
+			file_notice("sync_settings", $error, "Snort Settings Sync", "");
+		} elseif ($resp->faultCode()) {
+			$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+			log_error($error);
+			file_notice("sync_settings", $error, "Snort Settings Sync", "");
+		} else {
+			log_error("[snort] XMLRPC sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
+		}
+
+		$params2 = array(
+			XML_RPC_encode($password),
+			XML_RPC_encode($execcmd2)
+		);
+		log_error("[snort] XMLRPC sync sending {$url}:{$port} cmd to execute configuration reload.");
+		$msg2 = new XML_RPC_Message($method, $params2);
+		$resp = $cli->send($msg2, $synctimeout);
+		if (!$resp) {
+			$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
+			log_error($error);
+			file_notice("sync_settings", $error, "Snort Settings Sync", "");
+		} elseif ($resp->faultCode()) {
+			$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+			log_error($error);
+			file_notice("sync_settings", $error, "Snort Settings Sync", "");
+		} else {
+			log_error("[snort] XMLRPC sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
+		}
 	}
 }
-
 ?>


### PR DESCRIPTION
**Snort GUI Package**
This update fixes the XMLRPC package sync code so that it works in both 2.3 and 2.4 versions of pfSense.

**New Features**
None

**Bug Fixes**
1.  XMLRPC package sync does not work in pfSense 2.4-RC due to changes in the XMLRPC client.
