### PR TITLE
Shorten haproxy service description

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy.xml
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy.xml
@@ -45,7 +45,7 @@
 		<name>HAProxy</name>
 		<rcfile>haproxy.sh</rcfile>
 		<executable>haproxy</executable>
-		<description>The Reliable, High Performance TCP/HTTP Load Balancer</description>
+		<description>TCP/HTTP Load Balancer</description>
 	</service>	
 	<plugins>
 		<item>

--- a/net/pfSense-pkg-haproxy/files/usr/local/pkg/haproxy.xml
+++ b/net/pfSense-pkg-haproxy/files/usr/local/pkg/haproxy.xml
@@ -45,7 +45,7 @@
 		<name>HAProxy</name>
 		<rcfile>haproxy.sh</rcfile>
 		<executable>haproxy</executable>
-		<description>The Reliable, High Performance TCP/HTTP Load Balancer</description>
+		<description>TCP/HTTP Load Balancer</description>
 	</service>	
 	<plugins>
 		<item>


### PR DESCRIPTION
As is, the service description for HAProxy is a lot wider than other services, which causes unwanted line wrapping on dashboard. I discussed this with @PiBa-NL on IRC and he "approved" this small change.

_Before_
![image](https://user-images.githubusercontent.com/1992842/31136399-1de75ec0-a836-11e7-868d-6b2994e59f1f.png)

_After_
![image](https://user-images.githubusercontent.com/1992842/31136405-21fbbde4-a836-11e7-884e-613062a92476.png)
