### PR TITLE
Update Suricata binary to 4.0.1 to keep pace with upstream.

### DIFF
--- a/security/suricata/Makefile
+++ b/security/suricata/Makefile
@@ -2,7 +2,7 @@
 # $FreeBSD$
 
 PORTNAME=	suricata
-PORTVERSION=	4.0.0
+PORTVERSION=	4.0.1
 CATEGORIES=	security
 MASTER_SITES=	http://www.openinfosecfoundation.org/download/
 

--- a/security/suricata/distinfo
+++ b/security/suricata/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1501558442
-SHA256 (suricata-4.0.0.tar.gz) = 6b8b183a8409829ca92c71854cc1abed45f04ccfb7f14c08211f4edf571fa577
-SIZE (suricata-4.0.0.tar.gz) = 12252693
+TIMESTAMP = 1511319139
+SHA256 (suricata-4.0.1.tar.gz) = 0e73edb2911791644d82a62ab4f75517bbed339c0f21aadc0eb307b313643885
+SIZE (suricata-4.0.1.tar.gz) = 12311016


### PR DESCRIPTION
This updates the Suricata binary to version 4.0.1 to match upstream and FreeBSD ports.  No GUI package changes are necessary for this update.  Release Notes for Suricata 4.0.1 can be found at [https://suricata-ids.org/2017/10/18/suricata-4-0-1-available/](url).