### PR TITLE
pfSense-pkg-suricata - Remove useless conf_mount_{ro,rw} calls, Fix SID mods list download

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.0.0
-PORTREVISION=  2
+PORTREVISION=	3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -3902,9 +3902,7 @@ function suricata_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protoc
 	unset(\$g["suricata_postinstall"]);
 	log_error(gettext("[suricata] XMLRPC pkg sync: Generating suricata.yaml file using Master Host settings..."));
 	\$rebuild_rules = true;
-	conf_mount_rw();
 	sync_suricata_package_config();
-	conf_mount_ro();
 	\$rebuild_rules = false;
 	{$suricatastart}
 	log_error(gettext("[suricata] XMLRPC pkg sync process on this host is complete..."));

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -47,7 +47,6 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 
 	if ($suricatalogdirsizeKB > 0 && $suricatalogdirsizeKB > $suricataloglimitsizeKB) {
 		log_error(gettext("[Suricata] Log directory size exceeds configured limit of " . number_format($suricataloglimitsize) . " MB set on Global Settings tab. Starting cleanup of suricata logs."));
-		conf_mount_rw();
 
 		// Initialize an array of the log files we want to prune
 		$logs = array ( "alerts.log", "block.log", "dns.log", "eve.json", "http.log", "files-json.log", "sid_changes.log", "stats.log", "tls.log" );
@@ -130,7 +129,6 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 		cleanupExit:
 		// This is needed if suricata is run as suricata user
 		mwexec('/bin/chmod 660 /var/log/suricata/*', true);
-		conf_mount_ro();
 		log_error(gettext("[Suricata] Automatic clean-up of Suricata logs completed."));
 	}
 }

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -33,7 +33,6 @@ global $g, $rebuild_rules;
 
 $suricatadir = SURICATADIR;
 $suricatalogdir = SURICATALOGDIR;
-$mounted_rw = FALSE;
 
 /* define checks */
 $oinkid = $config['installedpackages']['suricata']['config'][0]['oinkcode'];
@@ -56,12 +55,6 @@ $snort_rule_url = VRT_DNLD_URL;
 $snort_community_rules_filename = GPLV2_DNLD_FILENAME;
 $snort_community_rules_filename_md5 = GPLV2_DNLD_FILENAME . ".md5";
 $snort_community_rules_url = GPLV2_DNLD_URL;
-
-/* Mount the Suricata conf directories R/W so we can modify files there */
-if (!is_subsystem_dirty('mount')) {
-	conf_mount_rw();
-	$mounted_rw = TRUE;
-}
 
 /* Set up Emerging Threats rules filenames and URL */
 if ($etpro == "on") {
@@ -681,10 +674,6 @@ if (is_dir("{$tmpfname}")) {
 suricata_update_status(gettext("The Rules update has finished.") . "\n");
 log_error(gettext("[Suricata] The Rules update has finished."));
 error_log(gettext("The Rules update has finished.  Time: " . date("Y-m-d H:i:s"). "\n\n"), 3, SURICATA_RULES_UPD_LOGFILE);
-
-/* Remount filesystem read-only if we changed it in this module */
-if ($mounted_rw == TRUE)
-	conf_mount_ro();
 
 /* Save this update status to the configuration file */
 if ($update_errors)

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
@@ -52,10 +52,6 @@ if (download_file("http://geolite.maxmind.com/download/geoip/database/GeoLiteCou
 if (download_file("http://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz", "{$geoip_tmppath}GeoIPv6.dat.gz") != true)
 	log_error(gettext("[Suricata] An error occurred downloading the 'GeoIPv6.dat.gz' update file for GeoIP."));
 
-// Mount filesystem read-write since we need to write
-// the extracted databases to PBI_BASE/share/GeoIP.
-conf_mount_rw();
-
 // If the files downloaded successfully, unpack them and store
 // the DB files in the PBI_BASE/share/GeoIP directory.
 if (file_exists("{$geoip_tmppath}GeoIP.dat.gz")) {
@@ -67,9 +63,6 @@ if (file_exists("{$geoip_tmppath}GeoIPv6.dat.gz")) {
 	mwexec("/usr/bin/gunzip -f {$geoip_tmppath}GeoIPv6.dat.gz");
 	@rename("{$geoip_tmppath}GeoIPv6.dat", "{$suricata_geoip_dbdir}GeoIPv6.dat");
 }
-
-// Finished with filesystem mods, so remount read-only
-conf_mount_ro();
 
 // Cleanup the tmp directory path
 rmdir_recursive("$geoip_tmppath");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -66,9 +66,6 @@ $g['suricata_postinstall'] = true;
 // Remove any LCK files for Suricata that might have been left behind
 unlink_if_exists("{$g['varrun_path']}/suricata_pkg_starting.lck");
 
-// Mount file system read/write so we can modify some files
-conf_mount_rw();
-
 // Remove any previously installed script since we rebuild it
 unlink_if_exists("{$rcdir}suricata.sh");
 
@@ -171,7 +168,6 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 	include('/usr/local/pkg/suricata/suricata_check_for_rule_updates.php');
 	update_status(gettext("Generating suricata.yaml configuration file from saved settings.") . "\n");
 	$rebuild_rules = true;
-	conf_mount_rw();
 
 	// Create the suricata.yaml files for each enabled interface
 	$suriconf = $config['installedpackages']['suricata']['rule'];
@@ -229,9 +225,6 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 // then default it to 'on'.
 if (empty($config['installedpackages']['suricata']['config'][0]['forcekeepsettings']))
 	$config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] = 'on';
-
-// Finished with file system mods, so remount it read-only
-conf_mount_ro();
 
 // Update Suricata package version in configuration
 $config['installedpackages']['suricata']['config'][0]['suricata_config_ver'] = $config['installedpackages']['package'][get_package_id("suricata")]['version'];

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
@@ -34,7 +34,6 @@ $iprep_path = SURICATA_IPREP_PATH;
 $rcdir = RCFILEPREFIX;
 $suricata_rules_upd_log = SURICATA_RULES_UPD_LOGFILE;
 $suri_pf_table = SURICATA_PF_TABLE;
-$mounted_rw = FALSE;
 
 log_error(gettext("[Suricata] Suricata package uninstall in progress..."));
 
@@ -71,15 +70,6 @@ if ($config['installedpackages']['suricata']['config'][0]['clearlogs'] == 'on') 
 	log_error(gettext("[Suricata] Clearing all Suricata-related log files..."));
 	unlink_if_exists("{$suricata_rules_upd_log}");
 	rmdir_recursive("{$suricatalogdir}");
-}
-
-/**************************************************/
-/* If not already, set Suricata conf partition to */
-/* read-write so we can make changes there        */
-/**************************************************/
-if (!is_subsystem_dirty('mount')) {
-	conf_mount_rw();
-	$mounted_rw = TRUE;
 }
 
 /*********************************************************/
@@ -123,13 +113,6 @@ if (!empty($widgets)) {
 	$config['widgets']['sequence'] = implode(",", $widgetlist);
 	write_config("Suricata pkg removed Dashboard Alerts widget.");
 }
-
-/*******************************************************/
-/* We're finished with conf partition mods, return to  */
-/* read-only if we changed it                          */
-/*******************************************************/
-if ($mounted_rw == TRUE)
-	conf_mount_ro();
 
 /* Keep this as a last step */
 if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] != 'on') {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -115,9 +115,7 @@ function suricata_add_supplist_entry($suppress) {
 	/* and return true; otherwise return false.                             */
 	if ($found_list) {
 		write_config();
-		conf_mount_rw();
 		sync_suricata_package_config();
-		conf_mount_ro();
 		return true;
 	}
 	else
@@ -349,9 +347,7 @@ if ($_POST['mode'] == 'togglesid' && is_numeric($_POST['sidid']) && is_numeric($
 	/* rules for this interface.                     */
 	/*************************************************/
 	$rebuild_rules = true;
-	conf_mount_rw();
 	suricata_generate_yaml($a_instance[$instanceid]);
-	conf_mount_ro();
 	$rebuild_rules = false;
 
 	/* Signal Suricata to live-load the new rules */

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
@@ -425,9 +425,7 @@ elseif ($_POST['save'] || $_POST['apply']) {
 			$a_nat[$id] = $natent;
 			write_config("Suricata pkg: saved updated app-layer parser configuration for " . convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']));
 			$rebuild_rules = false;
-			conf_mount_rw();
 			suricata_generate_yaml($natent);
-			conf_mount_ro();
 
 			// Sync to configured CARP slaves if any are enabled
 			suricata_sync_on_changes();

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_barnyard.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_barnyard.php
@@ -92,9 +92,7 @@ if ($_POST['save']) {
 
 		// No need to rebuild rules for Barnyard2 changes
 		$rebuild_rules = false;
-		conf_mount_rw();
 		sync_suricata_package_config();
-		conf_mount_ro();
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
 		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
@@ -196,9 +194,7 @@ if ($_POST['save']) {
 
 		// No need to rebuild rules for Barnyard2 changes
 		$rebuild_rules = false;
-		conf_mount_rw();
 		sync_suricata_package_config();
-		conf_mount_ro();
 
 		// If disabling Barnyard2 on the interface, stop any
 		// currently running instance.  If an instance is

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_define_vars.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_define_vars.php
@@ -116,9 +116,7 @@ if ($_POST) {
 
 		/* Update the suricata.yaml file for this interface. */
 		$rebuild_rules = false;
-		conf_mount_rw();
 		suricata_generate_yaml($a_nat[$id]);
-		conf_mount_ro();
 
 		/* Soft-restart Suricaa to live-load new variables. */
 		suricata_reload_config($a_nat[$id]);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
@@ -105,16 +105,10 @@ if ($_POST['clear']) {
 
 if ($_REQUEST['updatemode']) {
 	if ($_REQUEST['updatemode'] == 'force') {
-		// Mount file system R/W since we need to remove files
-		conf_mount_rw();
-
 		// Remove the existing MD5 signature files to force a download
 		unlink_if_exists("{$suricatadir}{$emergingthreats_filename}.md5");
 		unlink_if_exists("{$suricatadir}{$snort_community_rules_filename}.md5");
 		unlink_if_exists("{$suricatadir}{$snort_rules_file}.md5");
-
-		// Revert file system to R/O.
-		conf_mount_ro();
 	}
 	
 	// Launch a background process to download the updates

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
@@ -319,9 +319,7 @@ elseif ($_POST['save'] || $_POST['apply']) {
 			$a_nat[$id] = $natent;
 			write_config();
 			$rebuild_rules = false;
-			conf_mount_rw();
 			suricata_generate_yaml($natent);
-			conf_mount_ro();
 
 			// Sync to configured CARP slaves if any are enabled
 			suricata_sync_on_changes();

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -160,9 +160,7 @@ if (!$input_errors) {
 			install_cron_job("/usr/local/pkg/suricata/suricata_geoipupdate.php", FALSE);
 
 		/* create passlist and homenet file, then sync files */
-		conf_mount_rw();
 		sync_suricata_package_config();
-		conf_mount_ro();
 
 		/* forces page to reload new settings */
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -50,7 +50,6 @@ $ifaces = get_configured_interface_list();
 if (isset($_POST['del_x'])) {
 	/* delete selected interfaces */
 	if (is_array($_POST['rule']) && count($_POST['rule'])) {
-		conf_mount_rw();
 		foreach ($_POST['rule'] as $rulei) {
 			$if_real = get_real_interface($a_nat[$rulei]['interface']);
 			$if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$rulei]['interface']);
@@ -68,9 +67,7 @@ if (isset($_POST['del_x'])) {
 		write_config("Suricata pkg: deleted one or more Suricata interfaces.");
 		sleep(2);
 
-		conf_mount_rw();
 		sync_suricata_package_config();
-		conf_mount_ro();
 
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
@@ -104,9 +101,7 @@ if (isset($_POST['del_x'])) {
 		// Save updated configuration
 		write_config("Suricata pkg: deleted one or more Suricata interfaces.");
 		sleep(2);
-		conf_mount_rw();
 		sync_suricata_package_config();
-		conf_mount_ro();
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
 		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
@@ -125,9 +120,7 @@ if ($_POST['bartoggle']) {
 
 	if (!suricata_is_running($suricatacfg['uuid'], $if_real, 'barnyard2')) {
 		log_error("Toggle (barnyard starting) for {$if_friendly}({$suricatacfg['descr']})...");
-		conf_mount_rw();
 		sync_suricata_package_config();
-		conf_mount_ro();
 		suricata_barnyard_start($suricatacfg, $if_real);
 	} else {
 		log_error("Toggle (barnyard stopping) for {$if_friendly}({$suricatacfg['descr']})...");
@@ -148,9 +141,7 @@ if ($_POST['toggle']) {
 	switch($_POST['toggle']) {
 		case 'start' :
 				$rebuild_rules = true;
-				conf_mount_rw();
 				sync_suricata_package_config();
-				conf_mount_ro();
 				$rebuild_rules = false;
 
 			if (suricata_is_running($suricatacfg['uuid'], $if_real)) {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -282,9 +282,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		suricata_stop($a_rule[$id], get_real_interface($a_rule[$id]['interface']));
 		write_config("Suricata pkg: disabled Suricata on " . convert_friendly_interface_to_friendly_descr($a_rule[$id]['interface']));
 		$rebuild_rules = false;
-		conf_mount_rw();
 		sync_suricata_package_config();
-		conf_mount_ro();
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
 		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
@@ -430,9 +428,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 				else
 					$suricata_start = false;
 				@rename("{$suricatalogdir}suricata_{$oif_real}{$a_rule[$id]['uuid']}", "{$suricatalogdir}suricata_{$if_real}{$a_rule[$id]['uuid']}");
-				conf_mount_rw();
 				@rename("{$suricatadir}suricata_{$a_rule[$id]['uuid']}_{$oif_real}", "{$suricatadir}suricata_{$a_rule[$id]['uuid']}_{$if_real}");
-				conf_mount_ro();
 			}
 			$a_rule[$id] = $natent;
 		}
@@ -542,9 +538,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		write_config("Suricata pkg: modified interface configuration for " . convert_friendly_interface_to_friendly_descr($natent['interface']));
 
 		// Update suricata.conf and suricata.sh files for this interface
-		conf_mount_rw();
 		sync_suricata_package_config();
-		conf_mount_ro();
 
 		// Refresh page fields with just-saved values
 		$pconfig = $natent;

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
@@ -150,9 +150,7 @@ if ($_POST['save']) {
 
 		// Update the suricata conf file for this interface
 		$rebuild_rules = false;
-		conf_mount_rw();
 		suricata_generate_yaml($a_nat[$id]);
-		conf_mount_ro();
 
 		// Soft-restart Suricata to live-load new variables
 		suricata_reload_config($a_nat[$id]);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_mgmt.php
@@ -164,9 +164,7 @@ if (isset($_POST['save']) || isset($_POST['apply'])) {
 	if ($_POST['enable_log_mgmt'] != 'on') {
 		$config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] = $_POST['enable_log_mgmt'] ? 'on' :'off';
 		write_config("Suricata pkg: saved updated configuration for LOGS MGMT.");
-		conf_mount_rw();
 		sync_suricata_package_config();
-		conf_mount_ro();
 
 		/* forces page to reload new settings */
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
@@ -216,9 +214,7 @@ if (isset($_POST['save']) || isset($_POST['apply'])) {
 		$config['installedpackages']['suricata']['config'][0]['sid_changes_log_retention'] = $_POST['sid_changes_log_retention'];
 
 		write_config("Suricata pkg: saved updated configuration for LOGS MGMT.");
-		conf_mount_rw();
 		sync_suricata_package_config();
-		conf_mount_ro();
 
 		/* forces page to reload new settings */
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist.php
@@ -77,9 +77,7 @@ if (isset($_POST['del_btn'])) {
 		}
 		if ($need_save) {
 			write_config("Suricata pkg: deleted PASS LIST.");
-			conf_mount_rw();
 			sync_suricata_package_config();
-			conf_mount_ro();
 			header("Location: /suricata/suricata_passlist.php");
 			return;
 		}
@@ -101,9 +99,7 @@ else {
 		else {
 			unset($a_passlist[$delbtn_list]);
 			write_config("Suricata pkg: deleted PASS LIST.");
-			conf_mount_rw();
 			sync_suricata_package_config();
-			conf_mount_ro();
 			header("Location: /suricata/suricata_passlist.php");
 			return;
 		}

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -508,9 +508,7 @@ elseif (isset($_POST['clear'])) {
 	unset($a_rule[$id]['customrules']);
 	write_config("Suricata pkg: clear all custom rules for {$a_rule[$id]['interface']}.");
 	$rebuild_rules = true;
-	conf_mount_rw();
 	suricata_generate_yaml($a_rule[$id]);
-	conf_mount_ro();
 	$rebuild_rules = false;
 	$pconfig['customrules'] = '';
 
@@ -529,9 +527,7 @@ elseif (isset($_POST['save'])) {
 		unset($a_rule[$id]['customrules']);
 	write_config("Suricata pkg: save modified custom rules for {$a_rule[$id]['interface']}.");
 	$rebuild_rules = true;
-	conf_mount_rw();
 	suricata_generate_yaml($a_rule[$id]);
-	conf_mount_ro();
 	$rebuild_rules = false;
 	/* Signal Suricata to "live reload" the rules */
 	suricata_reload_config($a_rule[$id]);
@@ -561,9 +557,7 @@ elseif (isset($_POST['apply'])) {
 	/* rules for this interface.                     */
 	/*************************************************/
 	$rebuild_rules = true;
-	conf_mount_rw();
 	suricata_generate_yaml($a_rule[$id]);
-	conf_mount_ro();
 	$rebuild_rules = false;
 
 	/* Signal Suricata to "live reload" the rules */

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules_flowbits.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules_flowbits.php
@@ -128,9 +128,7 @@ if ($_POST['addsuppress'] && is_numeric($_POST['sid']) && is_numeric($_POST['gid
 	if ($found_list) {
 		write_config();
 		$rebuild_rules = false;
-		conf_mount_rw();
 		sync_suricata_package_config();
-		conf_mount_ro();
 		suricata_reload_config($a_nat[$id]);
 		$savemsg = gettext("An entry to suppress the Alert for 'gen_id {$_POST['gid']}, sig_id {$_POST['sid']}' has been added to Suppress List '{$a_nat[$id]['suppresslistname']}'.");
 	}

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -142,9 +142,7 @@ if (isset($_POST["save"])) {
 	/* rules for this interface.                     */
 	/*************************************************/
 	$rebuild_rules = true;
-	conf_mount_rw();
 	suricata_generate_yaml($a_nat[$id]);
-	conf_mount_ro();
 	$rebuild_rules = false;
 
 	/* Signal Suricata to "live reload" the rules */

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
@@ -173,9 +173,7 @@ if (isset($_POST['save_auto_sid_conf'])) {
 			// Update the suricata.yaml file and
 			// rebuild rules for this interface.
 			$rebuild_rules = true;
-			conf_mount_rw();
 			suricata_generate_yaml($a_nat[$k]);
-			conf_mount_ro();
 			$rebuild_rules = false;
 
 			// Signal Suricata to "live reload" the rules

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
@@ -192,18 +192,13 @@ if (isset($_POST['sidlist_dnload']) && isset($_POST['sidlist_fname'])) {
 	$file = $sidmods_path . basename($_POST['sidlist_fname']);
 	if (file_exists($file)) {
 		ob_start(); //important or other posts will fail
-		if (isset($_SERVER['HTTPS'])) {
-			header('Pragma: ');
-			header('Cache-Control: ');
-		} else {
-			header("Pragma: private");
-			header("Cache-Control: private, must-revalidate");
-		}
+		session_cache_limiter('nocache');
 		header("Content-Type: application/octet-stream");
-		header("Content-length: " . filesize($file));
-		header("Content-disposition: attachment; filename = " . basename($file));
+		header("Content-Length: " . filesize($file));
+		header("Content-Disposition: attachment; filename = " . basename($file));
 		ob_end_clean(); //important or other post will fail
 		readfile($file);
+		exit();
 	}
 	else
 		$savemsg = gettext("Unable to locate the file specified!");
@@ -212,25 +207,20 @@ if (isset($_POST['sidlist_dnload']) && isset($_POST['sidlist_fname'])) {
 if (isset($_POST['sidlist_dnload_all'])) {
 	$save_date = date("Y-m-d-H-i-s");
 	$file_name = "suricata_sid_conf_files_{$save_date}.tar.gz";
-	exec("cd {$sidmods_path} && /usr/bin/tar -czf /tmp/{$file_name} *");
+	exec("/usr/bin/tar -czf /tmp/{$file_name} --strip-components 5 {$sidmods_path}/*");
 
 	if (file_exists("/tmp/{$file_name}")) {
 		ob_start(); //important or other posts will fail
-		if (isset($_SERVER['HTTPS'])) {
-			header('Pragma: ');
-			header('Cache-Control: ');
-		} else {
-			header("Pragma: private");
-			header("Cache-Control: private, must-revalidate");
-		}
+		session_cache_limiter('nocache');
 		header("Content-Type: application/octet-stream");
-		header("Content-length: " . filesize("/tmp/{$file_name}"));
-		header("Content-disposition: attachment; filename = {$file_name}");
+		header("Content-Length: " . filesize("/tmp/{$file_name}"));
+		header("Content-Disposition: attachment; filename = {$file_name}");
 		ob_end_clean(); //important or other post will fail
 		readfile("/tmp/{$file_name}");
 
 		// Clean up the temp file
 		unlink_if_exists("/tmp/{$file_name}");
+		exit();
 	}
 	else
 		$savemsg = gettext("An error occurred while creating the gzip archive!");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress.php
@@ -93,9 +93,7 @@ if (isset($_POST['del_btn'])) {
 		}
 		if ($need_save) {
 			write_config("Suricata pkg: deleted SUPPRESSION LIST.");
-			conf_mount_rw();
 			sync_suricata_package_config();
-			conf_mount_ro();
 			header("Location: /suricata/suricata_suppress.php");
 			return;
 		}


### PR DESCRIPTION
@bmeeks8 - I (hopefully] fixed the SID mods list download with https://github.com/pfsense/FreeBSD-ports/pull/467/commits/dad6474f550c588644ac25c3222e3804668cabfa, it was appending HTML source code to the individual files, plus the gzip download did not work at all, because the same was appended to the tar.gz breaking it completely.

There are still multiple issues with the code here, e.g. 
- when you click the Download button next to lists, the Edit no longer works and turns into download as well. 
- when you click the Download button next to lists, the "Download all" button that's supposed to create the gzip instead keeps downloading the last individual file you downloaded previously.

I don't really understand the javascript stuff being done here but it's badly broken. Frankly it'd be a whole lot better to store the files base64-encoded in config.xml, they are not exactly so huge that it'd be a significant problem.
