### PR TITLE
pfSense-Status_Monitoring - fix other cases of "unknown" step value (Bug #6860)

### DIFF
--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
@@ -772,8 +772,11 @@ events.push(function() {
 		"86400": "%Y-%m-%d",
 		"43200": "%Y-%m-%d",
 		"3600": "%m/%d %H:%M",
+		"1800": "%m/%d %H:%M",
 		"300": "%H:%M:%S",
-		"60": "%H:%M:%S"
+		"150": "%H:%M:%S",
+		"60": "%H:%M:%S",
+		"30": "%H:%M:%S"
 	};
 
 	//lookup human readable time based on number of seconds


### PR DESCRIPTION
Based on the [description of the issue](https://forum.pfsense.org/index.php?topic=117036.msg662322#msg662322)  from people that are able to reproduce it (I definitely am not one of them), I added *all* the halved values, to prevent more revisits to the code here.
