### PR TITLE
pfSense-pkg-snort-3.2.9.5_2 - Remove use of deprecated XML code page tag

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	3.2.9.5
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_sync.xml
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_sync.xml
@@ -36,58 +36,47 @@
 		<tab>
 			<text>Snort Interfaces</text>
 			<url>/snort/snort_interfaces.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Global Settings</text>
 			<url>/snort/snort_interfaces_global.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Updates</text>
 			<url>/snort/snort_download_updates.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Alerts</text>
 			<url>/snort/snort_alerts.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Blocked</text>
 			<url>/snort/snort_blocked.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Pass Lists</text>
 			<url>/snort/snort_passlist.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Suppress</text>
 			<url>/snort/snort_interfaces_suppress.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>IP Lists</text>
 			<url>/snort/snort_ip_list_mgmt.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>SID Mgmt</text>
 			<url>/snort/snort_sid_mgmt.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Log Mgmt</text>
 			<url>/snort/snort_log_mgmt.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Sync</text>
 			<url>/pkg_edit.php?xml=snort/snort_sync.xml</url>
 			<active/>
-			<no_drop_down/>
 		</tab>
 	</tabs>
 	<fields>


### PR DESCRIPTION
## pfSense Snort GUI Package
This update removes the use of the deprecated <no_drop_down> XML code page tag on the SYNC tab of the Snort GUI.  The tag's former functionality was removed from pfSense during the Bootstrap conversion.

**New Features**
None

**Bug Fixes**
1.  Remove deprecated <no_drop_down> XML code page tag used in the SYNC tab GUI code.