### PR TITLE
tinc support for CARP

### DIFF
--- a/security/pfSense-pkg-tinc/files/usr/local/pkg/tinc.inc
+++ b/security/pfSense-pkg-tinc/files/usr/local/pkg/tinc.inc
@@ -25,6 +25,34 @@ require_once('service-utils.inc');
 require_once('util.inc');
 require_once('system.inc');
 
+function tinc_plugin_carp($pluginparams) {
+	// $pluginparams['type'] = 'carp';
+	// $pluginparams['event'] = 'rc.carpmaster';
+	// $pluginparams['interface'] = $argument;
+	log_error("[tinc] got carp event ");
+	if ($pluginparams['type'] == 'carp') {
+		if ($pluginparams['event'] == 'rc.carpmaster') {
+			// start
+			log_error("[tinc] got CARP:MASTER -> starting");
+			if (is_service_running('tinc')) {
+				log_error("[tinc] already running");
+			} else {
+				start_service("tinc");
+			}
+		}
+		if ($pluginparams['event'] == 'rc.carpbackup') {
+			// stop
+			log_error("[tinc] got CARP:BACKUP -> stopping");
+			if (!is_service_running('tinc')) {
+				log_error("[tinc] already stopped");
+			} else {
+				stop_service("tinc");
+			}
+		}
+	}
+}
+
+
 function tinc_save() {
 	global $config, $configpath;
 	$configpath = '/usr/local/etc/tinc';

--- a/security/pfSense-pkg-tinc/files/usr/local/pkg/tinc.inc
+++ b/security/pfSense-pkg-tinc/files/usr/local/pkg/tinc.inc
@@ -174,7 +174,7 @@ function tinc_save() {
 function tinc_write_rcfile() {
 	$rc['file'] = 'tinc.sh';
 	$rc['start'] .= "/usr/local/sbin/tincd --config=/usr/local/etc/tinc\n\t";
-	$rc['stop'] .= "/usr/local/sbin/tincd --kill \n\t";
+	$rc['stop'] .= "/usr/local/sbin/tincd --kill && sleep 2\n\t";
 	write_rcfile($rc);
 }
 

--- a/security/pfSense-pkg-tinc/files/usr/local/pkg/tinc.xml
+++ b/security/pfSense-pkg-tinc/files/usr/local/pkg/tinc.xml
@@ -47,6 +47,11 @@
 		<executable>tincd</executable>
 		<description>Tinc Mesh VPN</description>
 	</service>
+	<plugins>
+		<item>
+			<type>plugin_carp</type>
+		</item>
+	</plugins>
 	<tabs>
 		<tab>
 			<text>Settings</text>


### PR DESCRIPTION
Quick and dirty tinc support for CARP:
- make tinc a carp plugin
- when we get a rc.carpmaster event, start tinc if not already running
- when we get a rc.backup event, stop tinc if running

TODO: disable the option to launch tinc on a CARP BACKUP node