### PR TITLE
Avahi: Hook up "Publish DNS" option to fix #8366

### DIFF
--- a/net/pfSense-pkg-Avahi/Makefile
+++ b/net/pfSense-pkg-Avahi/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-Avahi
-PORTVERSION=	1.12
+PORTVERSION=	1.13
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-Avahi/files/usr/local/pkg/avahi.inc
+++ b/net/pfSense-pkg-Avahi/files/usr/local/pkg/avahi.inc
@@ -85,6 +85,11 @@ function avahi_write_config() {
 	$dns = str_replace(' ', ', ', $dns);
 	if ($dns) {
 		$publishdns = "publish-dns-servers={$dns}";
+
+		// but comment out the setting if DNS publishing is disabled
+		if (!$avahi_config['publish_resolv_conf_dns_servers']) {
+			$publishdns = "#" . $publishdns;
+		}
 	}
 
 	// Construct the avahi configuration


### PR DESCRIPTION
The "Publish DNS Servers" option was not being used when generating the avahi config which caused the DNS servers to always be published regardless of the setting. This patch comments out the publish-dns-servers line in the config file when the "Publish DNS Servers" option is disabled.