### PR TITLE
pfSense-pkg-suricata: Extended eve output selectable headers

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.0.3
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -449,8 +449,9 @@ if ($suricatacfg['eve_log_smtp'] == 'on') {
 		$eve_out_types .= "\n            extended: yes";
 	else
 		$eve_out_types .= "\n            extended: no";
+	if($suricatacfg['eve_log_smtp_extended_fields'] != "")
+		$eve_out_types .= "\n            custom: [".$suricatacfg['eve_log_smtp_extended_fields']."]";
 
-	$eve_out_types .= "\n            custom: [received, x-mailer, x-originating-ip, relays, reply-to, bcc]";
 	$eve_out_types .= "\n            md5: [subject]";
 }
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -406,17 +406,9 @@ if ($suricatacfg['eve_log_alerts_xff'] == 'on'){
 if ($suricatacfg['eve_log_http'] == 'on') {
 	$eve_out_types .= "\n        - http:";
 	if ($suricatacfg['eve_log_http_extended'] == 'on') {
-                $eve_out_types .= "\n            extended: yes";
-                $eve_out_types .= "\n            custom: [accept, accept-charset, accept-encoding, accept-language,";
-                $eve_out_types .= "\n                    accept-datetime, authorization, cache-control, cookie, from,";
-                $eve_out_types .= "\n                    max-forwards, origin, pragma, proxy-authorization, range, te, via,";
-                $eve_out_types .= "\n                    x-requested-with, dnt, x-forwarded-proto, accept-range, age,";
-                $eve_out_types .= "\n                    allow, connection, content-encoding, content-language,";
-                $eve_out_types .= "\n                    content-length, content-location, content-md5, content-range,";
-                $eve_out_types .= "\n                    content-type, date, etags, last-modified, link, location,";
-                $eve_out_types .= "\n                    proxy-authenticate, referrer, refresh, retry-after, server,";
-                $eve_out_types .= "\n                    set-cookie, trailer, transfer-encoding, upgrade, vary, warning,";
-                $eve_out_types .= "\n                    www-authenticate, x-flash-version, x-authenticated-user]";
+		$eve_out_types .= "\n            extended: yes";
+		if ($suricatacfg['eve_log_http_extended_headers'] != "")
+			$eve_out_types .= "\n            custom: [".$suricatacfg['eve_log_http_extended_headers']."]";
          } else {
                 $eve_out_types .= "\n            extended: no";
          }

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -217,7 +217,6 @@ stream:
   memcap: {$stream_memcap}
   checksum-validation: no
   inline: auto
-  max-sessions: {$stream_max_sessions}
   prealloc-sessions: {$stream_prealloc_sessions}
   midstream: {$stream_enable_midstream}
   async-oneside: {$stream_enable_async}

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1090,7 +1090,7 @@ $section->add($group)->addClass('eve_log_info');
 
 $section->addInput(new Form_Select(
 	'eve_log_http_extended_headers',
-	'HTTP Extended Headers',
+	'Extended HTTP Headers',
 	explode(", ",$pconfig['eve_log_http_extended_headers']),
 	array("accept"=>"accept","accept-charset"=>"accept-charset","accept-datetime"=>"accept-datetime","accept-encoding"=>"accept-encoding","accept-language"=>"accept-language","accept-range"=>"accept-range","age"=>"age","allow"=>"allow","authorization"=>"authorization","cache-control"=>"cache-control","connection"=>"connection","content-encoding"=>"content-encoding","content-language"=>"content-language","content-length"=>"content-length","content-location"=>"content-location","content-md5"=>"content-md5","content-range"=>"content-range","content-type"=>"content-type","cookie"=>"cookie","date"=>"date","dnt"=>"dnt","etags"=>"etags","from"=>"from","last-modified"=>"last-modified","link"=>"link","location"=>"location","max-forwards"=>"max-forwards","origin"=>"origin","pragma"=>"pragma","proxy-authenticate"=>"proxy-authenticate","proxy-authorization"=>"proxy-authorization","range"=>"range","referrer"=>"referrer","refresh"=>"refresh","retry-after"=>"retry-after","server"=>"server","set-cookie"=>"set-cookie","te"=>"te","trailer"=>"trailer","transfer-encoding"=>"transfer-encoding","upgrade"=>"upgrade","vary"=>"vary","via"=>"via","warning"=>"warning","www-authenticate"=>"www-authenticate","x-authenticated-user"=>"x-authenticated-user","x-flash-version"=>"x-flash-version","x-forwarded-proto"=>"x-forwarded-proto","x-requested-with"=>"x-requested-with"),
 	true
@@ -1099,7 +1099,7 @@ $section->addInput(new Form_Select(
 
 $section->addInput(new Form_Select(
 	'eve_log_smtp_extended_fields',
-	'SMTP Extended fields',
+	'Extended SMTP Fields',
 	explode(", ",$pconfig['eve_log_smtp_extended_fields']),
 	array("bcc"=>"bcc","content-md5"=>"content-md5","date"=>"date","importance"=>"importance","in-reply-to"=>"in-reply-to","message-id"=>"message-id","organization"=>"organization","priority"=>"priority","received"=>"received","references"=>"references","reply-to"=>"reply-to","sensitivity"=>"sensitivity","subject"=>"subject","user-agent"=>"user-agent","x-mailer"=>"x-mailer","x-originating-ip"=>"x-originating-ip"),
 	true
@@ -1565,6 +1565,7 @@ events.push(function(){
 	function toggle_eve_log_http() {
 		var disable = ! $('#eve_log_http').prop('checked');
 		disableInput('eve_log_http_extended',disable);
+		toggle_eve_log_http_extended();
 	}
 
 	function toggle_eve_log_tls() {
@@ -1575,6 +1576,7 @@ events.push(function(){
 	function toggle_eve_log_smtp() {
 		var disable = ! $('#eve_log_smtp').prop('checked');
 		disableInput('eve_log_smtp_extended',disable);
+		toggle_eve_log_smtp_extended();
 	}
 
 	function toggle_eve_log_files() {
@@ -1582,6 +1584,18 @@ events.push(function(){
 		hideCheckbox('eve_log_files_magic',hide);
 		hideSelect('eve_log_files_hash',hide);
 	}
+
+	function toggle_eve_log_http_extended() {
+		var hide = ! ($('#eve_log_http_extended').prop('checked') && $('#enable_eve_log').prop('checked') && $('#eve_log_http').prop('checked'));
+		hideSelect('eve_log_http_extended_headers\\[\\]',hide);
+	}
+
+	function toggle_eve_log_smtp_extended() {
+		var hide = ! ($('#eve_log_smtp_extended').prop('checked') && $('#enable_eve_log').prop('checked') && $('#eve_log_smtp').prop('checked'));
+		hideSelect('eve_log_smtp_extended_fields\\[\\]',hide);
+	}
+
+
 
 	function enable_change() {
 		var disable = ! $('#enable').prop('checked');
@@ -1676,6 +1690,10 @@ events.push(function(){
 		disableInput('eve_log_stats_deltas',disable);
 		disableInput('eve_log_stats_threads',disable);
 
+		disableInput('eve_log_http_extended_headers\\[\\]',disable);
+		disableInput('eve_log_smtp_extended_fields\\[\\]',disable);
+
+
 	}
 
 	// Call the list viewing page and write what it returns to the modal text area
@@ -1759,6 +1777,8 @@ events.push(function(){
 		toggle_eve_log_alerts();
 		toggle_eve_log_alerts_xff();
 		toggle_eve_log_stats();
+		toggle_eve_log_http_extended();
+		toggle_eve_log_smtp_extended();
 	});
 
 	$('#eve_output_type').change(function() {
@@ -1796,6 +1816,14 @@ events.push(function(){
 
 	$('#blockoffenders').click(function() {
 		enable_blockoffenders();
+	});
+
+	$('#eve_log_http_extended').click(function(){
+		toggle_eve_log_http_extended();
+	});
+
+	$('#eve_log_smtp_extended').click(function(){
+		toggle_eve_log_smtp_extended();
 	});
 
 	$('#ips_mode').on('change', function() {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -209,6 +209,9 @@ if (empty($pconfig['eve_log_smtp_extended']))
 if (empty($pconfig['eve_log_http_extended_headers']))
 	$pconfig['eve_log_http_extended_headers'] = "accept, accept-charset, accept-datetime, accept-encoding, accept-language, accept-range, age, allow, authorization, cache-control, connection, content-encoding, content-language, content-length, content-location, content-md5, content-range, content-type, cookie, date, dnt, etags, from, last-modified, link, location, max-forwards, origin, pragma, proxy-authenticate, proxy-authorization, range, referrer, refresh, retry-after, server, set-cookie, te, trailer, transfer-encoding, upgrade, vary, via, warning, www-authenticate, x-authenticated-user, x-flash-version, x-forwarded-proto, x-requested-with";
 
+if (empty($pconfig['eve_log_smtp_extended_fields']))
+	$pconfig['eve_log_smtp_extended_fields'] = "received, x-mailer, x-originating-ip, relays, reply-to, bcc";
+
 if (empty($pconfig['eve_log_files_magic']))
 	$pconfig['eve_log_files_magic'] = "off";
 if (empty($pconfig['eve_log_files_hash']))
@@ -398,7 +401,8 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['eve_log_tls_extended'] == "on") { $natent['eve_log_tls_extended'] = 'on'; }else{ $natent['eve_log_tls_extended'] = 'off'; }
 		if ($_POST['eve_log_smtp_extended'] == "on") { $natent['eve_log_smtp_extended'] = 'on'; }else{ $natent['eve_log_smtp_extended'] = 'off'; }
 
-		if ($_POST['eve_log_http_extended_headers']) { $natent['eve_log_http_extended_headers'] = implode(", ",$_POST['eve_log_http_extended_headers']); }else{ $natent['eve_log_extended_headers'] = ""; }
+		if ($_POST['eve_log_http_extended_headers']) { $natent['eve_log_http_extended_headers'] = implode(", ",$_POST['eve_log_http_extended_headers']); }else{ $natent['eve_log_http_extended_headers'] = ""; }
+		if ($_POST['eve_log_smtp_extended_fields']) { $natent['eve_log_smtp_extended_fields'] = implode(", ",$_POST['eve_log_smtp_extended_fields']); }else{ $natent['eve_log_smtp_extended_fields'] = ""; }
 
 		if ($_POST['eve_log_files_magic'] == "on") { $natent['eve_log_files_magic'] = 'on'; }else{ $natent['eve_log_files_magic'] = 'off'; }
 		if ($_POST['eve_log_files_hash']) { $natent['eve_log_files_hash'] = $_POST['eve_log_files_hash']; }else{ $natent['eve_log_files_hash'] = 'none'; }
@@ -1091,6 +1095,15 @@ $section->addInput(new Form_Select(
 	array("accept"=>"accept","accept-charset"=>"accept-charset","accept-datetime"=>"accept-datetime","accept-encoding"=>"accept-encoding","accept-language"=>"accept-language","accept-range"=>"accept-range","age"=>"age","allow"=>"allow","authorization"=>"authorization","cache-control"=>"cache-control","connection"=>"connection","content-encoding"=>"content-encoding","content-language"=>"content-language","content-length"=>"content-length","content-location"=>"content-location","content-md5"=>"content-md5","content-range"=>"content-range","content-type"=>"content-type","cookie"=>"cookie","date"=>"date","dnt"=>"dnt","etags"=>"etags","from"=>"from","last-modified"=>"last-modified","link"=>"link","location"=>"location","max-forwards"=>"max-forwards","origin"=>"origin","pragma"=>"pragma","proxy-authenticate"=>"proxy-authenticate","proxy-authorization"=>"proxy-authorization","range"=>"range","referrer"=>"referrer","refresh"=>"refresh","retry-after"=>"retry-after","server"=>"server","set-cookie"=>"set-cookie","te"=>"te","trailer"=>"trailer","transfer-encoding"=>"transfer-encoding","upgrade"=>"upgrade","vary"=>"vary","via"=>"via","warning"=>"warning","www-authenticate"=>"www-authenticate","x-authenticated-user"=>"x-authenticated-user","x-flash-version"=>"x-flash-version","x-forwarded-proto"=>"x-forwarded-proto","x-requested-with"=>"x-requested-with"),
 	true
 ))->setHelp('Select HTTP headers for logging');
+
+
+$section->addInput(new Form_Select(
+	'eve_log_smtp_extended_fields',
+	'SMTP Extended fields',
+	explode(", ",$pconfig['eve_log_smtp_extended_fields']),
+	array("bcc"=>"bcc","content-md5"=>"content-md5","date"=>"date","importance"=>"importance","in-reply-to"=>"in-reply-to","message-id"=>"message-id","organization"=>"organization","priority"=>"priority","received"=>"received","references"=>"references","reply-to"=>"reply-to","sensitivity"=>"sensitivity","subject"=>"subject","user-agent"=>"user-agent","x-mailer"=>"x-mailer","x-originating-ip"=>"x-originating-ip"),
+	true
+))->setHelp('Select SMTP fields for logging');
 
 
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -206,6 +206,9 @@ if (empty($pconfig['eve_log_tls_extended']))
 if (empty($pconfig['eve_log_smtp_extended']))
 	$pconfig['eve_log_smtp_extended'] = $pconfig['smtp_log_extended'];
 
+if (empty($pconfig['eve_log_http_extended_headers']))
+	$pconfig['eve_log_http_extended_headers'] = "accept, accept-charset, accept-datetime, accept-encoding, accept-language, accept-range, age, allow, authorization, cache-control, connection, content-encoding, content-language, content-length, content-location, content-md5, content-range, content-type, cookie, date, dnt, etags, from, last-modified, link, location, max-forwards, origin, pragma, proxy-authenticate, proxy-authorization, range, referrer, refresh, retry-after, server, set-cookie, te, trailer, transfer-encoding, upgrade, vary, via, warning, www-authenticate, x-authenticated-user, x-flash-version, x-forwarded-proto, x-requested-with";
+
 if (empty($pconfig['eve_log_files_magic']))
 	$pconfig['eve_log_files_magic'] = "off";
 if (empty($pconfig['eve_log_files_hash']))
@@ -394,6 +397,9 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['eve_log_http_extended'] == "on") { $natent['eve_log_http_extended'] = 'on'; }else{ $natent['eve_log_http_extended'] = 'off'; }
 		if ($_POST['eve_log_tls_extended'] == "on") { $natent['eve_log_tls_extended'] = 'on'; }else{ $natent['eve_log_tls_extended'] = 'off'; }
 		if ($_POST['eve_log_smtp_extended'] == "on") { $natent['eve_log_smtp_extended'] = 'on'; }else{ $natent['eve_log_smtp_extended'] = 'off'; }
+
+		if ($_POST['eve_log_http_extended_headers']) { $natent['eve_log_http_extended_headers'] = implode(", ",$_POST['eve_log_http_extended_headers']); }else{ $natent['eve_log_extended_headers'] = ""; }
+
 		if ($_POST['eve_log_files_magic'] == "on") { $natent['eve_log_files_magic'] = 'on'; }else{ $natent['eve_log_files_magic'] = 'off'; }
 		if ($_POST['eve_log_files_hash']) { $natent['eve_log_files_hash'] = $_POST['eve_log_files_hash']; }else{ $natent['eve_log_files_hash'] = 'none'; }
 		if ($_POST['eve_log_drop'] == "on") { $natent['eve_log_drop'] = 'on'; }else{ $natent['eve_log_drop'] = 'off'; }
@@ -1073,8 +1079,21 @@ $group->add(new Form_Checkbox(
 	'on'
 ));
 
+
+
 $group->setHelp('Selected which logs should have extended info.');
 $section->add($group)->addClass('eve_log_info');
+
+$section->addInput(new Form_Select(
+	'eve_log_http_extended_headers',
+	'HTTP Extended Headers',
+	explode(", ",$pconfig['eve_log_http_extended_headers']),
+	array("accept"=>"accept","accept-charset"=>"accept-charset","accept-datetime"=>"accept-datetime","accept-encoding"=>"accept-encoding","accept-language"=>"accept-language","accept-range"=>"accept-range","age"=>"age","allow"=>"allow","authorization"=>"authorization","cache-control"=>"cache-control","connection"=>"connection","content-encoding"=>"content-encoding","content-language"=>"content-language","content-length"=>"content-length","content-location"=>"content-location","content-md5"=>"content-md5","content-range"=>"content-range","content-type"=>"content-type","cookie"=>"cookie","date"=>"date","dnt"=>"dnt","etags"=>"etags","from"=>"from","last-modified"=>"last-modified","link"=>"link","location"=>"location","max-forwards"=>"max-forwards","origin"=>"origin","pragma"=>"pragma","proxy-authenticate"=>"proxy-authenticate","proxy-authorization"=>"proxy-authorization","range"=>"range","referrer"=>"referrer","refresh"=>"refresh","retry-after"=>"retry-after","server"=>"server","set-cookie"=>"set-cookie","te"=>"te","trailer"=>"trailer","transfer-encoding"=>"transfer-encoding","upgrade"=>"upgrade","vary"=>"vary","via"=>"via","warning"=>"warning","www-authenticate"=>"www-authenticate","x-authenticated-user"=>"x-authenticated-user","x-flash-version"=>"x-flash-version","x-forwarded-proto"=>"x-forwarded-proto","x-requested-with"=>"x-requested-with"),
+	true
+))->setHelp('Select HTTP headers for logging');
+
+
+
 
 $section->addInput(new Form_Checkbox(
 	'eve_log_files_magic',


### PR DESCRIPTION
This PR adds the functionality to configure the logged http headers and smtp fields in extended eve output. 

This might be helpful if one wants to reduce the log output for various reasons. For example the logging of the Authorization header could leak login credentials. At the moment all HTTP headers are logged if extended http logging is enabled. 
