### PR TITLE
Update acme.inc

### DIFF
--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
@@ -333,6 +333,12 @@ $acme_domain_validation_method['dns_he'] = array(name => "DNS-Hurricane Electric
 			'description' =>"Hurricane Electric password"
 		)
 	));
+@$acme_domain_validation_method['dns_gandi_livedns'] = array(name => "DNS-Gandi LiveDNS",
+        'fields' => array(
+                'GANDI_LIVEDNS_KEY' => array('name'=>"gandi_livedns_key",'columnheader'=>"API Key",'type'=>"textbox",
+                        'description' =>"Set the Gandi LiveDNS API Key once retrieved from https://account.gandi.net"
+                )
+        ));
 //TODO add more challenge validation types
 /* 
 $acme_domain_validation_method['http-post'] = array(name => "http-post",


### PR DESCRIPTION
Add the support of the Gandi Live API on the pfSense GUI.
The current version of acme.sh already supports the Gandi Live API, but there was no GUI in pfSense to setup the Gandi API key.