### PR TITLE
haproxy-devel, add gui support for crtlist nbthread hardstop

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/Makefile
+++ b/net/pfSense-pkg-haproxy-devel/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-haproxy-devel
-PORTVERSION=	0.54
-PORTREVISION=	2
+PORTVERSION=	0.55
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -1645,9 +1645,13 @@ function haproxy_writeconf($configpath) {
 					$crl_file = " crl-file $filename";
 				}
 				
-				$ssloptions .= " {$frontend['dcertadv']}";
-				$ssloptions .= "{$ca_file}{$crl_file}";
+				//$ssloptions .= " {$frontend['dcertadv']}";
+				$ssl_crtlist_advanced = empty($frontend['ssl_crtlist_advanced']) ? "" : " {$frontend['ssl_crtlist_advanced']}";
+				$ssloptions .= "{$ssl_crtlist_advanced}{$ca_file}{$crl_file}";
 				foreach($frontend['crtfiles'] as $crtfile) {
+					if ($frontendname == $frontend['name']) {
+//						continue;// skip primary from the crt-list
+					}
 					$crtlist .= "{$crtfile} [{$ssloptions}] {$frontend['sslsnifilter']}\r\n";
 				}
 			}

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -1314,7 +1314,7 @@ function haproxy_updateocsp($socketupdate = true) {
 		if (is_arrayset($frontend, 'ha_certificates', 'item')) {
 			$certs = $frontend['ha_certificates']['item'];
 			foreach($certs as $cert) {
-				$filename = "$subfolder/{$cert['ssl_certificate']}.pem";
+				$filename = "$subfolder/{$frontend['name']}_{$cert['ssl_certificate']}.pem";
 				haproxy_updateocsp_one($socketupdate, $filename, $frontend['name']);
 			}
 		}
@@ -1367,7 +1367,11 @@ function haproxy_writeconf($configpath) {
 		if ($a_global['remotesyslog']) {
 			fwrite ($fd, "\tlog\t\t\t{$a_global['remotesyslog']}\t{$a_global['logfacility']}\t{$a_global['loglevel']}\n");
 		}
-		fwrite ($fd, "\tstats socket /tmp/haproxy.socket level admin\n");
+		$exposefdlisteners = "";
+		if (haproxy_version() >= "1.8") {
+			$exposefdlisteners = " expose-fd listeners";
+		}
+		fwrite ($fd, "\tstats socket /tmp/haproxy.socket level admin $exposefdlisteners\n");
 		
 		if(!use_transparent_clientip_proxying()) {
 			fwrite ($fd, "\tuid\t\t\t80\n");
@@ -1376,8 +1380,15 @@ function haproxy_writeconf($configpath) {
 		fwrite ($fd, "\tgid\t\t\t80\n");
 		// Set numprocs if defined or use system default (#cores)
 		$numprocs = $a_global['nbproc'] ? $a_global['nbproc'] : "1";
-		fwrite ($fd, "\tnbproc\t\t\t$numprocs\n");
-		fwrite ($fd, "\tchroot\t\t\t$chroot_dir\n");
+		$numthread = $a_global['nbthread'] ? $a_global['nbthread'] : "1";
+		fwrite ($fd, "\tnbproc\t\t\t{$numprocs}\n");
+		if (haproxy_version() >= "1.8") {
+			fwrite ($fd, "\tnbthread\t\t\t{$numthread}\n");
+		}
+		$hard_stop_after = !empty($a_global['hard_stop_after']) ? $a_global['hard_stop_after'] : "15m";
+		fwrite ($fd, "\thard-stop-after\t\t{$hard_stop_after}\n");
+
+		fwrite ($fd, "\tchroot\t\t\t\t$chroot_dir\n");
 		fwrite ($fd, "\tdaemon\n");
 		
 		if ($a_global['ssldefaultdhparam']) {
@@ -1461,37 +1472,50 @@ function haproxy_writeconf($configpath) {
 			}
 			$primaryfrontend = get_primaryfrontend($frontend);
 
-			$bname = $primaryfrontend['name'];
-			if (!is_array($a_bind[$bname])) {
-				$a_bind[$bname] = array();
-				$a_bind[$bname] = $primaryfrontend;
-				$a_bind[$bname]['config'] = array();
+			$primary_fename = $primaryfrontend['name'];
+			if (!is_array($a_bind[$primary_fename])) {
+				$a_bind[$primary_fename] = array();
+				$a_bind[$primary_fename] = $primaryfrontend;
+				$a_bind[$primary_fename]['config'] = array();
 			}
 
 			//check ssl info
 			$ssl = get_frontend_uses_ssl($frontend);
-			
+			$crtfiles = array();
 			if ($ssl) {
+				$certfolder = "$configpath/{$primary_fename}";
+				$certs = $frontend['ha_certificates']['item'];
+				$ssl_crt = "";
+				
 				//ssl crt ./server.pem ca-file ./ca.crt verify optional crt-ignore-err all crl-file ./ca_crl.pem
-				$filename = "$configpath/{$frontend['name']}.pem";
-				$ssl_crt = " crt $filename";
+				if ($frontend['secondary'] != 'yes') {
+					$filename = "$configpath/{$frontend['name']}.pem";
+					$ssl_crt = " crt $filename";
+//					$ssl_crt .= " crt $certfolder";
+					@mkdir($certfolder, 0755, true);
 
-				haproxy_write_certificate_fullchain($filename, $frontend['ssloffloadcert']);
-				if ($frontend['sslocsp'] == 'yes') {
-					$ocspurl = haproxy_getocspurl($filename);
-					if (!empty($ocspurl)) {
-						haproxy_write_certificate_issuer($filename . ".issuer", $frontend['ssloffloadcert']);
-						touch($filename . ".ocsp");//create initial empty file. this will trigger updates, and inform haproxy it 'should' be using ocsp
+					$crtfiles[] = $filename;
+					haproxy_write_certificate_fullchain($filename, $frontend['ssloffloadcert']);
+					if ($frontend['sslocsp'] == 'yes') {
+						$ocspurl = haproxy_getocspurl($filename);
+						if (!empty($ocspurl)) {
+							haproxy_write_certificate_issuer($filename . ".issuer", $frontend['ssloffloadcert']);
+							touch($filename . ".ocsp");//create initial empty file. this will trigger updates, and inform haproxy it 'should' be using ocsp
+						}
 					}
+				} else {
+					// add the cert to the 'additional certs' array
+					$tempcert = array();
+					$tempcert['ssl_certificate'] = $frontend['ssloffloadcert'];
+					$certs[] = $tempcert;
 				}
 				
-				$subfolder = "$configpath/{$frontend['name']}";
-				$certs = $frontend['ha_certificates']['item'];
 				if (is_array($certs)) {
 					if (count($certs) > 0) {
-						@mkdir($subfolder, 0755, true);
+						@mkdir($certfolder, 0755, true);
 						foreach($certs as $cert){
-							$filenamefoldercert = "$subfolder/{$cert['ssl_certificate']}.pem";
+							$filenamefoldercert = "$certfolder/{$frontend['name']}_{$cert['ssl_certificate']}.pem";
+							$crtfiles[] = $filenamefoldercert;
 							haproxy_write_certificate_fullchain($filenamefoldercert, $cert['ssl_certificate']);
 							if ($frontend['sslocsp'] == 'yes') {
 								$ocspurl = haproxy_getocspurl($filenamefoldercert);
@@ -1501,7 +1525,6 @@ function haproxy_writeconf($configpath) {
 								}
 							}
 						}
-						$ssl_crt .= " crt $subfolder";
 					}
 				}
 			} else {
@@ -1509,21 +1532,22 @@ function haproxy_writeconf($configpath) {
 				unlink_if_exists("var/etc/{$frontend['name']}.{$frontend['port']}.crt");//cleanup for possible old haproxy package version
 			}
 
-			$b = &$a_bind[$bname];
+			$b = &$a_bind[$primary_fename];
 			
 			if (($frontend['secondary'] != 'yes') && ($frontend['name'] != $b['name'])) {
 				// only 1 frontend can be the primary for a set of frontends that share 1 address:port.
-					$input_errors[] = "Multiple primary frontends for $bname use the 'Shared Frontend' option instead";
+					$input_errors[] = "Multiple primary frontends for $primary_fename use the 'Shared Frontend' option instead";
 			}
 			
 			if ($ssl_crt != "") {
 				if ($b['ssl_info'] == "") {
-					$b['ssl_info'] = "ssl {$frontend['dcertadv']}";
+					$b['ssl_info'] = " {$frontend['dcertadv']}";
 				}
 				$b['ssl_info'] .= $ssl_crt;
 			}
+			$frontend['crtfiles'] = $crtfiles; // keep list of .pem files for building the crt-list
 
-			// pointer to each frontend 
+			// pointer to each frontend
 			$b['config'][] = $frontend;
 		}
 	}
@@ -1542,6 +1566,7 @@ function haproxy_writeconf($configpath) {
 			fwrite ($fd, "{$frontendinfo}");
 			
 			$advancedextra = array();
+/**/
 			$ca_file = "";
 			$first = true;
 			if (is_array($bind['clientcert_ca']['item'])) {
@@ -1565,12 +1590,18 @@ function haproxy_writeconf($configpath) {
 				}
 				$crl_file = " crl-file $filename";
 			}
+/**/
+			$ssl_ignoreclienterror = "";
+			if ($bind['sslclientcert-invalid']) {
+				$ssl_ignoreclienterror = " crt-ignore-err all";
+			}
+			
 			$advanced_bind = $bind['advanced_bind'];
 			$ssl_info = $bind['ssl_info'];
-			$ssl_info .= $ca_file . $crl_file;
-			if ($bind['sslclientcert-invalid']) {
-				$ssl_info .= " crt-ignore-err all";
-			}
+			$ssl_info .= $ca_file . $crl_file . $ssl_ignoreclienterror;
+			
+			$crtlistfilename = "$configpath/{$frontendname}.crt_list";
+			$ssl_crtlist = " crt-list {$crtlistfilename}";
 			
 			$useipv4 = false;
 			$useipv6 = false;
@@ -1578,12 +1609,49 @@ function haproxy_writeconf($configpath) {
 			$bindips = get_frontend_bindips($bind);
 			$listenip = "";
 			foreach($bindips as $bindip) {
-				$ssl = $bindip['extaddr_ssl'] == 'yes' ? $ssl_info : "";
+				$ssl = $bindip['extaddr_ssl'] == 'yes' ? " ssl" . $ssl_info . $ssl_crtlist : "";
 				$listenip .=  "\tbind\t\t\t{$bindip['addr']}:{$bindip['port']} name {$bindip['addr']}:{$bindip['port']} {$ssl} {$advanced_bind} {$bindip['extaddr_advanced']}\n";
 				$useipv4 |= is_ipaddrv4($bindip['addr']);
 				$useipv6 |= is_ipaddrv6($bindip['addr']);
 			}
 			fwrite ($fd, "{$listenip}");
+			
+			$crtlist = "";
+			foreach ($bind['config'] as $frontend) {
+				// loop through 'shared frontends' within one primary.
+				$ssloptions = "";
+				
+				$ca_file = "";
+				$first = true;
+				if (is_array($frontend['clientcert_ca']['item'])) {
+					$filename = "$configpath/clientca_{$frontend['name']}.pem";
+					foreach($frontend['clientcert_ca']['item'] as $ca) {
+						if (!empty($ca['cert_ca'])) {
+							haproxy_write_certificate_crt($filename, $ca['cert_ca'], false, !$first);
+							$first = false;
+						}
+					}
+					$verify = $frontend['sslclientcert-none'] == 'yes' ? "verify optional" : "verify required";
+					$ca_file = " ca-file $filename $verify";
+				}
+				$crl_file = "";
+				$first = true;
+				if (is_array($frontend['clientcert_crl']['item'])) {
+					$filename = "$configpath/clientcrl_{$frontend['name']}.pem";
+					foreach($frontend['clientcert_crl']['item'] as $ca) {
+						haproxy_write_certificate_crl($filename, $ca['cert_crl'], !$first);
+						$first = false;
+					}
+					$crl_file = " crl-file $filename";
+				}
+				
+				$ssloptions .= " {$frontend['dcertadv']}";
+				$ssloptions .= "{$ca_file}{$crl_file}";
+				foreach($frontend['crtfiles'] as $crtfile) {
+					$crtlist .= "{$crtfile} [{$ssloptions}] {$frontend['sslsnifilter']}\r\n";
+				}
+			}
+			file_put_contents($crtlistfilename, $crtlist);
 			
 			if (use_frontend_as_unixsocket($frontendname)) {
 				fwrite ($fd, "\tbind /tmp/haproxy_chroot/{$frontendname}.socket name unixsocket uid 80 accept-proxy {$ssl_info} {$advanced_bind}\n");
@@ -2165,7 +2233,7 @@ function haproxy_check_run($reload) {
 		}
 		$useocsp = haproxy_uses_ocsp();
 		if ($useocsp == "true") {
-			install_cron_job("/etc/rc.haproxy_ocsp.sh", true, "*/120");
+			install_cron_job("/etc/rc.haproxy_ocsp.sh", true, "1");
 		} else {
 			install_cron_job("/etc/rc.haproxy_ocsp.sh", false);
 		}
@@ -2215,7 +2283,11 @@ function haproxy_check_run($reload) {
 			}
 			
 			syslog(LOG_NOTICE, "haproxy: reload old pid:$old_pid");
-			exec("/usr/local/sbin/haproxy -f {$configpath}/haproxy.cfg -p /var/run/haproxy.pid $sf_st `cat /var/run/haproxy.pid` 2>&1", $output, $errcode);
+			$restartargs = "";
+			if (haproxy_version() >= "1.8") {
+				$restartargs = " -x /tmp/haproxy.socket";
+			}
+			exec("/usr/local/sbin/haproxy -f {$configpath}/haproxy.cfg -p /var/run/haproxy.pid -D $restartargs $sf_st `cat /var/run/haproxy.pid` 2>&1", $output, $errcode);
 		} else {
 			syslog(LOG_NOTICE, "haproxy: starting old pid:$old_pid");
 			exec("/usr/local/sbin/haproxy -f {$configpath}/haproxy.cfg -p /var/run/haproxy.pid -D 2>&1", $output, $errcode);

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_global.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_global.php
@@ -29,7 +29,7 @@ require_once("haproxy/haproxy_utils.inc");
 require_once("haproxy/haproxy_htmllist.inc");
 require_once("haproxy/pkg_haproxy_tabs.inc");
 
-$simplefields = array('localstats_refreshtime', 'localstats_sticktable_refreshtime', 'log-send-hostname', 'ssldefaultdhparam',
+$simplefields = array('nbthread', 'hard_stop_after', 'localstats_refreshtime', 'localstats_sticktable_refreshtime', 'log-send-hostname', 'ssldefaultdhparam',
   'email_level', 'email_myhostname', 'email_from', 'email_to',
   'resolver_retries', 'resolver_timeoutretry', 'resolver_holdvalid');
 
@@ -286,13 +286,21 @@ $section->add($group);
 $cpucores = trim(`/sbin/sysctl kern.smp.cpus | cut -d" " -f2`);
 
 $section->addInput(new Form_Input('nbproc', 'Number of processes to start', 'text', $pconfig['nbproc']
-))->setHelp(<<<EOD
+))->setPlaceholder("1")->setHelp(<<<EOD
 	Defaults to 1 if left blank ({$cpucores} CPU core(s) detected).<br/>
 	Note : Consider leaving this value empty or 1  because in multi-process mode (nbproc > 1) memory is not shared between the processes, which could result in random behaviours for several options like ACL's, sticky connections, stats pages, admin maintenance options and some others.<br/>
 	For more information about the <b>"nbproc"</b> option please see <b><a href='http://cbonte.github.io/haproxy-dconv/1.7/configuration.html#nbproc' target='_blank'>HAProxy Documentation</a></b>
 EOD
 );
 
+if (haproxy_version() >= "1.8") {
+	$section->addInput(new Form_Input('nbthread', 'Number of theads to start per process', 'text', $pconfig['nbthread']
+	))->setPlaceholder("1")->setHelp(<<<EOD
+		Defaults to 1 if left blank ({$cpucores} CPU core(s) detected).<br/>
+		FOR NOW, THREADS SUPPORT IN HAPROXY 1.8 IS HIGHLY EXPERIMENTAL AND IT MUST BE ENABLED WITH CAUTION AND AT YOUR OWN RISK.
+EOD
+	);
+}
 
 $section->addInput(new Form_Checkbox(
 	'terminate_on_reload',
@@ -307,6 +315,12 @@ $section->addInput(new Form_Checkbox(
 EOD
 );
 
+$section->addInput(new Form_Input('hard_stop_after', 'Reload stop behaviour', 'text', $pconfig['hard_stop_after']
+))->setPlaceholder("15m")->setHelp(<<<EOD
+	Defines the maximum time allowed to perform a clean soft-stop.
+	Defaults to 15 minutes, but could also be defined in different units like 30s, 15m, 3h or 1d.
+EOD
+);
 
 $vipinterfaces = array();
 $vipinterfaces[] = array('ip' => '', 'name' => 'Disabled');

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
@@ -53,7 +53,7 @@ uasort($a_pools, haproxy_compareByName);
 global $simplefields;
 $simplefields = array('name','desc','status','secondary','primary_frontend','type','forwardfor','httpclose','extaddr','backend_serverpool',
 	'max_connections','client_timeout','port','advanced_bind',
-	'ssloffloadcert','dcertadv','ssloffload','ssloffloadacl','ssloffloadacl_an','ssloffloadacladditional','ssloffloadacladditional_an',
+	'ssloffloadcert','sslsnifilter','dcertadv','ssloffload','ssloffloadacl','ssloffloadacl_an','ssloffloadacladditional','ssloffloadacladditional_an',
 	'sslclientcert-none','sslclientcert-invalid','sslocsp',
 	'socket-stats',
 	'dontlognull','dontlog-normal','log-separate-errors','log-detailed');
@@ -345,30 +345,30 @@ if ($_POST) {
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (preg_match("/[^a-zA-Z0-9\.\-_]/", $_POST['name'])) {
-		$input_errors[] = "The field 'Name' contains invalid characters.";
+		$input_errors[] = gettext("The field 'Name' contains invalid characters.");
 	}
 
 	if ($pconfig['secondary'] != "yes") {
 		if ($_POST['max_connections'] && !is_numeric($_POST['max_connections'])) {
-			$input_errors[] = "The field 'Max connections' value is not a number.";
+			$input_errors[] = sprintf(gettext("The value '%s' in field 'Max connections' is not a number."), htmlspecialchars($_POST['max_connections']));
 		}
 
 		$ports = split(",", $_POST['port'] . ",");
 		foreach($ports as $port) {
 			if ($port && !is_numeric($port) && !is_port_or_alias($port)) {
-				$input_errors[] = "The field 'Port' value '".htmlspecialchars($port)."' is not a number or alias thereof.";
+				$input_errors[] = sprintf(gettext("The value '%s' in field 'Port' is not a number or alias thereof."), htmlspecialchars($port));
 			}
 		}
 
 		if ($_POST['client_timeout'] !== "" && !is_numeric($_POST['client_timeout'])) {
-			$input_errors[] = "The field 'Client timeout' value is not a number.";
+			$input_errors[] = sprintf(gettext("The value '%s' in field 'Client timeout' is not a number."), htmlspecialchars($_POST['client_timeout']));
 		}
 	}
 
 	/* Ensure that our pool names are unique */
 	for ($i=0; isset($config['installedpackages']['haproxy']['ha_backends']['item'][$i]); $i++) {
 		if (($_POST['name'] == $config['installedpackages']['haproxy']['ha_backends']['item'][$i]['name']) && ($i != $id)) {
-			$input_errors[] = "This frontend name has already been used. Frontend names must be unique. $i != $id";
+			$input_errors[] = gettext("This frontend name has already been used. Frontend names must be unique.")." $i != $id";
 		}
 	}
 
@@ -395,31 +395,31 @@ if ($_POST) {
 
 		$acltype = haproxy_find_acl($acl['expression']);
 		if (preg_match("/[^a-zA-Z0-9\.\-_]/", $acl_name)) {
-			$input_errors[] = "The field 'Name' contains invalid characters.";
+			$input_errors[] = sprintf(gettext("The acl field 'Name' with value '%s' contains invalid characters."), $acl_name);
 		}
 
 		if (!isset($acltype['novalue'])) {
 			if (!preg_match("/.{1,}/", $acl_value)) {
-				$input_errors[] = "The field 'Value' is required.";
+				$input_errors[] = sprintf(gettext("The acl field 'Value' for acl '%s' is required."), $acl_name);
 			}
 		}
 
 		if (!preg_match("/.{2,}/", $acl_name)) {
-			$input_errors[] = "The field 'Name' is required with at least 2 characters.";
+			$input_errors[] = gettext("The acl field 'Name' is required with at least 2 characters.");
 		}
 	}
 	foreach($a_extaddr as $extaddr) {
 		$ports = explode(",",$extaddr['extaddr_port']);
 		foreach($ports as $port){
 			if ($port && !is_numeric($port) && !is_port_or_alias($port)) {
-				$input_errors[] = "The field 'Port' value '".htmlspecialchars($port)."' is not a number or alias thereof.";
+				$input_errors[] = sprintf(gettext("The external address field 'Port' value '%s' is not a number or alias thereof."), htmlspecialchars($port));
 			}
 		}
 	
 		if ($extaddr['extaddr'] == 'custom') {
 			$extaddr_custom = $extaddr['extaddr_custom'];
 			if (empty($extaddr_custom) || (!is_ipaddroralias($extaddr_custom))) {
-				$input_errors[] = sprintf(gettext("%s is not a valid source IP address or alias."),$extaddr_custom);
+				$input_errors[] = sprintf(gettext("The external address '%s' is not a valid source IP address or alias."), $extaddr_custom);
 			}
 		}
 	}
@@ -489,6 +489,7 @@ $primaryfrontends = get_haproxy_frontends($excludefrontend);
 	.haproxy_mode_http{display:none;}
 	.haproxy_ssloffloading_show{display:none;}
 	.haproxy_ssloffloading_enabled{display:none;}
+	.haproxy_ssl_advanced{display:none;}
 	.haproxy_primary{}
 	.haproxy_secondary{display:none;}
   </style>
@@ -537,6 +538,7 @@ $primaryfrontends = get_haproxy_frontends($excludefrontend);
 		var primary;
 		var secondary = d.getElementById("secondary");
 		var primary_frontend = d.getElementById("primary_frontend");
+		var sslsnifilter = d.getElementById("sslsnifilter");
 		if ((secondary !== null) && (secondary.checked)) {
 			primary = primaryfrontends[primary_frontend.value];
 			type = primary['ref']['type'];
@@ -558,10 +560,15 @@ $primaryfrontends = get_haproxy_frontends($excludefrontend);
 		setCSSdisplay(".haproxy_ssloffloading_show", sslshow);
 		setCSSdisplay(".haproxy_ssloffloading_enabled", ssl);
 		setCSSdisplay(".haproxy_mode_http", type === "http");
+		var issecondary = false;
+		var hassnifilter = false;
 		if (secondary !== null) {
+			issecondary = secondary.checked;
 			setCSSdisplay(".haproxy_primary", !secondary.checked);
 			setCSSdisplay(".haproxy_secondary", secondary.checked);
+			hassnifilter = sslsnifilter.value != '';
 		}
+		//setCSSdisplay(".haproxy_ssl_advanced", ssl && (!issecondary || hassnifilter));
 		
 		type_change(type);
 		
@@ -859,6 +866,16 @@ $section->addInput(new Form_Checkbox(
 	'Specify additional certificates for this shared-frontend.',
 	$pconfig['ssloffload']
 ),"haproxy_secondary");
+
+$section->addInput(new Form_Input(
+	'sslsnifilter',
+	'SNI Filter',
+	'text',
+	$pconfig['sslsnifilter']
+), "haproxy_secondary haproxy_ssloffloading_enabled"
+)->setHelp('Specify a SNI filter to apply below SSL settings to specific domain(s), see the "crt-list" option from haproxy for details. <br/>'.
+		'EXAMPLE: *.securedomain.tld !public.securedomain.tld');
+
 $section->addInput(
 	new Form_StaticText(
 		'Certificate',
@@ -883,13 +900,12 @@ $section->addInput(
 	))
 ),"haproxy_ssloffloading_enabled");
 
-
 $section->addInput(new Form_Checkbox(
 	'sslocsp',
 	'OCSP',
 	'Load certificate ocsp responses for easy certificate validation by the client.',
 	$pconfig['sslocsp']
-),"haproxy_ssloffloading_enabled")->setHelp("Make sure to add appropriate acl's to check for presence of a user certificate where needed.");
+),"haproxy_ssloffloading_enabled")->setHelp("A cron job wil update the ocsp response every hour.");
 
 $section->addInput(
 	new Form_StaticText(
@@ -911,14 +927,14 @@ $section->addInput(
 ),"haproxy_ssloffloading_enabled");
 
 $section->addInput(new Form_Input('dcertadv', 'Advanced ssl options', 'text', $pconfig['dcertadv']
-),"haproxy_ssloffloading_enabled haproxy_primary")->setHelp('NOTE: Paste additional ssl options(without commas) to include on ssl listening options.<br/>
+),"haproxy_ssloffloading_enabled")->setHelp('NOTE: Paste additional ssl options(without commas) to include on ssl listening options.<br/>
 	some options: force-sslv3, force-tlsv10 force-tlsv11 force-tlsv12 no-sslv3 no-tlsv10 no-tlsv11 no-tlsv12 no-tls-tickets<br/>
 	Example: no-sslv3 ciphers EECDH+aRSA+AES:TLSv1+kRSA+AES:TLSv1+kRSA+3DES');
-
+// haproxy_ssl_advanced << css class to hide field.?
 $form->add($section);
 
 $section = new Form_Section_class("SSL Offloading - client certificates");
-$section->addClass("haproxy_ssloffloading_enabled haproxy_primary");
+$section->addClass("haproxy_ssloffloading_enabled");
 $section->addInput(new Form_StaticText(
 	'Note',
 	"<b>Client certificate verification options, leave all these options empty if you do not want to ask for a client certificate</b><br/>
@@ -1013,6 +1029,9 @@ events.push(function() {
 		updatevisibility();
 	});
 	$('#ssloffload').click(function () {
+		updatevisibility();
+	});
+	$('#sslsnifilter').on('change input keyup cut paste', function () {
 		updatevisibility();
 	});
 

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
@@ -931,14 +931,12 @@ $section->addInput(new Form_Input('dcertadv', 'Advanced ssl options', 'text', $p
 	some options: force-sslv3, force-tlsv10 force-tlsv11 force-tlsv12 no-sslv3 no-tlsv10 no-tlsv11 no-tlsv12 no-tls-tickets<br/>
 	Example: no-sslv3 ciphers EECDH+aRSA+AES:TLSv1+kRSA+AES:TLSv1+kRSA+3DES');
 // haproxy_ssl_advanced << css class to hide field.?
-$form->add($section);
 
 $section->addInput(new Form_Input('ssl_crtlist_advanced', 'Advanced certificate specific ssl options',
 	'text', $pconfig['ssl_crtlist_advanced']
 ),"haproxy_ssloffloading_enabled")->setHelp('NOTE: Paste additional ssl options(without commas) to include on ssl listening options.<br/>
 	some options: alpn, no-ca-names, ecdhe, curves, ciphers, ssl-min-ver and ssl-max-ver<br/>
 	Example: alpn h2,http/1.1 ciphers EECDH+aRSA+AES:TLSv1+kRSA+AES:TLSv1+kRSA+3DES ecdhe secp256k1');
-// haproxy_ssl_advanced << css class to hide field.?
 $form->add($section);
 // options that are in the gui as regular settings: verify, ca-file, crl-file
 // deprecated: npn

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
@@ -53,7 +53,7 @@ uasort($a_pools, haproxy_compareByName);
 global $simplefields;
 $simplefields = array('name','desc','status','secondary','primary_frontend','type','forwardfor','httpclose','extaddr','backend_serverpool',
 	'max_connections','client_timeout','port','advanced_bind',
-	'ssloffloadcert','sslsnifilter','dcertadv','ssloffload','ssloffloadacl','ssloffloadacl_an','ssloffloadacladditional','ssloffloadacladditional_an',
+	'ssloffloadcert','sslsnifilter','ssl_crtlist_advanced','dcertadv','ssloffload','ssloffloadacl','ssloffloadacl_an','ssloffloadacladditional','ssloffloadacladditional_an',
 	'sslclientcert-none','sslclientcert-invalid','sslocsp',
 	'socket-stats',
 	'dontlognull','dontlog-normal','log-separate-errors','log-detailed');
@@ -927,11 +927,21 @@ $section->addInput(
 ),"haproxy_ssloffloading_enabled");
 
 $section->addInput(new Form_Input('dcertadv', 'Advanced ssl options', 'text', $pconfig['dcertadv']
-),"haproxy_ssloffloading_enabled")->setHelp('NOTE: Paste additional ssl options(without commas) to include on ssl listening options.<br/>
+),"haproxy_ssloffloading_enabled haproxy_primary")->setHelp('NOTE: Paste additional ssl options(without commas) to include on ssl listening options.<br/>
 	some options: force-sslv3, force-tlsv10 force-tlsv11 force-tlsv12 no-sslv3 no-tlsv10 no-tlsv11 no-tlsv12 no-tls-tickets<br/>
 	Example: no-sslv3 ciphers EECDH+aRSA+AES:TLSv1+kRSA+AES:TLSv1+kRSA+3DES');
 // haproxy_ssl_advanced << css class to hide field.?
 $form->add($section);
+
+$section->addInput(new Form_Input('ssl_crtlist_advanced', 'Advanced certificate specific ssl options',
+	'text', $pconfig['ssl_crtlist_advanced']
+),"haproxy_ssloffloading_enabled")->setHelp('NOTE: Paste additional ssl options(without commas) to include on ssl listening options.<br/>
+	some options: alpn, no-ca-names, ecdhe, curves, ciphers, ssl-min-ver and ssl-max-ver<br/>
+	Example: alpn h2,http/1.1 ciphers EECDH+aRSA+AES:TLSv1+kRSA+AES:TLSv1+kRSA+3DES ecdhe secp256k1');
+// haproxy_ssl_advanced << css class to hide field.?
+$form->add($section);
+// options that are in the gui as regular settings: verify, ca-file, crl-file
+// deprecated: npn
 
 $section = new Form_Section_class("SSL Offloading - client certificates");
 $section->addClass("haproxy_ssloffloading_enabled");


### PR DESCRIPTION
haproxy-devel
-add support for nbthread option available in haproxy 1.8 version, and add hard-stop-after setting
-use crt-list to specify certificates and certificate specific options regarding client certificates and advanced ssl options.