### PR TITLE
pfSense-pkg-softflowd: Added additional options now available in softflowd-0.9.9_1

### DIFF
--- a/net-mgmt/pfSense-pkg-softflowd/Makefile
+++ b/net-mgmt/pfSense-pkg-softflowd/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-softflowd
-PORTVERSION=	1.2.2
+PORTVERSION=	1.2.3
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.inc
+++ b/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.inc
@@ -38,6 +38,7 @@ function sync_package_softflowd() {
 	if (!empty($cf['host']) && !empty($interface_list) && $cf['enable'] != "off") {
 		$cf['host'] = is_ipaddrv6($cf['host']) ? "[{$cf['host']}]" : $cf['host'];
 		$start = "/usr/bin/killall -9 softflowd";
+		$if_index = 1;
 		foreach ($interface_list as $interface_friendly) {
 			if (empty($interface_friendly)) {
 				continue;
@@ -46,8 +47,9 @@ function sync_package_softflowd() {
 			if (empty($interface)) {
 				continue;
 			}
+			
 			$start .= "\n\t/usr/local/sbin/softflowd ";
-			$start .= " -i " . escapeshellarg($interface);
+			$start .= " -i " . $if_index++ . ":" . escapeshellarg($interface);
 			$start .= " -n " . escapeshellarg("{$cf['host']}:{$cf['port']}");
 			if (is_numericint($cf['maxflows'])) {
 				$start .= " -m " . escapeshellarg($cf['maxflows']);
@@ -113,10 +115,10 @@ function validate_form_softflowd($post, &$input_errors) {
 	if (!is_port($post['port'])) {
 		$input_errors[] = "You must specify a valid port number in the 'Port' field";
 	}
-	if (!in_array($post['version'], array(1, 5, 9))) {
+	if (!in_array($post['version'], array(1, 5, 9, 10))) {
 		$input_errors[] = 'You must specify a netflow version';
 	}
-	if (!in_array($post['flowtracking'], array("full", "proto", "ip"))) {
+	if (!in_array($post['flowtracking'], array("vlan", "full", "proto", "ip"))) {
 		$input_errors[] = 'You must specify a valid flow tracking selection';
 	}
 	if (!empty($post['hoplimit']) && (!is_numericint($post['hoplimit']) || ($post['hoplimit'] < 1) || ($post['hoplimit'] > 255))) {
@@ -157,6 +159,29 @@ function cleanup_config_softflowd() {
 	}
 	$a_pkg = array();
 	$a_pkg[0] = $pffconf;
+}
+
+function display_interface_indices_softflowd() {
+	global $config;
+
+	if (is_array($config['installedpackages']['softflowd']['config'][0])) {
+		$cf = $config['installedpackages']['softflowd']['config'][0];
+	} else {
+		$cf = array();
+	}
+	
+	/* Compile and display the list of interface indices if softflowd is active */
+	$interface_list = explode(",", $cf['interface']);
+	$interface_indices = "";
+	if (!empty($cf['host']) && !empty($interface_list) && $cf['enable'] != "off") {
+		$if_index = 1;
+		foreach ($interface_list as $interface_friendly) {
+			$interface_desc = convert_friendly_interface_to_friendly_descr($interface_friendly);
+			$interface_indices .= "{$if_index}: {$interface_desc}<br>";
+			$if_index++;
+		}
+		print_info_box("The following interface indices are currently in use:<br><br>{$interface_indices}", "info", "");
+	}
 }
 
 ?>

--- a/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.inc
+++ b/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.inc
@@ -49,7 +49,7 @@ function sync_package_softflowd() {
 			}
 			
 			$start .= "\n\t/usr/local/sbin/softflowd ";
-			$start .= " -i " . $if_index++ . ":" . escapeshellarg($interface);
+			$start .= " -i " . escapeshellarg($if_index++ . ":" . $interface);
 			$start .= " -n " . escapeshellarg("{$cf['host']}:{$cf['port']}");
 			if (is_numericint($cf['maxflows'])) {
 				$start .= " -m " . escapeshellarg($cf['maxflows']);
@@ -171,16 +171,18 @@ function display_interface_indices_softflowd() {
 	}
 	
 	/* Compile and display the list of interface indices if softflowd is active */
-	$interface_list = explode(",", $cf['interface']);
-	$interface_indices = "";
-	if (!empty($cf['host']) && !empty($interface_list) && $cf['enable'] != "off") {
-		$if_index = 1;
-		foreach ($interface_list as $interface_friendly) {
-			$interface_desc = convert_friendly_interface_to_friendly_descr($interface_friendly);
-			$interface_indices .= "{$if_index}: {$interface_desc}<br>";
-			$if_index++;
+	if (isset($cf) && isset($cf['interface'])) {
+		$interface_list = explode(",", $cf['interface']);
+		$interface_indices = "";
+		if (!empty($cf['host']) && !empty($interface_list) && $cf['enable'] != "off") {
+			$if_index = 1;
+			foreach ($interface_list as $interface_friendly) {
+				$interface_desc = convert_friendly_interface_to_friendly_descr($interface_friendly);
+				$interface_indices .= "{$if_index}: {$interface_desc}<br>";
+				$if_index++;
+			}
+			print_info_box("The following interface indices are currently in use:<br><br>{$interface_indices}", "info", "");
 		}
-		print_info_box("The following interface indices are currently in use:<br><br>{$interface_indices}", "info", "");
 	}
 }
 

--- a/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.inc
+++ b/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.inc
@@ -171,7 +171,7 @@ function display_interface_indices_softflowd() {
 	}
 	
 	/* Compile and display the list of interface indices if softflowd is active */
-	if (isset($cf) && isset($cf['interface'])) {
+	if (isset($cf['interface'])) {
 		$interface_list = explode(",", $cf['interface']);
 		$interface_indices = "";
 		if (!empty($cf['host']) && !empty($interface_list) && $cf['enable'] != "off") {

--- a/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.xml
+++ b/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.xml
@@ -61,7 +61,7 @@
 			<fielddescr>Interface</fielddescr>
 			<fieldname>interface</fieldname>
 			<type>interfaces_selection</type>
-			<description>Pick an interface from which to collect netflow data. A separate instance of softflowd will be launched for each interface.</description>
+			<description>Pick an interface from which to collect netflow data. A separate instance of softflowd will be launched for each interface. Flows tracked on each interface will be tagged with a unique interface index (starting at 1) populated in the same order as they're displayed above.</description>
 			<multiple/>
 		</field>
 		<field>
@@ -103,9 +103,10 @@
 		<field>
 			<fielddescr>Netflow version</fielddescr>
 			<fieldname>version</fieldname>
-			<description>Select the desired version of the NetFlow protocol.</description>
+			<description>Select the desired version of the NetFlow protocol (10 means IPFIX).</description>
 			<type>select</type>
 			<options>
+				<option><name>10</name><value>10</value></option>
 				<option><name>9</name><value>9</value></option>
 				<option><name>5</name><value>5</value></option>
 				<option><name>1</name><value>1</value></option>
@@ -121,8 +122,9 @@
 				<div class="infoblock">
 				The track_level value may be one of:<br/>
 				<dl class="dl-horizontal responsive">
-					<dt>full</dt><dd>Track everything in the flow, the default.</dd>
-					<dt>proto</dt><dd>Track source and destination addresses and protocol.</dd>
+					<dt>vlan</dt><dd>Track everything in the flow.</dd>
+					<dt>full</dt><dd>Track protocol, source and destination addresses and source and destination ports, the default.</dd>
+					<dt>proto</dt><dd>Track protocol and source and destination addresses.</dd>
 					<dt>ip</dt><dd>Only track source and destination addresses.</dd>
 				</dl>
 				Selecting either of the latter options will produce flows with less information in them (e.g. TCP/UDP ports will not be recorded).
@@ -133,6 +135,7 @@
 			</description>
 			<type>select</type>
 			<options>
+				<option><name>VLAN</name><value>vlan</value></option>
 				<option><name>Full</name><value>full</value></option>
 				<option><name>Proto</name><value>proto</value></option>
 				<option><name>IP</name><value>ip</value></option>
@@ -230,4 +233,7 @@
 	<custom_php_command_before_form>
 		cleanup_config_softflowd();
 	</custom_php_command_before_form>
+	<custom_php_after_head_command>
+		display_interface_indices_softflowd();
+	</custom_php_after_head_command>
 </packagegui>

--- a/net-mgmt/pfSense-pkg-softflowd/files/usr/local/share/pfSense-pkg-softflowd/info.xml
+++ b/net-mgmt/pfSense-pkg-softflowd/files/usr/local/share/pfSense-pkg-softflowd/info.xml
@@ -2,10 +2,10 @@
 <pfsensepkgs>
 	<package>
 		<name>softflowd</name>
-		<website>http://code.google.com/p/softflowd/</website>
+		<website>https://www.freshports.org/net-mgmt/softflowd/</website>
 		<descr><![CDATA[Softflowd is flow-based network traffic analyser capable of Cisco NetFlow data export.&lt;br/&gt;
 			Softflowd semi-statefully tracks traffic flows recorded by listening on a network interface or by reading a packet capture file. These flows may be reported via NetFlow to a collecting host or summarised within softflowd itself.&lt;br/&gt;
-			Softflowd supports Netflow versions 1, 5 and 9 and is fully IPv6-capable - it can track IPv6 flows and send export datagrams via IPv6. It also supports export to multicast groups, allowing for redundant flow collectors.&lt;br/&gt;]]></descr>
+			Softflowd supports Netflow versions 1, 5, 9 and 10 (IPFIX) and is fully IPv6-capable - it can track IPv6 flows and send export datagrams via IPv6. It also supports export to multicast groups, allowing for redundant flow collectors.&lt;br/&gt;]]></descr>
 		<version>%%PKGVERSION%%</version>
 		<configurationfile>softflowd.xml</configurationfile>
 	</package>

--- a/net-mgmt/pfSense-pkg-softflowd/pkg-descr
+++ b/net-mgmt/pfSense-pkg-softflowd/pkg-descr
@@ -5,7 +5,7 @@ by listening on a network interface or by reading a
 packet capture file. These flows may be reported via
 NetFlow to a collecting host or summarised within
 softflowd itself.<br/> Softflowd supports Netflow
-versions 1, 5 and 9 and is fully IPv6-capable - it can
+versions 1, 5, 9 and 10 (IPFIX) and is fully IPv6-capable - it can
 track IPv6 flows and send export datagrams via IPv6. It
 also supports export to multicast groups, allowing for
 redundant flow collectors.

--- a/net-mgmt/pfSense-pkg-softflowd/pkg-descr
+++ b/net-mgmt/pfSense-pkg-softflowd/pkg-descr
@@ -9,3 +9,4 @@ versions 1, 5, 9 and 10 (IPFIX) and is fully IPv6-capable - it can
 track IPv6 flows and send export datagrams via IPv6. It
 also supports export to multicast groups, allowing for
 redundant flow collectors.
+

--- a/net-mgmt/pfSense-pkg-softflowd/pkg-descr
+++ b/net-mgmt/pfSense-pkg-softflowd/pkg-descr
@@ -9,4 +9,3 @@ versions 1, 5, 9 and 10 (IPFIX) and is fully IPv6-capable - it can
 track IPv6 flows and send export datagrams via IPv6. It
 also supports export to multicast groups, allowing for
 redundant flow collectors.
-


### PR DESCRIPTION
Updated package version to 1.2.3

Includes new 'VLAN' flow tracking level

Includes new 'IPFIX' protocol option

Flows will now include a unique ID (or index) to differentiate between multiple instances of softflowd

The indexes will be displayed in an info box at the top of the settings page when softflowd is enabled