### PR TITLE
[pfSense-pkg-bind9] Fix XMLRPC Sync by assuring the timeout is an int

### DIFF
--- a/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.inc
+++ b/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.inc
@@ -887,7 +887,7 @@ function bind_sync_on_changes() {
 	if (is_array($config['installedpackages']['bindsync']['config'])) {
 		$bind_sync = $config['installedpackages']['bindsync']['config'][0];
 		$synconchanges = $bind_sync['synconchanges'];
-		$synctimeout = $bind_sync['synctimeout'] ?: '30';
+		$synctimeout = (int)$bind_sync['synctimeout'] ?: 30;
 		$master_zone_ip = $bind_sync['masterip'];
 		switch ($synconchanges) {
 			case 'manual':


### PR DESCRIPTION
After upgrading to pfSense 2.4, we found that the sync functionality of BIND broke the package.

The exact error was reported here by someone else:
https://redmine.pfsense.org/issues/7944

The bug was probably introduced on feb 15 in this commit:
https://github.com/pfsense/FreeBSD-ports/commit/22a3d6cb10641129cecf72444278bef46c038a62#diff-06c502c5c9e6a781e00da74f11873ef8L1008
