### PR TITLE
pfSense-pkg-snort-3.2.9.6 Update

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-snort
-PORTVERSION=	3.2.9.5
-PORTREVISION=	4
+PORTVERSION=	3.2.9.6
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -305,7 +305,7 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
 	/* though, to prevent locking out the firewall itself.              */
 	/********************************************************************/
 	$snortip = get_interface_ip($snortcfg['interface']);
-	if (($externallist && $localnet == 'yes') || (!$externallist && (!$whitelist || $localnet == 'yes' || empty($localnet)))) {
+	if (($externallist && $localnet == 'yes') || (!$externallist && $whitelist && ($localnet == 'yes' || empty($localnet)))) {
 		if (is_ipaddr($snortip)) {
 			if ($snortcfg['interface'] <> "wan") {
 				if ($sn = get_interface_subnet($snortcfg['interface'])) {
@@ -328,7 +328,7 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
 	// Trim off the interface designation (e.g., %em1) if present
 	if (strpos($snortip, "%") !== FALSE)
 		$snortip = substr($snortip, 0, strpos($snortip, "%"));
-	if (($externallist && $localnet == 'yes') || (!$externallist && (!$whitelist || $localnet == 'yes' || empty($localnet)))) {
+	if (($externallist && $localnet == 'yes') || ($whitelist && ($localnet == 'yes' || empty($localnet))) || (!$externallist && !$whitelist && ($localnet == 'yes' || empty($localnet)))) {
 		if (is_ipaddrv6($snortip)) {
 			if ($snortcfg['interface'] <> "wan") {
 				if ($sn = get_interface_subnetv6($snortcfg['interface'])) {
@@ -356,7 +356,7 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
 			$home_net[] = $snortip;
 	}
 
-	if (($externallist && $localnet == 'yes') || (!$externallist && (!$whitelist || $localnet == 'yes' || empty($localnet)))) {		
+	if (($externallist && $localnet == 'yes') || ($whitelist && ($localnet == 'yes' || empty($localnet))) || (!$externallist && !$whitelist && ($localnet == 'yes' || empty($localnet)))) {
 		/*************************************************************************/
 		/*  Iterate through the interface list and write out whitelist items and */
 		/*  also compile a HOME_NET list of all the local interfaces for snort.  */

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -1732,10 +1732,11 @@ function snort_load_vrt_policy($policy, $all_rules=null) {
 	/* This function returns an array of all rules  */
 	/* marked with the passed in $policy metadata.  */
 	/*                                              */
-	/*    $policy --> desired VRT security policy   */
+	/*    $policy --> desired Snort security policy */
 	/*                  1.  connectivity            */
 	/*                  2.  balanced                */
 	/*                  3.  security                */
+	/*                  4.  max-detect              */
 	/*                                              */
 	/* $all_rules --> optional Rules Map array of   */
 	/*                rules to scan for policy.     */
@@ -1746,11 +1747,11 @@ function snort_load_vrt_policy($policy, $all_rules=null) {
 	$snortdir = SNORTDIR;
 	$vrt_policy_rules = array();
 
-	/* Load a map of all the VRT rules if we were   */
+	/* Load a map of all the Snort rules if we were */
 	/* not passed a pre-loaded one to use.          */
 	if (is_null($all_rules)) {
-		/* Since only Snort VRT rules have IPS Policy metadata, */
-		/* limit our search to just those files.                */
+		/* Since only Snort Subscriber rules have IPS Policy */
+		/* metadata, limit our search to just those files.   */
 		$snort_vrt_files = glob("{$snortdir}/rules/snort_*.rules");
 		$all_rules = snort_load_rules_map($snort_vrt_files);
 	}
@@ -1819,7 +1820,7 @@ function snort_write_enforcing_rules_file($rule_map, $rule_path) {
 		@fwrite($fp, "# These rules are your current set of enforced rules for the protected\n");
 		@fwrite($fp, "# interface.  This list was compiled from the categories selected on the\n");
 		@fwrite($fp, "# CATEGORIES tab of the Snort configuration for the interface and/or any\n");
-		@fwrite($fp, "# chosen Snort VRT pre-defined IPS Policy.\n#\n");
+		@fwrite($fp, "# chosen Snort Subscriber Rules pre-defined IPS Policy.\n#\n");
 		@fwrite($fp, "# Any enablesid or disablesid customizations you made have been applied\n");
 		@fwrite($fp, "# to the rules in this file.\n\n");
 		foreach ($rule_map as $rulem) {
@@ -3211,8 +3212,8 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 			unset($enabled_files, $cat_mods, $rulem, $v);
 		}
 
-		/* Check if a pre-defined Snort VRT policy is selected. If so, */
-		/* add all the VRT policy rules to our enforcing rule set.     */
+		/* Check if a pre-defined Snort Subscriber rules policy is selected. */
+		/* If so, add all the VRT policy rules to our enforcing rule set.    */
 		if (!empty($snortcfg['ips_policy'])) {
 			$policy_rules = snort_load_vrt_policy($snortcfg['ips_policy'], $all_rules);
 			foreach ($policy_rules as $k1 => $policy) {
@@ -3370,7 +3371,7 @@ function snort_filter_preproc_rules($snortcfg, &$active_rules, $persist_log = fa
 	 *                                                 *
 	 * IMPORTANT -- Keep this part of the code current *
 	 * with changes to preprocessor rule options in    *
-	 * Snort VRT rules.                                *
+	 * Snort Subscriber rules.                         *
 	 *                                                 *
 	 *                                                 *
 	 * Format of array is:                             *

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -3028,16 +3028,21 @@ function snort_generate_barnyard2_conf($snortcfg, $if_real) {
 		$snortbarnyardlog_output_plugins .= "\n\n";
 	}
 	if ($snortcfg['barnyard_syslog_enable'] == 'on') {
-		$snortbarnyardlog_output_plugins .= "# syslog_full: log to a syslog receiver\noutput alert_syslog_full: ";
+		if ($snortcfg['barnyard_syslog_local'] == 'on') {
+			$snortbarnyardlog_output_plugins .= "# syslog_full: log to a local syslog receiver\noutput alert_syslog_full: ";
+		}
+		else {
+			$snortbarnyardlog_output_plugins .= "# syslog_full: log to a remote syslog receiver\noutput log_syslog_full: ";
+		}
 		if (isset($snortcfg['barnyard_sensor_name']) && strlen($snortcfg['barnyard_sensor_name']) > 0)
 			$snortbarnyardlog_output_plugins .= "sensor_name {$snortcfg['barnyard_sensor_name']}, ";
 		else
 			$snortbarnyardlog_output_plugins .= "sensor_name {$snortbarnyard_hostname_info}, ";
 		if ($snortcfg['barnyard_syslog_local'] == 'on')
-			$snortbarnyardlog_output_plugins .= "local, log_facility {$snortcfg['barnyard_syslog_facility']}, log_priority {$snortcfg['barnyard_syslog_priority']}\n\n";
+			$snortbarnyardlog_output_plugins .= "local, log_facility {$snortcfg['barnyard_syslog_facility']}, log_priority {$snortcfg['barnyard_syslog_priority']}, operation_mode default\n\n";
 		else {
 			$snortbarnyardlog_output_plugins .= "server {$snortcfg['barnyard_syslog_rhost']}, protocol {$snortcfg['barnyard_syslog_proto']}, ";
-			$snortbarnyardlog_output_plugins .= "port {$snortcfg['barnyard_syslog_dport']}, operation_mode {$snortcfg['barnyard_syslog_opmode']}, ";
+			$snortbarnyardlog_output_plugins .= "port {$snortcfg['barnyard_syslog_dport']}, operation_mode {$snortcfg['barnyard_syslog_opmode']}, payload_encoding {$snortcfg['barnyard_syslog_payload_encoding']}, ";
 			$snortbarnyardlog_output_plugins .= "log_facility {$snortcfg['barnyard_syslog_facility']}, log_priority {$snortcfg['barnyard_syslog_priority']}\n\n";
 		}
 	}

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -71,7 +71,7 @@ if ($etpro == "on") {
 	$emergingthreats_filename = SNORT_ETPRO_DNLD_FILENAME;
 	$emergingthreats_filename_md5 = SNORT_ETPRO_DNLD_FILENAME . ".md5";
 	$emergingthreats_url = ETPRO_BASE_DNLD_URL;
-	$emergingthreats_url .= "{$etproid}/snort-" . ET_VERSION . "/";
+	$emergingthreats_url .= "{$etproid}/snort-" . SNORT_BIN_VERSION . "/";
 	$emergingthreats = "on";
 	$et_name = "Emerging Threats Pro";
 	$et_md5_remove = SNORT_ET_DNLD_FILENAME . ".md5";
@@ -83,7 +83,7 @@ else {
 	$emergingthreats_url = ET_BASE_DNLD_URL;
 	// If using Sourcefire VRT rules with ET, then we should use the open-nogpl ET rules
 	$emergingthreats_url .= $vrt_enabled == "on" ? "open-nogpl/" : "open/";
-	$emergingthreats_url .= "snort-" . ET_VERSION . "/";
+	$emergingthreats_url .= "snort-" . SNORT_BIN_VERSION . "/";
 	$et_name = "Emerging Threats Open";
 	$et_md5_remove = SNORT_ETPRO_DNLD_FILENAME . ".md5";
 	unlink_if_exists("{$snortdir}/{$et_md5_remove}");

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -49,9 +49,9 @@ $openappid_rules_detectors = $config['installedpackages']['snortglobal']['openap
 /* Working directory for downloaded rules tarballs and extraction */
 $tmpfname = "{$g['tmp_path']}/snort_rules_up";
 
-/* Use the Snort binary version to construct the proper Snort VRT */
-/* rules tarball and md5 filenames. Save the version with decimal */
-/* delimiters for use in extracting the rules.                    */
+/* Use the Snort binary version to construct the proper Snort Subscriber */
+/* Rules tarball and md5 filenames. Save the version with decimal        */
+/* delimiters for use in extracting the rules.                           */
 $snort_version = SNORT_BIN_VERSION;
 
 // Create a collapsed version string for use in the tarball filename
@@ -81,7 +81,7 @@ else {
 	$emergingthreats_filename = SNORT_ET_DNLD_FILENAME;
 	$emergingthreats_filename_md5 = SNORT_ET_DNLD_FILENAME . ".md5";
 	$emergingthreats_url = ET_BASE_DNLD_URL;
-	// If using Sourcefire VRT rules with ET, then we should use the open-nogpl ET rules
+	// If using Sourcefire Subscriber rules with ET, then we should use the open-nogpl ET rules
 	$emergingthreats_url .= $vrt_enabled == "on" ? "open-nogpl/" : "open/";
 	$emergingthreats_url .= "snort-" . SNORT_BIN_VERSION . "/";
 	$et_name = "Emerging Threats Open";
@@ -404,12 +404,12 @@ error_log(gettext("Starting rules update...  Time: " . date("Y-m-d H:i:s") . "\n
 $last_curl_error = "";
 $update_errors = false;
 
-/*  Check for and download any new Snort VRT sigs */
+/*  Check for and download any new Snort Subscriber Rules sigs */
 if ($snortdownload == 'on') {
-	if (snort_check_rule_md5("{$snort_rule_url}{$snort_filename_md5}?oinkcode={$oinkid}", "{$tmpfname}/{$snort_filename_md5}", "Snort VRT rules")) {
+	if (snort_check_rule_md5("{$snort_rule_url}{$snort_filename_md5}?oinkcode={$oinkid}", "{$tmpfname}/{$snort_filename_md5}", "Snort Subscriber rules")) {
 		/* download snortrules file */
 		$file_md5 = trim(file_get_contents("{$tmpfname}/{$snort_filename_md5}"));
-		if (!snort_fetch_new_rules("{$snort_rule_url}{$snort_filename}?oinkcode={$oinkid}", "{$tmpfname}/{$snort_filename}", $file_md5, "Snort VRT rules"))
+		if (!snort_fetch_new_rules("{$snort_rule_url}{$snort_filename}?oinkcode={$oinkid}", "{$tmpfname}/{$snort_filename}", $file_md5, "Snort Subscriber rules"))
 			$snortdownload = 'off';
 	}
 	else
@@ -468,7 +468,7 @@ if ($emergingthreats == 'on') {
 /* Untar Snort rules file to tmp and install the rules */
 if ($snortdownload == 'on') {
 	if (file_exists("{$tmpfname}/{$snort_filename}")) {
-		snort_update_status(gettext("Installing Sourcefire VRT rules..."));
+		snort_update_status(gettext("Installing Snort Subscriber ruleset..."));
 
 		/* Currently, only FreeBSD-8-1, FreeBSD-9-0 and FreeBSD-10-0 precompiled SO rules exist from Snort.org */
 		/* Default to FreeBSD-10-0 for now as that is highest available version of SO rules */
@@ -478,7 +478,7 @@ if ($snortdownload == 'on') {
 		$vrt_prefix = VRT_FILE_PREFIX;
 		unlink_if_exists("{$snortdir}/rules/{$vrt_prefix}*.rules");
 
-		error_log(gettext("\tExtracting and installing Snort VRT rules...\n"), 3, SNORT_RULES_UPD_LOGFILE);
+		error_log(gettext("\tExtracting and installing Snort Subscriber Ruleset...\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		/* extract snort.org rules and add VRT_FILE_PREFIX prefix to all snort.org files */
 		safe_mkdir("{$tmpfname}/snortrules");
 		exec("/usr/bin/tar xzf {$tmpfname}/{$snort_filename} -C {$tmpfname}/snortrules rules/");
@@ -503,7 +503,7 @@ if ($snortdownload == 'on') {
 		}
 		rmdir_recursive("{$tmpfname}/preproc_rules");
 		/* extract so rules */
-		error_log(gettext("\tUsing Snort VRT precompiled SO rules for {$freebsd_version_so} ...\n"), 3, SNORT_RULES_UPD_LOGFILE);
+		error_log(gettext("\tUsing Snort Subscriber precompiled SO rules for {$freebsd_version_so} ...\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		$snort_arch = php_uname("m");
 		$nosorules = false;
 		if ($snort_arch  == 'i386'){
@@ -537,7 +537,7 @@ if ($snortdownload == 'on') {
 			@copy("{$tmpfname}/{$snort_filename_md5}", "{$snortdir}/{$snort_filename_md5}");
 		}
 		snort_update_status(gettext(" done.") . "\n");
-		error_log(gettext("\tInstallation of Snort VRT rules completed.\n"), 3, SNORT_RULES_UPD_LOGFILE);
+		error_log(gettext("\tInstallation of Snort Subscriber rules completed.\n"), 3, SNORT_RULES_UPD_LOGFILE);
 	}
 }
 
@@ -678,7 +678,7 @@ function snort_apply_customizations($snortcfg, $if_real) {
 	$snortdir = SNORTDIR;
 
 	/* Update the Preprocessor rules from the master configuration for the interface if Snort */
-	/* VRT rules are in use and the interface's preprocessor rules are not protected.         */
+	/* Subscriber rules are in use and the interface's preprocessor rules are not protected.  */
 	if ($vrt_enabled == 'on' && ($snortcfg['protect_preproc_rules'] != 'on' || $g['snort_postinstall'])) {
 		$preproc_files = glob("{$snortdir}/preproc_rules/*.rules");
 		foreach ($preproc_files as $file) {
@@ -713,11 +713,11 @@ if ($snortdownload == 'on' || $emergingthreats == 'on' || $snortcommunityrules =
 	$cfgs[] = "{$snortdir}/classification.config";
 	snort_merge_classification_configs($cfgs, "{$snortdir}/classification.config");
 
-	/*******************************************************************/
-        /* Determine which map files set to use for the master copy.  If   */
-        /* the Snort VRT rules are not enabled, then use Emerging Threats  */
-	/* or Snort Community Rules, in that order, if either is enabled.  */
-	/*******************************************************************/
+	/**********************************************************************/
+	/* Determine which map files set to use for the master copy.  If the  */
+	/* Snort Subscriber rules are not enabled, then use Emerging Threats  */
+	/* or Snort Community Rules, in that order, if either is enabled.     */
+	/**********************************************************************/
 	if ($snortdownload == 'on' || $vrt_enabled == 'on')
 		$prefix = "VRT_";
 	elseif ($emergingthreats == 'on')

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009 Robert Zelaya
- * Copyright (c) 2013-2017 Bill Meeks
+ * Copyright (c) 2013-2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,7 +71,7 @@ if ($etpro == "on") {
 	$emergingthreats_filename = SNORT_ETPRO_DNLD_FILENAME;
 	$emergingthreats_filename_md5 = SNORT_ETPRO_DNLD_FILENAME . ".md5";
 	$emergingthreats_url = ETPRO_BASE_DNLD_URL;
-	$emergingthreats_url .= "{$etproid}/snort-" . SNORT_BIN_VERSION . "/";
+	$emergingthreats_url .= "{$etproid}/snort-" . ET_VERSION . "/";
 	$emergingthreats = "on";
 	$et_name = "Emerging Threats Pro";
 	$et_md5_remove = SNORT_ET_DNLD_FILENAME . ".md5";
@@ -83,7 +83,7 @@ else {
 	$emergingthreats_url = ET_BASE_DNLD_URL;
 	// If using Sourcefire Subscriber rules with ET, then we should use the open-nogpl ET rules
 	$emergingthreats_url .= $vrt_enabled == "on" ? "open-nogpl/" : "open/";
-	$emergingthreats_url .= "snort-" . SNORT_BIN_VERSION . "/";
+	$emergingthreats_url .= "snort-" . ET_VERSION . "/";
 	$et_name = "Emerging Threats Open";
 	$et_md5_remove = SNORT_ETPRO_DNLD_FILENAME . ".md5";
 	unlink_if_exists("{$snortdir}/{$et_md5_remove}");

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2017 Bill Meeks
+ * Copyright (c) 2013-2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,11 +36,12 @@ if (!defined("SNORTLOGDIR"))
 if (!defined("SNORT_BIN_VERSION")) {
 	// Grab the Snort binary version programmatically
 	$snortbindir = SNORT_PBI_BINDIR;
-	$snortver = exec_command("{$snortbindir}/snort -V 2>&1 |/usr/bin/grep Version | /usr/bin/cut -c20-26");
+	$snortver = exec_command("{$snortbindir}/snort -V 2>&1 |/usr/bin/grep Version | /usr/bin/cut -c20-27");
+	$snortver = trim($snortver);
 	if (!empty($snortver))
 		define("SNORT_BIN_VERSION", $snortver);
 	else
-		define("SNORT_BIN_VERSION", "2.9.9.0");
+		define("SNORT_BIN_VERSION", "2.9.11.1");
 }
 if (!defined("SNORT_SID_MODS_PATH"))
 	define('SNORT_SID_MODS_PATH', "{$g['vardb_path']}/snort/sidmods/");

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
@@ -177,8 +177,14 @@ $snort_ports = array(
 /* Check for defined Aliases that may override default port settings as we build the portvars array */
 $portvardef = "";
 foreach ($snort_ports as $alias => $avalue) {
-	if (!empty($snortcfg["def_{$alias}"]) && is_alias($snortcfg["def_{$alias}"]))
-		$snort_ports[$alias] = trim(filter_expand_alias($snortcfg["def_{$alias}"]));
+	if (!empty($snortcfg["def_{$alias}"]) && is_alias($snortcfg["def_{$alias}"])) {
+		if (strlen(trim(filter_expand_alias($snortcfg["def_{$alias}"]))) > 0) {
+			$snort_ports[$alias] = trim(filter_expand_alias($snortcfg["def_{$alias}"]));
+		}
+		else {
+			log_error("[snort] WARNING: unable to resolve Alias specified for PORTS variable " . strtoupper($alias) . " ... using default value '{$avalue}' instead.");
+		}
+	}
 	$snort_ports[$alias] = preg_replace('/\s+/', ',', trim($snort_ports[$alias]));
 	$portvardef .= "portvar " . strtoupper($alias) . " [" . $snort_ports[$alias] . "]\n";
 }
@@ -628,8 +634,13 @@ if (!empty($snortcfg['pscan_sense_level']))
 $sf_pscan_ignore_scanners = "\$HOME_NET";
 if (!empty($snortcfg['pscan_ignore_scanners'])) {
 	if (is_alias($snortcfg['pscan_ignore_scanners'])) {
-		$sf_pscan_ignore_scanners = trim(filter_expand_alias($snortcfg['pscan_ignore_scanners']));
-		$sf_pscan_ignore_scanners = preg_replace('/\s+/', ',', trim($sf_pscan_ignore_scanners));
+		if (strlen(trim(filter_expand_alias($snortcfg['pscan_ignore_scanners']))) > 0) {
+			$sf_pscan_ignore_scanners = trim(filter_expand_alias($snortcfg['pscan_ignore_scanners']));
+			$sf_pscan_ignore_scanners = preg_replace('/\s+/', ',', trim($sf_pscan_ignore_scanners));
+		}
+		else {
+			log_error("[snort] WARNING: unable to resolve Alias {$snortcfg['pscan_ignore_scanners']} for PSCAN_IGNORE_SCANNERS ... reverting to default value of HOME_NET.");
+		}
 	} else {
         	$sf_pscan_ignore_scanners = $snortcfg['pscan_ignore_scanners'];
         }
@@ -637,8 +648,13 @@ if (!empty($snortcfg['pscan_ignore_scanners'])) {
 $sf_pscan_ignore_scanned = "";
 if (!empty($snortcfg['pscan_ignore_scanned'])) {
 	if (is_alias($snortcfg['pscan_ignore_scanned'])) {
-		$sf_pscan_ignore_scanned = trim(filter_expand_alias($snortcfg['pscan_ignore_scanned']));
-		$sf_pscan_ignore_scanned = preg_replace('/\s+/', ',', trim($sf_pscan_ignore_scanned));
+		if (strlen(trim(filter_expand_alias($snortcfg['pscan_ignore_scanned']))) > 0) {
+			$sf_pscan_ignore_scanned = trim(filter_expand_alias($snortcfg['pscan_ignore_scanned']));
+			$sf_pscan_ignore_scanned = preg_replace('/\s+/', ',', trim($sf_pscan_ignore_scanned));
+		}
+		else {
+			log_error("[snort] WARNING: unable to resolve Alias {$snortcfg['pscan_ignore_scanned']} for PSCAN_IGNORE_SCANNED ... reverting to default value of null.");
+		}
 	} else {
           	$sf_pscan_ignore_scanned = $snortcfg['pscan_ignore_scanned'];
         }
@@ -964,8 +980,13 @@ $snort_servers = array (
 $ipvardef = "";
 foreach ($snort_servers as $alias => $avalue) {
 	if (!empty($snortcfg["def_{$alias}"]) && is_alias($snortcfg["def_{$alias}"])) {
-		$avalue = trim(filter_expand_alias($snortcfg["def_{$alias}"]));
-		$avalue = preg_replace('/\s+/', ',', trim($avalue));
+		if (strlen(trim(filter_expand_alias($snortcfg["def_{$alias}"]))) > 0) {
+			$avalue = trim(filter_expand_alias($snortcfg["def_{$alias}"]));
+			$avalue = preg_replace('/\s+/', ',', trim($avalue));
+		}
+		else {
+			log_error("[snort] WARNING: unable to resolve Alias specified for SERVERS variable " . strtoupper($alias) . " ... using default value '{$avalue}' instead.");
+		}
 	}
 	$ipvardef .= "ipvar " . strtoupper($alias) . " [{$avalue}]\n";
 }

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2013-2014 Bill Meeks
+ * Copyright (c) 2013-2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -511,6 +511,13 @@ foreach ($rule as &$r) {
 	if (!empty($pconfig['unified2_log_limit']) && 
 	    !preg_match('/^\d+[g|k|m|G|K|M]/', $pconfig['unified2_log_limit'])) {
 		$pconfig['unified2_log_limit'] .= "M";
+		$updated_cfg = true;
+	}
+
+	// Set new BY2 syslog parameter to default if it is empty
+	// and Barnyard2 is enabled.
+	if ($pconfig['barnyard_enable'] == 'on' && empty($pconfig['barnyard_syslog_payload_encoding'])) {
+		$pconfig['barnyard_syslog_payload_encoding'] = 'hex';
 		$updated_cfg = true;
 	}
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_barnyard.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_barnyard.php
@@ -6,7 +6,7 @@
  * Copyright (c) 2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>
  * Copyright (c) 2008-2009 Robert Zelaya
- * Copyright (c) 2014-2017 Bill Meeks
+ * Copyright (c) 2014-2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,6 +74,8 @@ if (isset($id) && $a_nat[$id]) {
 		$pconfig['barnyard_syslog_proto'] = "udp";
 	if (empty($a_nat[$id]['barnyard_syslog_opmode']))
 		$pconfig['barnyard_syslog_opmode'] = "default";
+	if (empty($a_nat[$id]['barnyard_syslog_payload_encoding']))
+		$pconfig['barnyard_syslog_payload_encoding'] = "hex";
 	if (empty($a_nat[$id]['barnyard_syslog_facility']))
 		$pconfig['barnyard_syslog_facility'] = "LOG_USER";
 	if (empty($a_nat[$id]['barnyard_syslog_priority']))
@@ -170,6 +172,7 @@ if ($_POST['save']) {
 		$natent['barnyard_bro_ids_enable'] = $_POST['barnyard_bro_ids_enable'] ? 'on' : 'off';
 		$natent['barnyard_disable_sig_ref_tbl'] = $_POST['barnyard_disable_sig_ref_tbl'] ? 'on' : 'off';
 		$natent['barnyard_syslog_opmode'] = $_POST['barnyard_syslog_opmode'];
+		$natent['barnyard_syslog_payload_encoding'] = $_POST['barnyard_syslog_payload_encoding'];
 		$natent['barnyard_syslog_proto'] = $_POST['barnyard_syslog_proto'];
 
 		if ($_POST['unified2_log_limit']) $natent['unified2_log_limit'] = $_POST['unified2_log_limit']; else unset($natent['unified2_log_limit']);
@@ -389,20 +392,25 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['barnyard_syslog_enable'] == 'on' ? true:false,
 	'on'
 ));
-
+$section->addInput(new Form_Checkbox(
+	'barnyard_syslog_local',
+	'Local Only',
+	'Enable logging of alerts to the local system only. This will send alert data (without payload) to the local system using the facility and priority values selected below.',
+	$pconfig['barnyard_syslog_local'] == 'on' ? true:false,
+	'on'
+));
 $section->addInput(new Form_Select(
 	'barnyard_syslog_opmode',
 	'Operation Mode',
 	$pconfig['barnyard_syslog_opmode'],
 	array( "default" => "DEFAULT", "complete" => "COMPLETE" )
-))->setHelp('Select the level of detail to include when reporting. DEFAULT mode is compatible with the standard Snort syslog format. COMPLETE mode includes additional information such as the raw packet data (displayed in hex format).');
-$section->addInput(new Form_Checkbox(
-	'barnyard_syslog_local',
-	'Local Only',
-	'Enable logging of alerts to the local system only. This will send alert data to the local system only and overrides the host, port and protocol values below.',
-	$pconfig['barnyard_syslog_local'] == 'on' ? true:false,
-	'on'
-));
+))->setHelp('Select the level of detail to include when reporting. DEFAULT mode is compatible with the standard Snort syslog format. COMPLETE mode includes additional information such as the raw packet data.');
+$section->addInput(new Form_Select(
+	'barnyard_syslog_payload_encoding',
+	'Payload Encoding',
+	$pconfig['barnyard_syslog_payload_encoding'],
+	array( "hex" => "Hex", "ascii" => "ASCII", "base64" => "Base64" )
+))->setHelp('Select the encoding method to use for logging raw packet data.');
 $section->addInput(new Form_Input(
 	'barnyard_syslog_rhost',
 	'Remote Host',
@@ -426,13 +434,13 @@ $section->addInput(new Form_Select(
 	'Log Facility',
 	$pconfig['barnyard_syslog_facility'],
 	array(  "LOG_AUTH" => "LOG_AUTH", "LOG_AUTHPRIV" => "LOG_AUTHPRIV", "LOG_DAEMON" => "LOG_DAEMON", "LOG_KERN" => "LOG_KERN", "LOG_SYSLOG" => "LOG_SYSLOG", "LOG_USER" => "LOG_USER", "LOG_LOCAL0" => "LOG_LOCAL0", "LOG_LOCAL1" => "LOG_LOCAL1", "LOG_LOCAL2" => "LOG_LOCAL2", "LOG_LOCAL3" => "LOG_LOCAL3", "LOG_LOCAL4" => "LOG_LOCAL4", "LOG_LOCAL5" => "LOG_LOCAL5", "LOG_LOCAL6" => "LOG_LOCAL6", "LOG_LOCAL7" => "LOG_LOCAL7" )
-))->setHelp('Select Syslog Facility to use for remote reporting. Default is LOG_LOCAL1.');
+))->setHelp('Select Syslog Facility to use for reporting. Default is LOG_LOCAL1.');
 $section->addInput(new Form_Select(
 	'barnyard_syslog_priority',
 	'Log Priority',
 	$pconfig['barnyard_syslog_priority'],
 	array( "LOG_EMERG" => "LOG_EMERG", "LOG_CRIT" => "LOG_CRIT", "LOG_ALERT" => "LOG_ALERT", "LOG_ERR" => "LOG_ERR", "LOG_WARNING" => "LOG_WARNING", "LOG_NOTICE" => "LOG_NOTICE", "LOG_INFO" => "LOG_INFO" )
-))->setHelp('Select Syslog Priority (Level) to use for remote reporting. Default is LOG_INFO.');
+))->setHelp('Select Syslog Priority (Level) to use for reporting. Default is LOG_INFO.');
 $form->add($section);
 
 $section = new Form_Section('Bro-IDS Output Settings');
@@ -484,20 +492,31 @@ events.push(function(){
 
 	function toggle_syslog() {
 		var hide = ! $('#barnyard_syslog_enable').prop('checked');
-		hideSelect('barnyard_syslog_opmode', hide);
-		hideCheckbox('barnyard_syslog_local', hide);
-		hideInput('barnyard_syslog_rhost', hide);
-		hideInput('barnyard_syslog_dport', hide);
-		hideSelect('barnyard_syslog_proto', hide);
-		hideSelect('barnyard_syslog_facility', hide);
-		hideSelect('barnyard_syslog_priority', hide);
+		if (hide) {
+			hideCheckbox('barnyard_syslog_local', hide);
+			hideSelect('barnyard_syslog_opmode', hide);
+			hideSelect('barnyard_syslog_payload_encoding', hide);
+			hideInput('barnyard_syslog_rhost', hide);
+			hideInput('barnyard_syslog_dport', hide);
+			hideSelect('barnyard_syslog_proto', hide);
+			hideSelect('barnyard_syslog_facility', hide);
+			hideSelect('barnyard_syslog_priority', hide);
+		}
+		else {
+			hideCheckbox('barnyard_syslog_local', hide);
+			hideSelect('barnyard_syslog_facility', hide);
+			hideSelect('barnyard_syslog_priority', hide);
+			toggle_local_syslog();
+		}
 	}
 
 	function toggle_local_syslog() {
 		var hide = $('#barnyard_syslog_local').prop('checked');
-		disableInput('barnyard_syslog_rhost', hide);
-		disableInput('barnyard_syslog_dport', hide);
-		disableInput('barnyard_syslog_proto', hide);
+		hideSelect('barnyard_syslog_opmode', hide);
+		hideSelect('barnyard_syslog_payload_encoding', hide);
+		hideInput('barnyard_syslog_rhost', hide);
+		hideInput('barnyard_syslog_dport', hide);
+		hideSelect('barnyard_syslog_proto', hide);
 	}
 
 	function toggle_bro_ids() {
@@ -514,6 +533,8 @@ events.push(function(){
 		disableInput('barnyard_obfuscate_ip', hide);
 		disableInput('barnyard_sensor_id', hide);
 		disableInput('barnyard_sensor_name', hide);
+		disableInput('barnyard_log_vlan_events', hide);
+		disableInput('barnyard_log_mpls_events', hide);
 		disableInput('barnyard_mysql_enable', hide);
 		disableInput('barnyard_dbhost', hide);
 		disableInput('barnyard_dbname', hide);
@@ -521,13 +542,9 @@ events.push(function(){
 		disableInput('barnyard_dbpwd', hide);
 		disableInput('barnyard_disable_sig_ref_tbl', hide);
 		disableInput('barnyard_syslog_enable', hide);
-		disableInput('barnyard_syslog_opmode', hide);
 		disableInput('barnyard_syslog_local', hide);
 		disableInput('barnyard_syslog_rhost', hide);
 		disableInput('barnyard_syslog_dport', hide);
-		disableInput('barnyard_syslog_proto', hide);
-		disableInput('barnyard_syslog_facility', hide);
-		disableInput('barnyard_syslog_priority', hide);
 		disableInput('barnyard_bro_ids_enable', hide);
 		disableInput('barnyard_bro_ids_rhost', hide);
 		disableInput('barnyard_bro_ids_dport', hide);
@@ -563,7 +580,6 @@ events.push(function(){
 	
 	toggle_mySQL();
 	toggle_syslog();
-	toggle_local_syslog();
 	toggle_bro_ids();
 	
 });

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2004-2016 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -223,7 +223,7 @@ display_top_tabs($tab_array, true);
 				</thead>
 				<tbody>
 				<tr>
-					<td><?=gettext("Snort VRT Rules");?></td>
+					<td><?=gettext("Snort Subscriber Ruleset");?></td>
 					<td><?=trim($snort_org_sig_chk_local);?></td>
 					<td><?=gettext($snort_org_sig_date);?></td>
 				</tr>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
@@ -512,8 +512,8 @@ $form->add($section);
 $section = new Form_Section('Alert Settings');
 $section->addInput(new Form_Checkbox(
 	'alertsystemlog',
-	'Send Alerts to System Logs',
-	'Snort will send Alerts to the firewall\'s system logs',
+	'Send Alerts to System Log',
+	'Snort will send Alerts to the firewall\'s system log.  Default is Not Checked.',
 	$pconfig['alertsystemlog'] == 'on' ? true:false,
 	'on'
 ));

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2011-2016 Rubicon Communications, LLC (Netgate)
  * Copyright (C) 2008-2009 Robert Zelaya
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -567,28 +567,28 @@ $section->addInput(new Form_Select(
 $section->addInput(new Form_Checkbox(
 	'fpm_split_any_any',
 	'Split ANY-ANY',
-	'Enable splitting of ANY-ANY port group',
+	'Enable splitting of ANY-ANY port group.  Default is Not Checked.',
 	$pconfig['fpm_split_any_any'] == 'on' ? true:false,
 	'yes'
 ));
 $section->addInput(new Form_Checkbox(
 	'fpm_search_optimize',
 	'Search Optimize',
-	'Enable search optimization',
+	'Enable search optimization.  Default is Not Checked.',
 	$pconfig['fpm_search_optimize'] == 'on' ? true:false,
 	'on'
 ));
 $section->addInput(new Form_Checkbox(
 	'fpm_no_stream_inserts',
 	'Stream Inserts',
-	'Do not evaluate stream inserted packets against the detection engine',
+	'Do not evaluate stream inserted packets against the detection engine.  Default is Not Checked.',
 	$pconfig['fpm_no_stream_inserts'] == 'on' ? true:false,
 	'on'
 ));
 $section->addInput(new Form_Checkbox(
 	'cksumcheck',
 	'Checksum Check Disable',
-	'Disable checksum checking within Snort to improve performance',
+	'Disable checksum checking within Snort to improve performance.  Default is Not Checked.',
 	$pconfig['cksumcheck'] == 'on' ? true:false,
 	'on'
 ));

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2011-2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2006 Manuel Kasper <mk@neon1.net>.
- * Copyright (c) 2015 Bill Meeks
+ * Copyright (c) 2018 Bill Meeks
  * Copyright (c) 2008-2009 Robert Zelaya
  * All rights reserved.
  *
@@ -76,7 +76,7 @@ if ($_POST['rule_update_starttime']) {
 }
 
 if ($_POST['snortdownload'] == "on" && empty($_POST['oinkmastercode']))
-		$input_errors[] = "You must supply an Oinkmaster code in the box provided in order to enable Snort VRT rules!";
+		$input_errors[] = "You must supply an Oinkmaster code in the box provided in order to enable Snort Subscriber rules!";
 
 if ($_POST['emergingthreats_pro'] == "on" && empty($_POST['etpro_code']))
 		$input_errors[] = "You must supply a subscription code in the box provided in order to enable Emerging Threats Pro rules!";
@@ -118,7 +118,7 @@ if (!$input_errors) {
 		// any matching the disabled ruleset prefixes.
 		if (is_array($config['installedpackages']['snortglobal']['rule'])) {
 			foreach ($config['installedpackages']['snortglobal']['rule'] as &$iface) {
-				// Disable Snort IPS policy if VRT rules are disabled
+				// Disable Snort IPS policy if Snort Subscriber rules are disabled
 				if ($disable_ips_policy) {
 					$iface['ips_policy_enable'] = 'off';
 					unset($iface['ips_policy']);
@@ -192,17 +192,17 @@ $form = new Form(new Form_Button(
 	'Save'
 ));
 
-$section = new Form_Section('Snort Vulnerability Research Team (VRT) Rules');
+$section = new Form_Section('Snort Subscriber Rules');
 $section->addInput(new Form_Checkbox(
 	'snortdownload',
 	'Enable Snort VRT',
-	'Click to enable download of Snort VRT free Registered User or paid Subscriber rules',
+	'Click to enable download of Snort free Registered User or paid Subscriber rules',
 	$pconfig['snortdownload'] == 'on' ? true:false,
 	'on'
 ));
 $section->addInput(new Form_StaticText(
 	null,
-	'<a href="https://www.snort.org/users/sign_up" target="_blank">' . 'Sign Up for a free Registered User Rule Account' . '</a><br/><a href="https://www.snort.org/products" target="_blank">' . 'Sign Up for paid Sourcefire VRT Certified Subscriber Rules' . '</a>'
+	'<a href="https://www.snort.org/users/sign_up" target="_blank">' . 'Sign Up for a free Registered User Rules Account' . '</a><br/><a href="https://www.snort.org/products" target="_blank">' . 'Sign Up for paid Snort Subscriber Rule Set (by Talos)' . '</a>'
 ));
 $section->addInput(new Form_Input(
 	'oinkmastercode',
@@ -223,7 +223,7 @@ $section->addInput(new Form_Checkbox(
 ));
 $section->addInput(new Form_StaticText(
 	null,
-	'The Snort Community Ruleset is a GPLv2 VRT certified ruleset that is distributed free of charge without any VRT License restrictions.  This ruleset is updated daily and is a subset of the subscriber ruleset.'
+	'The Snort Community Ruleset is a GPLv2 Talos certified ruleset that is distributed free of charge without any Snort Subscriber License restrictions.  This ruleset is updated daily and is a subset of the subscriber ruleset.'
 ));
 
 $form->add($section);

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist.php
@@ -160,8 +160,13 @@ display_top_tabs($tab_array, true);
 			<tr>
 				<td><input type="checkbox" id="frc<?=$i?>" name="del[]" value="<?=$i?>" onclick="fr_bgcolor('<?=$i?>')" /></td>
 				<td ondblclick="document.location='snort_passlist_edit.php?id=<?=$i;?>';"><?=htmlspecialchars($list['name']);?></td>
+		<?php if (strlen($list['address']) > 0) : ?>
 				<td ondblclick="document.location='snort_passlist_edit.php?id=<?=$i;?>';" title="<?=filter_expand_alias($list['address']);?>">
 					<?=gettext($list['address']);?></td>
+		<?php else : ?>
+				<td ondblclick="document.location='snort_passlist_edit.php?id=<?=$i;?>';">
+				</td>
+		<?php endif; ?>
 				<td ondblclick="document.location='snort_passlist_edit.php?id=<?=$i;?>';"><?=htmlspecialchars($list['descr']);?>&nbsp;</td>
 				<td style="cursor: pointer;"><a href="snort_passlist_edit.php?id=<?=$i;?>" class="fa fa-pencil" title="<?=gettext('Edit Pass List');?>"></a>
 				<a class="fa fa-trash no-confirm" id="Xcdel_<?=$i?>" title="<?=gettext('Delete Pass List'); ?>"></a>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
@@ -6,7 +6,7 @@
  * Copyright (c) 2011-2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2008-2009 Robert Zelaya
- * Copyright (c) 2013-2017 Bill Meeks
+ * Copyright (c) 2013-2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -769,8 +769,8 @@ print_callout('<p>' . gettext("Rules may be dependent on enbled preprocessors!  
 		'Enable this only if you maintain customized preprocessor text rules files for this interface. Default is Not Checked.',
 		$pconfig['protect_preproc_rules'] == 'on' ? true:false,
 		'on'
-	))->setHelp('Enable this only if you use customized preprocessor text rules files and you do not want them overwritten by automatic Snort VRT rule updates.  ' . 
-		    'This option is disabled when Snort VRT rules download is not enabled on the Global Settings tab.  Most users should leave this option unchecked.');
+	))->setHelp('Enable this only if you use customized preprocessor text rules files and you do not want them overwritten by automatic Snort Subscriber Rules updates.  ' . 
+		    'This option is disabled when Snort Subscriber Rules download is not enabled on the Global Settings tab.  Most users should leave this option unchecked.');
 	$section->add($group);
 	$group = new Form_Group('Auto Rule Disable');
 	$group->add(new Form_Checkbox(
@@ -1558,7 +1558,7 @@ print_callout('<p>' . gettext("Rules may be dependent on enbled preprocessors!  
 		'sensitive_data',
 		'Enable',
 		'Sensitive data searches for credit card numbers, Social Security numbers and e-mail addresses in data.  Default is Not Checked.' . 
-		'To enable this preprocessor, you must enable the Snort VRT rules on the GLOBAL SETTINGS tab.',
+		'To enable this preprocessor, you must enable the Snort Subscriber Rules on the GLOBAL SETTINGS tab.',
 		$pconfig['sensitive_data'] == 'on' ? true:false,
 		'on'
 	));

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
@@ -1392,7 +1392,7 @@ print_callout('<p>' . gettext("Rules may be dependent on enbled preprocessors!  
 	//----- END Portscan settings -----
 
 	//----- START FTP/Telnet Global setttings -----
-	if ($pconfig['ftp_preprocessor']=="on") {
+	if ($pconfig['ftp_preprocessor'] == "on") {
 		$section = new Form_Section('FTP and Telnet Global Options', 'preproc_ftpglobal', COLLAPSIBLE|SEC_OPEN);
 	} else {
 		$section = new Form_Section('FTP and Telnet Global Options', 'preproc_ftpglobal', COLLAPSIBLE|SEC_CLOSED);
@@ -1428,7 +1428,12 @@ print_callout('<p>' . gettext("Rules may be dependent on enbled preprocessors!  
 	//----- END FTP/Telnet Global settings -----
 
 	//----- START Telnet Protocol setttings -----
-	$section = new Form_Section('Telnet Protocol Options', 'preproc_telnet', COLLAPSIBLE|SEC_OPEN);
+	if ($pconfig['ftp_preprocessor'] == "on" && $pconfig['ftp_telnet_normalize'] == "on") {
+		$section = new Form_Section('Telnet Protocol Options', 'preproc_telnet', COLLAPSIBLE|SEC_OPEN);
+	}
+	else {
+		$section = new Form_Section('Telnet Protocol Options', 'preproc_telnet', COLLAPSIBLE|SEC_CLOSED);
+	}
 	$section->addInput(new Form_Checkbox(
 		'ftp_telnet_normalize',
 		'Normalization',
@@ -1576,12 +1581,12 @@ print_callout('<p>' . gettext("Rules may be dependent on enbled preprocessors!  
 		'number',
 		$pconfig['sdf_alert_threshold']
 	))->setAttribute('min', '0')->setHelp('Personally Identifiable Information (PII) combination alert threshold.  Default is 25.');
-	$group->setHelp('This value sets the number of PII combinations required to trigger an alert.  This should be set higher than the highest individual count in your <em>sd_pattern</em> rules.');
+	$group->setHelp('This value sets the number of PII combinations required to trigger an alert.  This should be set higher than the highest individual count in any of your sd_pattern rules.');
 	$section->add($group);
 	$section->addInput(new Form_Checkbox(
 		'sdf_mask_output',
 		'Mask Output',
-		'Replace all but last 4 digits of PII with <em>X</em> on credit card and Social Security Numbers.  Default is Not Checked.',
+		'Replace all but last 4 digits of credit card and Social Security Numbers with X.  Default is Not Checked.',
 		$pconfig['sdf_mask_output'] == 'on' ? true:false,
 		'on'
 	));
@@ -2164,9 +2169,19 @@ print_callout('<p>' . gettext("Remember to save your changes before you exit thi
 	function ftp_telnet_enable_change() {
 		// Hide FTP-Telnet sections if FTP preprocessor is disabled
 		if (!($('#ftp_preprocessor').prop('checked'))) {
-			$('#preproc_ftpglobal_panel-body').collapse('toggle');
-			$('#preproc_telnet_panel-body').collapse('toggle');
-			$('#preproc_ftp_panel-body').collapse('toggle');
+			$('#preproc_telnet_panel-body').collapse('hide');
+			$('#preproc_ftp_panel-body').collapse('hide');
+			$('#preproc_ftpglobal_panel-body').collapse('hide');
+		}
+		else {
+			$('#preproc_ftpglobal_panel-body').collapse('show');
+			$('#preproc_ftp_panel-body').collapse('show');
+			if ($('#ftp_telnet_normalize').prop('checked')) {
+				$('#preproc_telnet_panel-body').collapse('show');
+			}
+			else {
+				$('#preproc_telnet_panel-body').collapse('hide');
+			}
 		}
 	}
 
@@ -2321,6 +2336,10 @@ events.push(function(){
 	});
 
 	$('#ftp_preprocessor').click(function() {
+		ftp_telnet_enable_change();
+	});
+
+	$('#ftp_telnet_normalize').click(function() {
 		ftp_telnet_enable_change();
 	});
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
@@ -920,10 +920,10 @@ print($section);
 									<tr class="text-nowrap">
 										<td><?=$textss; ?>
 								<?php if ($v['managed'] == 1) : ?>
-											<i {$iconb_class} title='{$title}'</i>{$textse}";
+										<i <?=$iconb_class; ?> title="<?=$title; ?>"</i><?=$textse; ?>
 								<?php else : ?>
-											<a id="rule_<?=$gid; ?>_<?=$sid; ?>" href="#" onClick="doToggle('<?=$gid; ?>', '<?=$sid; ?>');" 
-											<?=$iconb_class; ?> title="<?=$title; ?>"</a><?=$textse; ?>
+										<a id="rule_<?=$gid; ?>_<?=$sid; ?>" href="#" onClick="doToggle('<?=$gid; ?>', '<?=$sid; ?>');" 
+										<?=$iconb_class; ?> title="<?=$title; ?>"></a><?=$textse; ?>
 								<?php endif; ?>
 									       </td>
 									       <td ondblclick="getRuleFileContents('<?=$gid; ?>','<?=$sid; ?>');">

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2004-2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2008-2009 Robert Zelaya
- * Copyright (c) 2017 Bill Meeks
+ * Copyright (c) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009 Robert Zelaya
- * Copyright (c) 2017 Bill Meeks
+ * Copyright (c) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -92,8 +92,8 @@ if (!file_exists("{$snortdir}/rules/" . GPL_FILE_PREFIX . "community.rules"))
 if (($snortdownload == 'off') || ($a_nat[$id]['ips_policy_enable'] != 'on'))
 	$policy_select_disable = "disabled";
 
-// If a Snort VRT policy is enabled and selected, remove all Snort VRT
-// rules from the configured rule sets to allow automatic selection.
+// If a Snort Subscriber Rules policy is enabled and selected, remove all Snort
+// Subscriber rules from the configured rule sets to allow automatic selection.
 if ($a_nat[$id]['ips_policy_enable'] == 'on') {
 	if (isset($a_nat[$id]['ips_policy'])) {
 		$disable_vrt_rules = "disabled";
@@ -227,7 +227,7 @@ if (isset($_POST['selectall'])) {
 			$enabled_rulesets_array[] = basename($file);
 	}
 
-	/* Include the Snort VRT rules only if enabled and no IPS policy is set */
+	/* Include the Snort Subscriber rules only if enabled and no IPS policy is set */
 	if ($snortdownload == 'on' && $a_nat[$id]['ips_policy_enable'] == 'off') {
 		$files = glob("{$snortdir}/rules/" . VRT_FILE_PREFIX . "*.rules");
 		foreach ($files as $file)
@@ -351,17 +351,17 @@ if ($btn_view_flowb_rules == TRUE) {
 print($section);
 
 if ($snortdownload == "on") {
-	$section = new Form_Section('Snort VRT IPS Policy Selection');
+	$section = new Form_Section('Snort Subscriber IPS Policy Selection');
 	$section->addInput(new Form_Checkbox(
 		'ips_policy_enable',
 		'Use IPS Policy',
-		'If checked, Snort will use rules from one of three pre-defined IPS policies in the Snort VRT rules. Default is Not Checked.',
+		'If checked, Snort will use rules from one of three pre-defined IPS policies in the Snort Subscriber rules. Default is Not Checked.',
 		$pconfig['ips_policy_enable'] == 'on' ? true:false,
 		'on'
 	));
 	$section->addInput(new Form_StaticText(
 	null,
-	'<span class="help-block">Selecting this option disables manual selection of Snort VRT categories in the list below, ' . 
+	'<span class="help-block">Selecting this option disables manual selection of Snort Subscriber categories in the list below, ' . 
 		'although Emerging Threats categories may still be selected if enabled on the Global Settings tab.  These ' . 
 		'will be added to the pre-defined Snort IPS policy rules from the Snort VRT.</span>'
 	));
@@ -369,15 +369,17 @@ if ($snortdownload == "on") {
 		'ips_policy',
 		'IPS Policy Selection',
 		$pconfig['ips_policy'],
-		array('connectivity' => 'Connectivity', 'balanced' => 'Balanced', 'security' => 'Security')
-	))->setHelp('Snort IPS policies are:  Connectivity, Balanced or Security.');
+		array('connectivity' => 'Connectivity', 'balanced' => 'Balanced', 'security' => 'Security', 'max-detect' => 'Max-Detect')
+	))->setHelp('Snort IPS policies are:  Connectivity, Balanced, Security or Max-Detect.');
 
 	$section->addInput(new Form_StaticText(
 		'',
 		'<span class="help-block">Connectivity blocks most major threats with few or no false positives. ' . 
 		'Balanced is a good starter policy. It is speedy, has good base coverage level, and covers ' . 
 		'most threats of the day.  It includes all rules in Connectivity. Security is a stringent ' . 
-		'policy.  It contains everything in the first two plus policy-type rules such as a Flash object in an Excel file.</span>'
+		'policy.  It contains everything in the first two plus policy-type rules such as a Flash object ' . 
+		'in an Excel file.  Max-Detect is a policy created for testing network traffic through your ' . 
+		'device.  This policy should be used with caution on production systems!</span>'
 	));
 	print($section);
 }
@@ -408,7 +410,7 @@ if ($snortdownload == "on") {
 			<?php if ($no_community_files)
 				$msg_community = gettext("NOTE: Snort Community Rules have not been downloaded.  Perform a Rules Update to enable them.");
 			      else
-				$msg_community = gettext("Snort GPLv2 Community Rules (VRT certified)");
+				$msg_community = gettext("Snort GPLv2 Community Rules (Talos certified)");
 			      $community_rules_file = gettext(GPL_FILE_PREFIX . "community.rules");
 			?>
 
@@ -507,7 +509,7 @@ if ($snortdownload == "on") {
 						<th><?=gettext("Enabled"); ?></th>
 						<th><?=gettext('Ruleset: Snort SO Rules');?></th>
 					<?php else: ?>
-						<th colspan="4"><?=gettext("Snort VRT rules {$msg_snort}"); ?></th>
+						<th colspan="4"><?=gettext("Snort Subscriber rules {$msg_snort}"); ?></th>
 					<?php endif; ?>
 					<?php if ($openappid_rulesdownload == 'on' && !$no_openappid_files): ?>
 						<th><?=gettext("Enabled"); ?></th>

--- a/security/pfSense-pkg-snort/files/var/db/snort/sidmods/disablesid-sample.conf
+++ b/security/pfSense-pkg-snort/files/var/db/snort/sidmods/disablesid-sample.conf
@@ -28,7 +28,7 @@
 # pcre:"Joomla"
 
 # Example of modifying state for specific categories entirely.
-# "snort_" limits to Snort VRT rules, "emerging-" limits to 
+# "snort_" limits to Snort Subscriber rules, "emerging-" limits to 
 # Emerging Threats Open rules, "etpro-" limits to ET-PRO rules.
 # "shellcode" with no prefix would match in any vendor set.
 # snort_web-iis,emerging-shellcode,etpro-imap,shellcode

--- a/security/pfSense-pkg-snort/files/var/db/snort/sidmods/enablesid-sample.conf
+++ b/security/pfSense-pkg-snort/files/var/db/snort/sidmods/enablesid-sample.conf
@@ -28,7 +28,7 @@
 # pcre:"Joomla"
 
 # Example of modifying state for specific categories entirely.
-# "snort_" limits to Snort VRT rules, "emerging-" limits to 
+# "snort_" limits to Snort Subscriber rules, "emerging-" limits to 
 # Emerging Threats Open rules, "etpro-" limits to ET-PRO rules.
 # "shellcode" with no prefix would match in any vendor set.
 # snort_web-iis,emerging-shellcode,etpro-imap,shellcode


### PR DESCRIPTION
## pfSense-pkg-snort-3.2.9.6
This update to the Snort GUI package incorporates six bug fixes and two new features.  The GUI package now supports the latest 2.9.11.1 version of Snort.  References to the text "Snort VRT rules" within hints, help messages, log entries and titles within the GUI have been changed to read "Snort Subscriber Rules" to align with the naming convention preferred by Talos and Cisco.

**New Features**
1.  Added dynamic updating of service status to INTERFACES tab for Snort and Barnyard2.  When starting Snort on an interface, the task is launched as a background job and the GUI monitors the task status to update the icons on the INTERFACES tab.
2.  Added support for the new "Max-Detect" IPS Policy available with Snort Subscriber Rules.  This new policy is designed mainly for testing purposes as it is maximizes detection (as the name implies) but also raises the number of potential false positives.  The new mode is not recommended for production systems!

**Bug Fixes**
1.  FQDN aliases are accepted without flagging an error, but do not process and result in no parts of the alias being used at runtime when an FQDN alias is nested within a normal static IP alias.  With the fix, a warning message is printed to the system log and a safe default value is used (if applicable).
2.  Bogus gettext() header info displayed on PASS LISTS tab in Alias column when alias is empty.
3.  HOME_NET and EXTERNAL_NET custom lists ignore the setting to exclude locally-attached networks.
4.  Fix syntax error on RULES tab causing rule status icons to display twice for 'User Force Disabled" rules.
5.  Barnyard2 configuration is not properly configured to allow full packet dumps.  See forum message here:  [https://forum.pfsense.org/index.php?topic=142690.msg778984#msg778984](url).
6.  Modify SNORT_BIN_VERSION constant's calculated value to account for longer version number string in latest Snort binary (such as 2.9.11.1).