### PR TITLE
Adjust Suricata ET-Pro rules URL based on recent changes by Proofpoint.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.0.1
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -68,7 +68,7 @@ if ($etpro == "on") {
 	$emergingthreats_filename = ETPRO_DNLD_FILENAME;
 	$emergingthreats_filename_md5 = ETPRO_DNLD_FILENAME . ".md5";
 	$emergingthreats_url = ETPRO_BASE_DNLD_URL;
-	$emergingthreats_url .= "{$etproid}/suricata/";
+	$emergingthreats_url .= "{$etproid}/suricata-4.0/";
 	$et_name = "Emerging Threats Pro";
 	$et_md5_remove = ET_DNLD_FILENAME . ".md5";
 	unlink_if_exists("{$suricatadir}{$et_md5_remove}");
@@ -79,7 +79,7 @@ else {
 	$emergingthreats_url = ET_BASE_DNLD_URL;
 	// If using Sourcefire VRT rules with ET, then we should use the open-nogpl ET rules
 	$emergingthreats_url .= $vrt_enabled == "on" ? "open-nogpl/" : "open/";
-	$emergingthreats_url .= "suricata/";
+	$emergingthreats_url .= "suricata-4.0/";
 	$et_name = "Emerging Threats Open";
 	$et_md5_remove = ETPRO_DNLD_FILENAME . ".md5";
 	unlink_if_exists("{$suricatadir}{$et_md5_remove}");


### PR DESCRIPTION
## pfSense-pkg-Suricata v4.0.1_1
This updates the URLs used for downloading the Proofpoint ET-Pro and ET-Open rules packages.  Proofpoint recently changed the folder structure on the download site to include the Suricata engine version as part of the rules download URL.

There are no new features or functionality changes in this update.

**Bug Fixes:**
1. Update the URL generation for ET-Pro and ET-Open rules package downloads to reflect recent changes made by Proofpoint.

