### PR TITLE
Update OpenAppID rules URL in Snort GUI package

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	3.2.9.5
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -80,7 +80,7 @@ if (!defined("SNORT_OPENAPPID_DNLD_URL"))
 if (!defined("SNORT_OPENAPPID_DNLD_FILENAME"))
 	define("SNORT_OPENAPPID_DNLD_FILENAME", "snort-openappid.tar.gz");
 if (!defined("SNORT_OPENAPPID_RULES_URL"))
-	define("SNORT_OPENAPPID_RULES_URL", "http://www.ifs.edu.br/");
+	define("SNORT_OPENAPPID_RULES_URL", "http://files.pfsense.org/openappid/");
 if (!defined("SNORT_OPENAPPID_RULES_FILENAME"))
 	define("SNORT_OPENAPPID_RULES_FILENAME", "appid_rules.tar.gz");
 if (!defined("SNORT_RULES_UPD_LOGFILE"))

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
@@ -286,9 +286,9 @@ $group->add(new Form_Checkbox(
         $pconfig['openappid_rules_detectors'] == 'on' ? true:false,
         'on'
 ));
-$group->setHelp('Note - the AppID Open Rules file is maintained by a volunteer contributor.  The file is hosted at a University in Brazil that employs Geo-IP protection for their network.  ' . 
-'Snort users in some countries may experience issues downloading the rules package because of the Geo-IP blocking used by the hosting web site.  The URL for the file ' . 
-'is <a href="' . SNORT_OPENAPPID_RULES_URL . SNORT_OPENAPPID_RULES_FILENAME . '" target="_blank">' . SNORT_OPENAPPID_RULES_URL . SNORT_OPENAPPID_RULES_FILENAME . '</a>.');
+$group->setHelp('Note - the AppID Open Rules file is maintained by a volunteer contributor and hosted by the pfSense team.  ' . 
+'The URL for the file ' . 'is <a href="' . SNORT_OPENAPPID_RULES_URL . SNORT_OPENAPPID_RULES_FILENAME . '" target="_blank">' . 
+SNORT_OPENAPPID_RULES_URL . SNORT_OPENAPPID_RULES_FILENAME . '</a>.');
 $section->add($group);
 $form->add($section);
 


### PR DESCRIPTION
## pfSense-pkg-snort v3.2.9.5_4
The OpenAppID rules file is maintained by a volunteer contributor.  The pfSense team has agreed to host the OpenAppID rules file archive to increase reliability of the rules file download from users impacted by the geo-blocking policies enforced at the original hosting site in Brazil.

**Updates:**
The URL for the OpenAppID rules archive file now points to http://files.pfsense.org/openappid/.

**Bug Fixes:**
1. Clear out the dynamic_preprocessors sub-directory while rebuilding the _snort.conf_ file for an interface.  This ensures dynamic preprocessor libraries are removed when the corresponding dynamic preprocessor has been disabled in the GUI.  Otherwise, Snort will continue to load the disabled preprocessor so long as the library exists in the dynamic_preprocessors sub-directory.