### PR TITLE
pfSense-pkg-suricata-4.0.0_2 - Remove use of deprecated XML code page tag.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.0.0
-PORTREVISION=  1
+PORTREVISION=  2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_sync.xml
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_sync.xml
@@ -10,7 +10,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2013 Marcello Coutinho
- * Copyright (c) 2014-2015 Bill Meeks
+ * Copyright (c) 2014-2017 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,63 +34,51 @@
 		<tab>
 			<text>Interfaces</text>
 			<url>/suricata/suricata_interfaces.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Global Settings</text>
 			<url>/suricata/suricata_global.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Updates</text>
 			<url>/suricata/suricata_download_updates.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Alerts</text>
 			<url>/suricata/suricata_alerts.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Blocks</text>
 			<url>/suricata/suricata_blocked.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Pass Lists</text>
 			<url>/suricata/suricata_passlist.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Suppress</text>
 			<url>/suricata/suricata_suppress.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Logs View</text>
 			<url>/suricata/suricata_logs_browser.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Logs Mgmt</text>
 			<url>/suricata/suricata_logs_mgmt.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>SID Mgmt</text>
 			<url>/suricata/suricata_sid_mgmt.php</url>
-			<no_drop_down/>
 		</tab>
 		<tab>
 			<text>Sync</text>
 			<url>/pkg_edit.php?xml=suricata/suricata_sync.xml</url>
-			<no_drop_down/>
 			<active/>
 		</tab>
 		<tab>
 			<text>IP Lists</text>
 			<url>/suricata/suricata_ip_list_mgmt.php</url>
-			<no_drop_down/>
 		</tab>
 	</tabs>
 	<fields>

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -222,12 +222,11 @@ stream:
   midstream: {$stream_enable_midstream}
   async-oneside: {$stream_enable_async}
   max-synack-queued: {$max_synack_queued}
-
-reassembly:
-  memcap: {$reassembly_memcap}
-  depth: {$reassembly_depth}
-  toserver-chunk-size: {$reassembly_to_server_chunk}
-  toclient-chunk-size: {$reassembly_to_client_chunk}
+  reassembly:
+    memcap: {$reassembly_memcap}
+    depth: {$reassembly_depth}
+    toserver-chunk-size: {$reassembly_to_server_chunk}
+    toclient-chunk-size: {$reassembly_to_client_chunk}
 
 # Host table is used by tagging and per host thresholding subsystems.
 host:

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -409,7 +409,13 @@ if (isset($_POST["save"]) && !$input_errors) {
 		// Check if EVE OUTPUT TYPE is 'syslog' and auto-enable Suricata syslog output if true.
 		if ($natent['eve_output_type'] == "syslog" && $natent['alertsystemlog'] == "off") {
 			$natent['alertsystemlog'] = "on";
-			$savemsg = gettext("EVE Output to syslog requires Suricata alerts to be copied to the system log, so 'Send Alerts to System Log' has been auto-enabled.");
+			$savemsg1 = gettext("EVE Output to syslog requires Suricata alerts to be copied to the system log, so 'Send Alerts to System Log' has been auto-enabled.");
+		}
+
+		// Check if Inline IPS mode is enabled and display a message about potential
+		// incompatibilities with Netmap and some NIC hardware drivers.
+		if ($natent['ips_mode'] == "ips_mode_inline") {
+			$savemsg2 = gettext("Inline IPS Mode is selected.  Not all hardware NIC drivers support Netmap operation which is required for Inline IPS Mode.  If problems are experienced, switch to Legacy Mode instead.");
 		}
 
 		$if_real = get_real_interface($natent['interface']);
@@ -571,8 +577,11 @@ include_once("head.inc");
 if ($input_errors) {
 	print_input_errors($input_errors);
 }
-if ($savemsg) {
-	print_info_box($savemsg);
+if ($savemsg1) {
+	print_info_box($savemsg1);
+}
+if ($savemsg2) {
+	print_info_box($savemsg2);
 }
 
 if ($pconfig['enable'] == 'on' && $pconfig['ips_mode'] == 'ips_mode_inline' && (!isset($config['system']['disablechecksumoffloading']) || !isset($config['system']['disablesegmentationoffloading']) || !isset($config['system']['disablelargereceiveoffloading']))) {
@@ -1134,7 +1143,8 @@ $group->add(new Form_Select(
 $group->setHelp('Legacy Mode uses the PCAP engine to generate copies of packets for inspection as they traverse the interface.  Some "leakage" of packets will occur before ' . 
 		'Suricata can determine if the traffic matches a rule and should be blocked.  Inline mode instead intercepts and inspects packets before they are handed ' . 
 		'off to the host network stack for further processing.  Packets matching DROP rules are simply discarded (dropped) and not passed to the host ' . 
-		'network stack.  No leakage of packets occurs with Inline Mode.  Note that Inline Mode only works with NIC drivers which support Netmap.');
+		'network stack.  No leakage of packets occurs with Inline Mode.  WARNING:  Inline Mode only works with NIC drivers which properly support Netmap!  If the ' . 
+		'hardware NIC driver does not support Netmap, using Inline Mode can result in a firewall system crash!  If problems are experienced with Inline Mode, switch to Legacy Mode instead.');
 $section->add($group);
 
 $section->addInput(new Form_Checkbox(


### PR DESCRIPTION
## pfSense-pkg-suricata
This update removes the use of the deprecated _<no_drop_down>_ XML tag on the SYNC tab in the Suricata GUI.  Additional warning messages and help text has been added to alert users of potential limited hardware NIC driver support when selecting IPS Inline Mode operation.

**New Features**
None

**Bug Fixes**
1. Remove use of the deprecated _<no_drop_down>_ XML tag in the code page for the SYNC tab.  This tag is no longer honored after the pfSense conversion to Bootstrap.

2. Add additional help text to the group section, and display a save message warning when saving changes if selecting IPS Inline Mode operation, on the INTERFACE SETTINGS tab.  The user is warned of limited Netmap support in some NIC drivers and the potential for system crashes when selecting Inline IPS Mode operation with unsupported network cards. 

3. Modify Suricata config template so that stream reassembly settings are a child of the stream settings.  Thanks to @securitym0nkey for the code contribution.