### PR TITLE
pfSense-pkg-zabbix-[agent|proxy]: Bring all versions of Zabbix with Active Support to pfSense

### DIFF
--- a/net-mgmt/pfSense-pkg-zabbix-agent/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/Makefile
@@ -1,12 +1,11 @@
 # $FreeBSD$
 
-PORTNAME=	pfSense-pkg-zabbix-agent
+PORTNAME?=	pfSense-pkg-zabbix-agent
 PORTVERSION=	1.0.0
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty
 EXTRACT_ONLY=	# empty
-PKGNAMESUFFIX?=	30
 
 MAINTAINER=	coreteam@pfsense.org
 COMMENT=	pfSense package zabbix-agent
@@ -25,8 +24,14 @@ NO_MTREE=	yes
 SUB_FILES=	pkg-install pkg-deinstall
 SUB_LIST=	PORTNAME=${PORTNAME}
 
-ZABBIXUNIQNAME?=	zabbixagentlts
+ZABBIXINTERNALNAME?=	zabbix-agent
 ZABBIXTITLE?=	Zabbix Agent LTS
+
+# Same for all Zabbix Proxy ports to share their configs
+# zabbixagentlts for keep compatibility with current configs
+ZABBIXUNIQNAME?=	zabbixagentlts
+
+ZABBIXVERSION?=	30
 
 do-extract:
 	${MKDIR} ${WRKSRC}
@@ -41,12 +46,13 @@ do-install:
 		${STAGEDIR}${PREFIX}/pkg
 	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/zabbix-agent.priv.inc \
 		${STAGEDIR}/etc/inc/priv
-	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \
+	${INSTALL_DATA} ${FILESDIR}/usr/local/share/pfSense-pkg-zabbix-agent/info.xml \
 		${STAGEDIR}${DATADIR}
 	${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
-		-e "s|%%ZABBIXVERSION%%|${PKGNAMESUFFIX}|" \
+		-e "s|%%ZABBIXVERSION%%|${ZABBIXVERSION}|" \
 		-e "s|%%ZABBIXUNIQNAME%%|${ZABBIXUNIQNAME}|" \
 		-e "s|%%ZABBIXTITLE%%|${ZABBIXTITLE}|" \
+		-e "s|%%ZABBIXINTERNALNAME%%|${ZABBIXINTERNALNAME}|" \
 		${STAGEDIR}${DATADIR}/info.xml \
 		${STAGEDIR}${PREFIX}/pkg/zabbix-agent.inc \
 		${STAGEDIR}${PREFIX}/pkg/zabbix-agent.xml

--- a/net-mgmt/pfSense-pkg-zabbix-agent/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-zabbix-agent
-PORTVERSION=	0.8.9
-PORTREVISION=	3
+PORTVERSION=	1.0.0
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-zabbix-agent/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/Makefile
@@ -27,7 +27,7 @@ SUB_LIST=	PORTNAME=${PORTNAME}
 ZABBIXINTERNALNAME?=	zabbix-agent
 ZABBIXTITLE?=	Zabbix Agent LTS
 
-# Same for all Zabbix Proxy ports to share their configs
+# Same for all Zabbix Agent ports to share their configs
 # zabbixagentlts for keep compatibility with current configs
 ZABBIXUNIQNAME?=	zabbixagentlts
 

--- a/net-mgmt/pfSense-pkg-zabbix-agent/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/Makefile
@@ -7,19 +7,27 @@ CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty
 EXTRACT_ONLY=	# empty
+PKGNAMESUFFIX?=	30
 
 MAINTAINER=	coreteam@pfsense.org
 COMMENT=	pfSense package zabbix-agent
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	${LOCALBASE}/sbin/zabbix_agentd:net-mgmt/zabbix3-agent
+CONFLICTS?=	pfSense-pkg-zabbix-agent22 \
+		pfSense-pkg-zabbix-agent32 \
+		pfSense-pkg-zabbix-agent34
+
+RUN_DEPENDS?=	zabbix_agentd:net-mgmt/zabbix3-agent
 
 NO_BUILD=	yes
 NO_MTREE=	yes
 
 SUB_FILES=	pkg-install pkg-deinstall
 SUB_LIST=	PORTNAME=${PORTNAME}
+
+ZABBIXUNIQNAME?=	zabbixagentlts
+ZABBIXTITLE?=	Zabbix Agent LTS
 
 do-extract:
 	${MKDIR} ${WRKSRC}
@@ -28,15 +36,20 @@ do-install:
 	${MKDIR} ${STAGEDIR}${PREFIX}/pkg
 	${MKDIR} ${STAGEDIR}/etc/inc/priv
 	${MKDIR} ${STAGEDIR}${DATADIR}
-	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/zabbix-agent-lts.xml \
+	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/zabbix-agent.xml \
 		${STAGEDIR}${PREFIX}/pkg
-	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/zabbix-agent-lts.inc \
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/zabbix-agent.inc \
 		${STAGEDIR}${PREFIX}/pkg
-	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/zabbix-agent-lts.priv.inc \
+	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/zabbix-agent.priv.inc \
 		${STAGEDIR}/etc/inc/priv
 	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \
 		${STAGEDIR}${DATADIR}
-	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
-		${STAGEDIR}${DATADIR}/info.xml
+	${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
+		-e "s|%%ZABBIXVERSION%%|${PKGNAMESUFFIX}|" \
+		-e "s|%%ZABBIXUNIQNAME%%|${ZABBIXUNIQNAME}|" \
+		-e "s|%%ZABBIXTITLE%%|${ZABBIXTITLE}|" \
+		${STAGEDIR}${DATADIR}/info.xml \
+		${STAGEDIR}${PREFIX}/pkg/zabbix-agent.inc \
+		${STAGEDIR}${PREFIX}/pkg/zabbix-agent.xml
 
 .include <bsd.port.mk>

--- a/net-mgmt/pfSense-pkg-zabbix-agent/files/etc/inc/priv/zabbix-agent.priv.inc
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/files/etc/inc/priv/zabbix-agent.priv.inc
@@ -1,6 +1,6 @@
 <?php
 /*
- * zabbix-agent-lts.priv.inc
+ * zabbix-agent.priv.inc
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
@@ -21,11 +21,11 @@
 
 global $priv_list;
 
-$priv_list['page-services-zabbix-agent-lts'] = array();
-$priv_list['page-services-zabbix-agent-lts']['name'] = "WebCfg - Services: Zabbix Agent LTS package";
-$priv_list['page-services-zabbix-agent-lts']['descr'] = "Allow access to Zabbix Agent LTS package GUI";
+$priv_list['page-services-zabbix-agent'] = array();
+$priv_list['page-services-zabbix-agent']['name'] = "WebCfg - Services: Zabbix Agent package";
+$priv_list['page-services-zabbix-agent']['descr'] = "Allow access to Zabbix Agent package GUI";
 
-$priv_list['page-services-zabbix-agent-lts']['match'] = array();
-$priv_list['page-services-zabbix-agent-lts']['match'][] = "pkg_edit.php?xml=zabbix-agent-lts.xml*";
+$priv_list['page-services-zabbix-agent']['match'] = array();
+$priv_list['page-services-zabbix-agent']['match'][] = "pkg_edit.php?xml=zabbix-agent.xml*";
 
 ?>

--- a/net-mgmt/pfSense-pkg-zabbix-agent/files/usr/local/pkg/zabbix-agent.inc
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/files/usr/local/pkg/zabbix-agent.inc
@@ -282,7 +282,7 @@ EOF;
 	$zagent_rcfile = "/usr/local/etc/rc.d/zabbix_agentd.sh";
 	if (is_array($zbagent_config) && $zbagent_config['agentenabled'] == "on") {
 		$zagent_start .= strtr($dir_checks, array("\r" => "")). "\necho \"Starting Zabbix Agent...\"\n";
-		$zagent_start .= ZABBIX_AGENT_BASE . "/sbin/zabbix_agentd\n";
+		$zagent_start .= ZABBIX_AGENT_BASE . "/sbin/zabbix_agentd -c /usr/local/etc/zabbix%%ZABBIXVERSION%%/zabbix_agentd.conf\n";
 
 		$zagent_stop = "echo \"Stopping Zabbix Agent...\"\n";
 		$zagent_stop .= "/usr/bin/killall zabbix_agentd\n";

--- a/net-mgmt/pfSense-pkg-zabbix-agent/files/usr/local/pkg/zabbix-agent.inc
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/files/usr/local/pkg/zabbix-agent.inc
@@ -1,6 +1,6 @@
 <?php
 /*
- * zabbix-agent-lts.inc
+ * zabbix-agent.inc
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
@@ -28,21 +28,22 @@ require_once("globals.inc");
 require_once("certs.inc");
 
 define('ZABBIX_AGENT_BASE', '/usr/local');
+define('ZABBIX_VERSION', %%ZABBIXVERSION%%);
 
-function php_deinstall_zabbix_agent_lts() {
-	unlink_if_exists(ZABBIX_AGENT_BASE . "/etc/zabbix3/zabbix_agentd.conf");
-	unlink_if_exists("/var/log/zabbix-agent-lts/zabbix_agentd_lts.log");
-	unlink_if_exists("/var/run/zabbix-agent-lts/zabbix_agentd_lts.pid");
+function php_deinstall_zabbix_agent() {
+	unlink_if_exists(ZABBIX_AGENT_BASE . "/etc/zabbix%%ZABBIXVERSION%%/zabbix_agentd.conf");
+	unlink_if_exists("/var/log/zabbix-agent/zabbix_agentd.log");
+	unlink_if_exists("/var/run/zabbix-agent/zabbix_agentd.pid");
 
-	if (is_dir("/var/log/zabbix-agent-lts")) {
-		mwexec("/bin/rm -rf /var/log/zabbix-agent-lts/");
+	if (is_dir("/var/log/zabbix-agent")) {
+		mwexec("/bin/rm -rf /var/log/zabbix-agent/");
 	}
-	if (is_dir("/var/run/zabbix-agent-lts")) {
-		mwexec("/bin/rm -rf /var/run/zabbix-agent-lts/");
+	if (is_dir("/var/run/zabbix-agent")) {
+		mwexec("/bin/rm -rf /var/run/zabbix-agent/");
 	}
 }
 
-function validate_input_zabbix_agent_lts($post, &$input_errors) {
+function validate_input_zabbix_agent($post, &$input_errors) {
 
 	if (isset($post['agentenabled'])) {
 		if (!preg_match("/\w+/", $post['server'])) {
@@ -109,14 +110,14 @@ function validate_input_zabbix_agent_lts($post, &$input_errors) {
 	}
 }
 
-function sync_package_zabbix_agent_lts() {
+function sync_package_zabbix_agent() {
 	global $config, $g;
 
 	conf_mount_rw();
 
 	// Check Zabbix Agent settings
-	if (is_array($config['installedpackages']['zabbixagentlts'])) {
-		$zbagent_config = $config['installedpackages']['zabbixagentlts']['config'][0];
+	if (is_array($config['installedpackages']['%%ZABBIXUNIQNAME%%'])) {
+		$zbagent_config = $config['installedpackages']['%%ZABBIXUNIQNAME%%']['config'][0];
 		if ($zbagent_config['agentenabled'] == "on") {
 			$RefreshActChecks = (preg_match("/(\d+)/", $zbagent_config['refreshactchecks'], $matches)? $matches[1] : "120");
 			$BufferSend = (preg_match("/(\d+)/", $zbagent_config['buffersend'], $matches) ? $matches[1] : "5");
@@ -126,43 +127,57 @@ function sync_package_zabbix_agent_lts() {
 			$ListenIp = $zbagent_config['listenip'] ?: "0.0.0.0";
 			$ListenPort = $zbagent_config['listenport'] ?: "10050";
 			$TimeOut = $zbagent_config['timeout'] ?: "3";
-			$TLSConnect = $zbagent_config['tlsconnect'];
-			$TLSAccept = $zbagent_config['tlsaccept'] ?: "unencrypted";
 
-			if ($zbagent_config['tlscaso']) {
-				$TlsCAfile = "TLSCAFile=/usr/local/etc/ssl/cert.pem";
-			} else {
-				if ($zbagent_config['tlscafile'] != "none") {
-					$ca = lookup_ca($zbagent_config['tlscafile']);
-					zabbix_agent_add_keyfile($ca['crt'], "ca");
-					$TlsCAfile = "TLSCAFile=/usr/local/etc/zabbix3/zabbix_agentd.ca";
+			// Zabbix TLS is present in 3.0 or later versions.
+			if(ZABBIX_VERSION >= 30) {
+				$TLSConnect = "TLSConnect=" . $zbagent_config['tlsconnect'];
+				$TLSAccept = "TLSAccept=";
+				$TLSAccept .= $zbagent_config['tlsaccept'] ?: "unencrypted";
+
+				if ($zbagent_config['tlscaso']) {
+					$TlsCAfile = "TLSCAFile=/usr/local/etc/ssl/cert.pem";
+				} else {
+					if ($zbagent_config['tlscafile'] != "none") {
+						$ca = lookup_ca($zbagent_config['tlscafile']);
+						zabbix_agent_add_keyfile($ca['crt'], "ca");
+						$TlsCAfile = "TLSCAFile=/usr/local/etc/zabbix%%ZABBIXVERSION%%/zabbix_agentd.ca";
+					}
 				}
-			}
 
-			if ($zbagent_config['tlscrlfile'] != "none") {
-				$crl = lookup_crl($zbagent_config['tlscrlfile']);
-				crl_update($crl);
-				zabbix_agent_add_keyfile($crl['text'], "crl-verify");
-				$TlsCRLfile = "TLSCRLFile=/usr/local/etc/zabbix3/zabbix_agentd.crl-verify";
-			}
+				if ($zbagent_config['tlscrlfile'] != "none") {
+					$crl = lookup_crl($zbagent_config['tlscrlfile']);
+					crl_update($crl);
+					zabbix_agent_add_keyfile($crl['text'], "crl-verify");
+					$TlsCRLfile = "TLSCRLFile=/usr/local/etc/zabbix%%ZABBIXVERSION%%/zabbix_agentd.crl-verify";
+				}
 
-			if ($zbagent_config['tlscertfile'] != "none") {
-				$cert = lookup_cert($zbagent_config['tlscertfile']);
+				if ($zbagent_config['tlscertfile'] != "none") {
+					$cert = lookup_cert($zbagent_config['tlscertfile']);
 
-				zabbix_agent_add_keyfile($cert['crt'], "cert");
-				$TlsCERTfile = "TLSCertFile=/usr/local/etc/zabbix3/zabbix_agentd.cert";
+					zabbix_agent_add_keyfile($cert['crt'], "cert");
+					$TlsCERTfile = "TLSCertFile=/usr/local/etc/zabbix%%ZABBIXVERSION%%/zabbix_agentd.cert";
 
-				zabbix_agent_add_keyfile($cert['prv'], "key");
-				$TlsKEYfile = "TLSKeyFile=/usr/local/etc/zabbix3/zabbix_agentd.key";
-			}
+					zabbix_agent_add_keyfile($cert['prv'], "key");
+					$TlsKEYfile = "TLSKeyFile=/usr/local/etc/zabbix%%ZABBIXVERSION%%/zabbix_agentd.key";
+				}
 
-			if (! empty($zbagent_config['tlspskidentity']) ) {
-				$TLSPSKIdentity = "TLSPSKIdentity={$zbagent_config['tlspskidentity']}";
-			}
+				if (! empty($zbagent_config['tlspskidentity']) ) {
+					$TLSPSKIdentity = "TLSPSKIdentity={$zbagent_config['tlspskidentity']}";
+				}
 
-			if (! empty($zbagent_config['tlspskfile']) ) {
-				zabbix_agent_add_keyfile($zbagent_config['tlspskfile'], "psk");
-				$TLSPSKFile = "TLSPSKFile=/usr/local/etc/zabbix3/zabbix_agentd.psk";
+				if (! empty($zbagent_config['tlspskfile']) ) {
+					zabbix_agent_add_keyfile($zbagent_config['tlspskfile'], "psk");
+					$TLSPSKFile = "TLSPSKFile=/usr/local/etc/zabbix%%ZABBIXVERSION%%/zabbix_agentd.psk";
+				}
+			} else {
+				$TLSConnect = "#TLSConnect=";
+				$TLSAccept = "#TLSAccept=";
+				$TlsCAfile = "#TlsCAfile=";
+				$TlsCRLfile = "#TlsCRLfile=";
+				$TlsCERTfile = "#TlsCERTfile=";
+				$TlsKEYfile = "#TlsKEYfile=";
+				$TLSPSKIdentity = "#TLSPSKIdentity=";
+				$TLSPSKFile = "#TLSPSKFile=";
 			}
 
 
@@ -174,15 +189,15 @@ ListenIP={$ListenIp}
 ListenPort={$ListenPort}
 RefreshActiveChecks={$RefreshActChecks}
 DebugLevel=3
-PidFile=/var/run/zabbix-agent-lts/zabbix_agentd_lts.pid
-LogFile=/var/log/zabbix-agent-lts/zabbix_agentd_lts.log
+PidFile=/var/run/zabbix-agent/zabbix_agentd.pid
+LogFile=/var/log/zabbix-agent/zabbix_agentd.log
 LogFileSize=1
 Timeout={$TimeOut}
 BufferSend={$BufferSend}
 BufferSize={$BufferSize}
 StartAgents={$StartAgents}
-TLSConnect={$TLSConnect}
-TLSAccept={$TLSAccept}
+{$TLSConnect}
+{$TLSAccept}
 {$TlsCAfile}
 {$TlsCRLfile}
 {$TlsCERTfile}
@@ -192,7 +207,7 @@ TLSAccept={$TLSAccept}
 {$UserParams}
 
 EOF;
-			file_put_contents(ZABBIX_AGENT_BASE . "/etc/zabbix3/zabbix_agentd.conf", strtr($zbagent_conf_file, array("\r" => "")));
+			file_put_contents(ZABBIX_AGENT_BASE . "/etc/zabbix%%ZABBIXVERSION%%/zabbix_agentd.conf", strtr($zbagent_conf_file, array("\r" => "")));
 		}
 	}
 
@@ -244,46 +259,46 @@ EOF;
 
 	// Check startup script files
 	// Create a few directories and ensure the sample files are in place
-	if (!is_dir(ZABBIX_AGENT_BASE . "/etc/zabbix3")) {
-		mwexec("/bin/mkdir -p " . ZABBIX_AGENT_BASE . "/etc/zabbix3");
+	if (!is_dir(ZABBIX_AGENT_BASE . "/etc/zabbix%%ZABBIXVERSION%%")) {
+		mwexec("/bin/mkdir -p " . ZABBIX_AGENT_BASE . "/etc/zabbix%%ZABBIXVERSION%%");
 	}
 
 	$dir_checks = <<< EOF
 
-	if [ ! -d /var/log/zabbix-agent-lts ]; then
-		/bin/mkdir -p /var/log/zabbix-agent-lts
-		/usr/sbin/chmod 755 /var/log/zabbix-agent-lts
+	if [ ! -d /var/log/zabbix-agent ]; then
+		/bin/mkdir -p /var/log/zabbix-agent
+		/usr/sbin/chmod 755 /var/log/zabbix-agent
 	fi
-	/usr/sbin/chown -R zabbix:zabbix /var/log/zabbix-agent-lts
+	/usr/sbin/chown -R zabbix:zabbix /var/log/zabbix-agent
 
-	if [ ! -d /var/run/zabbix-agent-lts ]; then
-		/bin/mkdir -p /var/run/zabbix-agent-lts
-		/usr/sbin/chmod 755 /var/run/zabbix-agent-lts
+	if [ ! -d /var/run/zabbix-agent ]; then
+		/bin/mkdir -p /var/run/zabbix-agent
+		/usr/sbin/chmod 755 /var/run/zabbix-agent
 	fi
-	/usr/sbin/chown -R zabbix:zabbix /var/run/zabbix-agent-lts
+	/usr/sbin/chown -R zabbix:zabbix /var/run/zabbix-agent
 
 EOF;
 
-	$zagent_rcfile = "/usr/local/etc/rc.d/zabbix_agentd_lts.sh";
+	$zagent_rcfile = "/usr/local/etc/rc.d/zabbix_agentd.sh";
 	if (is_array($zbagent_config) && $zbagent_config['agentenabled'] == "on") {
-		$zagent_start .= strtr($dir_checks, array("\r" => "")). "\necho \"Starting Zabbix Agent LTS...\"\n";
+		$zagent_start .= strtr($dir_checks, array("\r" => "")). "\necho \"Starting Zabbix Agent...\"\n";
 		$zagent_start .= ZABBIX_AGENT_BASE . "/sbin/zabbix_agentd\n";
 
-		$zagent_stop = "echo \"Stopping Zabbix Agent LTS...\"\n";
+		$zagent_stop = "echo \"Stopping Zabbix Agent...\"\n";
 		$zagent_stop .= "/usr/bin/killall zabbix_agentd\n";
 		$zagent_stop .= "/bin/sleep 5\n";
 
 		// write out rc.d start/stop file
 		write_rcfile(array(
-			"file" => "zabbix_agentd_lts.sh",
+			"file" => "zabbix_agentd.sh",
 			"start" => "$zagent_start",
 			"stop" => "$zagent_stop"
 			)
 		);
-		restart_service("zabbix_agentd_lts");
+		restart_service("zabbix_agentd");
 	} else {
-		if (is_service_running("zabbix_agentd_lts")) {
-			stop_service("zabbix_agentd_lts");
+		if (is_service_running("zabbix_agentd")) {
+			stop_service("zabbix_agentd");
 		}
 		unlink_if_exists($zagent_rcfile);
 	}
@@ -294,7 +309,7 @@ EOF;
 // Based on openvpn_add_keyfile() function
 function zabbix_agent_add_keyfile($data, $directive) {
 
-	$fpath = "/usr/local/etc/zabbix3/zabbix_agentd.{$directive}";
+	$fpath = "/usr/local/etc/zabbix%%ZABBIXVERSION%%/zabbix_agentd.{$directive}";
 
 	file_put_contents($fpath, base64_decode($data));
 	@chmod($fpath, 0600);

--- a/net-mgmt/pfSense-pkg-zabbix-agent/files/usr/local/pkg/zabbix-agent.xml
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/files/usr/local/pkg/zabbix-agent.xml
@@ -5,7 +5,7 @@
 	<copyright>
 	<![CDATA[
 /*
- * zabbix-agent-lts.xml
+ * zabbix-agent.xml
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
@@ -27,40 +27,40 @@
  */
 	]]>
 	</copyright>
-	<name>zabbixagentlts</name>
-	<title>Services: Zabbix Agent LTS</title>
+	<name>%%ZABBIXUNIQNAME%%</name>
+	<title>Services: %%ZABBIXTITLE%%</title>
 	<category>Monitoring</category>
-	<include_file>/usr/local/pkg/zabbix-agent-lts.inc</include_file>
-	<addedit_string>Zabbix Agent LTS has been created/modified.</addedit_string>
-	<delete_string>Zabbix Agent LTS has been deleted.</delete_string>
+	<include_file>/usr/local/pkg/zabbix-agent.inc</include_file>
+	<addedit_string>Zabbix Agent has been created/modified.</addedit_string>
+	<delete_string>Zabbix Agent has been deleted.</delete_string>
 	<menu>
-		<name>Zabbix Agent LTS</name>
+		<name>%%ZABBIXTITLE%%</name>
 		<section>Services</section>
-		<url>/pkg_edit.php?xml=zabbix-agent-lts.xml&amp;id=0</url>
+		<url>/pkg_edit.php?xml=zabbix-agent.xml&amp;id=0</url>
 	</menu>
 	<service>
-		<name>zabbix_agentd_lts</name>
-		<rcfile>zabbix_agentd_lts.sh</rcfile>
+		<name>zabbix_agentd</name>
+		<rcfile>zabbix_agentd.sh</rcfile>
 		<executable>zabbix_agentd</executable>
-		<description>Zabbix Agent LTS Host Monitor Daemon</description>
+		<description>Zabbix Agent Host Monitor Daemon</description>
 	</service>
 	<tabs>
 		<tab>
 			<text>Agent</text>
-			<url>/pkg_edit.php?xml=zabbix-agent-lts.xml&amp;id=0</url>
+			<url>/pkg_edit.php?xml=zabbix-agent.xml&amp;id=0</url>
 			<active />
 		</tab>
 	</tabs>
 	<advanced_options>enabled</advanced_options>
 	<fields>
 		<field>
-			<name>Zabbix Agent LTS Settings</name>
+			<name>Zabbix Agent Settings</name>
 			<type>listtopic</type>
 		</field>
 		<field>
 			<fielddescr>Enable</fielddescr>
 			<fieldname>agentenabled</fieldname>
-			<description>Enable Zabbix Agent LTS service.</description>
+			<description>Enable Zabbix Agent service.</description>
 			<type>checkbox</type>
 		</field>
 		<field>
@@ -280,15 +280,15 @@
 		</field>
 	</fields>
 	<custom_php_install_command>
-		sync_package_zabbix_agent_lts();
+		sync_package_zabbix_agent();
 	</custom_php_install_command>
 	<custom_php_validation_command>
-		validate_input_zabbix_agent_lts($_POST, $input_errors);
+		validate_input_zabbix_agent($_POST, $input_errors);
 	</custom_php_validation_command>
 	<custom_php_resync_config_command>
-		sync_package_zabbix_agent_lts();
+		sync_package_zabbix_agent();
 	</custom_php_resync_config_command>
 	<custom_php_deinstall_command>
-		php_deinstall_zabbix_agent_lts();
+		php_deinstall_zabbix_agent();
 	</custom_php_deinstall_command>
 </packagegui>

--- a/net-mgmt/pfSense-pkg-zabbix-agent/files/usr/local/share/pfSense-pkg-zabbix-agent/info.xml
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/files/usr/local/share/pfSense-pkg-zabbix-agent/info.xml
@@ -1,15 +1,20 @@
 <?xml version="1.0"?>
 <pfsensepkgs>
 	<package>
-		<name>Zabbix Agent LTS</name>
+		<name>%%ZABBIXTITLE%%</name>
 		<internal_name>zabbix-agent</internal_name>
-		<descr><![CDATA[LTS (Long Term Support) release of Zabbix Monitoring agent. Zabbix LTS releases are supported for 
+		<descr><![CDATA[LTS (Long Term Support) release. Zabbix LTS releases are supported for 
 			Zabbix customers during five (5) years i.e. 3 years of Full Support (general, critical and security issues) 
 			and 2 additional years of Limited Support (critical and security issues only). Zabbix LTS version release 
 			will result in change of the first version number.&lt;br /&gt;
+			Standard release. Standard Zabbix releases are supported for Zabbix customers during
+			six (6) months of Full Support (general, critical and security issues) until the next
+			Zabbix stable release, plus one (1) additional month of Limited Support (critical and
+			security issues only). Zabbix Standard version release will result in change of the
+			second version number.&lt;br /&gt;
 			More info in &lt;a href=&quot;http://www.zabbix.com/life_cycle_and_release_policy.php&quot;&gt;Zabbix Life Cycle and Release Policy&lt;/a&gt;.]]></descr>
 		<website>http://www.zabbix.com/product.php</website>
 		<version>%%PKGVERSION%%</version>
-		<configurationfile>zabbix-agent-lts.xml</configurationfile>
+		<configurationfile>zabbix-agent.xml</configurationfile>
 	</package>
 </pfsensepkgs>

--- a/net-mgmt/pfSense-pkg-zabbix-agent/files/usr/local/share/pfSense-pkg-zabbix-agent/info.xml
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/files/usr/local/share/pfSense-pkg-zabbix-agent/info.xml
@@ -2,7 +2,7 @@
 <pfsensepkgs>
 	<package>
 		<name>%%ZABBIXTITLE%%</name>
-		<internal_name>zabbix-agent</internal_name>
+		<internal_name>%%ZABBIXINTERNALNAME%%</internal_name>
 		<descr><![CDATA[LTS (Long Term Support) release. Zabbix LTS releases are supported for 
 			Zabbix customers during five (5) years i.e. 3 years of Full Support (general, critical and security issues) 
 			and 2 additional years of Limited Support (critical and security issues only). Zabbix LTS version release 

--- a/net-mgmt/pfSense-pkg-zabbix-agent/pkg-plist
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/pkg-plist
@@ -1,5 +1,5 @@
-pkg/zabbix-agent-lts.xml
-pkg/zabbix-agent-lts.inc
-/etc/inc/priv/zabbix-agent-lts.priv.inc
+pkg/zabbix-agent.xml
+pkg/zabbix-agent.inc
+/etc/inc/priv/zabbix-agent.priv.inc
 %%DATADIR%%/info.xml
 @dir /etc/inc/priv

--- a/net-mgmt/pfSense-pkg-zabbix-agent22/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent22/Makefile
@@ -2,15 +2,16 @@
 
 MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-agent
 
-PKGNAMESUFFIX=	22
+PORTNAME=	pfSense-pkg-zabbix-agent${ZABBIXVERSION}
 
 CONFLICTS=	pfSense-pkg-zabbix-agent \
 		pfSense-pkg-zabbix-agent32 \
 		pfSense-pkg-zabbix-agent34
 
-RUN_DEPENDS=	zabbix_agentd:net-mgmt/zabbix22-agent
+RUN_DEPENDS=	zabbix_agentd:net-mgmt/zabbix${ZABBIXVERSION}-agent
 
-ZABBIXUNIQNAME=	zabbixagent22
+ZABBIXINTERNALNAME=	zabbix-agent${ZABBIXVERSION}
 ZABBIXTITLE=	Zabbix Agent 2.2
+ZABBIXVERSION=	22
 
 .include "${MASTERDIR}/Makefile"

--- a/net-mgmt/pfSense-pkg-zabbix-agent22/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent22/Makefile
@@ -1,0 +1,16 @@
+# $FreeBSD$
+
+MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-agent
+
+PKGNAMESUFFIX=	22
+
+CONFLICTS=	pfSense-pkg-zabbix-agent \
+		pfSense-pkg-zabbix-agent32 \
+		pfSense-pkg-zabbix-agent34
+
+RUN_DEPENDS=	zabbix_agentd:net-mgmt/zabbix22-agent
+
+ZABBIXUNIQNAME=	zabbixagent22
+ZABBIXTITLE=	Zabbix Agent 2.2
+
+.include "${MASTERDIR}/Makefile"

--- a/net-mgmt/pfSense-pkg-zabbix-agent32/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent32/Makefile
@@ -1,0 +1,16 @@
+# $FreeBSD$
+
+MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-agent
+
+PKGNAMESUFFIX=	32
+
+CONFLICTS=	pfSense-pkg-zabbix-agent \
+		pfSense-pkg-zabbix-agent22 \
+		pfSense-pkg-zabbix-agent34
+
+RUN_DEPENDS=	zabbix_agentd:net-mgmt/zabbix32-agent
+
+ZABBIXUNIQNAME=	zabbixagent32
+ZABBIXTITLE=	Zabbix Agent 3.2
+
+.include "${MASTERDIR}/Makefile"

--- a/net-mgmt/pfSense-pkg-zabbix-agent32/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent32/Makefile
@@ -2,15 +2,16 @@
 
 MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-agent
 
-PKGNAMESUFFIX=	32
+PORTNAME=	pfSense-pkg-zabbix-agent${ZABBIXVERSION}
 
 CONFLICTS=	pfSense-pkg-zabbix-agent \
 		pfSense-pkg-zabbix-agent22 \
 		pfSense-pkg-zabbix-agent34
 
-RUN_DEPENDS=	zabbix_agentd:net-mgmt/zabbix32-agent
+RUN_DEPENDS=	zabbix_agentd:net-mgmt/zabbix${ZABBIXVERSION}-agent
 
-ZABBIXUNIQNAME=	zabbixagent32
+ZABBIXINTERNALNAME=	zabbix-agent${ZABBIXVERSION}
 ZABBIXTITLE=	Zabbix Agent 3.2
+ZABBIXVERSION=	32
 
 .include "${MASTERDIR}/Makefile"

--- a/net-mgmt/pfSense-pkg-zabbix-agent34/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent34/Makefile
@@ -2,15 +2,16 @@
 
 MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-agent
 
-PKGNAMESUFFIX=	34
+PORTNAME=	pfSense-pkg-zabbix-agent${ZABBIXVERSION}
 
 CONFLICTS=	pfSense-pkg-zabbix-agent \
 		pfSense-pkg-zabbix-agent22 \
 		pfSense-pkg-zabbix-agent32
 
-RUN_DEPENDS=	zabbix_agentd:net-mgmt/zabbix34-agent
+RUN_DEPENDS=	zabbix_agentd:net-mgmt/zabbix${ZABBIXVERSION}-agent
 
-ZABBIXUNIQNAME=	zabbixagent34
+ZABBIXINTERNALNAME=	zabbix-agent${ZABBIXVERSION}
 ZABBIXTITLE=	Zabbix Agent 3.4
+ZABBIXVERSION=	34	
 
 .include "${MASTERDIR}/Makefile"

--- a/net-mgmt/pfSense-pkg-zabbix-agent34/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent34/Makefile
@@ -1,0 +1,16 @@
+# $FreeBSD$
+
+MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-agent
+
+PKGNAMESUFFIX=	34
+
+CONFLICTS=	pfSense-pkg-zabbix-agent \
+		pfSense-pkg-zabbix-agent22 \
+		pfSense-pkg-zabbix-agent32
+
+RUN_DEPENDS=	zabbix_agentd:net-mgmt/zabbix34-agent
+
+ZABBIXUNIQNAME=	zabbixagent34
+ZABBIXTITLE=	Zabbix Agent 3.4
+
+.include "${MASTERDIR}/Makefile"

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-zabbix-proxy
-PORTVERSION=	0.9.0
+PORTVERSION=	1.0.0
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/Makefile
@@ -26,7 +26,7 @@ SUB_FILES=	pkg-install pkg-deinstall
 SUB_LIST=	PORTNAME=${PORTNAME}
 
 ZABBIXUNIQNAME?=	zabbixproxylts
-ZABBIXTITLE?=	Zabbix Proxy LTS	
+ZABBIXTITLE?=	Zabbix Proxy LTS
 
 do-extract:
 	${MKDIR} ${WRKSRC}

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/Makefile
@@ -1,12 +1,11 @@
 # $FreeBSD$
 
-PORTNAME=	pfSense-pkg-zabbix-proxy
+PORTNAME?=	pfSense-pkg-zabbix-proxy
 PORTVERSION=	1.0.0
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty
 EXTRACT_ONLY=	# empty
-PKGNAMESUFFIX?=	30
 
 MAINTAINER=	coreteam@pfsense.org
 COMMENT=	pfSense package zabbix-proxy
@@ -25,8 +24,14 @@ NO_MTREE=	yes
 SUB_FILES=	pkg-install pkg-deinstall
 SUB_LIST=	PORTNAME=${PORTNAME}
 
-ZABBIXUNIQNAME?=	zabbixproxylts
+ZABBIXINTERNALNAME?=	zabbix-proxy
 ZABBIXTITLE?=	Zabbix Proxy LTS
+
+# Same for all Zabbix Proxy ports to share their configs
+# zabbixproxylts for keep compatibility with current configs
+ZABBIXUNIQNAME?=	zabbixproxylts
+
+ZABBIXVERSION?=	30
 
 do-extract:
 	${MKDIR} ${WRKSRC}
@@ -41,12 +46,13 @@ do-install:
 		${STAGEDIR}${PREFIX}/pkg
 	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/zabbix-proxy.priv.inc \
 		${STAGEDIR}/etc/inc/priv
-	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \
+	${INSTALL_DATA} ${FILESDIR}/usr/local/share/pfSense-pkg-zabbix-proxy/info.xml \
 		${STAGEDIR}${DATADIR}
 	${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|"  \
-		-e "s|%%ZABBIXVERSION%%|${PKGNAMESUFFIX}|" \
+		-e "s|%%ZABBIXVERSION%%|${ZABBIXVERSION}|" \
 		-e "s|%%ZABBIXUNIQNAME%%|${ZABBIXUNIQNAME}|" \
 		-e "s|%%ZABBIXTITLE%%|${ZABBIXTITLE}|" \
+		-e "s|%%ZABBIXINTERNALNAME%%|${ZABBIXINTERNALNAME}|" \
 		${STAGEDIR}${DATADIR}/info.xml \
 		${STAGEDIR}${PREFIX}/pkg/zabbix-proxy.inc \
 		${STAGEDIR}${PREFIX}/pkg/zabbix-proxy.xml

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/Makefile
@@ -6,19 +6,27 @@ CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty
 EXTRACT_ONLY=	# empty
+PKGNAMESUFFIX?=	30
 
 MAINTAINER=	coreteam@pfsense.org
 COMMENT=	pfSense package zabbix-proxy
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	${LOCALBASE}/sbin/zabbix_proxy:net-mgmt/zabbix3-proxy
+CONFLICTS?=	pfSense-pkg-zabbix-proxy22 \
+		pfSense-pkg-zabbix-proxy32 \
+		pfSense-pkg-zabbix-proxy34
+
+RUN_DEPENDS?=	zabbix_proxy:net-mgmt/zabbix3-proxy
 
 NO_BUILD=	yes
 NO_MTREE=	yes
 
 SUB_FILES=	pkg-install pkg-deinstall
 SUB_LIST=	PORTNAME=${PORTNAME}
+
+ZABBIXUNIQNAME?=	zabbixproxylts
+ZABBIXTITLE?=	Zabbix Proxy LTS	
 
 do-extract:
 	${MKDIR} ${WRKSRC}
@@ -27,15 +35,20 @@ do-install:
 	${MKDIR} ${STAGEDIR}${PREFIX}/pkg
 	${MKDIR} ${STAGEDIR}/etc/inc/priv
 	${MKDIR} ${STAGEDIR}${DATADIR}
-	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/zabbix-proxy-lts.xml \
+	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/zabbix-proxy.xml \
 		${STAGEDIR}${PREFIX}/pkg
-	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/zabbix-proxy-lts.inc \
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/zabbix-proxy.inc \
 		${STAGEDIR}${PREFIX}/pkg
-	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/zabbix-proxy-lts.priv.inc \
+	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/zabbix-proxy.priv.inc \
 		${STAGEDIR}/etc/inc/priv
 	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \
 		${STAGEDIR}${DATADIR}
-	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
-		${STAGEDIR}${DATADIR}/info.xml
-
+	${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|"  \
+		-e "s|%%ZABBIXVERSION%%|${PKGNAMESUFFIX}|" \
+		-e "s|%%ZABBIXUNIQNAME%%|${ZABBIXUNIQNAME}|" \
+		-e "s|%%ZABBIXTITLE%%|${ZABBIXTITLE}|" \
+		${STAGEDIR}${DATADIR}/info.xml \
+		${STAGEDIR}${PREFIX}/pkg/zabbix-proxy.inc \
+		${STAGEDIR}${PREFIX}/pkg/zabbix-proxy.xml
+		
 .include <bsd.port.mk>

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/files/etc/inc/priv/zabbix-proxy.priv.inc
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/files/etc/inc/priv/zabbix-proxy.priv.inc
@@ -1,6 +1,6 @@
 <?php
 /*
- * zabbix-proxy-lts.priv.inc
+ * zabbix-proxy.priv.inc
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
@@ -21,11 +21,11 @@
 
 global $priv_list;
 
-$priv_list['page-services-zabbix-proxy-lts'] = array();
-$priv_list['page-services-zabbix-proxy-lts']['name'] = "WebCfg - Services: Zabbix Proxy LTS package";
-$priv_list['page-services-zabbix-proxy-lts']['descr'] = "Allow access to Zabbix Proxy LTS package GUI";
+$priv_list['page-services-zabbix-proxy'] = array();
+$priv_list['page-services-zabbix-proxy']['name'] = "WebCfg - Services: Zabbix Proxy package";
+$priv_list['page-services-zabbix-proxy']['descr'] = "Allow access to Zabbix Proxy package GUI";
 
-$priv_list['page-services-zabbix-proxy-lts']['match'] = array();
-$priv_list['page-services-zabbix-proxy-lts']['match'][] = "pkg_edit.php?xml=zabbix-proxy-lts.xml*";
+$priv_list['page-services-zabbix-proxy']['match'] = array();
+$priv_list['page-services-zabbix-proxy']['match'][] = "pkg_edit.php?xml=zabbix-proxy.xml*";
 
 ?>

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/pkg/zabbix-proxy.inc
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/pkg/zabbix-proxy.inc
@@ -274,7 +274,7 @@ EOF;
 	if (is_array($zbproxy_config) && $zbproxy_config['proxyenabled'] == "on") {
 		$zproxy_start = strtr($dir_checks, array("\r" => ""));
 		$zproxy_start .= "\techo \"Starting Zabbix Proxy\"...\n";
-		$zproxy_start .= "\t" . ZABBIX_PROXY_BASE . "/sbin/zabbix_proxy\n";
+		$zproxy_start .= "\t" . ZABBIX_PROXY_BASE . "/sbin/zabbix_proxy -c /usr/local/etc/zabbix%%ZABBIXVERSION%%/zabbix_proxy.conf\n";
 
 		$zproxy_stop = "echo \"Stopping Zabbix Proxy\"\n";
 		$zproxy_stop .= "\t/usr/bin/killall zabbix_proxy\n";

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/pkg/zabbix-proxy.inc
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/pkg/zabbix-proxy.inc
@@ -1,6 +1,6 @@
 <?php
 /*
- * zabbix-proxy-lts.inc
+ * zabbix-proxy.inc
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
@@ -28,24 +28,29 @@ require_once("globals.inc");
 require_once("certs.inc");
 
 define('ZABBIX_PROXY_BASE', '/usr/local');
+define('ZABBIX_VERSION', %%ZABBIXVERSION%%);
 
-function php_deinstall_zabbix_proxy_lts() {
-	unlink_if_exists(ZABBIX_PROXY_BASE . "/etc/zabbix3/zabbix_proxy_lts.conf");
-	unlink_if_exists("/var/log/zabbix-proxy-lts/zabbix_proxy_lts.log");
-	unlink_if_exists("/var/run/zabbix-proxy-lts/zabbix_proxy_lts.pid");
+function php_deinstall_zabbix_proxy() {
+	unlink_if_exists(ZABBIX_PROXY_BASE . "/etc/zabbix%%ZABBIXVERSION%%/zabbix_proxy.conf");
+	unlink_if_exists("/var/log/zabbix-proxy/zabbix_proxy.log");
+	unlink_if_exists("/var/run/zabbix-proxy/zabbix_proxy.pid");
 
-	if (is_dir("/var/log/zabbix-proxy-lts")) {
-		mwexec("/bin/rm -rf /var/log/zabbix-proxy-lts/");
+
+	if (is_dir(ZABBIX_PROXY_BASE . "/etc/zabbix%%ZABBIXVERSION%%")) {
+		mwexec("/bin/rm -rf " . ZABBIX_PROXY_BASE . "/etc/zabbix%%ZABBIXVERSION%%");
 	}
-	if (is_dir("/var/run/zabbix-proxy-lts")) {
-		mwexec("/bin/rm -rf /var/run/zabbix-proxy-lts/");
+	if (is_dir("/var/log/zabbix-proxy")) {
+		mwexec("/bin/rm -rf /var/log/zabbix-proxy/");
 	}
-	if (is_dir("/var/db/zabbix-proxy-lts")) {
-		mwexec("/bin/rm -rf /var/db/zabbix-proxy-lts/");
+	if (is_dir("/var/run/zabbix-proxy")) {
+		mwexec("/bin/rm -rf /var/run/zabbix-proxy/");
+	}
+	if (is_dir("/var/db/zabbix-proxy")) {
+		mwexec("/bin/rm -rf /var/db/zabbix-proxy/");
 	}
 }
 
-function validate_input_zabbix_proxy_lts($post, &$input_errors) {
+function validate_input_zabbix_proxy($post, &$input_errors) {
 	if (isset($post['proxyenabled'])) {
 		if (!preg_match("/\w+/", $post['server'])) {
 			$input_errors[] = "'Server' field is required.";
@@ -79,54 +84,68 @@ function validate_input_zabbix_proxy_lts($post, &$input_errors) {
 	}
 }
 
-function sync_package_zabbix_proxy_lts() {
+function sync_package_zabbix_proxy() {
 	global $config, $g;
 
 	conf_mount_rw();
 
 	// Check zabbix proxy config
-	if (is_array($config['installedpackages']['zabbixproxylts'])) {
-		$zbproxy_config = $config['installedpackages']['zabbixproxylts']['config'][0];
+	if (is_array($config['installedpackages']['%%ZABBIXUNIQNAME%%'])) {
+		$zbproxy_config = $config['installedpackages']['%%ZABBIXUNIQNAME%%']['config'][0];
 		if ($zbproxy_config['proxyenabled'] == "on") {
 			$Mode = (is_numericint($zbproxy_config['proxymode']) ? $zbproxy_config['proxymode'] : 0);
 			$AdvancedParams = base64_decode($zbproxy_config['advancedparams']);
-			$TLSConnect = $zbproxy_config['tlsconnect'];
-			$TLSAccept = $zbproxy_config['tlsaccept'] ?: "unencrypted";
 
-			if ($zbproxy_config['tlscaso']) {
-				$TlsCAfile = "TLSCAFile=/usr/local/etc/ssl/cert.pem";
-			} else {
-				if ($zbproxy_config['tlscafile'] != "none") {
-					$ca = lookup_ca($zbproxy_config['tlscafile']);
-					zabbix_proxy_add_keyfile($ca['crt'], "ca");
-					$TlsCAfile = "TLSCAFile=/usr/local/etc/zabbix3/zabbix_proxy.ca";
+			// Zabbix TLS is present in 3.0 or later versions.
+			if(ZABBIX_VERSION >= 30) {
+				$TLSConnect = "TLSConnect=" . $zbproxy_config['tlsconnect'];
+				$TLSAccept = "TLSAccept=";
+				$TLSAccept .= $zbproxy_config['tlsaccept'] ?: "unencrypted";
+
+				if ($zbproxy_config['tlscaso']) {
+					$TlsCAfile = "TLSCAFile=/usr/local/etc/ssl/cert.pem";
+				} else {
+					if ($zbproxy_config['tlscafile'] != "none") {
+						$ca = lookup_ca($zbproxy_config['tlscafile']);
+						zabbix_proxy_add_keyfile($ca['crt'], "ca");
+						$TlsCAfile = "TLSCAFile=/usr/local/etc/zabbix%%ZABBIXVERSION%%/zabbix_proxy.ca";
+					}
 				}
-			}
 
-			if ($zbproxy_config['tlscrlfile'] != "none") {
-				$crl = lookup_crl($zbproxy_config['tlscrlfile']);
-				crl_update($crl);
-				zabbix_proxy_add_keyfile($crl['text'], "crl-verify");
-				$TlsCRLfile = "TLSCRLFile=/usr/local/etc/zabbix3/zabbix_proxy.crl-verify";
-			}
+				if ($zbproxy_config['tlscrlfile'] != "none") {
+					$crl = lookup_crl($zbproxy_config['tlscrlfile']);
+					crl_update($crl);
+					zabbix_proxy_add_keyfile($crl['text'], "crl-verify");
+					$TlsCRLfile = "TLSCRLFile=/usr/local/etc/zabbix%%ZABBIXVERSION%%/zabbix_proxy.crl-verify";
+				}
 
-			if ($zbproxy_config['tlscertfile'] != "none") {
-				$cert = lookup_cert($zbproxy_config['tlscertfile']);
+				if ($zbproxy_config['tlscertfile'] != "none") {
+					$cert = lookup_cert($zbproxy_config['tlscertfile']);
 
-				zabbix_proxy_add_keyfile($cert['crt'], "cert");
-				$TlsCERTfile = "TLSCertFile=/usr/local/etc/zabbix3/zabbix_proxy.cert";
+					zabbix_proxy_add_keyfile($cert['crt'], "cert");
+					$TlsCERTfile = "TLSCertFile=/usr/local/etc/zabbix%%ZABBIXVERSION%%/zabbix_proxy.cert";
 
-				zabbix_proxy_add_keyfile($cert['prv'], "key");
-				$TlsKEYfile = "TLSKeyFile=/usr/local/etc/zabbix3/zabbix_proxy.key";
-			}
+					zabbix_proxy_add_keyfile($cert['prv'], "key");
+					$TlsKEYfile = "TLSKeyFile=/usr/local/etc/zabbix%%ZABBIXVERSION%%/zabbix_proxy.key";
+				}
 
-			if (! empty($zbproxy_config['tlspskidentity']) ) {
-				$TLSPSKIdentity = "TLSPSKIdentity={$zbproxy_config['tlspskidentity']}";
-			}
+				if (! empty($zbproxy_config['tlspskidentity']) ) {
+					$TLSPSKIdentity = "TLSPSKIdentity={$zbproxy_config['tlspskidentity']}";
+				}
 
-			if (! empty($zbproxy_config['tlspskfile']) ) {
-				zabbix_proxy_add_keyfile($zbproxy_config['tlspskfile'], "psk");
-				$TLSPSKFile = "TLSPSKFile=/usr/local/etc/zabbix3/zabbix_proxy.psk";
+				if (! empty($zbproxy_config['tlspskfile']) ) {
+					zabbix_proxy_add_keyfile($zbproxy_config['tlspskfile'], "psk");
+					$TLSPSKFile = "TLSPSKFile=/usr/local/etc/zabbix%%ZABBIXVERSION%%/zabbix_proxy.psk";
+				}
+			} else {
+				$TLSConnect = "#TLSConnect=";
+				$TLSAccept = "#TLSAccept=";
+				$TlsCAfile = "#TlsCAfile=";
+				$TlsCRLfile = "#TlsCRLfile=";
+				$TlsCERTfile = "#TlsCERTfile=";
+				$TlsKEYfile = "#TlsKEYfile=";
+				$TLSPSKIdentity = "#TLSPSKIdentity=";
+				$TLSPSKFile = "#TLSPSKFile=";
 			}
 
 			$StartSNMPTrapper = $zbproxy_config['startsnmptrapper'];
@@ -143,17 +162,17 @@ function sync_package_zabbix_proxy_lts() {
 Server={$zbproxy_config['server']}
 ServerPort={$zbproxy_config['serverport']}
 Hostname={$zbproxy_config['hostname']}
-PidFile=/var/run/zabbix-proxy-lts/zabbix_proxy_lts.pid
-DBName=/var/db/zabbix-proxy-lts/proxy.db
-LogFile=/var/log/zabbix-proxy-lts/zabbix_proxy_lts.log
+PidFile=/var/run/zabbix-proxy/zabbix_proxy.pid
+DBName=/var/db/zabbix-proxy/proxy.db
+LogFile=/var/log/zabbix-proxy/zabbix_proxy.log
 ConfigFrequency={$zbproxy_config['configfrequency']}
 FpingLocation=/usr/local/sbin/fping
 # There's currently no fping6 (IPv6) dependency in the package,
 # but if there was, the binary would likely also be in /usr/local/sbin.
 Fping6Location=/usr/local/sbin/fping6
 ProxyMode={$Mode}
-TLSConnect={$TLSConnect}
-TLSAccept={$TLSAccept}
+{$TLSConnect}
+{$TLSAccept}
 {$TlsCAfile}
 {$TlsCRLfile}
 {$TlsCERTfile}
@@ -167,7 +186,7 @@ StartTrappers={$StartTrappers}
 {$AdvancedParams}
 
 EOF;
-			file_put_contents(ZABBIX_PROXY_BASE . "/etc/zabbix3/zabbix_proxy.conf", strtr($zbproxy_conf_file, array("\r" => "")));
+			file_put_contents(ZABBIX_PROXY_BASE . "/etc/zabbix%%ZABBIXVERSION%%/zabbix_proxy.conf", strtr($zbproxy_conf_file, array("\r" => "")));
 		}
 	}
 
@@ -219,29 +238,29 @@ EOF;
 
 	// Check startup script files
 	// Create a few directories and ensure the sample files are in place
-	if (!is_dir(ZABBIX_PROXY_BASE . "/etc/zabbix3")) {
-		mwexec("/bin/mkdir -p " . ZABBIX_PROXY_BASE . "/etc/zabbix3");
+	if (!is_dir(ZABBIX_PROXY_BASE . "/etc/zabbix%%ZABBIXVERSION%%")) {
+		mwexec("/bin/mkdir -p " . ZABBIX_PROXY_BASE . "/etc/zabbix%%ZABBIXVERSION%%");
 	}
 
 	$dir_checks = <<< EOF
 
-	if [ ! -d /var/log/zabbix-proxy-lts ]; then
-		/bin/mkdir -p /var/log/zabbix-proxy-lts
-		/usr/sbin/chmod 755 /var/log/zabbix-proxy-lts
+	if [ ! -d /var/log/zabbix-proxy ]; then
+		/bin/mkdir -p /var/log/zabbix-proxy
+		/usr/sbin/chmod 755 /var/log/zabbix-proxy
 	fi
-	/usr/sbin/chown -R zabbix:zabbix /var/log/zabbix-proxy-lts
+	/usr/sbin/chown -R zabbix:zabbix /var/log/zabbix-proxy
 
-	if [ ! -d /var/run/zabbix-proxy-lts ]; then
-		/bin/mkdir -p /var/run/zabbix-proxy-lts
-		/usr/sbin/chmod 755 /var/run/zabbix-proxy-lts
+	if [ ! -d /var/run/zabbix-proxy ]; then
+		/bin/mkdir -p /var/run/zabbix-proxy
+		/usr/sbin/chmod 755 /var/run/zabbix-proxy
 	fi
-	/usr/sbin/chown -R zabbix:zabbix /var/run/zabbix-proxy-lts
+	/usr/sbin/chown -R zabbix:zabbix /var/run/zabbix-proxy
 
-	if [ ! -d /var/db/zabbix-proxy-lts ]; then
-		/bin/mkdir -p /var/db/zabbix-proxy-lts
-		/usr/sbin/chmod 755 /var/db/zabbix-proxy-lts
+	if [ ! -d /var/db/zabbix-proxy ]; then
+		/bin/mkdir -p /var/db/zabbix-proxy
+		/usr/sbin/chmod 755 /var/db/zabbix-proxy
 	fi
-	/usr/sbin/chown -R zabbix:zabbix /var/db/zabbix-proxy-lts
+	/usr/sbin/chown -R zabbix:zabbix /var/db/zabbix-proxy
 
 EOF;
 
@@ -250,33 +269,33 @@ EOF;
 	/bin/pgrep -anx zabbix_proxy 2>/dev/null
 	if [ "\$?" -eq "0" ]; then
 		/usr/bin/killall -9 zabbix_proxy
-		/bin/rm -f /var/run/zabbix-proxy-lts/zabbix_proxy_lts.pid
+		/bin/rm -f /var/run/zabbix-proxy/zabbix_proxy.pid
 	fi
 
 EOF;
 
-	$zproxy_rcfile = "/usr/local/etc/rc.d/zabbix_proxy_lts.sh";
+	$zproxy_rcfile = "/usr/local/etc/rc.d/zabbix_proxy.sh";
 	if (is_array($zbproxy_config) && $zbproxy_config['proxyenabled'] == "on") {
 		$zproxy_start = strtr($dir_checks, array("\r" => ""));
-		$zproxy_start .= "\techo \"Starting Zabbix Proxy LTS\"...\n";
+		$zproxy_start .= "\techo \"Starting Zabbix Proxy\"...\n";
 		$zproxy_start .= "\t" . ZABBIX_PROXY_BASE . "/sbin/zabbix_proxy\n";
 
-		$zproxy_stop = "echo \"Stopping Zabbix Proxy LTS\"\n";
+		$zproxy_stop = "echo \"Stopping Zabbix Proxy\"\n";
 		$zproxy_stop .= "\t/usr/bin/killall zabbix_proxy\n";
 		$zproxy_stop .= "\t/bin/sleep 5\n";
 		$zproxy_stop .= strtr($pid_check, array("\r" => ""));
 
 		// write out rc.d start/stop file
 		write_rcfile(array(
-			"file" => "zabbix_proxy_lts.sh",
+			"file" => "zabbix_proxy.sh",
 			"start" => $zproxy_start,
 			"stop" => $zproxy_stop
 			)
 		);
-		restart_service("zabbix_proxy_lts");
+		restart_service("zabbix_proxy");
 	} else {
-		if (is_service_running("zabbix_proxy_lts")) {
-			stop_service("zabbix_proxy_lts");
+		if (is_service_running("zabbix_proxy")) {
+			stop_service("zabbix_proxy");
 		}
 		unlink_if_exists($zproxy_rcfile);
 	}
@@ -287,7 +306,7 @@ EOF;
 // Based on openvpn_add_keyfile() function
 function zabbix_proxy_add_keyfile($data, $directive) {
 
-	$fpath = "/usr/local/etc/zabbix3/zabbix_proxy.{$directive}";
+	$fpath = "/usr/local/etc/zabbix%%ZABBIXVERSION%%/zabbix_proxy.{$directive}";
 
 	file_put_contents($fpath, base64_decode($data));
 	@chmod($fpath, 0600);

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/pkg/zabbix-proxy.inc
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/pkg/zabbix-proxy.inc
@@ -35,10 +35,6 @@ function php_deinstall_zabbix_proxy() {
 	unlink_if_exists("/var/log/zabbix-proxy/zabbix_proxy.log");
 	unlink_if_exists("/var/run/zabbix-proxy/zabbix_proxy.pid");
 
-
-	if (is_dir(ZABBIX_PROXY_BASE . "/etc/zabbix%%ZABBIXVERSION%%")) {
-		mwexec("/bin/rm -rf " . ZABBIX_PROXY_BASE . "/etc/zabbix%%ZABBIXVERSION%%");
-	}
 	if (is_dir("/var/log/zabbix-proxy")) {
 		mwexec("/bin/rm -rf /var/log/zabbix-proxy/");
 	}

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/pkg/zabbix-proxy.xml
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/pkg/zabbix-proxy.xml
@@ -5,7 +5,7 @@
 	<copyright>
 	<![CDATA[
 /*
- * zabbix-proxy-lts.xml
+ * zabbix-proxy.xml
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2015 Rubicon Communications, LLC (Netgate)
@@ -27,40 +27,40 @@
  */
 	]]>
 	</copyright>
-	<name>zabbixproxylts</name>
-	<title>Services: Zabbix Proxy LTS</title>
+	<name>%%ZABBIXUNIQNAME%%</name>
+	<title>Services: %%ZABBIXTITLE%%</title>
 	<category>Monitoring</category>
-	<include_file>/usr/local/pkg/zabbix-proxy-lts.inc</include_file>
+	<include_file>/usr/local/pkg/zabbix-proxy.inc</include_file>
 	<addedit_string>Zabbix Proxy has been created/modified.</addedit_string>
 	<delete_string>Zabbix Proxy has been deleted.</delete_string>
 	<menu>
-		<name>Zabbix Proxy LTS</name>
+		<name>%%ZABBIXTITLE%%</name>
 		<section>Services</section>
-		<url>/pkg_edit.php?xml=zabbix-proxy-lts.xml&amp;id=0</url>
+		<url>/pkg_edit.php?xml=zabbix-proxy.xml&amp;id=0</url>
 	</menu>
 	<service>
-		<name>zabbix_proxy_lts</name>
-		<rcfile>zabbix_proxy_lts.sh</rcfile>
+		<name>zabbix_proxy</name>
+		<rcfile>zabbix_proxy.sh</rcfile>
 		<executable>zabbix_proxy</executable>
-		<description>Zabbix Proxy LTS Collection Daemon</description>
+		<description>Zabbix Proxy Collection Daemon</description>
 	</service>
 	<tabs>
 		<tab>
 			<text>Proxy</text>
-			<url>/pkg_edit.php?xml=zabbix-proxy-lts.xml&amp;id=0</url>
+			<url>/pkg_edit.php?xml=zabbix-proxy.xml&amp;id=0</url>
 			<active />
 		</tab>
 	</tabs>
 	<advanced_options>enabled</advanced_options>
 	<fields>
 		<field>
-			<name>Zabbix Proxy LTS Settings</name>
+			<name>Zabbix Proxy Settings</name>
 			<type>listtopic</type>
 		</field>
 		<field>
 			<fielddescr>Enable</fielddescr>
 			<fieldname>proxyenabled</fieldname>
-			<description>Enable Zabbix Proxy LTS service.</description>
+			<description>Enable Zabbix Proxy service.</description>
 			<type>checkbox</type>
 		</field>
 		<field>
@@ -275,15 +275,15 @@
 		</field>
 	</fields>
 	<custom_php_install_command>
-		sync_package_zabbix_proxy_lts();
+		sync_package_zabbix_proxy();
 	</custom_php_install_command>
 	<custom_php_validation_command>
-		validate_input_zabbix_proxy_lts($_POST, $input_errors);
+		validate_input_zabbix_proxy($_POST, $input_errors);
 	</custom_php_validation_command>
 	<custom_php_resync_config_command>
-		sync_package_zabbix_proxy_lts();
+		sync_package_zabbix_proxy();
 	</custom_php_resync_config_command>
 	<custom_php_deinstall_command>
-		php_deinstall_zabbix_proxy_lts();
+		php_deinstall_zabbix_proxy();
 	</custom_php_deinstall_command>
 </packagegui>

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/share/pfSense-pkg-zabbix-proxy/info.xml
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/share/pfSense-pkg-zabbix-proxy/info.xml
@@ -1,15 +1,20 @@
 <?xml version="1.0"?>
 <pfsensepkgs>
 	<package>
-		<name>Zabbix Proxy LTS</name>
+		<name>%%ZABBIXTITLE%%</name>
 		<internal_name>zabbix-proxy</internal_name>
-		<descr><![CDATA[LTS (Long Term Support) release of Zabbix agent proxy. Zabbix LTS releases are supported for 
+		<descr><![CDATA[LTS (Long Term Support) release. Zabbix LTS releases are supported for 
 			Zabbix customers during five (5) years i.e. 3 years of Full Support (general, critical and security issues) 
 			and 2 additional years of Limited Support (critical and security issues only). Zabbix LTS version release 
 			will result in change of the first version number.&lt;br /&gt;
+			Standard release. Standard Zabbix releases are supported for Zabbix customers during
+			six (6) months of Full Support (general, critical and security issues) until the next
+			Zabbix stable release, plus one (1) additional month of Limited Support (critical and
+			security issues only). Zabbix Standard version release will result in change of the
+			second version number.&lt;br /&gt;
 			More info in &lt;a href=&quot;http://www.zabbix.com/life_cycle_and_release_policy.php&quot;&gt;Zabbix Life Cycle and Release Policy&lt;/a&gt;.]]></descr>
 		<website>http://www.zabbix.com/product.php</website>
 		<version>%%PKGVERSION%%</version>
-		<configurationfile>zabbix-proxy-lts.xml</configurationfile>
+		<configurationfile>zabbix-proxy.xml</configurationfile>
 	</package>
 </pfsensepkgs>

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/share/pfSense-pkg-zabbix-proxy/info.xml
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/share/pfSense-pkg-zabbix-proxy/info.xml
@@ -2,7 +2,7 @@
 <pfsensepkgs>
 	<package>
 		<name>%%ZABBIXTITLE%%</name>
-		<internal_name>zabbix-proxy</internal_name>
+		<internal_name>%%ZABBIXINTERNALNAME%%</internal_name>
 		<descr><![CDATA[LTS (Long Term Support) release. Zabbix LTS releases are supported for 
 			Zabbix customers during five (5) years i.e. 3 years of Full Support (general, critical and security issues) 
 			and 2 additional years of Limited Support (critical and security issues only). Zabbix LTS version release 

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/pkg-plist
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/pkg-plist
@@ -1,5 +1,5 @@
-pkg/zabbix-proxy-lts.xml
-pkg/zabbix-proxy-lts.inc
-/etc/inc/priv/zabbix-proxy-lts.priv.inc
+pkg/zabbix-proxy.xml
+pkg/zabbix-proxy.inc
+/etc/inc/priv/zabbix-proxy.priv.inc
 %%DATADIR%%/info.xml
 @dir /etc/inc/priv

--- a/net-mgmt/pfSense-pkg-zabbix-proxy22/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy22/Makefile
@@ -1,0 +1,16 @@
+# $FreeBSD$
+
+MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-proxy
+
+PKGNAMESUFFIX=	22
+
+CONFLICTS=	pfSense-pkg-zabbix-proxy \
+		pfSense-pkg-zabbix-proxy32 \
+		pfSense-pkg-zabbix-proxy34
+
+RUN_DEPENDS=	zabbix_proxy:net-mgmt/zabbix32-proxy
+
+ZABBIXUNIQNAME=	zabbixproxy22
+ZABBIXTITLE=	Zabbix Proxy 2.2
+
+.include "${MASTERDIR}/Makefile"

--- a/net-mgmt/pfSense-pkg-zabbix-proxy22/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy22/Makefile
@@ -2,15 +2,16 @@
 
 MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-proxy
 
-PKGNAMESUFFIX=	22
+PORTNAME=	pfSense-pkg-zabbix-proxy${ZABBIXVERSION}
 
 CONFLICTS=	pfSense-pkg-zabbix-proxy \
 		pfSense-pkg-zabbix-proxy32 \
 		pfSense-pkg-zabbix-proxy34
 
-RUN_DEPENDS=	zabbix_proxy:net-mgmt/zabbix22-proxy
+RUN_DEPENDS=	zabbix_proxy:net-mgmt/zabbix${ZABBIXVERSION}-proxy
 
-ZABBIXUNIQNAME=	zabbixproxy22
+ZABBIXINTERNALNAME=	zabbix-proxy${ZABBIXVERSION}
 ZABBIXTITLE=	Zabbix Proxy 2.2
+ZABBIXVERSION=	22
 
 .include "${MASTERDIR}/Makefile"

--- a/net-mgmt/pfSense-pkg-zabbix-proxy22/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy22/Makefile
@@ -8,7 +8,7 @@ CONFLICTS=	pfSense-pkg-zabbix-proxy \
 		pfSense-pkg-zabbix-proxy32 \
 		pfSense-pkg-zabbix-proxy34
 
-RUN_DEPENDS=	zabbix_proxy:net-mgmt/zabbix32-proxy
+RUN_DEPENDS=	zabbix_proxy:net-mgmt/zabbix22-proxy
 
 ZABBIXUNIQNAME=	zabbixproxy22
 ZABBIXTITLE=	Zabbix Proxy 2.2

--- a/net-mgmt/pfSense-pkg-zabbix-proxy32/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy32/Makefile
@@ -1,0 +1,16 @@
+# $FreeBSD$
+
+MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-proxy
+
+PKGNAMESUFFIX=	32
+
+CONFLICTS=	pfSense-pkg-zabbix-proxy \
+		pfSense-pkg-zabbix-proxy22 \
+		pfSense-pkg-zabbix-proxy34
+
+RUN_DEPENDS=	zabbix_proxy:net-mgmt/zabbix32-proxy
+
+ZABBIXUNIQNAME=	zabbixproxy32
+ZABBIXTITLE=	Zabbix Proxy 3.2
+
+.include "${MASTERDIR}/Makefile"

--- a/net-mgmt/pfSense-pkg-zabbix-proxy32/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy32/Makefile
@@ -2,15 +2,16 @@
 
 MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-proxy
 
-PKGNAMESUFFIX=	32
+PORTNAME=	pfSense-pkg-zabbix-proxy${ZABBIXVERSION}
 
 CONFLICTS=	pfSense-pkg-zabbix-proxy \
 		pfSense-pkg-zabbix-proxy22 \
 		pfSense-pkg-zabbix-proxy34
 
-RUN_DEPENDS=	zabbix_proxy:net-mgmt/zabbix32-proxy
+RUN_DEPENDS=	zabbix_proxy:net-mgmt/zabbix${ZABBIXVERSION}-proxy
 
-ZABBIXUNIQNAME=	zabbixproxy32
+ZABBIXINTERNALNAME=	zabbix-proxy${ZABBIXVERSION}
 ZABBIXTITLE=	Zabbix Proxy 3.2
+ZABBIXVERSION=	32	
 
 .include "${MASTERDIR}/Makefile"

--- a/net-mgmt/pfSense-pkg-zabbix-proxy34/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy34/Makefile
@@ -1,0 +1,16 @@
+# $FreeBSD$
+
+MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-proxy
+
+PKGNAMESUFFIX=	34
+
+CONFLICTS=	pfSense-pkg-zabbix-proxy \
+		pfSense-pkg-zabbix-proxy22 \
+		pfSense-pkg-zabbix-proxy32
+
+RUN_DEPENDS=	zabbix_proxy:net-mgmt/zabbix34-proxy
+
+ZABBIXUNIQNAME=	zabbixproxy34
+ZABBIXTITLE=	Zabbix Proxy 3.4
+
+.include "${MASTERDIR}/Makefile"

--- a/net-mgmt/pfSense-pkg-zabbix-proxy34/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy34/Makefile
@@ -2,15 +2,16 @@
 
 MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-proxy
 
-PKGNAMESUFFIX=	34
+PORTNAME=	pfSense-pkg-zabbix-proxy${ZABBIXVERSION}
 
 CONFLICTS=	pfSense-pkg-zabbix-proxy \
 		pfSense-pkg-zabbix-proxy22 \
 		pfSense-pkg-zabbix-proxy32
 
-RUN_DEPENDS=	zabbix_proxy:net-mgmt/zabbix34-proxy
+RUN_DEPENDS=	zabbix_proxy:net-mgmt/zabbix${ZABBIXVERSION}-proxy
 
-ZABBIXUNIQNAME=	zabbixproxy34
+ZABBIXINTERNALNAME=	zabbix-proxy${ZABBIXVERSION}
 ZABBIXTITLE=	Zabbix Proxy 3.4
+ZABBIXVERSION=	34	
 
 .include "${MASTERDIR}/Makefile"


### PR DESCRIPTION
Bring all versions of Zabbix with Active Support to pfSense.

`net-mgmt/pfSense-pkg-zabbix-agent` and `net-mgmt/pfSense-pkg-zabbix-proxy` Zabbix LTS 3.0 are Master Ports.

Slave Ports:
`net-mgmt/pfSense-pkg-zabbix-agent22` Zabbix LTS 2.2
`net-mgmt/pfSense-pkg-zabbix-agent32` Zabbix Standard 3.2
`net-mgmt/pfSense-pkg-zabbix-agent34` Zabbix Standard 3.4

`net-mgmt/pfSense-pkg-zabbix-proxy22` Zabbix LTS 2.2
`net-mgmt/pfSense-pkg-zabbix-proxy32` Zabbix Standard 3.2
`net-mgmt/pfSense-pkg-zabbix-proxy34` Zabbix Standard 3.4

All packages will share the same config.

Stable LTS release | Release date | End of Full Support*(3 years) | End of Limited Support**(5 years)
-- | -- | -- | --
Zabbix 3.0 | 16 February 2016 | February, 2019 | February, 2021
Zabbix 2.2 | 12 November 2013 | August, 2017 | August, 2019
Zabbix 2.0 | 21 May 2012 | May, 2015 | May, 2017 (support ended)


Stable release | Release date | End of Full Support | End of Limited Support
-- | -- | -- | --
Zabbix 4.0 LTS | Q1, 2018 | Q1, 2021 | Q1, 2023
Zabbix 3.4 | August, 2017 | February, 2018 | March, 2018
Zabbix 3.2 | 14 September, 2016 | October, 2017 | November, 2017

More info about Zabbix Releases [here](https://www.zabbix.com/life_cycle_and_release_policy).