### PR TITLE
Pfblockerng grammar error in pfblockerng.php

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng.php
@@ -1019,7 +1019,7 @@ $xml = <<<EOF
 			<fielddescr>NOTES</fielddescr>
 			<description><![CDATA[Click here for IMPORTANT info on:&emsp;
 				<a target="_blank" href="https://dev.maxmind.com/geoip/geoip2/whats-new-in-geoip2/">
-				<span class="text-danger"><strong>What new in GeoIP2</strong></span></a><br /><br /> 
+				<span class="text-danger"><strong>What's new in GeoIP2</strong></span></a><br /><br /> 
 
 				<span class="text-danger"><strong>Note:&emsp;</strong></span>
 				pfSense by default implicitly blocks all unsolicited inbound traffic to the WAN interface.<br />


### PR DESCRIPTION
Correct a grammar error, “What new” to “What’s new”.