### PR TITLE
Change Snort to always use FreeBSD-10-0 precompiled SO rules in pfSense 2.4.x releases.

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	3.2.9.5
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009 Robert Zelaya
- * Copyright (c) 2013-2016 Bill Meeks
+ * Copyright (c) 2013-2017 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -471,12 +471,8 @@ if ($snortdownload == 'on') {
 		snort_update_status(gettext("Installing Sourcefire VRT rules..."));
 
 		/* Currently, only FreeBSD-8-1, FreeBSD-9-0 and FreeBSD-10-0 precompiled SO rules exist from Snort.org */
-		/* Default to FreeBSD 8.1, and then test for FreeBSD 9.x  or FreeBSD 10.x */
-		$freebsd_version_so = 'FreeBSD-8-1';
-		if (substr(php_uname("r"), 0, 1) == '9')
-			$freebsd_version_so = 'FreeBSD-9-0';
-		elseif (substr(php_uname("r"), 0, 2) == '10')
-			$freebsd_version_so = 'FreeBSD-10-0';
+		/* Default to FreeBSD-10-0 for now as that is highest available version of SO rules */
+		$freebsd_version_so = 'FreeBSD-10-0';
 
 		/* Remove the old Snort rules files */
 		$vrt_prefix = VRT_FILE_PREFIX;


### PR DESCRIPTION
Snort.org distributes three versions of shared-object precompiled rules for FreeBSD.  The versions are for FreeBSD 8.1, FreeBSD 9 and FreeBSD 10.  The former Snort package code defaulted to the 8.1 rules (from way back when) and then tested via a _uname -r_ call to  see if FreeBSD 10 was present.  That worked for older pfSense releases, but with the release of 2.4 and the new FreeBSD 11.x underlying OS, the old code would incorrectly default to FreeBSD 8.1.  This change makes Snort always use the FreeBSD 10 SO rules until such time as Snort.org provides FreeBSD 11 rules.