### PR TITLE
pfSense-pkg-suricata 4.0.3 Update

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	4.0.1
-PORTREVISION=	1
+PORTVERSION=	4.0.3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2016 Bill Meeks
+ * Copyright (C) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -348,7 +348,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 	/* IP for Suricata, though, to prevent locking out the firewall.    */
 	/********************************************************************/
 	$suricataip = get_interface_ip($suricatacfg['interface']);
-	if (($externallist && $localnet == 'yes') || (!$externallist && (!$passlist || $localnet == 'yes' || empty($localnet)))) {
+	if (($externallist && $localnet == 'yes') || (!$externallist && $passlist && ($localnet == 'yes' || empty($localnet)))) {
 		if (is_ipaddrv4($suricataip)) {
 			if ($suricatacfg['interface'] <> "wan") {
 				if ($sn = get_interface_subnet($suricatacfg['interface'])) {
@@ -374,7 +374,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 	if (strpos($suricataip, "%") !== FALSE) {
 		$suricataip = substr($suricataip, 0, strpos($suricataip, "%"));
 	}
-	if (($externallist && $localnet == 'yes') || (!$externallist && (!$passlist || $localnet == 'yes' || empty($localnet)))) {
+	if (($externallist && $localnet == 'yes') || ($passlist && ($localnet == 'yes' || empty($localnet))) || (!$externallist && !$passlist && ($localnet == 'yes' || empty($localnet)))) {
 		if (is_ipaddrv6($suricataip)) {
 			if ($suricatacfg['interface'] <> "wan") {
 				if ($sn = get_interface_subnetv6($suricatacfg['interface'])) {
@@ -408,7 +408,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 
 	// Now find all the locally-attached network subnets and add them to the
 	// list if user chose to include Local Networks.
-	if (($externallist && $localnet == 'yes') || (!$externallist && (!$passlist || $localnet == 'yes' || empty($localnet)))) {		
+	if (($externallist && $localnet == 'yes') || ($passlist && ($localnet == 'yes' || empty($localnet))) || (!$externallist && !$passlist && ($localnet == 'yes' || empty($localnet)))) {		
 		/*************************************************************************/
 		/*  Iterate through the interface list and write out pass list items and */
 		/*  also compile a HOME_NET list of all local interfaces for suricata.   */

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2016 Bill Meeks
+ * Copyright (C) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -33,6 +33,7 @@ global $g, $rebuild_rules;
 
 $suricatadir = SURICATADIR;
 $suricatalogdir = SURICATALOGDIR;
+$suri_eng_ver = filter_var(SURICATA_BIN_VERSION, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
 $mounted_rw = FALSE;
 
 /* define checks */
@@ -68,7 +69,7 @@ if ($etpro == "on") {
 	$emergingthreats_filename = ETPRO_DNLD_FILENAME;
 	$emergingthreats_filename_md5 = ETPRO_DNLD_FILENAME . ".md5";
 	$emergingthreats_url = ETPRO_BASE_DNLD_URL;
-	$emergingthreats_url .= "{$etproid}/suricata-4.0/";
+	$emergingthreats_url .= "{$etproid}/suricata-{$suri_eng_ver}/";
 	$et_name = "Emerging Threats Pro";
 	$et_md5_remove = ET_DNLD_FILENAME . ".md5";
 	unlink_if_exists("{$suricatadir}{$et_md5_remove}");
@@ -79,7 +80,7 @@ else {
 	$emergingthreats_url = ET_BASE_DNLD_URL;
 	// If using Sourcefire VRT rules with ET, then we should use the open-nogpl ET rules
 	$emergingthreats_url .= $vrt_enabled == "on" ? "open-nogpl/" : "open/";
-	$emergingthreats_url .= "suricata-4.0/";
+	$emergingthreats_url .= "suricata-{$suri_eng_ver}/";
 	$et_name = "Emerging Threats Open";
 	$et_md5_remove = ETPRO_DNLD_FILENAME . ".md5";
 	unlink_if_exists("{$suricatadir}{$et_md5_remove}");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2016 Bill Meeks
+ * Copyright (C) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -81,7 +81,8 @@ $suricata_servers = array (
 	"sql_servers" => "\$HOME_NET", "telnet_servers" => "\$HOME_NET", "dnp3_server" => "\$HOME_NET",
 	"dnp3_client" => "\$HOME_NET", "modbus_server" => "\$HOME_NET", "modbus_client" => "\$HOME_NET",
 	"enip_server" => "\$HOME_NET", "enip_client" => "\$HOME_NET", "ftp_servers" => "\$HOME_NET", "ssh_servers" => "\$HOME_NET", 
-	"aim_servers" => "64.12.24.0/23,64.12.28.0/23,64.12.161.0/24,64.12.163.0/24,64.12.200.0/24,205.188.3.0/24,205.188.5.0/24,205.188.7.0/24,205.188.9.0/24,205.188.153.0/24,205.188.179.0/24,205.188.248.0/24"
+	"aim_servers" => "64.12.24.0/23,64.12.28.0/23,64.12.161.0/24,64.12.163.0/24,64.12.200.0/24,205.188.3.0/24,205.188.5.0/24,205.188.7.0/24,205.188.9.0/24,205.188.153.0/24,205.188.179.0/24,205.188.248.0/24", 
+	"sip_servers" => "\$HOME_NET"
 );
 $addr_vars = "";
 	foreach ($suricata_servers as $alias => $avalue) {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_define_vars.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_define_vars.php
@@ -49,7 +49,8 @@ $suricata_servers = array (
 	"sql_servers" => "\$HOME_NET", "telnet_servers" => "\$HOME_NET", "dnp3_server" => "\$HOME_NET",
 	"dnp3_client" => "\$HOME_NET", "modbus_server" => "\$HOME_NET", "modbus_client" => "\$HOME_NET",
 	"enip_server" => "\$HOME_NET", "enip_client" => "\$HOME_NET", "ftp_servers" => "\$HOME_NET", "ssh_servers" => "\$HOME_NET",
-	"aim_servers" => "64.12.24.0/23,64.12.28.0/23,64.12.161.0/24,64.12.163.0/24,64.12.200.0/24,205.188.3.0/24,205.188.5.0/24,205.188.7.0/24,205.188.9.0/24,205.188.153.0/24,205.188.179.0/24,205.188.248.0/24"
+	"aim_servers" => "64.12.24.0/23,64.12.28.0/23,64.12.161.0/24,64.12.163.0/24,64.12.200.0/24,205.188.3.0/24,205.188.5.0/24,205.188.7.0/24,205.188.9.0/24,205.188.153.0/24,205.188.179.0/24,205.188.248.0/24", 
+	"sip_servers" => "\$HOME_NET"
 );
 
 /* if user has defined a custom ssh port, use it */

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_define_vars.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_define_vars.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2014 Bill Meeks
+ * Copyright (c) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -298,7 +298,7 @@ $section->addInput(new Form_Select(
 		  '1h_b' => gettext('1 HOUR'), '3h_b' => gettext('3 HOURS'), '6h_b' => gettext('6 HOURS'),
 		  '12h_b' => gettext('12 HOURS'), '1d_b' => gettext('1 DAY'), '4d_b' => gettext('4 DAYS'),
 		  '7d_b' => gettext('7 DAYS'), '28d_b' => gettext('28 DAYS'))
-))->setHelp('Please select the amount of time you would like hosts to be blocked.<br /><br />Hint: in most cases, 1 hour is a good choice.');
+))->setHelp('Please select the amount of time you would like hosts to be blocked.  Note this setting is only applicable when using Legacy Mode blocking!  This setting is ignored when using Inline IPS Mode.<br /><br />Hint: in most cases, 1 hour is a good choice.');
 $section->addInput(new Form_Checkbox(
 	'log_to_systemlog',
 	'Log to System Log',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -408,7 +408,7 @@ include_once("head.inc"); ?>
 							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start Suricata on this interface');?>"></i>
 							<i id="suricata_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop Suricata on this interface');?>"></i>
 						<?php elseif ($suri_starting == TRUE || file_exists("{$g['varrun_path']}/suricata_pkg_starting.lck")) : ?>
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>" class="fa fa-spinner fa-spin text-info icon-primary" title="<?=gettext('Suricata is starting on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>" class="fa fa-cog fa-spin text-info icon-primary" title="<?=gettext('Suricata is starting on this interface');?>"></i>
 							&nbsp;
 							<i id="suricata_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart Suricata on this interface');?>"></i>
 							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start Suricata on this interface');?>"></i>
@@ -599,7 +599,7 @@ include_once("head.inc"); ?>
 		for(var key in data) {
 			if (data[key] != 'DISABLED') {
 				if (data[key] == 'STOPPED') {
-					$('#' + key).removeClass('fa-check-circle fa-spinner fa-spin text-success text-info');
+					$('#' + key).removeClass('fa-check-circle fa-cog fa-spin text-success text-info');
 					$('#' + key).addClass('fa-times-circle text-danger');
 					$('#' + key + '_restart').addClass('hidden');
 					$('#' + key + '_stop').addClass('hidden');
@@ -607,14 +607,14 @@ include_once("head.inc"); ?>
 				}
 				if (data[key] == 'STARTING') {
 					$('#' + key).removeClass('fa-check-circle fa-times-circle text-success text-danger');
-					$('#' + key).addClass('fa-spinner fa-spin text-info');
+					$('#' + key).addClass('fa-cog fa-spin text-info');
 					$('#' + key + '_restart').addClass('hidden');
 					$('#' + key + '_start').addClass('hidden');
 					$('#' + key + '_stop').removeClass('hidden');
 				}
 				if (data[key] == 'RUNNING') {
 					$('#' + key).addClass('fa-check-circle text-success');
-					$('#' + key).removeClass('fa-times-circle fa-spinner fa-spin text-danger text-info');
+					$('#' + key).removeClass('fa-times-circle fa-cog fa-spin text-danger text-info');
 					$('#' + key + '_restart').removeClass('hidden');
 					$('#' + key + '_stop').removeClass('hidden');
 					$('#' + key + '_start').addClass('hidden');

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2014 Bill Meeks
+ * Copyright (c) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -118,25 +118,36 @@ if (isset($_POST['del_x'])) {
 }
 
 /* start/stop Barnyard2 */
-if ($_POST['bartoggle']) {
+if ($_POST['by2toggle']) {
 	$suricatacfg = $config['installedpackages']['suricata']['rule'][$id];
 	$if_real = get_real_interface($suricatacfg['interface']);
 	$if_friendly = convert_friendly_interface_to_friendly_descr($suricatacfg['interface']);
 
 	if (!suricata_is_running($suricatacfg['uuid'], $if_real, 'barnyard2')) {
-		log_error("Toggle (barnyard starting) for {$if_friendly}({$suricatacfg['descr']})...");
+		if ($if_friendly == $suricatacfg['descr']) {
+			log_error("Toggle (barnyard starting) for {$if_friendly}...");
+		}
+		else {
+			log_error("Toggle (barnyard starting) for {$if_friendly}({$suricatacfg['descr']})...");
+		}
+		// No need to rebuild Suricata rules for Barnyard2,
+		// so flag that task as "off" to save time.
+		$rebuild_rules = false;
 		conf_mount_rw();
 		sync_suricata_package_config();
 		conf_mount_ro();
 		suricata_barnyard_start($suricatacfg, $if_real);
+		$by2_starting = TRUE;
 	} else {
-		log_error("Toggle (barnyard stopping) for {$if_friendly}({$suricatacfg['descr']})...");
+		if ($if_friendly == $suricatacfg['descr']) {
+			log_error("Toggle (barnyard stopping) for {$if_friendly}...");
+		}
+		else {
+			log_error("Toggle (barnyard stopping) for {$if_friendly}({$suricatacfg['descr']})...");
+		}
 		suricata_barnyard_stop($suricatacfg, $if_real);
+		$by2_starting = FALSE;
 	}
-
-	sleep(3); // So the GUI reports correctly
-	header("Location: /suricata/suricata_interfaces.php");
-	exit;
 }
 
 /* start/stop Suricata */
@@ -145,38 +156,129 @@ if ($_POST['toggle']) {
 	$if_real = get_real_interface($suricatacfg['interface']);
 	$if_friendly = convert_friendly_interface_to_friendly_descr($suricatacfg['interface']);
 
+	// Suricata can take several seconds to startup, so to
+	// make the GUI more responsive, startup commands are
+	// are executed as a background process.  The commands
+	// are written to a PHP file in the 'tmp_path' which
+	// is executed by a PHP command line session launched
+	// as a background task.
+
+	// Create steps for the background task to start Suricata.
+	// These commands will be handed off to a CLI PHP session
+	// for background execution as self-deleting PHP file.
+	$start_lck_file = "{$g['varrun_path']}/suricata_{$if_real}{$suricatacfg['uuid']}_starting.lck";
+	$suricata_start_cmd = <<<EOD
+	<?php
+	require_once('/usr/local/pkg/suricata/suricata.inc');
+	require_once('service-utils.inc');
+	global \$g, \$rebuild_rules, \$config;
+	\$suricatacfg = \$config['installedpackages']['suricata']['rule'][{$id}];
+	\$rebuild_rules = true;
+	touch('{$start_lck_file}');
+	conf_mount_rw();
+	sync_suricata_package_config();
+	conf_mount_ro();
+	\$rebuild_rules = false;
+	suricata_start(\$suricatacfg, '{$if_real}');
+	unlink_if_exists('{$start_lck_file}');
+	unlink(__FILE__);
+	?>
+EOD;
+
 	switch($_POST['toggle']) {
 		case 'start' :
-				$rebuild_rules = true;
-				conf_mount_rw();
-				sync_suricata_package_config();
-				conf_mount_ro();
-				$rebuild_rules = false;
-
+			file_put_contents("{$g['tmp_path']}/suricata_{$if_real}{$suricatacfg['uuid']}_startcmd.php", $suricata_start_cmd);
 			if (suricata_is_running($suricatacfg['uuid'], $if_real)) {
-				log_error("Toggle (suricata stopping) for {$if_friendly}({$suricatacfg['descr']})...");
+				if ($if_friendly == $suricatacfg['descr']) {
+					log_error("Toggle (suricata restarting) for {$if_friendly}...");
+				}
+				else {
+					log_error("Toggle (suricata restarting) for {$if_friendly}({$suricatacfg['descr']})...");
+				}
 				suricata_stop($suricatacfg, $if_real);
-				suricata_start($suricatacfg, $if_real);
+				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/suricata_{$if_real}{$suricatacfg['uuid']}_startcmd.php");
 			} else {
-				log_error("Toggle (suricata starting) for {$if_friendly}({$suricatacfg['descr']})...");
-				// set flag to rebuild interface rules before starting Suricata
-				suricata_start($suricatacfg, $if_real);
+				if ($if_friendly == $suricatacfg['descr']) {
+					log_error("Toggle (suricata restarting) for {$if_friendly}...");
+				}
+				else {
+					log_error("Toggle (suricata restarting) for {$if_friendly}({$suricatacfg['descr']})...");
+				}
+				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/suricata_{$if_real}{$suricatacfg['uuid']}_startcmd.php");
 			}
+			$suri_starting = TRUE;
 			break;
-		case 'stop' :
-//			if (suricata_is_running($suricatacfg['uuid'], $if_real)) {
-				log_error("Toggle (suricata stopping) for {$if_friendly}({$suricatacfg['descr']})...");
-				suricata_stop($suricatacfg, $if_real);
-//			}
 
+		case 'stop' :
+			if ($if_friendly == $suricatacfg['descr']) {
+				log_error("Toggle (suricata stopping) for {$if_friendly}...");
+			}
+			else {
+				log_error("Toggle (suricata stopping) for {$if_friendly}({$suricatacfg['descr']})...");
+			}
+			suricata_stop($suricatacfg, $if_real);
+			$suri_starting = FALSE;
+			unlink_if_exists($start_lck_file);
 			break;
 
 		default:
+			$suri_starting = FALSE;
 	}
-
-	sleep(3); // So the GUI reports correctly
+	unset($suricata_start_cmd);
 }
 
+/* Ajax call to periodically check Suricata status */
+/* on each configured interface.                   */
+if ($_POST['status'] == 'check') {
+	$list = array();
+
+	// Iterate configured Suricata interfaces and get status of each
+	// into an associative array.  Return the array to the Ajax
+	// caller as a JSON object.
+	foreach ($a_nat as $natent) {
+		$intf_key = "suricata_" . get_real_interface($natent['interface']) . $natent['uuid'];
+		if ($natent['enable'] == "on") {
+			if (suricata_is_running($natent['uuid'], get_real_interface($natent['interface']))) {
+				$list[$intf_key] = "RUNNING";
+			}
+			elseif (file_exists("{$g['varrun_path']}/{$intf_key}_starting.lck") || file_exists("{$g['varrun_path']}/suricata_pkg_starting.lck")) {
+				$list[$intf_key] = "STARTING";
+			}
+			else {
+				$list[$intf_key] = "STOPPED";
+			}
+		}
+		else {
+			$list[$intf_key] = "DISABLED";
+		}
+	}
+
+	// Iterate configured Barnyard2 interfaces and add status of each
+	// to the JSON array object.
+	foreach ($a_nat as $natent) {
+		$intf_key = "barnyard2_" . get_real_interface($natent['interface']) . $natent['uuid'];
+		if ($natent['enable'] == "on") {
+			if (suricata_is_running($natent['uuid'], get_real_interface($natent['interface']), 'barnyard2')) {
+				$list[$intf_key] = "RUNNING";
+			}
+			elseif (file_exists("{$g['varrun_path']}/{$intf_key}_starting.lck") || file_exists("{$g['varrun_path']}/suricata_pkg_starting.lck")) {
+				$list[$intf_key] = "STARTING";
+			}
+			else {
+				$list[$intf_key] = "STOPPED";
+			}
+		}
+		else {
+			$list[$intf_key] = "DISABLED";
+		}
+	}
+
+	// Return a JSON encoded array as the page output
+	echo json_encode($list);
+	exit;
+}
+
+// May decide to use these again for display, but for now they are not used
 $suri_bin_ver = SURICATA_BIN_VERSION;
 $suri_pkg_ver = SURICATA_PKG_VER;
 
@@ -253,26 +355,11 @@ include_once("head.inc"); ?>
 ?>
 				<tr id="fr<?=$nnats?>">
 <?php
-					$icon_suricata_msg = 'default';
 					/* convert fake interfaces to real and check if iface is up */
 					/* There has to be a smarter way to do this */
 					$if_real = get_real_interface($natent['interface']);
 					$natend_friendly= convert_friendly_interface_to_friendly_descr($natent['interface']);
 					$suricata_uuid = $natent['uuid'];
-
-					if (!suricata_is_running($suricata_uuid, $if_real)){
-						$icon_suricata_msg = 'Click to start Suricata on ' . $natend_friendly;
-					}
-					else{
-						$icon_suricata_msg = 'Click to restart Suricata on ' . $natend_friendly;
-					}
-
-					if (!suricata_is_running($suricata_uuid, $if_real, 'barnyard2')){
-						$icon_by2_msg = 'Click to start Barnyard2 on ' . $natend_friendly;
-					}
-					else{
-						$icon_by2_msg = 'Click to restart Barnyard2 on ' . $natend_friendly;
-					}
 
 					/* See if interface has any rules defined and set boolean flag */
 					$no_rules = true;
@@ -315,14 +402,23 @@ include_once("head.inc"); ?>
 ?>
 					<?php if ($check_suricata_info == "on") : ?>
 						<?php if (suricata_is_running($suricata_uuid, $if_real)) : ?>
-							<i class="fa fa-check-circle text-success icon-primary" title="<?=gettext('Suricata is running on ' . $natend_friendly);?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('Suricata is running on this interface');?>"></i>
 							&nbsp;
-							<i class="fa fa-repeat icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext($icon_suricata_msg);?>"></i>
-							<i class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Click to stop Suricata on ' . $natend_friendly);?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart Suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start Suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop Suricata on this interface');?>"></i>
+						<?php elseif ($suri_starting == TRUE || file_exists("{$g['varrun_path']}/suricata_pkg_starting.lck")) : ?>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>" class="fa fa-spinner fa-spin text-info icon-primary" title="<?=gettext('Suricata is starting on this interface');?>"></i>
+							&nbsp;
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart Suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start Suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop Suricata on this interface');?>"></i>
 						<?php else: ?>
-							<i class="fa fa-times-circle text-warning icon-primary" title="<?=gettext('Suricata is stopped on ' . $natend_friendly);?>"></i>
+							<i class="fa fa-times-circle text-danger icon-primary" title="<?=gettext('Suricata is stopped on this interface');?>"></i>
 							&nbsp;
-							<i class="fa fa-play-circle icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext($icon_suricata_msg);?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart Suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start Suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop Suricata on this interface');?>"></i>
 						<?php endif; ?>
 					<?php else : ?>
 						<?=gettext('DISABLED');?>&nbsp;
@@ -365,14 +461,23 @@ include_once("head.inc"); ?>
 					<td id="frd<?=$nnats?>" ondblclick="document.location='suricata_interfaces_edit.php?id=<?=$nnats?>';">
 						<?php if ($config['installedpackages']['suricata']['rule'][$nnats]['barnyard_enable'] == 'on') : ?>
 							<?php if (suricata_is_running($suricata_uuid, $if_real, 'barnyard2')) : ?>
-								<i class="fa fa-check-circle text-success icon-primary" title="<?=gettext('Barnyard2 is running on ' . $natend_friendly);?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('Barnyard2 is running on this interface');?>"></i>
 								&nbsp;
-								<i class="fa fa-repeat icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext($icon_by2_msg);?>"></i>
-								<i class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Click to stop Barnyard2 on ' . $natend_friendly);?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart Barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start Barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop Barnyard2 on this interface');?>"></i>
+							<?php elseif ($by2_starting == TRUE  || file_exists("{$g['varrun_path']}/suricata_pkg_starting.lck")) : ?>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('Barnyard2 is running on this interface');?>"></i>
+								&nbsp;
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart Barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start Barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop Barnyard2 on this interface');?>"></i>
 							<?php else: ?>
-								<i class="fa fa-times-circle text-warning icon-primary" title="<?=gettext('Barnyard2 is stopped on ' . $natend_friendly);?>"></i>
+								<i class="fa fa-times-circle text-danger icon-primary" title="<?=gettext('Barnyard2 is stopped on this interface');?>"></i>
 								&nbsp;
-								<i class="fa fa-play-circle icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext($icon_by2_msg);?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart Barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start Barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop Barnyard2 on this interface');?>"></i>
 							<?php endif; ?>
 						<?php else : ?>
 							<?=gettext('DISABLED');?>&nbsp;
@@ -425,30 +530,98 @@ include_once("head.inc"); ?>
 
 <div class="infoblock">
 	<?=print_info_box('<div class="row">
-							<div class="col-md-12">
-								<p>This is where you can see an overview of all your interface settings. Please configure the parameters on the <strong>Global Settings</strong> tab before adding an interface.</p>
-								<p><strong>Warning: New settings will not take effect until interface restart</strong></p>
-							</div>
-						</div>
-						<div class="row">
-							<div class="col-md-6">
-								<p>
-									Click on the <i class="fa fa-lg fa-pencil" alt="Edit Icon"></i> icon to edit an interface and settings.<br/>
-									Click on the <i class="fa fa-lg fa-trash" alt="Delete Icon"></i> icon to delete an interface and settings.<br/>
-									Click on the <i class="fa fa-lg fa-clone" alt="Clone Icon"></i> icon to clone an existing interface.
-								</p>
-							</div>
-							<div class="col-md-6">
-								<p>
-									<i class="fa fa-lg fa-check-circle" alt="Running"></i> <i class="fa fa-lg fa-times" alt="Not Running"></i> icons will show current Suricata and barnyard2 status<br/>
-									Click the <i class="fa fa-lg fa-play-circle" alt="Start"></i> or <i class="fa fa-lg fa-repeat" alt="Restart"></i> or <i class="fa fa-lg fa-stop-circle-o" alt="Stop"></i> icons to start/restart/stop Suricata and Barnyard2.
-								</p>
-							</div>
-						</div>', info, false)?>
+		<div class="col-md-12">
+			<p>This is where you can see an overview of all your interface settings. Please configure the parameters on the <strong>Global Settings</strong> tab before adding an interface.</p>
+			<p><strong>Warning: New settings will not take effect until interface restart</strong></p>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-md-6">
+			<p>
+				Click on the <i class="fa fa-lg fa-pencil" alt="Edit Icon"></i> icon to edit an interface and settings.<br/>
+				Click on the <i class="fa fa-lg fa-trash" alt="Delete Icon"></i> icon to delete an interface and settings.<br/>
+				Click on the <i class="fa fa-lg fa-clone" alt="Clone Icon"></i> icon to clone an existing interface.
+			</p>
+		</div>
+		<div class="col-md-6">
+			<p>
+				<i class="fa fa-lg fa-check-circle" alt="Running"></i> <i class="fa fa-lg fa-times" alt="Not Running"></i> icons will show current Suricata and barnyard2 status<br/>
+				Click the <i class="fa fa-lg fa-play-circle" alt="Start"></i> or <i class="fa fa-lg fa-repeat" alt="Restart"></i> or <i class="fa fa-lg fa-stop-circle-o" alt="Stop"></i> icons to start/restart/stop Suricata and Barnyard2.
+			</p>
+		</div>
+	</div>', 'info')?>
 </div>
 
 <script type="text/javascript">
 //<![CDATA[
+	function check_status() {
+
+		// This function uses Ajax to post a query to
+		// this page requesting the status of each
+		// configured interface.  The result is returned
+		// as a JSON array object.  A timer is set upon
+		// completion to call the function again in
+		// 2 seconds.  This allows dynamic updating
+		// of interface status in the GUI.
+		$.ajax(
+			"<?=$_SERVER['SCRIPT_NAME'];?>",
+			{
+				type: 'post',
+				data: {
+					status: 'check'
+				},
+				success: showStatus,
+				complete: function() {
+					setTimeout(check_status, 2000);
+				}
+			}
+		);
+	}
+
+	function showStatus(responseData) {
+
+		// The JSON object returned by check_status() is an associative array
+		// of interface unique IDs and corresponding service status.  The
+		// "key" is the service name followed by the physical interface and a UUID.
+		// The "value" of the key is either "DISABLED, STOPPED, STARTING, or RUNNING".
+		//
+		// Example keys:  suricata_em1998 or barnyard2_em1998
+		//
+		// Within the HTML of this page, icon controls for displaying status
+		// and for starting/restarting/stopping the service are tagged with
+		// control IDs using "key" followed by the icon's function.  These
+		// control IDs are used in the code below to alter icon appearance
+		// depending on the service status.
+
+		var data = jQuery.parseJSON(responseData);
+
+		// Iterate the associative array and update interface status icons
+		for(var key in data) {
+			if (data[key] != 'DISABLED') {
+				if (data[key] == 'STOPPED') {
+					$('#' + key).removeClass('fa-check-circle fa-spinner fa-spin text-success text-info');
+					$('#' + key).addClass('fa-times-circle text-danger');
+					$('#' + key + '_restart').addClass('hidden');
+					$('#' + key + '_stop').addClass('hidden');
+					$('#' + key + '_start').removeClass('hidden');
+				}
+				if (data[key] == 'STARTING') {
+					$('#' + key).removeClass('fa-check-circle fa-times-circle text-success text-danger');
+					$('#' + key).addClass('fa-spinner fa-spin text-info');
+					$('#' + key + '_restart').addClass('hidden');
+					$('#' + key + '_start').addClass('hidden');
+					$('#' + key + '_stop').removeClass('hidden');
+				}
+				if (data[key] == 'RUNNING') {
+					$('#' + key).addClass('fa-check-circle text-success');
+					$('#' + key).removeClass('fa-times-circle fa-spinner fa-spin text-danger text-info');
+					$('#' + key + '_restart').removeClass('hidden');
+					$('#' + key + '_stop').removeClass('hidden');
+					$('#' + key + '_start').addClass('hidden');
+				}
+			}
+		}
+	}	
 
 	function suricata_iface_toggle(action, id) {
 		$('#toggle').val(action);
@@ -483,7 +656,13 @@ include_once("head.inc"); ?>
 				$('#' + event.target.id.slice(1)).click();
 			}
 		});
+
 	});
+
+	// Set a timer to call the check_status()
+	// function in two seconds.
+	setTimeout(check_status, 2000);
+
 //]]>
 </script>
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -31,6 +31,8 @@ global $g, $rebuild_rules;
 $suricatadir = SURICATADIR;
 $suricatalogdir = SURICATALOGDIR;
 $rcdir = RCFILEPREFIX;
+$suri_starting = array();
+$by2_starting = array();
 
 if ($_POST['id'])
 	$id = $_POST['id'];
@@ -137,7 +139,7 @@ if ($_POST['by2toggle']) {
 		sync_suricata_package_config();
 		conf_mount_ro();
 		suricata_barnyard_start($suricatacfg, $if_real);
-		$by2_starting = TRUE;
+		$by2_starting[$id] = 'TRUE';
 	} else {
 		if ($if_friendly == $suricatacfg['descr']) {
 			log_error("Toggle (barnyard stopping) for {$if_friendly}...");
@@ -146,7 +148,7 @@ if ($_POST['by2toggle']) {
 			log_error("Toggle (barnyard stopping) for {$if_friendly}({$suricatacfg['descr']})...");
 		}
 		suricata_barnyard_stop($suricatacfg, $if_real);
-		$by2_starting = FALSE;
+		unset($by2_starting[$id]);
 	}
 }
 
@@ -206,7 +208,7 @@ EOD;
 				}
 				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/suricata_{$if_real}{$suricatacfg['uuid']}_startcmd.php");
 			}
-			$suri_starting = TRUE;
+			$suri_starting[$id] = 'TRUE';
 			break;
 
 		case 'stop' :
@@ -217,12 +219,12 @@ EOD;
 				log_error("Toggle (suricata stopping) for {$if_friendly}({$suricatacfg['descr']})...");
 			}
 			suricata_stop($suricatacfg, $if_real);
-			$suri_starting = FALSE;
+			unset($suri_starting[$id]);
 			unlink_if_exists($start_lck_file);
 			break;
 
 		default:
-			$suri_starting = FALSE;
+			unset($suri_starting[$id]);
 	}
 	unset($suricata_start_cmd);
 }
@@ -402,23 +404,23 @@ include_once("head.inc"); ?>
 ?>
 					<?php if ($check_suricata_info == "on") : ?>
 						<?php if (suricata_is_running($suricata_uuid, $if_real)) : ?>
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('Suricata is running on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('suricata is running on this interface');?>"></i>
 							&nbsp;
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart Suricata on this interface');?>"></i>
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start Suricata on this interface');?>"></i>
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop Suricata on this interface');?>"></i>
-						<?php elseif ($suri_starting == TRUE || file_exists("{$g['varrun_path']}/suricata_pkg_starting.lck")) : ?>
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>" class="fa fa-cog fa-spin text-info icon-primary" title="<?=gettext('Suricata is starting on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop suricata on this interface');?>"></i>
+						<?php elseif ($suri_starting[$nnats] == 'TRUE' || file_exists("{$g['varrun_path']}/suricata_pkg_starting.lck")) : ?>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>" class="fa fa-cog fa-spin text-info icon-primary" title="<?=gettext('suricata is starting on this interface');?>"></i>
 							&nbsp;
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart Suricata on this interface');?>"></i>
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start Suricata on this interface');?>"></i>
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop Suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop suricata on this interface');?>"></i>
 						<?php else: ?>
-							<i class="fa fa-times-circle text-danger icon-primary" title="<?=gettext('Suricata is stopped on this interface');?>"></i>
+							<i class="fa fa-times-circle text-danger icon-primary" title="<?=gettext('suricata is stopped on this interface');?>"></i>
 							&nbsp;
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart Suricata on this interface');?>"></i>
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start Suricata on this interface');?>"></i>
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop Suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop suricata on this interface');?>"></i>
 						<?php endif; ?>
 					<?php else : ?>
 						<?=gettext('DISABLED');?>&nbsp;
@@ -461,23 +463,23 @@ include_once("head.inc"); ?>
 					<td id="frd<?=$nnats?>" ondblclick="document.location='suricata_interfaces_edit.php?id=<?=$nnats?>';">
 						<?php if ($config['installedpackages']['suricata']['rule'][$nnats]['barnyard_enable'] == 'on') : ?>
 							<?php if (suricata_is_running($suricata_uuid, $if_real, 'barnyard2')) : ?>
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('Barnyard2 is running on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('barnyard2 is running on this interface');?>"></i>
 								&nbsp;
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart Barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start Barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop Barnyard2 on this interface');?>"></i>
-							<?php elseif ($by2_starting == TRUE  || file_exists("{$g['varrun_path']}/suricata_pkg_starting.lck")) : ?>
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('Barnyard2 is running on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop barnyard2 on this interface');?>"></i>
+							<?php elseif ($by2_starting[$nnats] == 'TRUE'  || file_exists("{$g['varrun_path']}/suricata_pkg_starting.lck")) : ?>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('barnyard2 is running on this interface');?>"></i>
 								&nbsp;
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart Barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start Barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop Barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop barnyard2 on this interface');?>"></i>
 							<?php else: ?>
-								<i class="fa fa-times-circle text-danger icon-primary" title="<?=gettext('Barnyard2 is stopped on this interface');?>"></i>
+								<i class="fa fa-times-circle text-danger icon-primary" title="<?=gettext('barnyard2 is stopped on this interface');?>"></i>
 								&nbsp;
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart Barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start Barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop Barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop barnyard2 on this interface');?>"></i>
 							<?php endif; ?>
 						<?php else : ?>
 							<?=gettext('DISABLED');?>&nbsp;
@@ -498,7 +500,7 @@ include_once("head.inc"); ?>
 					</td>
 
 				</tr>
-				<?php $i++; $nnats++; endforeach; ob_end_flush(); ?>
+				<?php $i++; $nnats++; endforeach; ob_end_flush(); unset($suri_starting); unset($by2_starting); ?>
 				<tr>
 					<td></td>
 					<td colspan="7">
@@ -597,10 +599,12 @@ include_once("head.inc"); ?>
 
 		// Iterate the associative array and update interface status icons
 		for(var key in data) {
+			var service_name = key.substring(0, key.indexOf('_'));
 			if (data[key] != 'DISABLED') {
 				if (data[key] == 'STOPPED') {
 					$('#' + key).removeClass('fa-check-circle fa-cog fa-spin text-success text-info');
 					$('#' + key).addClass('fa-times-circle text-danger');
+					$('#' + key).prop('title', service_name + ' is stopped on this interface');
 					$('#' + key + '_restart').addClass('hidden');
 					$('#' + key + '_stop').addClass('hidden');
 					$('#' + key + '_start').removeClass('hidden');
@@ -608,6 +612,7 @@ include_once("head.inc"); ?>
 				if (data[key] == 'STARTING') {
 					$('#' + key).removeClass('fa-check-circle fa-times-circle text-success text-danger');
 					$('#' + key).addClass('fa-cog fa-spin text-info');
+					$('#' + key).prop('title', service_name + ' is starting on this interface');
 					$('#' + key + '_restart').addClass('hidden');
 					$('#' + key + '_start').addClass('hidden');
 					$('#' + key + '_stop').removeClass('hidden');
@@ -615,6 +620,7 @@ include_once("head.inc"); ?>
 				if (data[key] == 'RUNNING') {
 					$('#' + key).addClass('fa-check-circle text-success');
 					$('#' + key).removeClass('fa-times-circle fa-cog fa-spin text-danger text-info');
+					$('#' + key).prop('title', service_name + ' is running on this interface');
 					$('#' + key + '_restart').removeClass('hidden');
 					$('#' + key + '_stop').removeClass('hidden');
 					$('#' + key + '_start').addClass('hidden');

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2017 Bill Meeks
+ * Copyright (c) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1172,6 +1172,28 @@ $section->addInput(new Form_Checkbox(
 
 $form->add($section);
 
+// Add Inline IPS rule edit warning modal pop-up
+$modal = new Modal('Important Information About IPS Inline Mode Blocking', 'ips_warn_dlg', 'large', 'Close');
+
+$modal->addInput(new Form_StaticText (
+	null,
+	'<span class="help-block">' . 
+	gettext('When using Inline IPS Mode blocking, you must manually change the rule action ') . 
+	gettext('from ALERT to DROP for every rule which you wish to block traffic when triggered.') . 
+	'<br/><br/>' . 
+	gettext('The default action for rules is ALERT.  This will produce alerts but will not ') . 
+	gettext('block traffic when using Inline IPS Mode for blocking. ') . 
+	'<br/><br/>' . 
+	gettext('Use the "dropsid.conf" feature on the SID MGMT tab to select rules whose action ') . 
+	gettext('should be changed from ALERT to DROP.  If you run the Snort VRT rules and have ') . 
+	gettext('an IPS policy selected on the CATEGORIES tab, then rules defined as DROP by the ') . 
+	gettext('selected IPS policy will have their action automatically changed to DROP when the ') . 
+	gettext('"IPS Policy Mode" selector is configured for "Policy".') . 
+	'</span>'
+));
+
+$form->add($modal);
+
 $section = new Form_Section('Detection Engine Settings');
 $section->addInput(new Form_Input(
 	'max_pending_packets',
@@ -1750,6 +1772,7 @@ events.push(function(){
 			hideCheckbox('block_drops_only', true);
 			hideSelect('blockoffendersip', true);
 			$('#eve_log_drop').parent().show();
+			$('#ips_warn_dlg').modal('show');
 		}
 		else {
 			hideCheckbox('blockoffenderskill', false);
@@ -1757,6 +1780,7 @@ events.push(function(){
 			hideSelect('blockoffendersip', false);
 			hideClass('passlist', false);
 			$('#eve_log_drop').parent().hide();
+			$('#ips_warn_dlg').modal('hide');
 		}
 	});
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist.php
@@ -161,9 +161,14 @@ display_top_tabs($tab_array, true);
 					<td>
 						<?=htmlspecialchars($list['name'])?>
 					</td>
+					<?php if (!empty($list['address'])) : ?>
 					<td title="<?=filter_expand_alias($list['address'])?>">
 						<?=gettext($list['address'])?>
 					</td>
+					<?php else : ?>
+					<td>
+					</td>
+					<?php endif; ?>
 					<td>
 						<?=htmlspecialchars($list['descr'])?>
 					</td>


### PR DESCRIPTION
## pfSense-pkg-suricata-4.0.3
This update to the Suricata GUI package contains three bug fixes and five new or updated features.  The version is changed to 4.0.3 to match that of the underlying Suricata binary.

**New Features:**
1.  Add the SIP_SERVERS variable to the list of other automatically included rules variables on the VARIABLES tab.
2.  Add some help/hint text to the INTERFACE SETTINGS tab in the blocking section to emphasize Inline mode needs rule actions changed to DROP.
3.  Add notice to "Clear Blocks Interval" setting on GLOBAL SETTINGS tab that clearing only works for Legacy Mode.
4.  Make INTERFACES tab dynamic by periodically polling Suricata binary status and updating status icons for each configured interface.
5.  Configure ET-Pro rules download URL path based on full Suricata engine version.  See this post on Forum:  [https://forum.pfsense.org/index.php?topic=140652.msg769710#msg769710](url).

**Bug Fixes:**
1.  Barnyard2 start/stop toggle icon not working on INTERFACES tab.
2.  Customized HOME_NET passlist ignores option to exclude locally-attached networks.
3.  Fix display of bogus header info from gettext() when displaying an "empty" alias on PASS LISTS tab.
