### PR TITLE
Update Let's Encrypt Agreement URL

### DIFF
--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.sh
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.sh
@@ -15,7 +15,7 @@ _SUB_FOLDERS="dnsapi deploy"
 
 _OLD_CA_HOST="https://acme-v01.api.letsencrypt.org"
 DEFAULT_CA="https://acme-v01.api.letsencrypt.org/directory"
-DEFAULT_AGREEMENT="https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf"
+DEFAULT_AGREEMENT="https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf.pdf"
 
 DEFAULT_USER_AGENT="$PROJECT_NAME/$VER ($PROJECT)"
 DEFAULT_ACCOUNT_EMAIL=""


### PR DESCRIPTION
The agreement was updated on November 15th, and certificate issuance fails if the old agreement URL is provided.

Not sure if this is the right place to submit this patch. If not, please point me in the right direction, if the issue has not already been fixed there.

Also, not sure if I need to bump the package version, or if that is handled by a release manager.