### PR TITLE
pfSense-pkg-zabbix: Fix a bug in Zabbix Proxy / Active Checks

### DIFF
--- a/net-mgmt/pfSense-pkg-zabbix-agent/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME?=	pfSense-pkg-zabbix-agent
-PORTVERSION=	1.0.0
+PORTVERSION=	1.0.1
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -25,7 +25,7 @@ SUB_FILES=	pkg-install pkg-deinstall
 SUB_LIST=	PORTNAME=${PORTNAME}
 
 ZABBIXINTERNALNAME?=	zabbix-agent
-ZABBIXTITLE?=	Zabbix Agent LTS
+ZABBIXTITLE?=	Zabbix Agent 3.0
 
 # Same for all Zabbix Agent ports to share their configs
 # zabbixagentlts for keep compatibility with current configs

--- a/net-mgmt/pfSense-pkg-zabbix-agent/pkg-descr
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/pkg-descr
@@ -1,7 +1,11 @@
-LTS (Long Term Support) release of Zabbix Monitoring agent. Zabbix LTS releases
-are supported for Zabbix customers during five (5) years i.e. 3 years of
-Full Support (general, critical and security issues) and 2 additional years
-of Limited Support (critical and security issues only). Zabbix LTS version
-release will result in change of the first version number.
+Zabbix agent is deployed on a monitoring target to actively monitor local
+resources and applications (hard drives, memory, processor statistics etc).
 
-WWW: http://www.zabbix.com/life_cycle_and_release_policy.php
+The agent gathers operational information locally and reports data to Zabbix
+server for further processing. In case of failures (such as a hard disk running
+full or a crashed service process), Zabbix server can actively alert the
+administrators of the particular machine that reported the failure.
+
+Zabbix is an enterprise-class open source distributed monitoring solution.
+
+WWW: https://www.zabbix.com/zabbix_agent

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME?=	pfSense-pkg-zabbix-proxy
-PORTVERSION=	1.0.0
+PORTVERSION=	1.0.1
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -25,7 +25,7 @@ SUB_FILES=	pkg-install pkg-deinstall
 SUB_LIST=	PORTNAME=${PORTNAME}
 
 ZABBIXINTERNALNAME?=	zabbix-proxy
-ZABBIXTITLE?=	Zabbix Proxy LTS
+ZABBIXTITLE?=	Zabbix Proxy 3.0
 
 # Same for all Zabbix Proxy ports to share their configs
 # zabbixproxylts for keep compatibility with current configs

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/pkg/zabbix-proxy.inc
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/pkg/zabbix-proxy.inc
@@ -62,6 +62,14 @@ function validate_input_zabbix_proxy($post, &$input_errors) {
 			$input_errors[] = "'Hostname' field is required.";
 		}
 
+		if ($post['listenport'] != '') {
+			if (!is_numericint($post['listenport'])) {
+				$input_errors[] = "'Listen Port' value is not numeric.";
+			} elseif ($post['listenport'] < 1 || $post['listenport'] > 65535) {
+				$input_errors[] = "You must enter a valid value for 'Listen Port'.";
+			}
+		}
+
 		if (!is_numericint($post['configfrequency'])) {
 			$input_errors[] = "'Config Frequency' value is not numeric.";
 		}
@@ -89,6 +97,8 @@ function sync_package_zabbix_proxy() {
 	if (is_array($config['installedpackages']['%%ZABBIXUNIQNAME%%'])) {
 		$zbproxy_config = $config['installedpackages']['%%ZABBIXUNIQNAME%%']['config'][0];
 		if ($zbproxy_config['proxyenabled'] == "on") {
+			$ListenIp = $zbproxy_config['listenip'] ?: "0.0.0.0";
+			$ListenPort = $zbproxy_config['listenport'] ?: "10051";
 			$Mode = (is_numericint($zbproxy_config['proxymode']) ? $zbproxy_config['proxymode'] : 0);
 			$AdvancedParams = base64_decode($zbproxy_config['advancedparams']);
 
@@ -147,17 +157,14 @@ function sync_package_zabbix_proxy() {
 			$StartSNMPTrapper = $zbproxy_config['startsnmptrapper'];
 			$SNMPTrapperFile = $zbproxy_config['snmptrapperfile'] ?: "/tmp/zabbix_traps.tmp";
 			$TrapperTimeout = $zbproxy_config['trappertimeout'] ?: "300";
-
-			if ($StartSNMPTrapper) {
-				$StartTrappers = $zbproxy_config['starttrappers'] ?: "5";
-			} else {
-				$StartTrappers = "0";
-			}
+			$StartTrappers = $zbproxy_config['starttrappers'] ?: "5";
 
 			$zbproxy_conf_file = <<< EOF
 Server={$zbproxy_config['server']}
 ServerPort={$zbproxy_config['serverport']}
 Hostname={$zbproxy_config['hostname']}
+ListenIP={$ListenIp}
+ListenPort={$ListenPort}
 PidFile=/var/run/zabbix-proxy/zabbix_proxy.pid
 DBName=/var/db/zabbix-proxy/proxy.db
 LogFile=/var/log/zabbix-proxy/zabbix_proxy.log

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/pkg/zabbix-proxy.xml
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/pkg/zabbix-proxy.xml
@@ -91,6 +91,22 @@
 			<required>true</required>
 		</field>
 		<field>
+			<fielddescr>Listen IP</fielddescr>
+			<fieldname>listenip</fieldname>
+			<default_value>0.0.0.0</default_value>
+			<type>input</type>
+			<size>60</size>
+			<description>List of comma delimited IP addresses that the trapper should listen on. (Default: 0.0.0.0 - all interfaces)</description>
+		</field>
+		<field>
+			<fielddescr>Listen Port</fielddescr>
+			<fieldname>listenport</fieldname>
+			<default_value>10051</default_value>
+			<type>input</type>
+			<size>5</size>
+			<description>Listen port for trapper. (Default: 10051)</description>
+		</field>
+		<field>
 			<fielddescr>Proxy Mode</fielddescr>
 			<fieldname>proxymode</fieldname>
 			<description>Select Zabbix proxy mode (Default: Active)</description>
@@ -110,6 +126,29 @@
 			<type>input</type>
 			<size>10</size>
 			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Trapper Timeout</fielddescr>
+			<fieldname>trappertimeout</fieldname>
+			<description>Specifies how many seconds trapper may spend processing new data. (Default: 300) (Range: 1-300)</description>
+			<default_value>300</default_value>
+			<type>input</type>
+			<size>3</size>
+		</field>
+		<field>
+			<fielddescr>Start Trappers</fielddescr>
+			<fieldname>starttrappers</fieldname>
+			<description>
+				<![CDATA[
+					Number of pre-forked instances of trappers.<br/>
+					Trappers accept incoming connections from Zabbix sender and active agents.<br/>
+					Default: 5<br/>
+					Range: 0-1000<br/>
+				]]>
+			</description>
+			<default_value>5</default_value>
+			<type>input</type>
+			<size>4</size>
 		</field>
 		<field>
 			<name>TLS-RELATED Parameters</name>
@@ -239,29 +278,6 @@
 			<default_value>/tmp/zabbix_traps.tmp</default_value>
 			<type>input</type>
 			<size>150</size>
-		</field>
-		<field>
-			<fielddescr>Trapper Timeout</fielddescr>
-			<fieldname>trappertimeout</fieldname>
-			<description>Specifies how many seconds trapper may spend processing new data. (Default: 300) (Range: 1-300)</description>
-			<default_value>300</default_value>
-			<type>input</type>
-			<size>3</size>
-		</field>
-		<field>
-			<fielddescr>Start Trappers</fielddescr>
-			<fieldname>starttrappers</fieldname>
-			<description>
-				<![CDATA[
-					Number of pre-forked instances of trappers.<br/>
-					Trappers accept incoming connections from Zabbix sender and active agents.<br/>
-					Default: 5<br/>
-					Range: 0-1000<br/>
-				]]>
-			</description>
-			<default_value>5</default_value>
-			<type>input</type>
-			<size>4</size>
 		</field>
 		<field>
 			<fielddescr>Advanced Parameters</fielddescr>

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/pkg-descr
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/pkg-descr
@@ -1,7 +1,11 @@
-LTS (Long Term Support) release of Zabbix Agent proxy. Zabbix LTS releases
-are supported for Zabbix customers during five (5) years i.e. 3 years of
-Full Support (general, critical and security issues) and 2 additional years
-of Limited Support (critical and security issues only). Zabbix LTS version release
-will result in change of the first version number.
+A Zabbix proxy can collect performance and availability data on behalf of the
+Zabbix server. This way, a proxy can take on itself some of the load of
+collecting data and offload the Zabbix server.
 
-WWW: http://www.zabbix.com/life_cycle_and_release_policy.php
+Also, using a proxy is the easiest way of implementing centralized and
+distributed monitoring, when all agents and proxies report to one Zabbix server
+and all data is collected centrally.
+
+Zabbix is an enterprise-class open source distributed monitoring solution.
+
+WWW: https://www.zabbix.com/


### PR DESCRIPTION
When SNMPTrapper is disabled, it is preventing Zabbix Proxy to listen
Active Checks from agents.

Also introduce new fields in web config, `ListenIP` and `ListenPort`.

While here, improve pkg-descr from Agent/Proxy and bump version.