### PR TITLE
Cellular Package change link to symlink

### DIFF
--- a/net/pfSense-pkg-cellular/Makefile
+++ b/net/pfSense-pkg-cellular/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-cellular
-PORTVERSION=	1.2
+PORTVERSION=	1.2.1
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-cellular/files/usr/local/bin/cellular_dev.py
+++ b/net/pfSense-pkg-cellular/files/usr/local/bin/cellular_dev.py
@@ -87,11 +87,11 @@ if args.add:
 
         data_ug = path_ug + ".0"
         if os.path.exists(data_ug):
-            os.link(data_ug, data_path)
+            os.symlink(data_ug, data_path)
 
         mgmt_ug = path_ug + ".2"
         if os.path.exists(mgmt_ug):
-            os.link(mgmt_ug, mgmt_path)
+            os.symlink(mgmt_ug, mgmt_path)
 
 elif args.remove:
 


### PR DESCRIPTION
Hi,

it seems that pythons os.link does not work reliably os.symlink does seem to work.
This patch changes the link to symlink.

Best
Sven