### PR TITLE
pfSense-pkg-AutoConfigBackup - Remove useless conf_mount_{ro,rw} calls, add missing include

### DIFF
--- a/sysutils/pfSense-pkg-AutoConfigBackup/Makefile
+++ b/sysutils/pfSense-pkg-AutoConfigBackup/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-AutoConfigBackup
 PORTVERSION=	1.47
+PORTREVISION=	1
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/pkg/autoconfigbackup.inc
+++ b/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/pkg/autoconfigbackup.inc
@@ -21,6 +21,7 @@
 
 require_once("filter.inc");
 require_once("notices.inc");
+require_once("util.inc");
 
 // Plugin moved to save only
 unlink_if_exists("/usr/local/pkg/parse_config/parse_config_upload.inc");
@@ -88,11 +89,7 @@ function acb_custom_php_resync_config_command() {
 		return;
 	}
 
-	if (is_file("/cf/conf/lastpfSbackup.txt")) {
-		conf_mount_rw();
-		unlink("/cf/conf/lastpfSbackup.txt");
-		conf_mount_ro();
-	}
+	unlink_if_exists("/cf/conf/lastpfSbackup.txt");
 	if (!function_exists("filter_configure")) {
 		require_once("filter.inc");
 	}

--- a/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/pkg/autoconfigbackup.xml
+++ b/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/pkg/autoconfigbackup.xml
@@ -71,7 +71,7 @@
 		<field>
 			<fielddescr>Subscription Username</fielddescr>
 			<fieldname>username</fieldname>
-			<description>Enter the subscription username for portal.pfsense.org</description>
+			<description>Enter the subscription username (not email address) for portal.pfsense.org</description>
 			<type>input</type>
 		</field>
 		<field>

--- a/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/www/autoconfigbackup.php
+++ b/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/www/autoconfigbackup.php
@@ -18,8 +18,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-require("guiconfig.inc");
-require("autoconfigbackup.inc");
+require_once("autoconfigbackup.inc");
+require_once("guiconfig.inc");
+require_once("util.inc");
 
 // Separator used during client / server communications
 $oper_sep = "\|\|";
@@ -190,7 +191,6 @@ if ($_REQUEST['newver'] != "") {
 	}
 
 	if (!$input_errors && $data) {
-		conf_mount_rw();
 		if (config_restore("/tmp/config_restore.xml") == 0) {
 			$savemsg = "Successfully reverted the pfSense configuration to revision " . urldecode($_REQUEST['newver']) . ".";
 			$savemsg .= <<<EOF
@@ -208,7 +208,6 @@ EOF;
 		log_error("There was an error when restoring the AutoConfigBackup item");
 	}
 	unlink_if_exists("/tmp/config_restore.xml");
-	conf_mount_ro();
 }
 
 if ($_REQUEST['download']) {

--- a/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/www/autoconfigbackup_backup.php
+++ b/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/www/autoconfigbackup_backup.php
@@ -18,9 +18,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-require("globals.inc");
-require("guiconfig.inc");
-require("autoconfigbackup.inc");
+require_once("autoconfigbackup.inc");
+require_once("globals.inc");
+require_once("guiconfig.inc");
+require_once("util.inc");
 
 if (!$config['installedpackages']['autoconfigbackup']['config'][0]['username']) {
 	Header("Location: /pkg_edit.php?xml=autoconfigbackup.xml&id=0&savemsg=Please+setup+Auto+Config+Backup");
@@ -41,9 +42,7 @@ if ($_POST) {
 		$savemsg = "Backup not completed - write_config() failed.";
 	}
 	$config = parse_config(true);
-	conf_mount_rw();
 	unlink_if_exists("/cf/conf/lastpfSbackup.txt");
-	conf_mount_ro();
 
 	/* The config write above will trigger a fresh upload with the given reason.
 	 * This manual upload appears to be a relic of an older time (1.2.x)

--- a/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/www/autoconfigbackup_stats.php
+++ b/sysutils/pfSense-pkg-AutoConfigBackup/files/usr/local/www/autoconfigbackup_stats.php
@@ -18,9 +18,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-require("globals.inc");
-require("guiconfig.inc");
-require("autoconfigbackup.inc");
+require_once("globals.inc");
+require_once("guiconfig.inc");
+require_once("autoconfigbackup.inc");
 
 // Seperator used during client / server communications
 $oper_sep = "\|\|";


### PR DESCRIPTION
While here, added a more explicit wording to use portal username and not email address (requested in #7688).