### PR TITLE
Suricata 4.0.3

### DIFF
--- a/security/suricata/Makefile
+++ b/security/suricata/Makefile
@@ -2,7 +2,7 @@
 # $FreeBSD$
 
 PORTNAME=	suricata
-PORTVERSION=	4.0.1
+PORTVERSION=	4.0.3
 CATEGORIES=	security
 MASTER_SITES=	http://www.openinfosecfoundation.org/download/
 

--- a/security/suricata/distinfo
+++ b/security/suricata/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1508393375
-SHA256 (suricata-4.0.1.tar.gz) = 0e73edb2911791644d82a62ab4f75517bbed339c0f21aadc0eb307b313643885
-SIZE (suricata-4.0.1.tar.gz) = 12311016
+TIMESTAMP = 1515365816
+SHA256 (suricata-4.0.3.tar.gz) = 81a0bcb10b5c0b00efeafb4aac3ef70bf0e36b060ac6300d867f15f3dbe0e437
+SIZE (suricata-4.0.3.tar.gz) = 12392388


### PR DESCRIPTION
## Suricata v4.0.3
Update the Suricata binary to version 4.0.3 to keep pace with upstream.  This binary update is compatible with the current GUI package on pfSense, but an updated GUI package will also be posted soon to fix some other issues and match up GUI and binary version numbers.  For binary version release notes see:  [https://suricata-ids.org/2017/12/06/suricata-4-0-3-available/](url)