### PR TITLE
haproxy-devel, dont check 'external address' for a valid ip/port when shared frontend is checked.

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/Makefile
+++ b/net/pfSense-pkg-haproxy-devel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-haproxy-devel
 PORTVERSION=	0.55
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
@@ -408,18 +408,20 @@ if ($_POST) {
 			$input_errors[] = gettext("The acl field 'Name' is required with at least 2 characters.");
 		}
 	}
-	foreach($a_extaddr as $extaddr) {
-		$ports = explode(",",$extaddr['extaddr_port']);
-		foreach($ports as $port){
-			if ($port && !is_numeric($port) && !is_port_or_alias($port)) {
-				$input_errors[] = sprintf(gettext("The external address field 'Port' value '%s' is not a number or alias thereof."), htmlspecialchars($port));
+	if ($pconfig['secondary'] != "yes") {
+		foreach($a_extaddr as $extaddr) {
+			$ports = explode(",",$extaddr['extaddr_port']);
+			foreach($ports as $port){
+				if ($port && !is_numeric($port) && !is_port_or_alias($port)) {
+					$input_errors[] = sprintf(gettext("The external address field 'Port' value '%s' is not a number or alias thereof."), htmlspecialchars($port));
+				}
 			}
-		}
-	
-		if ($extaddr['extaddr'] == 'custom') {
-			$extaddr_custom = $extaddr['extaddr_custom'];
-			if (empty($extaddr_custom) || (!is_ipaddroralias($extaddr_custom))) {
-				$input_errors[] = sprintf(gettext("The external address '%s' is not a valid source IP address or alias."), $extaddr_custom);
+
+			if ($extaddr['extaddr'] == 'custom') {
+				$extaddr_custom = $extaddr['extaddr_custom'];
+				if (empty($extaddr_custom) || (!is_ipaddroralias($extaddr_custom))) {
+					$input_errors[] = sprintf(gettext("The external address '%s' is not a valid source IP address or alias."), $extaddr_custom);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
haproxy-devel, dont check 'external address' for a valid ip/port when shared frontend is checked.