### PR TITLE
pfSense-pkg-suricata v4.0.3_2

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.0.3
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -3090,6 +3090,58 @@ function suricata_modify_sids_action(&$rule_map, $suricatacfg) {
 	unset($alertsid, $dropsid);
 }
 
+function suricata_get_filtered_rules($rules, $filter) {
+
+	/************************************************/
+	/* This function returns a rules_map array of   */
+	/* of rules filtered using the GID:SID pairs    */
+	/* found in the passed filter criteria array.   */
+	/*                                              */
+	/*   $rules --> file, a directory or an array   */
+	/*              containing rules files to scan  */
+	/*                                              */
+	/*  $filter --> array of GID:SID pairs to use   */
+	/*              for filtering returned rules    */
+	/*              map array.                      */
+	/*                                              */
+	/*  Returns --> rules_map array                 */
+	/************************************************/
+
+	$tmp_map = array();
+	$filtered_map = array();
+
+	// If the filter array is empty, just
+	// return an empty result to save time
+	// since nothing would match.
+	if (empty($filter)) {
+		return filtered_map;
+	}
+
+	// Load up all the rules from the location passed
+	$tmp_map = suricata_load_rules_map($rules);
+
+	// Now walk the loaded filter list and copy
+	// matching GID:SID rules from the target list
+	// over to the filtered array.
+	foreach ($filter as $k1 => $rulem) {
+		foreach($rulem as $k2 => $v) {
+			$filtered_map[$k1][$k2] = array();
+			$filtered_map[$k1][$k2]['rule'] = $tmp_map[$k1][$k2]['rule'];
+			$filtered_map[$k1][$k2]['category'] = $tmp_map[$k1][$k2]['category'];
+			$filtered_map[$k1][$k2]['action'] = $tmp_map[$k1][$k2]['action'];
+			$filtered_map[$k1][$k2]['modified'] = $tmp_map[$k1][$k2]['modified'];
+			$filtered_map[$k1][$k2]['disabled'] = $tmp_map[$k1][$k2]['disabled'];
+			$filtered_map[$k1][$k2]['flowbits'] = $tmp_map[$k1][$k2]['flowbits'];
+			$filtered_map[$k1][$k2]['managed'] = $tmp_map[$k1][$k2]['managed'];
+			$filtered_map[$k1][$k2]['state_toggled'] = $tmp_map[$k1][$k2]['state_toggled'];
+		}
+	}
+
+	// Clean up and return the filtered list of rules
+	unset($tmp_map);
+	return $filtered_map;
+}
+
 function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 
 	/***********************************************************/

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -1899,14 +1899,14 @@ function suricata_load_vrt_policy($policy, $mode='alert', $all_rules=null) {
 function suricata_parse_sidconf_file($sidconf_file,$split_lines=TRUE) {
 
 	/**********************************************/
-	/* This function loads and processes the file */
-	/* specified by '$sidconf_file'.  The file is */
+	/* This function loads and processes the list */
+	/* specified by '$sidconf_file'.  The list is */
 	/* assumed to contain valid instructions for  */
 	/* matching rule SIDs as supported by the     */
 	/* Oinkmaster and PulledPork utilities.       */
 	/*                                            */
-	/*  $sidconf_file ==> full path and name of   */
-	/*                    file to process         */
+	/*  $sidconf_file ==> name of SID Mgmt        */
+	/*                    list to process         */
 	/*                                            */
 	/*  $split_lines ==> determines whether lines */
 	/*                   should be split at       */
@@ -1917,16 +1917,36 @@ function suricata_parse_sidconf_file($sidconf_file,$split_lines=TRUE) {
 	/*                    SID modifier tokens     */
 	/**********************************************/
 
+	global $config;
 	$buf = "";
 	$sid_mods = array();
+	$list = array();
 
-	$fd = fopen("{$sidconf_file}", "r");
-	if ($fd == FALSE) {
-		log_error("[Suricata] Failed to open SID MGMT file '{$sidconf_file}' for processing.");
-		return $sid_mods;
+	// Find the list we need
+	if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists'])) {
+		$config['installedpackages']['suricata']['sid_mgmt_lists'] = array();
+	}
+	if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists']['item'])) {
+		$config['installedpackages']['suricata']['sid_mgmt_lists']['item'] = array();
+	}
+	foreach($config['installedpackages']['suricata']['sid_mgmt_lists']['item'] as $item) {
+		if ($item['name'] == $sidconf_file) {
+			$list = $item;
+			break;
+		}
 	}
 
-	// Read and parse the conf file line-by-line
+	// Decode the list contents into a PHP temp buffer
+	// we can read like a normal file.
+	$fd = fopen("php://temp", "r+");
+	if ($fd == FALSE) {
+		log_error("[Suricata] Failed to open SID MGMT list '{$sidconf_file}' for processing.");
+		return $sid_mods;
+	}
+	fwrite($fd, Base64_decode($list['content']));
+	rewind($fd);
+
+	// Read and parse the conf list line-by-line
 	while (($buf = fgets($fd)) !== FALSE) {
 		$line = array();
 
@@ -1963,19 +1983,50 @@ function suricata_parse_sidconf_file($sidconf_file,$split_lines=TRUE) {
 	// Close the file, release unneeded memory and return
 	// the array of SID mod tokens parsed from the file.
 	fclose($fd);
-	unset($line, $buf);
+	unset($list, $line, $buf);
 	return $sid_mods;
+}
+
+function suricata_sid_mgmt_list_exist($sid_mgmt_list) {
+
+	/****************************************************/
+	/* This function tests whether or not the passed    */
+	/* automatic SID MGMT list exists in the config     */
+	/* file for the firewall.                           */
+	/*                                                  */
+	/*   $sid_mgmt_list ==> name of SID Mgmt List       */
+	/*                                                  */
+	/*          Returns ==> TRUE if list exists, or     */
+	/*                      FALSE if not found          */
+	/*                                                  */
+	/****************************************************/
+
+	global $config, $g;
+
+	if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists'])) {
+		$config['installedpackages']['suricata']['sid_mgmt_lists'] = array();
+	}
+	if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists']['item'])) {
+		$config['installedpackages']['suricata']['sid_mgmt_lists']['item'] = array();
+	}
+
+	foreach($config['installedpackages']['suricata']['sid_mgmt_lists']['item'] as $list) {
+		if ($list['name'] == $sid_mgmt_list) {
+			return TRUE;
+		}
+	}
+	return FALSE;
 }
 
 function suricata_sid_mgmt_auto_categories($suricatacfg, $log_results = FALSE) {
 
 	/****************************************************/
-	/* This function parses any auto-SID conf files     */
+	/* This function parses any auto-SID conf lists     */
 	/* configured for the interface and returns an      */
 	/* array of rule categories adjusted from the       */
 	/* ['enabled_rulesets'] element in the config for   */
 	/* the interface in accordance with the contents    */
-	/* of the SID Mgmt conf files.                      */
+	/* of the SID Mgmt conf lists.                      */
 	/*                                                  */
 	/* The returned array shows which files should be   */
 	/* removed and which should be added to the list    */
@@ -2002,7 +2053,6 @@ function suricata_sid_mgmt_auto_categories($suricatacfg, $log_results = FALSE) {
 	/****************************************************/
 
 	global $config;
-	$suricata_sidmods_dir = SURICATA_SID_MODS_PATH;
 	$sid_mods = array();
 	$enables = array();
 	$disables = array();
@@ -2038,44 +2088,45 @@ function suricata_sid_mgmt_auto_categories($suricatacfg, $log_results = FALSE) {
 		case "disable_enable":
 			if (!empty($suricatacfg['disable_sid_file'])) {
 				if ($log_results == TRUE) {
-					error_log(gettext("Processing disable_sid file: {$suricatacfg['disable_sid_file']}\n"), 3, $log_file);
+					error_log(gettext("Processing disable_sid list: {$suricatacfg['disable_sid_file']}\n"), 3, $log_file);
 				}
 
 				// Attempt to open the 'disable_sid_file' for the interface
-				if (!file_exists("{$suricata_sidmods_dir}{$suricatacfg['disable_sid_file']}")) {
-					log_error(gettext("[Suricata] Error - unable to open 'disable_sid_file' \"{$suricatacfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+				// Verify the assigned SID Mgmt List still exists in the firewall configuration
+				if (!suricata_sid_mgmt_list_exist($suricatacfg['disable_sid_file'])) {
+					log_error(gettext("[Suricata] Error - unable to open disable_sid list \"{$suricatacfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 					if ($log_results == TRUE) {
-						error_log(gettext("Unable to open disable_sid file \"{$suricatacfg['disable_sid_file']}\".\n"), 3, $log_file);
+						error_log(gettext("Unable to find disable_sid list \"{$suricatacfg['disable_sid_file']}\".\n"), 3, $log_file);
 					}
 				} else {
-					$sid_mods = suricata_parse_sidconf_file("{$suricata_sidmods_dir}{$suricatacfg['disable_sid_file']}");
+					$sid_mods = suricata_parse_sidconf_file($suricatacfg['disable_sid_file']);
 				}
 
 				if (!empty($sid_mods)) {
 					$disables = suricata_get_auto_category_mods($enabled_cats, $sid_mods, "disable", $log_results, $log_file);
 				} elseif ($log_results == TRUE && !empty($log_file)) {
-					error_log(gettext("WARNING: no valid SID match tokens found in file \"{$suricatacfg['disable_sid_file']}\".\n"), 3, $log_file);
+					error_log(gettext("WARNING: no valid SID match tokens found in list \"{$suricatacfg['disable_sid_file']}\".\n"), 3, $log_file);
 				}
 			}
 			if (!empty($suricatacfg['enable_sid_file'])) {
 				if ($log_results == TRUE) {
-					error_log(gettext("Processing enable_sid file: {$suricatacfg['enable_sid_file']}\n"), 3, $log_file);
+					error_log(gettext("Processing enable_sid list: {$suricatacfg['enable_sid_file']}\n"), 3, $log_file);
 				}
 
 				// Attempt to open the 'enable_sid_file' for the interface
-				if (!file_exists("{$suricata_sidmods_dir}{$suricatacfg['enable_sid_file']}")) {
-					log_error(gettext("[Suricata] Error - unable to open 'enable_sid_file' \"{$suricatacfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+				if (!suricata_sid_mgmt_list_exist($suricatacfg['enable_sid_file'])) {
+					log_error(gettext("[Suricata] Error - unable to open enable_sid list \"{$suricatacfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 					if ($log_results == TRUE) {
-						error_log(gettext("Unable to open enable_sid file \"{$suricatacfg['enable_sid_file']}\".\n"), 3, $log_file);
+						error_log(gettext("Unable to find enable_sid list \"{$suricatacfg['enable_sid_file']}\".\n"), 3, $log_file);
 					}
 				} else {
-					$sid_mods = suricata_parse_sidconf_file("{$suricata_sidmods_dir}{$suricatacfg['enable_sid_file']}");
+					$sid_mods = suricata_parse_sidconf_file($suricatacfg['enable_sid_file']);
 				}
 
 				if (!empty($sid_mods)) {
 					$enables = suricata_get_auto_category_mods($enabled_cats, $sid_mods, "enable", $log_results, $log_file);
 				} elseif ($log_results == TRUE && !empty($log_file)) {
-					error_log(gettext("WARNING: no valid SID match tokens found in file \"{$suricatacfg['enable_sid_file']}\".\n"), 3, $log_file);
+					error_log(gettext("WARNING: no valid SID match tokens found in list \"{$suricatacfg['enable_sid_file']}\".\n"), 3, $log_file);
 				}
 			}
 			break;
@@ -2083,45 +2134,45 @@ function suricata_sid_mgmt_auto_categories($suricatacfg, $log_results = FALSE) {
 		case "enable_disable":
 			if (!empty($suricatacfg['enable_sid_file'])) {
 				if ($log_results == TRUE) {
-					error_log(gettext("Processing enable_sid file: {$suricatacfg['enable_sid_file']}\n"), 3, $log_file);
+					error_log(gettext("Processing enable_sid list: {$suricatacfg['enable_sid_file']}\n"), 3, $log_file);
 				}
 
 				// Attempt to open the 'enable_sid_file' for the interface
-				if (!file_exists("{$suricata_sidmods_dir}{$suricatacfg['enable_sid_file']}")) {
-					log_error(gettext("[Suricata] Error - unable to open 'enable_sid_file' \"{$suricatacfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+				if (!suricata_sid_mgmt_list_exist($suricatacfg['enable_sid_file'])) {
+					log_error(gettext("[Suricata] Error - unable to find enable_sid list \"{$suricatacfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 					if ($log_results == TRUE) {
-						error_log(gettext("Unable to open enable_sid file \"{$suricatacfg['enable_sid_file']}\".\n"), 3, $log_file);
+						error_log(gettext("Unable to open enable_sid list \"{$suricatacfg['enable_sid_file']}\".\n"), 3, $log_file);
 					}
 				} else {
-					$sid_mods = suricata_parse_sidconf_file("{$suricata_sidmods_dir}{$suricatacfg['enable_sid_file']}");
+					$sid_mods = suricata_parse_sidconf_file($suricatacfg['enable_sid_file']);
 				}
 
 				if (!empty($sid_mods)) {
 					$enables = suricata_get_auto_category_mods($enabled_cats, $sid_mods, "enable", $log_results, $log_file);
 				} elseif ($log_results == TRUE && !empty($log_file)) {
-					error_log(gettext("WARNING: no valid SID match tokens found in file \"{$suricatacfg['enable_sid_file']}\".\n"), 3, $log_file);
+					error_log(gettext("WARNING: no valid SID match tokens found in list \"{$suricatacfg['enable_sid_file']}\".\n"), 3, $log_file);
 				}
 			}
 			if (!empty($suricatacfg['disable_sid_file'])) {
 				if ($log_results == TRUE) {
-					error_log(gettext("Processing disable_sid file: {$suricatacfg['disable_sid_file']}\n"), 3, $log_file);
+					error_log(gettext("Processing disable_sid list: {$suricatacfg['disable_sid_file']}\n"), 3, $log_file);
 				}
 
 				// Attempt to open the 'disable_sid_file' for the interface
-				if (!file_exists("{$suricata_sidmods_dir}{$suricatacfg['disable_sid_file']}")) {
-					log_error(gettext("[Suricata] Error - unable to open 'disable_sid_file' \"{$suricatacfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+				if (!suricata_sid_mgmt_list_exist($suricatacfg['disable_sid_file'])) {
+					log_error(gettext("[Suricata] Error - unable to open disable_sid list \"{$suricatacfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 					if ($log_results == TRUE) {
-						error_log(gettext("Unable to open disable_sid file \"{$suricatacfg['disable_sid_file']}\".\n"), 3, $log_file);
+						error_log(gettext("Unable to find disable_sid list \"{$suricatacfg['disable_sid_file']}\".\n"), 3, $log_file);
 					}
 				}
 				else {
-					$sid_mods = suricata_parse_sidconf_file("{$suricata_sidmods_dir}{$suricatacfg['disable_sid_file']}");
+					$sid_mods = suricata_parse_sidconf_file($suricatacfg['disable_sid_file']);
 				}
 
 				if (!empty($sid_mods)) {
 					$disables = suricata_get_auto_category_mods($enabled_cats, $sid_mods, "disable", $log_results, $log_file);
 				} elseif ($log_results == TRUE && !empty($log_file)) {
-					error_log(gettext("WARNING: no valid SID match tokens found in file \"{$suricatacfg['disable_sid_file']}\".\n"), 3, $log_file);
+					error_log(gettext("WARNING: no valid SID match tokens found in list \"{$suricatacfg['disable_sid_file']}\".\n"), 3, $log_file);
 				}
 			}
 			break;
@@ -2586,10 +2637,10 @@ function suricata_modify_sid_content(&$rule_map, $sid_mods, $log_results = FALSE
 function suricata_process_enablesid(&$rule_map, $suricatacfg, $log_results = FALSE, $log_file = NULL) {
 
 	/**********************************************/
-	/* This function loads and processes the file */
+	/* This function loads and processes the list */
 	/* specified by 'enable_sid_file' for the     */
-	/* interface.  The file is assumed to be a    */
-	/* valid enablesid.conf file containing       */
+	/* interface.  The list is assumed to be a    */
+	/* valid enablesid.conf list containing       */
 	/* instructions for enabling matching rule    */
 	/* SIDs.                                      */
 	/*                                            */
@@ -2605,7 +2656,6 @@ function suricata_process_enablesid(&$rule_map, $suricatacfg, $log_results = FAL
 	/*                   $rule_map array          */
 	/**********************************************/
 
-	$suricata_sidmods_dir = SURICATA_SID_MODS_PATH;
 	$suricatalogdir = SURICATALOGDIR;
 	$sid_mods = array();
 
@@ -2614,18 +2664,18 @@ function suricata_process_enablesid(&$rule_map, $suricatacfg, $log_results = FAL
 		return;
 	}
 
-	// Attempt to open the 'enable_sid_file' for the interface
-	if (!file_exists("{$suricata_sidmods_dir}{$suricatacfg['enable_sid_file']}")) {
-		log_error(gettext("[Suricata] Error - unable to open 'enable_sid_file' \"{$suricatacfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+	// Verify the 'enable_sid' list for the interface exists
+	if (!suricata_sid_mgmt_list_exist($suricatacfg['enable_sid_file'])) {
+		log_error(gettext("[Suricata] Error - unable to find enable_sid list \"{$suricatacfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 		return;
 	}
 	else
-		$sid_mods = suricata_parse_sidconf_file("{$suricata_sidmods_dir}{$suricatacfg['enable_sid_file']}");
+		$sid_mods = suricata_parse_sidconf_file($suricatacfg['enable_sid_file']);
 
 	if (!empty($sid_mods))
 		suricata_modify_sid_state($rule_map, $sid_mods, "enable", $log_results, $log_file);
 	elseif ($log_results == TRUE && !empty($log_file)) {
-		error_log(gettext("WARNING: no valid SID match tokens found in file \"{$suricatacfg['enable_sid_file']}\".\n"), 3, $log_file);
+		error_log(gettext("WARNING: no valid SID match tokens found in list \"{$suricatacfg['enable_sid_file']}\".\n"), 3, $log_file);
 	}
 
 	unset($sid_mods);
@@ -2634,10 +2684,10 @@ function suricata_process_enablesid(&$rule_map, $suricatacfg, $log_results = FAL
 function suricata_process_disablesid(&$rule_map, $suricatacfg, $log_results = FALSE, $log_file = NULL) {
 
 	/**********************************************/
-	/* This function loads and processes the file */
+	/* This function loads and processes the list */
 	/* specified by 'disable_sid_file' for the    */
-	/* interface.  The file is assumed to be a    */
-	/* valid disablesid.conf file containing      */
+	/* interface.  The list is assumed to be a    */
+	/* valid disablesid.conf list containing      */
 	/* instructions for disabling matching rule   */
 	/* SIDs.                                      */
 	/*                                            */
@@ -2653,7 +2703,6 @@ function suricata_process_disablesid(&$rule_map, $suricatacfg, $log_results = FA
 	/*                   $rule_map array          */
 	/**********************************************/
 
-	$suricata_sidmods_dir = SURICATA_SID_MODS_PATH;
 	$suricatalogdir = SURICATALOGDIR;
 	$sid_mods = array();
 
@@ -2662,18 +2711,18 @@ function suricata_process_disablesid(&$rule_map, $suricatacfg, $log_results = FA
 		return;
 	}
 
-	// Attempt to open the 'disable_sid_file' for the interface
-	if (!file_exists("{$suricata_sidmods_dir}{$suricatacfg['disable_sid_file']}")) {
-		log_error(gettext("[Suricata] Error - unable to open 'disable_sid_file' \"{$suricatacfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+	// Verify the 'disable_sid' list for the interface exists
+	if (!suricata_sid_mgmt_list_exist($suricatacfg['disable_sid_file'])) {
+		log_error(gettext("[Suricata] Error - unable to find disable_sid list \"{$suricatacfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 		return;
 	} else {
-		$sid_mods = suricata_parse_sidconf_file("{$suricata_sidmods_dir}{$suricatacfg['disable_sid_file']}");
+		$sid_mods = suricata_parse_sidconf_file($suricatacfg['disable_sid_file']);
 	}
 
 	if (!empty($sid_mods)) {
 		suricata_modify_sid_state($rule_map, $sid_mods, "disable", $log_results, $log_file);
 	} elseif ($log_results == TRUE && !empty($log_file)) {
-		error_log(gettext("WARNING: no valid SID match tokens found in file \"{$suricatacfg['disable_sid_file']}\".\n"), 3, $log_file);
+		error_log(gettext("WARNING: no valid SID match tokens found in list \"{$suricatacfg['disable_sid_file']}\".\n"), 3, $log_file);
 	}
 
 	unset($sid_mods);
@@ -2682,10 +2731,10 @@ function suricata_process_disablesid(&$rule_map, $suricatacfg, $log_results = FA
 function suricata_process_modifysid(&$rule_map, $suricatacfg, $log_results = FALSE, $log_file = NULL) {
 
 	/**********************************************/
-	/* This function loads and processes the file */
+	/* This function loads and processes the list */
 	/* specified by 'modify_sid_file' for the     */
-	/* interface.  The file is assumed to be a    */
-	/* valid modifysid.conf file containing       */
+	/* interface.  The list is assumed to be a    */
+	/* valid modifysid.conf list containing       */
 	/* instructions for modifying matching rule   */
 	/* SIDs.                                      */
 	/*                                            */
@@ -2701,7 +2750,6 @@ function suricata_process_modifysid(&$rule_map, $suricatacfg, $log_results = FAL
 	/*                   $rule_map array          */
 	/**********************************************/
 
-	$suricata_sidmods_dir = SURICATA_SID_MODS_PATH;
 	$suricatalogdir = SURICATALOGDIR;
 	$sid_mods = array();
 
@@ -2710,18 +2758,18 @@ function suricata_process_modifysid(&$rule_map, $suricatacfg, $log_results = FAL
 		return;
 	}
 
-	// Attempt to open the 'modify_sid_file' for the interface
-	if (!file_exists("{$suricata_sidmods_dir}{$suricatacfg['modify_sid_file']}")) {
-		log_error(gettext("[Suricata] Error - unable to open 'modify_sid_file' \"{$suricatacfg['modify_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+	// Verify the 'modify_sid' list for the interface exists
+	if (!suricata_sid_mgmt_list_exist($suricatacfg['modify_sid_file'])) {
+		log_error(gettext("[Suricata] Error - unable to find modify_sid list \"{$suricatacfg['modify_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 		return;
 	} else {
-		$sid_mods = suricata_parse_sidconf_file("{$suricata_sidmods_dir}{$suricatacfg['modify_sid_file']}",FALSE);
+		$sid_mods = suricata_parse_sidconf_file($suricatacfg['modify_sid_file'],FALSE);
 	}
 
 	if (!empty($sid_mods)) {
 		suricata_modify_sid_content($rule_map, $sid_mods, $log_results, $log_file);
 	} elseif ($log_results == TRUE && !empty($log_file)) {
-		error_log(gettext("WARNING: no valid SID match tokens found in file \"{$suricatacfg['modify_sid_file']}\".\n"), 3, $log_file);
+		error_log(gettext("WARNING: no valid SID match tokens found in list \"{$suricatacfg['modify_sid_file']}\".\n"), 3, $log_file);
 	}
 
 	unset($sid_mods);
@@ -2730,10 +2778,10 @@ function suricata_process_modifysid(&$rule_map, $suricatacfg, $log_results = FAL
 function suricata_process_dropsid(&$rule_map, $suricatacfg, $log_results = FALSE, $log_file = NULL) {
 
 	/**********************************************/
-	/* This function loads and processes the file */
+	/* This function loads and processes the list */
 	/* specified by 'drop_sid_file' for the       */
-	/* interface.  The file is assumed to be a    */
-	/* valid dropsid.conf file containing         */
+	/* interface.  The list is assumed to be a    */
+	/* valid dropsid.conf list containing         */
 	/* instructions for modifying the action for  */
 	/* matching rule SIDs.                        */
 	/*                                            */
@@ -2749,7 +2797,6 @@ function suricata_process_dropsid(&$rule_map, $suricatacfg, $log_results = FALSE
 	/*                   $rule_map array          */
 	/**********************************************/
 
-	$suricata_sidmods_dir = SURICATA_SID_MODS_PATH;
 	$suricatalogdir = SURICATALOGDIR;
 	$sid_mods = array();
 
@@ -2758,18 +2805,18 @@ function suricata_process_dropsid(&$rule_map, $suricatacfg, $log_results = FALSE
 		return;
 	}
 
-	// Attempt to open the 'drop_sid_file' for the interface
-	if (!file_exists("{$suricata_sidmods_dir}{$suricatacfg['drop_sid_file']}")) {
-		log_error(gettext("[Suricata] Error - unable to open 'drop_sid_file' \"{$suricatacfg['drop_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+	// Verify the 'drop_sid' list for the interface exists
+	if (!suricata_sid_mgmt_list_exist($suricatacfg['drop_sid_file'])) {
+		log_error(gettext("[Suricata] Error - unable to find drop_sid list \"{$suricatacfg['drop_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 		return;
 	} else {
-		$sid_mods = suricata_parse_sidconf_file("{$suricata_sidmods_dir}{$suricatacfg['drop_sid_file']}");
+		$sid_mods = suricata_parse_sidconf_file($suricatacfg['drop_sid_file']);
 	}
 
 	if (!empty($sid_mods)) {
 		suricata_modify_sid_state($rule_map, $sid_mods, "drop", $log_results, $log_file);
 	} elseif ($log_results == TRUE && !empty($log_file)) {
-		error_log(gettext("WARNING: no valid SID match tokens found in file \"{$suricatacfg['drop_sid_file']}\".\n"), 3, $log_file);
+		error_log(gettext("WARNING: no valid SID match tokens found in list \"{$suricatacfg['drop_sid_file']}\".\n"), 3, $log_file);
 	}
 
 	unset($sid_mods);
@@ -2781,7 +2828,7 @@ function suricata_auto_sid_mgmt(&$rule_map, $suricatacfg, $log_results = FALSE) 
 	/* This function modifies the rules in the        */
 	/* passed rule_map array based on values in the   */
 	/* files 'enable_sid_file', 'disable_sid_file'    */
-	/* 'modify_sid_file' abd 'drop_sid_file' for      */
+	/* 'modify_sid_file' and 'drop_sid_file' for      */
 	/* the interface.                                 */
 	/*                                                */
 	/* If auto-mgmt of SIDs is enabled via the        */
@@ -2824,25 +2871,25 @@ function suricata_auto_sid_mgmt(&$rule_map, $suricatacfg, $log_results = FALSE) 
 			case "disable_enable":
 				if (!empty($suricatacfg['disable_sid_file'])) {
 					if ($log_results == TRUE) {
-						error_log(gettext("Processing disable_sid file: {$suricatacfg['disable_sid_file']}\n"), 3, $log_file);
+						error_log(gettext("Processing disable_sid list: {$suricatacfg['disable_sid_file']}\n"), 3, $log_file);
 					}
 					suricata_process_disablesid($rule_map, $suricatacfg, $log_results, $log_file);
 				}
 				if (!empty($suricatacfg['enable_sid_file'])) {
 					if ($log_results == TRUE) {
-						error_log(gettext("Processing enable_sid file: {$suricatacfg['enable_sid_file']}\n"), 3, $log_file);
+						error_log(gettext("Processing enable_sid list: {$suricatacfg['enable_sid_file']}\n"), 3, $log_file);
 					}
 					suricata_process_enablesid($rule_map, $suricatacfg, $log_results, $log_file);
 				}
 				if (!empty($suricatacfg['modify_sid_file'])) {
 					if ($log_results == TRUE) {
-						error_log(gettext("Processing modify_sid file: {$suricatacfg['modify_sid_file']}\n"), 3, $log_file);
+						error_log(gettext("Processing modify_sid list: {$suricatacfg['modify_sid_file']}\n"), 3, $log_file);
 					}
 					suricata_process_modifysid($rule_map, $suricatacfg, $log_results, $log_file);
 				}
 				if (!empty($suricatacfg['drop_sid_file'])) {
 					if ($log_results == TRUE) {
-						error_log(gettext("Processing drop_sid file: {$suricatacfg['drop_sid_file']}\n"), 3, $log_file);
+						error_log(gettext("Processing drop_sid list: {$suricatacfg['drop_sid_file']}\n"), 3, $log_file);
 					}
 					suricata_process_dropsid($rule_map, $suricatacfg, $log_results, $log_file);
 				}
@@ -2852,25 +2899,25 @@ function suricata_auto_sid_mgmt(&$rule_map, $suricatacfg, $log_results = FALSE) 
 			case "enable_disable":
 				if (!empty($suricatacfg['enable_sid_file'])) {
 					if ($log_results == TRUE) {
-						error_log(gettext("Processing enable_sid file: {$suricatacfg['enable_sid_file']}\n"), 3, $log_file);
+						error_log(gettext("Processing enable_sid list: {$suricatacfg['enable_sid_file']}\n"), 3, $log_file);
 					}
 					suricata_process_enablesid($rule_map, $suricatacfg, $log_results, $log_file);
 				}
 				if (!empty($suricatacfg['disable_sid_file'])) {
 					if ($log_results == TRUE) {
-						error_log(gettext("Processing disable_sid file: {$suricatacfg['disable_sid_file']}\n"), 3, $log_file);
+						error_log(gettext("Processing disable_sid list: {$suricatacfg['disable_sid_file']}\n"), 3, $log_file);
 					}
 					suricata_process_disablesid($rule_map, $suricatacfg, $log_results, $log_file);
 				}
 				if (!empty($suricatacfg['modify_sid_file'])) {
 					if ($log_results == TRUE) {
-						error_log(gettext("Processing modify_sid file: {$suricatacfg['modify_sid_file']}\n"), 3, $log_file);
+						error_log(gettext("Processing modify_sid list: {$suricatacfg['modify_sid_file']}\n"), 3, $log_file);
 					}
 					suricata_process_modifysid($rule_map, $suricatacfg, $log_results, $log_file);
 				}
 				if (!empty($suricatacfg['drop_sid_file'])) {
 					if ($log_results == TRUE) {
-						error_log(gettext("Processing drop_sid file: {$suricatacfg['drop_sid_file']}\n"), 3, $log_file);
+						error_log(gettext("Processing drop_sid list: {$suricatacfg['drop_sid_file']}\n"), 3, $log_file);
 					}
 					suricata_process_dropsid($rule_map, $suricatacfg, $log_results, $log_file);
 				}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -1971,7 +1971,7 @@ function suricata_parse_sidconf_file($sidconf_file,$split_lines=TRUE) {
 		log_error("[Suricata] Failed to open SID MGMT list '{$sidconf_file}' for processing.");
 		return $sid_mods;
 	}
-	fwrite($fd, Base64_decode($list['content']));
+	fwrite($fd, base64_decode($list['content']));
 	rewind($fd);
 
 	// Read and parse the conf list line-by-line

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -1346,26 +1346,28 @@ function suricata_load_rules_map($rules_path) {
 	 * Read all the rules into the map array.
 	 * The structure of the map array is:
 	 *
-	 *  map[gid][sid]['rule']['category']['action']['disabled']['managed']['flowbits']
+	 *  map[gid][sid]['rule']['category']['action']['disabled']['managed']
+         *     ['default_state']['default_action']['state_toggled']['modified']['flowbits']
 	 *
 	 *  where:
-	 *   gid           = Generator ID from rule, or 1 if general text 
-	 *                   rule
-	 *   sid           = Signature ID from rule
-         *   rule          = Complete rule text
-	 *   category      = File name of file containing the rule
-	 *   action        = alert, drop, reject or pass
-	 *   disabled      = 1 if rule is disabled (commented out), 0 if 
-	 *                   rule is enabled
-	 *   managed       = 1 if rule is auto-managed by SID MGMT process,
-	 *                   0 if not auto-managed 
-	 *   state_toggled = 1 if rule was toggled by SID MGMT process,
-	 *                   0 if not toggled
-	 *   modified      = 1 if rule action or content is modified by SID MGMT or
-	 *                     IPS Poliocy process,
-	 *                   0 if not modified
-	 *   flowbits      = Array of applicable flowbits if rule contains 
-	 *                   flowbits options
+	 *   gid            = Generator ID from rule, or 1 if general text rule
+	 *   sid            = Signature ID from rule
+         *   rule           = Complete rule text
+	 *   category       = File name of file containing the rule
+	 *   action         = alert, drop, reject or pass
+	 *   disabled       = 1 if rule is disabled (commented out), 0 if 
+	 *                    rule is enabled
+	 *   managed        = 1 if rule is auto-managed by SID MGMT process,
+	 *                    0 if not auto-managed
+	 *   default_state  = 1 if rule is default enabled, 0 if default disabled
+	 *   default_action = alert, drop, reject or pass  
+	 *   state_toggled  = 1 if rule was toggled by SID MGMT process,
+	 *                    0 if not toggled
+	 *   modified       = 1 if rule action or content is modified by SID MGMT or
+	 *                      IPS Policy process,
+	 *                    0 if not modified
+	 *   flowbits       = Array of applicable flowbits if rule contains 
+	 *                    flowbits options
 	 ************************************************************************************/
 
 	// First check if we were passed a directory, a single file
@@ -1459,11 +1461,13 @@ function suricata_load_rules_map($rules_path) {
 			$map_ref[$gid][$sid]['category'] = basename($file, ".rules");
 			$map_ref[$gid][$sid]['state_toggled'] = 0;
 			$map_ref[$gid][$sid]['modified'] = 0;
+			$map_ref[$gid][$sid]['managed'] = 0;
 
 			// Grab the rule action
 			$matches = array();
 			if (preg_match('/^\s*#*\s*(alert|drop|pass|reject)/i', $rule, $matches)) {
 				$map_ref[$gid][$sid]['action'] = $matches[1];
+				$map_ref[$gid][$sid]['default_action'] = $matches[1];
 			} else {
 				$map_ref[$gid][$sid]['action'] = "";
 			}
@@ -1471,8 +1475,10 @@ function suricata_load_rules_map($rules_path) {
 			// Determine if default state is "disabled"
 			if (preg_match('/^\s*\#+/', $rule)) {
 				$map_ref[$gid][$sid]['disabled'] = 1;
+				$map_ref[$gid][$sid]['default_state'] = 0;
 			} else {
 				$map_ref[$gid][$sid]['disabled'] = 0;
+				$map_ref[$gid][$sid]['default_state'] = 1;
 			}
 
 			// Grab any associated flowbits from the rule.
@@ -1676,6 +1682,15 @@ function suricata_find_flowbit_required_rules($rules, $unchecked_flowbits) {
 	/* in order to satisfy the "checked flowbits" used by   */
 	/* the currently enabled rules.  It returns the list    */
 	/* of required rules in an array.                       */
+	/*                                                      */
+	/*           $rules     = rules_map array of all rules  */
+	/*  $unchecked_flowbits = array of flowbit strings with */
+	/*                        unmatched set/isset pairings  */
+	/*                                                      */
+	/*              Returns = rules_map array consisting    */
+	/*                        of additional rules needed    */
+	/*                        to satisfy all set/isset      */
+	/*                        flowbit pairings              */
 	/********************************************************/
 
 	$required_flowbits_rules = array();
@@ -1704,15 +1719,24 @@ function suricata_find_flowbit_required_rules($rules, $unchecked_flowbits) {
 						if (!is_array($required_flowbits_rules[$k1][$k2])) {
 							$required_flowbits_rules[$k1][$k2] = array();
 						}
-						$required_flowbits_rules[$k1][$k2]['category'] = $rule2['category'];
 						if ($rule2['disabled'] == 0) {
 							// If not disabled, just return the rule text "as is"
 							$required_flowbits_rules[$k1][$k2]['rule'] = ltrim($rule2['rule']);
+							$required_flowbits_rules[$k1][$k2]['disabled'] = $rule2['disabled'];
 						} else {
 							// If rule is disabled, remove leading '#' to enable it
 							$required_flowbits_rules[$k1][$k2]['rule'] = ltrim(substr($rule2['rule'], strpos($rule2['rule'], "#") + 1));
 							$required_flowbits_rules[$k1][$k2]['disabled'] = 0;
 						}
+						// Copy over the remaining rule_map entries for this rule
+						$required_flowbits_rules[$k1][$k2]['category'] = $rule2['category'];
+						$required_flowbits_rules[$k1][$k2]['action'] = $rule2['action'];
+						$required_flowbits_rules[$k1][$k2]['managed'] = $rule2['managed'];
+						$required_flowbits_rules[$k1][$k2]['modified'] = $rule2['modified'];
+						$required_flowbits_rules[$k1][$k2]['default_state'] = $rule2['default_state'];
+						$required_flowbits_rules[$k1][$k2]['default_action'] = $rule2['default_action'];
+						$required_flowbits_rules[$k1][$k2]['state_toggled'] = $rule2['state_toggled'];
+						$required_flowbits_rules[$k1][$k2]['flowbits'] = $rule2['flowbits'];
 					}
 				}
 			}
@@ -2387,7 +2411,7 @@ function suricata_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results 
 
 	// Walk the SID mod tokens and decode each one.
 	// Place all matching GID:SID combos along with
-	// the requestion $action into our $sids[] array.
+	// the requested $action into our $sids[] array.
 	foreach ($sid_mods as $tok) {
 		$matches = array();
 		// Test the SID token for a GID:SID range
@@ -3042,13 +3066,15 @@ function suricata_modify_sids_action(&$rule_map, $suricatacfg) {
 	/***********************************************/
 
 	if (!isset($suricatacfg['rule_sid_force_alert']) && 
-	    !isset($suricatacfg['rule_sid_force_drop'])) {
+	    !isset($suricatacfg['rule_sid_force_drop']) && 
+	    !isset($suricatacfg['rule_sid_force_reject'])) {
 		return;
 	}
 
-	/* Load up our alertsid and dropsid arrays with manually changed SID actions */
+	/* Load up our SID forced action arrays with manually changed SID actions */
 	$alertsid = suricata_load_sid_mods($suricatacfg['rule_sid_force_alert']);
 	$dropsid = suricata_load_sid_mods($suricatacfg['rule_sid_force_drop']);
+	$rejectsid = suricata_load_sid_mods($suricatacfg['rule_sid_force_reject']);
 
 	/* Change action for any rules that need to be */
 	/* forced to "alert" with alertsid mods.       */
@@ -3087,7 +3113,27 @@ function suricata_modify_sids_action(&$rule_map, $suricatacfg) {
 			}
 		}
 	}
-	unset($alertsid, $dropsid);
+
+	/* Change action for any rules that need to be */
+	/* forced to "reject" with rejectsid mods.     */
+	if (!empty($rejectsid)) {
+		foreach ($rule_map as $k1 => $rulem) {
+			foreach ($rulem as $k2 => $v) {
+				if (isset($rejectsid[$k1][$k2]) && $v['action'] != 'reject') {
+					$matches = array();
+					if (preg_match('/^\s*#*\s*(alert|pass|drop)/i', $v['rule'], $matches)) {
+						$txt_regx = '/^\s*' . "{$matches[1]}" . '\s/';
+						if ($tmp = preg_replace($txt_regx, 'reject ', $v['rule'], 1)) {
+							$rule_map[$k1][$k2]['rule'] = $tmp;
+							$rule_map[$k1][$k2]['action'] = 'reject';
+						}
+					}
+				}
+			}
+		}
+	}
+
+	unset($alertsid, $dropsid, $rejectsid);
 }
 
 function suricata_get_filtered_rules($rules, $filter) {
@@ -3114,7 +3160,7 @@ function suricata_get_filtered_rules($rules, $filter) {
 	// return an empty result to save time
 	// since nothing would match.
 	if (empty($filter)) {
-		return filtered_map;
+		return $filtered_map;
 	}
 
 	// Load up all the rules from the location passed
@@ -3125,15 +3171,20 @@ function suricata_get_filtered_rules($rules, $filter) {
 	// over to the filtered array.
 	foreach ($filter as $k1 => $rulem) {
 		foreach($rulem as $k2 => $v) {
-			$filtered_map[$k1][$k2] = array();
-			$filtered_map[$k1][$k2]['rule'] = $tmp_map[$k1][$k2]['rule'];
-			$filtered_map[$k1][$k2]['category'] = $tmp_map[$k1][$k2]['category'];
-			$filtered_map[$k1][$k2]['action'] = $tmp_map[$k1][$k2]['action'];
-			$filtered_map[$k1][$k2]['modified'] = $tmp_map[$k1][$k2]['modified'];
-			$filtered_map[$k1][$k2]['disabled'] = $tmp_map[$k1][$k2]['disabled'];
-			$filtered_map[$k1][$k2]['flowbits'] = $tmp_map[$k1][$k2]['flowbits'];
-			$filtered_map[$k1][$k2]['managed'] = $tmp_map[$k1][$k2]['managed'];
-			$filtered_map[$k1][$k2]['state_toggled'] = $tmp_map[$k1][$k2]['state_toggled'];
+			if (isset($tmp_map[$k1][$k2])) {
+				$filtered_map[$k1] = array();
+				$filtered_map[$k1][$k2] = array();
+				$filtered_map[$k1][$k2]['rule'] = $tmp_map[$k1][$k2]['rule'];
+				$filtered_map[$k1][$k2]['category'] = $tmp_map[$k1][$k2]['category'];
+				$filtered_map[$k1][$k2]['action'] = $tmp_map[$k1][$k2]['action'];
+				$filtered_map[$k1][$k2]['modified'] = $tmp_map[$k1][$k2]['modified'];
+				$filtered_map[$k1][$k2]['disabled'] = $tmp_map[$k1][$k2]['disabled'];
+				$filtered_map[$k1][$k2]['flowbits'] = $tmp_map[$k1][$k2]['flowbits'];
+				$filtered_map[$k1][$k2]['managed'] = $tmp_map[$k1][$k2]['managed'];
+				$filtered_map[$k1][$k2]['state_toggled'] = $tmp_map[$k1][$k2]['state_toggled'];
+				$filtered_map[$k1][$k2]['default_state'] = $tmp_map[$k1][$k2]['default_state'];
+				$filtered_map[$k1][$k2]['default_action'] = $tmp_map[$k1][$k2]['default_action'];
+			}
 		}
 	}
 
@@ -3241,6 +3292,7 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 						$enabled_rules[$k1][$k2]['rule'] = $v['rule'];
 						$enabled_rules[$k1][$k2]['category'] = $v['category'];
 						$enabled_rules[$k1][$k2]['disabled'] = $v['disabled'];
+						$enabled_rules[$k1][$k2]['action'] = $v['action'];
 						$enabled_rules[$k1][$k2]['flowbits'] = $v['flowbits'];
 					}
 				}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -295,23 +295,27 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 	$home_net = array();
 
 	if (!$externallist && ($listname == 'default' || empty($listname))) {
-		// When using inline IPS mode, do not include
-		// locally-attached network segments or the WAN IP in
+		// When using inline IPS mode, exclude VPNs, VIPs,
+		// locally-attached network segments and the WAN IP from
 		// the default Pass List as this will kill all alerts
 		// and allow all traffic to pass!  We do include
-		// locally-attached networks and the WAN IP when
-		// building only the HOME_NET variable.
+		// locally-attached networks, VPNs, VIPs and the WAN IP
+		// when building only the HOME_NET variable.
 		if ($suricatacfg['ips_mode'] == 'ips_mode_inline' && $passlist == TRUE) {
 			$localnet = 'no';
 			$wanip = 'no';
+			$vpns = 'no';
+			$vips = 'no';
 		}
 		else {
 			$localnet = 'yes';
 			$wanip = 'yes';
+			$vpns = 'yes';
+			$vips = 'yes';
 		}
 
 		// Default the remaining Pass List/HOME_NET items to 'yes'.
-		$wangw = 'yes'; $wandns = 'yes'; $vips = 'yes'; $vpns = 'yes';
+		$wangw = 'yes'; $wandns = 'yes';
 	}
 	else {
 		$list = suricata_find_list($listname);

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -49,7 +49,7 @@ $snortcommunityrules = $config['installedpackages']['suricata']['config'][0]['sn
 /* Working directory for downloaded rules tarballs */
 $tmpfname = "{$g['tmp_path']}/suricata_rules_up";
 
-/* Snort VRT Rules filenames and URL */
+/* Snort Rules filenames and URL */
 $snort_filename_md5 = "{$snort_filename}.md5";
 $snort_rule_url = VRT_DNLD_URL;
 
@@ -78,7 +78,7 @@ else {
 	$emergingthreats_filename = ET_DNLD_FILENAME;
 	$emergingthreats_filename_md5 = ET_DNLD_FILENAME . ".md5";
 	$emergingthreats_url = ET_BASE_DNLD_URL;
-	// If using Sourcefire VRT rules with ET, then we should use the open-nogpl ET rules
+	// If using Snort rules with ET, then we should use the open-nogpl ET rules
 	$emergingthreats_url .= $vrt_enabled == "on" ? "open-nogpl/" : "open/";
 	$emergingthreats_url .= "suricata-{$suri_eng_ver}/";
 	$et_name = "Emerging Threats Open";
@@ -397,17 +397,17 @@ if ($emergingthreats == 'on') {
 		$emergingthreats = 'off';
 }
 
-/*  Check for and download any new Snort VRT sigs */
+/*  Check for and download any new Snort rule sigs */
 if ($snortdownload == 'on') {
 	if (empty($snort_filename)) {
-		log_error(gettext("No snortrules-snapshot filename has been set on Snort pkg GLOBAL SETTINGS tab.  Snort VRT rules cannot be updated."));
-		error_log(gettext("\tWARNING-- No snortrules-snapshot filename set on GLOBAL SETTINGS tab. Snort VRT rules cannot be updated!\n"), 3, SURICATA_RULES_UPD_LOGFILE);
+		log_error(gettext("No snortrules-snapshot filename has been set on Snort pkg GLOBAL SETTINGS tab.  Snort rules cannot be updated."));
+		error_log(gettext("\tWARNING-- No snortrules-snapshot filename set on GLOBAL SETTINGS tab. Snort rules cannot be updated!\n"), 3, SURICATA_RULES_UPD_LOGFILE);
 		$snortdownload = 'off';
 	}
 	elseif (suricata_check_rule_md5("{$snort_rule_url}{$snort_filename_md5}?oinkcode={$oinkid}", "{$tmpfname}/{$snort_filename_md5}", "Snort VRT rules")) {
 		/* download snortrules file */
 		$file_md5 = trim(file_get_contents("{$tmpfname}/{$snort_filename_md5}"));
-		if (!suricata_fetch_new_rules("{$snort_rule_url}{$snort_filename}?oinkcode={$oinkid}", "{$tmpfname}/{$snort_filename}", $file_md5, "Snort VRT rules"))
+		if (!suricata_fetch_new_rules("{$snort_rule_url}{$snort_filename}?oinkcode={$oinkid}", "{$tmpfname}/{$snort_filename}", $file_md5, "Snort rules"))
 			$snortdownload = 'off';
 	}
 	else
@@ -495,8 +495,8 @@ if ($snortdownload == 'on') {
 		/* Remove the old Snort rules files */
 		$vrt_prefix = VRT_FILE_PREFIX;
 		unlink_if_exists("{$suricatadir}rules/{$vrt_prefix}*.rules");
-		suricata_update_status(gettext("Installing Sourcefire VRT rules..."));
-		error_log(gettext("\tExtracting and installing Snort VRT rules...\n"), 3, SURICATA_RULES_UPD_LOGFILE);
+		suricata_update_status(gettext("Installing Snort rules..."));
+		error_log(gettext("\tExtracting and installing Snort rules...\n"), 3, SURICATA_RULES_UPD_LOGFILE);
 
 		/* extract snort.org rules and add prefix to all snort.org files */
 		safe_mkdir("{$tmpfname}/snortrules");
@@ -526,7 +526,7 @@ if ($snortdownload == 'on') {
 			@copy("{$tmpfname}/{$snort_filename_md5}", "{$suricatadir}{$snort_filename_md5}");
 		}
 		suricata_update_status(gettext(" done.") . "\n");
-		error_log(gettext("\tInstallation of Snort VRT rules completed.\n"), 3, SURICATA_RULES_UPD_LOGFILE);
+		error_log(gettext("\tInstallation of Snort rules completed.\n"), 3, SURICATA_RULES_UPD_LOGFILE);
 	}
 }
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -856,8 +856,6 @@ if (filesize("{$suricatacfgdir}/rules/".FLOWBITS_FILENAME) > 0)
 	$rules_files .= "\n - " . FLOWBITS_FILENAME;
 if (filesize("{$suricatacfgdir}/rules/custom.rules") > 0)
 	$rules_files .= "\n - custom.rules";
-if (filesize("{$suricatacfgdir}/rules/passlist.rules") > 0)
-	$rules_files .= "\n - passlist.rules";
 $rules_files = ltrim($rules_files, '\n -');
 
 // Add the general logging settings to the configuration (non-interface specific)

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -160,6 +160,13 @@ if ($suricatacfg['intf_promisc_mode'] == 'on')
 else
 	$intf_promisc_mode = "no";
 
+if (!empty($suricatacfg['intf_snaplen'])) {
+	$intf_snaplen = $suricatacfg['intf_snaplen'];
+}
+else {
+	$intf_snaplen = "1518";
+}
+
 // Add interface-specific blocking settings
 if ($suricatacfg['blockoffenders'] == 'on' && $suricatacfg['ips_mode'] == 'ips_mode_legacy')
 	$suri_blockoffenders = "yes";
@@ -892,6 +899,7 @@ pcap:
   - interface: {$if_real}
     checksum-checks: auto
     promisc: {$intf_promisc_mode}
+    snaplen: {$intf_snaplen}
 EOD;
 }
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -550,6 +550,15 @@ foreach ($rule as &$r) {
 		$updated_cfg = true;
 	}
 
+	/**********************************************************/
+	/* Set default value for new interface snaplen parameter  */
+	/* if one has not been previously configured.             */
+	/**********************************************************/
+	if (empty($pconfig['intf_snaplen'])) {
+		$pconfig['intf_snaplen'] = "1518";
+		$updated_cfg = true;
+	}
+
 	// Save the new configuration data into the $config array pointer
 	$r = $pconfig;
 }

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -91,7 +91,7 @@ if (empty($config['installedpackages']['suricata']['config'][0]['sid_list_migrat
 			$tmp = array();
 			$tmp['name'] = basename($sidfile);
 			$tmp['modtime'] = filemtime("/var/db/suricata/sidmods/" . $sidfile);
-			$tmp['content'] = Base64_encode($data);
+			$tmp['content'] = base64_encode($data);
 			$a_list[] = $tmp;
 		}
 	}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016 Rubicon Communications, LLC (Netgate)
- * Copyright (C) 2017 Bill Meeks
+ * Copyright (C) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,6 +69,35 @@ if (empty($config['installedpackages']['suricata']['config'][0]['auto_manage_sid
 	$config['installedpackages']['suricata']['config'][0]['sid_changes_log_limit_size'] = "250";
 	$config['installedpackages']['suricata']['config'][0]['sid_changes_log_retention'] = "336";
 	$updated_cfg = true;
+}
+
+/**********************************************************/
+/* Migrate content of any existing SID Mgmt files in the  */
+/* /var/db/suricata/sidmods directory to Base64 encoded   */
+/* strings in SID_MGMT_LIST array in config.xml.          */
+/**********************************************************/
+if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists'])) {
+	$config['installedpackages']['suricata']['sid_mgmt_lists'] = array();
+}
+if (empty($config['installedpackages']['suricata']['config'][0]['sid_list_migration']) && count($config['installedpackages']['suricata']['sid_mgmt_lists']) < 1) {
+	if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists']['item'])) {
+		$config['installedpackages']['suricata']['sid_mgmt_lists']['item'] = array();
+	}
+	$a_list = &$config['installedpackages']['suricata']['sid_mgmt_lists']['item'];
+	$sidmodfiles = return_dir_as_array("/var/db/suricata/sidmods/");
+	foreach ($sidmodfiles as $sidfile) {
+		$data = file_get_contents("/var/db/suricata/sidmods/" . $sidfile);
+		if ($data !== FALSE) {
+			$tmp = array();
+			$tmp['name'] = basename($sidfile);
+			$tmp['modtime'] = filemtime("/var/db/suricata/sidmods/" . $sidfile);
+			$tmp['content'] = Base64_encode($data);
+			$a_list[] = $tmp;
+		}
+	}
+	$config['installedpackages']['suricata']['config'][0]['sid_list_migration'] = "1";
+	$updated_cfg = true;
+	unset($a_list);
 }
 
 /**********************************************************/
@@ -565,10 +594,12 @@ foreach ($rule as &$r) {
 // Release reference to final array element
 unset($r);
 
-// Write out the new configuration to disk if we changed anything
-if ($updated_cfg)
+// Log a message indicating what we did
+if ($updated_cfg) {
 	log_error("[Suricata] Settings successfully migrated to new configuration format.");
-else
+}
+else {
 	log_error("[Suricata] Configuration version is current.");
+}
 
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -169,6 +169,18 @@ $suricatalogdir = SURICATALOGDIR;
 $enablesid = suricata_load_sid_mods($a_instance[$instanceid]['rule_sid_on']);
 $disablesid = suricata_load_sid_mods($a_instance[$instanceid]['rule_sid_off']);
 
+// Load up the arrays of forced-alert, forced-drop or forced-reject
+// rules as applicable to the current IPS mode.
+if ($a_instance[$instanceid]['blockoffenders'] == 'on' && ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' || $a_instance[$instanceid]['block_drops_only'] == 'on')) {
+	$alertsid = suricata_load_sid_mods($a_instance[$instanceid]['rule_sid_force_alert']);
+	$dropsid = suricata_load_sid_mods($a_instance[$instanceid]['rule_sid_force_drop']);
+
+	// REJECT forcing is only applicable to Inline IPS Mode
+	if ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' ) {
+		$rejectsid = suricata_load_sid_mods($a_instance[$instanceid]['rule_sid_force_reject']);
+	}
+}
+
 $pconfig = array();
 if (is_array($config['installedpackages']['suricata']['alertsblocks'])) {
 	$pconfig['arefresh'] = $config['installedpackages']['suricata']['alertsblocks']['arefresh'];
@@ -243,6 +255,145 @@ if ($_POST['save']) {
 
 	header("Location: /suricata/suricata_alerts.php?instance={$instanceid}");
 	exit;
+}
+
+if (isset($_POST['rule_action_save']) && $_POST['mode'] == "toggle_action" && isset($_POST['ruleActionOptions']) && is_numeric($_POST['sidid']) && is_numeric($_POST['gen_id'])) {
+
+	// Get the GID:SID tags embedded in the clicked rule icon.
+	$gid = $_POST['gen_id'];
+	$sid = $_POST['sidid'];
+
+	// Get the posted rule action
+	$action = $_POST['ruleActionOptions'];
+
+	// Put the target SID in the appropriate lists of modified
+	// SID actions based on the requested action; if default
+	// action is requested, remove the SID from all SID modified
+	// action lists.
+	switch ($action) {
+		case "action_default":
+			if (isset($alertsid[$gid][$sid])) {
+				unset($alertsid[$gid][$sid]);
+			}
+			if (isset($dropsid[$gid][$sid])) {
+				unset($dropsid[$gid][$sid]);
+			}
+			if (isset($rejectsid[$gid][$sid])) {
+				unset($rejectsid[$gid][$sid]);
+			}
+			break;
+
+		case "action_alert":
+			if (!is_array($alertsid[$gid])) {
+				$alertsid[$gid] = array();
+			}
+			if (!is_array($alertsid[$gid][$sid])) {
+				$alertsid[$gid][$sid] = array();
+			}
+			$alertsid[$gid][$sid] = "alertsid";
+			if (isset($dropsid[$gid][$sid])) {
+				unset($dropsid[$gid][$sid]);
+			}
+			if (isset($rejectsid[$gid][$sid])) {
+				unset($rejectsid[$gid][$sid]);
+			}
+			break;
+
+		case "action_drop":
+			if (!is_array($dropsid[$gid])) {
+				$dropsid[$gid] = array();
+			}
+			if (!is_array($dropsid[$gid][$sid])) {
+				$dropsid[$gid][$sid] = array();
+			}
+			$dropsid[$gid][$sid] = "dropsid";
+			if (isset($alertsid[$gid][$sid])) {
+				unset($alertsid[$gid][$sid]);
+			}
+			if (isset($rejectsid[$gid][$sid])) {
+				unset($rejectsid[$gid][$sid]);
+			}
+			break;
+
+		case "action_reject":
+			if (!is_array($rejectsid[$gid])) {
+				$rejectsid[$gid] = array();
+			}
+			if (!is_array($rejectsid[$gid][$sid])) {
+				$rejectsid[$gid][$sid] = array();
+			}
+			$rejectsid[$gid][$sid] = "rejectsid";
+			if (isset($alertsid[$gid][$sid])) {
+				unset($alertsid[$gid][$sid]);
+			}
+			if (isset($dropsid[$gid][$sid])) {
+				unset($dropsid[$gid][$sid]);
+			}
+			break;
+
+		default:
+			$input_errors[] = gettext("WARNING - unknown rule action of '{$action}' passed in $_POST parameter.  No change made to rule action.");
+	}
+
+	if (!$input_errors) {
+		// Write the updated forced rule action values to the config file.
+		$tmp = "";
+		foreach (array_keys($alertsid) as $k1) {
+			foreach (array_keys($alertsid[$k1]) as $k2)
+				$tmp .= "{$k1}:{$k2}||";
+		}
+		$tmp = rtrim($tmp, "||");
+
+		if (!empty($tmp))
+			$a_instance[$instanceid]['rule_sid_force_alert'] = $tmp;
+		else
+			unset($a_instance[$instanceid]['rule_sid_force_alert']);
+
+		$tmp = "";
+		foreach (array_keys($dropsid) as $k1) {
+			foreach (array_keys($dropsid[$k1]) as $k2)
+				$tmp .= "{$k1}:{$k2}||";
+		}
+		$tmp = rtrim($tmp, "||");
+
+		if (!empty($tmp))
+			$a_instance[$instanceid]['rule_sid_force_drop'] = $tmp;
+		else
+			unset($a_instance[$instanceid]['rule_sid_force_drop']);
+
+		$tmp = "";
+		foreach (array_keys($rejectsid) as $k1) {
+			foreach (array_keys($rejectsid[$k1]) as $k2)
+				$tmp .= "{$k1}:{$k2}||";
+		}
+		$tmp = rtrim($tmp, "||");
+
+		if (!empty($tmp))
+			$a_instance[$instanceid]['rule_sid_force_reject'] = $tmp;
+		else
+			unset($a_instance[$instanceid]['rule_sid_force_reject']);
+
+		/* Update the config.xml file. */
+		write_config("Suricata pkg: User-forced rule action override applied for rule {$gid}:{$sid} on ALERTS tab for interface {$a_instance[$instanceid]['interface']}.");
+
+		/*************************************************/
+		/* Update the suricata.yaml file and rebuild the */
+		/* rules for this interface.                     */
+		/*************************************************/
+		$rebuild_rules = true;
+		conf_mount_rw();
+		suricata_generate_yaml($a_instance[$instanceid]);
+		conf_mount_ro();
+		$rebuild_rules = false;
+
+		/* Signal Suricata to live-load the new rules */
+		suricata_reload_config($a_instance[$instanceid]);
+
+		// Sync to configured CARP slaves if any are enabled
+		suricata_sync_on_changes();
+
+		$savemsg = gettext("The action for rule {$gid}:{$sid} has been modified.  Suricata is 'live-reloading' the new rules list.  Please wait at least 15 secs for the process to complete before toggling additional rule actions.");
+	}
 }
 
 if ($_POST['mode']=='unblock' && $_POST['ip']) {
@@ -919,6 +1070,30 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 				$sid_dsbl_link = "<i class=\"fa fa-times icon-pointer text-danger\" onClick=\"encRuleSig('{$fields['gid']}','{$fields['sid']}','','');$('#mode').val('togglesid');$('#formalert').submit();\"";
 				$sid_dsbl_link .= ' title="' . gettext("Force-disable this rule and remove it from current rules set.") . '"></i>';
 			}
+
+			/* Add icon for toggling rule action if applicable to current mode */
+			if ($a_instance[$instanceid]['blockoffenders'] == 'on') {
+				if ($a_instance[$instanceid]['block_drops_only'] == 'on' || $a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline') {
+					$sid_action_link = "<i class=\"fa fa-pencil-square-o icon-pointer text-info\" onClick=\"toggleAction('{$fields['gid']}', '{$fields['sid']}');\"";
+					$sid_action_link .= ' title="' . gettext("Click to force a different action for this rule.") . '"></i>';
+					if (isset($alertsid[$fields['gid']][$fields['sid']])) {
+						$sid_action_link = "<i class=\"fa fa-exclamation-triangle icon-pointer text-warning\" onClick=\"toggleAction('{$fields['gid']}', '{$fields['sid']}');\"";
+						$sid_action_link .= ' title="' . gettext("Rule is forced to ALERT. Click to change the action for this rule.") . '"></i>';
+					}
+					if (isset($rejectsid[$fields['gid']][$fields['sid']])) {
+						$sid_action_link = "<i class=\"fa fa-hand-paper-o icon-pointer text-warning\" onClick=\"toggleAction('{$fields['gid']}', '{$fields['sid']}');\"";
+						$sid_action_link .= ' title="' . gettext("Rule is forced to REJECT. Click to change the action for this rule.") . '"></i>';
+					}
+					if (isset($dropsid[$fields['gid']][$fields['sid']])) {
+						$sid_action_link = "<i class=\"fa fa-thumbs-down icon-pointer text-danger\" onClick=\"toggleAction('{$fields['gid']}', '{$fields['sid']}');\"";
+						$sid_action_link .= ' title="' . gettext("Rule is forced to DROP. Click to change the action for this rule.") . '"></i>';
+					}
+				}
+			}
+			else {
+				$sid_action_link = '';
+			}
+
 			/* DESCRIPTION */
 			$alert_class = $fields['class'];
 	?>
@@ -935,7 +1110,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 				<td><?=$alert_src_p;?></td>
 				<td style="word-wrap:break-word; white-space:normal"><?=$alert_ip_dst;?></td>
 				<td><?=$alert_dst_p;?></td>
-				<td><?=$alert_sid_str;?><br/><?=$sidsupplink;?>&nbsp;&nbsp;<?=$sid_dsbl_link;?></td>
+				<td><?=$alert_sid_str;?><br/><?=$sidsupplink;?>&nbsp;&nbsp;<?=$sid_dsbl_link;?>&nbsp;&nbsp;<?=$sid_action_link;?></td>
 				<td style="word-wrap:break-word; white-space:normal"><?=$alert_descr;?></td>
 			</tr>
 	<?php
@@ -951,6 +1126,53 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 		</table>
 	</div>
 </div>
+
+<?php if ($a_instance[$instanceid]['blockoffenders'] == 'on') : ?>
+	<!-- Modal Rule SID action selector window -->
+	<div class="modal fade" role="dialog" id="sid_action_selector">
+		<div class="modal-dialog">
+			<div class="modal-content">
+				<div class="modal-header">
+					<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+						<span aria-hidden="true">&times;</span>
+					</button>
+					<h3 class="modal-title"><?=gettext("Rule Action Selection")?></h3>
+				</div>
+				<div class="modal-body">
+					<h4><?=gettext("Choose desired rule action from selections below: ");?></h4>
+					<label class="radio-inline">
+						<input type="radio" form="formalert" name="ruleActionOptions" id="action_default" value="action_default"> <span class = "label label-default">Default</span>
+					</label>
+					<label class="radio-inline">
+						<input type="radio" form="formalert" name="ruleActionOptions" id="action_alert" value="action_alert"> <span class = "label label-warning">ALERT</span>
+					</label>
+					<label class="radio-inline">
+						<input type="radio" form="formalert" name="ruleActionOptions" id="action_drop" value="action_drop"> <span class = "label label-danger">DROP</span>
+					</label>
+
+			<?php if ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' && $a_instance[$instanceid]['blockoffenders'] == 'on') : ?>
+					<label class="radio-inline">
+						<input type="radio" form="formalert" name="ruleActionOptions" id="action_reject" value="action_reject"> <span class = "label label-warning">REJECT</span>
+					</label>
+			<?php endif; ?>
+					<br /><br />
+						<p><?=gettext("Choosing 'Default' will return the rule action to the original value specified by the rule author.  Note this is usually ALERT.");?></p>
+				</div>
+				<div class="modal-footer">
+					<button type="submit" form="formalert" class="btn btn-sm btn-primary" id="rule_action_save" name="rule_action_save" value="<?=gettext("Save");?>" title="<?=gettext("Save changes and close selector");?>" onClick="$('#sid_action_selector').modal('hide');">
+						<i class="fa fa-save icon-embed-btn"></i>
+						<?=gettext("Save");?>
+					</button>
+					<button type="button" class="btn btn-sm btn-warning" id="cancel" name="cancel" value="<?=gettext("Cancel");?>" data-dismiss="modal" title="<?=gettext("Abandon changes and quit selector");?>">
+						<?=gettext("Cancel");?>
+					</button>
+				</div>
+			</div>
+		</div>
+	</div>
+<?php endif; ?>
+
+
 
 <script type="text/javascript">
 //<![CDATA[
@@ -971,6 +1193,13 @@ function encRuleSig(rulegid,rulesid,srcip,ruledescr) {
 	$('#gen_id').val(rulegid);
 	$('#ip').val(srcip);
 	$('#descr').val(ruledescr);
+}
+
+function toggleAction(gid, sid) {
+	$('#sidid').val(sid);
+	$('#gen_id').val(gid);
+	$('#mode').val('toggle_action');
+	$('#sid_action_selector').modal('show');
 }
 
 function enable_showFilter() {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
@@ -213,7 +213,7 @@ include_once("head.inc");
 					<td><?=gettext($emergingt_net_sig_date);?></td>
 				</tr>
 				<tr>
-					<td><b><?=gettext("Snort VRT Rules");?></b></td>
+					<td><b><?=gettext("Snort Subscriber Rules");?></b></td>
 					<td><?=trim($snort_org_sig_chk_local);?></td>
 					<td><?=gettext($snort_org_sig_date);?></td>
 				</tr>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -67,10 +67,10 @@ if ($_POST['autoruleupdatetime']) {
 }
 
 if ($_POST['enable_vrt_rules'] == "on" && empty($_POST['snort_rules_file']))
-		$input_errors[] = "You must supply a snort rules tarball filename in the box provided in order to enable Snort VRT rules!";
+		$input_errors[] = "You must supply a snort rules tarball filename in the box provided in order to enable Snort Subscriber rules!";
 
 if ($_POST['enable_vrt_rules'] == "on" && empty($_POST['oinkcode']))
-		$input_errors[] = "You must supply an Oinkmaster code in the box provided in order to enable Snort VRT rules!";
+		$input_errors[] = "You must supply an Oinkmaster code in the box provided in order to enable Snort Subscriber rules!";
 
 if ($_POST['enable_etpro_rules'] == "on" && empty($_POST['etprocode']))
 		$input_errors[] = "You must supply a subscription code in the box provided in order to enable Emerging Threats Pro rules!";
@@ -106,7 +106,7 @@ if (!$input_errors) {
 		// any matching the disabled ruleset prefixes.
 		if (is_array($config['installedpackages']['suricata']['rule'])) {
 			foreach ($config['installedpackages']['suricata']['rule'] as &$iface) {
-				// Disable Snort IPS policy if VRT rules are disabled
+				// Disable Snort IPS policy if Snort rules are disabled
 				if ($disable_ips_policy) {
 					$iface['ips_policy_enable'] = 'off';
 					unset($iface['ips_policy']);
@@ -226,30 +226,30 @@ $section->addInput(new Form_Input(
 ))->setHelp('Obtain an ETPro subscription code and paste it here.');
 $section->addInput(new Form_Checkbox(
 	'enable_vrt_rules',
-	'Install Snort VRT rules',
-	'Snort VRT free Registered User or paid Subscriber rules',
+	'Install Snort rules',
+	'Snort free Registered User or paid Subscriber rules',
 	$pconfig['enable_vrt_rules'] == 'on' ? true:false,
 	'on'
-))->setHelp('<a href="https://www.snort.org/users/sign_up">Sign Up for a free Registered User Rule Account</a><br /><a href="https://www.snort.org/products">Sign Up for paid Sourcefire VRT Certified Subscriber Rules</a>');
+))->setHelp('<a href="https://www.snort.org/users/sign_up">Sign Up for a free Registered User Rules Account</a><br /><a href="https://www.snort.org/products">Sign Up for paid Snort Subscriber Rule Set (by Talos)</a>');
 $section->addInput(new Form_Input(
 	'snort_rules_file',
-	'Snort VRT Rules Filename',
+	'Snort Rules Filename',
 	'text',
 	$pconfig['snort_rules_file']
-))->setHelp('Enter the rules tarball filename (filename only, do not include the URL.)<br />Example: snortrules-snapshot-2990.tar.gz');
+))->setHelp('Enter the rules tarball filename (filename only, do not include the URL.)<br />Example: snortrules-snapshot-29111.tar.gz');
 $section->addInput(new Form_Input(
 	'oinkcode',
-	'Snort VRT Oinkmaster Code',
+	'Snort Oinkmaster Code',
 	'text',
 	$pconfig['oinkcode']
 ))->setHelp('Obtain a snort.org Oinkmaster code and paste it here.');
 $section->addInput(new Form_Checkbox(
 	'snortcommunityrules',
-	'Install Snort Community rules',
-	'The Snort Community Ruleset is a GPLv2 VRT certified ruleset that is distributed free of charge without any VRT License restrictions. This ruleset is updated daily and is a subset of the subscriber ruleset.',
+	'Install Snort GPLv2 Community rules',
+	'The Snort Community Ruleset is a GPLv2 Talos-certified ruleset that is distributed free of charge without any Snort Subscriber License restrictions. This ruleset is updated daily and is a subset of the subscriber ruleset.',
 	$pconfig['snortcommunityrules'] == 'on' ? true:false,
 	'on'
-))->setHelp('If you are a Snort VRT Paid Subscriber, the community ruleset is already built into your download of the Snort VRT rules, and there is no benefit in adding this rule set.');
+))->setHelp('If you are a Snort Subscriber Rules customer (paid subscriber), the community ruleset is already built into your download of the Snort Subscriber rules, and there is no benefit in adding this rule set separately.');
 $section->addInput(new Form_Checkbox(
 	'hide_deprecated_rules',
 	'Hide Deprecated Rules Categories',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1217,7 +1217,7 @@ $modal->addInput(new Form_StaticText (
 	gettext('block traffic when using Inline IPS Mode for blocking. ') . 
 	'<br/><br/>' . 
 	gettext('Use the "dropsid.conf" feature on the SID MGMT tab to select rules whose action ') . 
-	gettext('should be changed from ALERT to DROP.  If you run the Snort VRT rules and have ') . 
+	gettext('should be changed from ALERT to DROP.  If you run the Snort rules and have ') . 
 	gettext('an IPS policy selected on the CATEGORIES tab, then rules defined as DROP by the ') . 
 	gettext('selected IPS policy will have their action automatically changed to DROP when the ') . 
 	gettext('"IPS Policy Mode" selector is configured for "Policy".') . 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -504,6 +504,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$natent['enable_async_sessions'] = 'off';
 			$natent['delayed_detect'] = 'off';
 			$natent['intf_promisc_mode'] = 'on';
+			$natent['intf_snaplen'] = '1518';
 
 			$natent['asn1_max_frames'] = '256';
 			$natent['dns_global_memcap'] = "16777216";

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1361,9 +1361,8 @@ $group->add(new Form_Button(
 	'fa-file-text-o'
 ))->removeClass('btn-primary')->addClass('btn-info')->addClass('btn-sm')->setAttribute('data-target', '#passlist')->setAttribute('data-toggle', 'modal');
 
-$group->setHelp('The default Pass List adds Gateways, DNS servers and, when Legacy Mode Blocking is used, locally-attached networks, the WAN IP, VPNs and VIPs.  Create a Pass List with an alias to customize.  ' . 
-		'This option will only be used when block offenders is on.  Choosing "none" will disable Pass List generation ' . 
-		'and this is the recommended choice when using Inline IPS Mode.');
+$group->setHelp('The default Pass List adds Gateways, DNS servers, locally-attached networks, the WAN IP, VPNs and VIPs.  Create a Pass List with an alias to customize whitelisted IP addresses.  ' . 
+		'This option will only be used when block offenders is on.  Choosing "none" will disable Pass List generation.');
 
 $section->add($group);
 
@@ -1488,6 +1487,7 @@ events.push(function(){
 			hideCheckbox('blockoffenderskill', true);
 			hideCheckbox('block_drops_only', true);
 			hideSelect('blockoffendersip', true);
+			hideClass('passlist', true);
 			hideInput('intf_snaplen', true);
 			if (hide) {
 				$('#eve_log_drop').parent().hide();
@@ -1848,6 +1848,7 @@ events.push(function(){
 			hideCheckbox('blockoffenderskill', true);
 			hideCheckbox('block_drops_only', true);
 			hideSelect('blockoffendersip', true);
+			hideClass('passlist', true);
 			hideInput('intf_snaplen', true);
 			$('#eve_log_drop').parent().show();
 			$('#ips_warn_dlg').modal('show');

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -230,6 +230,8 @@ if (empty($pconfig['eve_redis_key']))
 
 if (empty($pconfig['intf_promisc_mode']))
 	$pconfig['intf_promisc_mode'] = "on";
+if (empty($pconfig['intf_snaplen']))
+	$pconfig['intf_snaplen'] = "1518";
 
 // See if creating a new interface by duplicating an existing one
 if (strcasecmp($action, 'dup') == 0) {
@@ -316,6 +318,9 @@ if (isset($_POST["save"]) && !$input_errors) {
 	if (!empty($_POST['inspect_recursion_limit']) && !is_numeric($_POST['inspect_recursion_limit']))
 		$input_errors[] = gettext("The value for Inspect Recursion Limit can either be blank or contain only digits evaluating to an integer greater than or equal to 0.");
 
+	if ($_POST['intf_snaplen'] < 1 || !is_numeric($_POST['intf_snaplen']))
+		$input_errors[] = gettext("The value for Interface Snaplen must contain only digits evaluating to an integer value greater than or equal to 1.");
+
 	if (!empty($_POST['eve_redis_server']) && !is_ipaddr($_POST['eve_redis_server']))
 		$input_errors[] = gettext("The value for 'EVE REDIS Server' must be an IP address.");
 
@@ -353,6 +358,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['enable_eve_log'] == "on") { $natent['enable_eve_log'] = 'on'; }else{ $natent['enable_eve_log'] = 'off'; }
 		if ($_POST['max_pending_packets']) $natent['max_pending_packets'] = $_POST['max_pending_packets']; else unset($natent['max_pending_packets']);
 		if ($_POST['inspect_recursion_limit'] >= '0') $natent['inspect_recursion_limit'] = $_POST['inspect_recursion_limit']; else unset($natent['inspect_recursion_limit']);
+		if ($_POST['intf_snaplen'] > '0') $natent['intf_snaplen'] = $_POST['intf_snaplen']; else $natent['inspect_recursion_limit'] = "1518";
 		if ($_POST['detect_eng_profile']) $natent['detect_eng_profile'] = $_POST['detect_eng_profile']; else unset($natent['detect_eng_profile']);
 		if ($_POST['mpm_algo']) $natent['mpm_algo'] = $_POST['mpm_algo']; else unset($natent['mpm_algo']);
 		if ($_POST['sgh_mpm_context']) $natent['sgh_mpm_context'] = $_POST['sgh_mpm_context']; else unset($natent['sgh_mpm_context']);
@@ -1282,6 +1288,13 @@ $section->addInput(new Form_Checkbox(
 	'on'
 ));
 
+$section->addInput(new Form_Input(
+	'intf_snaplen',
+	'Interface PCAP Snaplen',
+	'text',
+	$pconfig['intf_snaplen']
+))->setHelp('Enter value in bytes for the interface PCAP snaplen. Default is 1518.  This parameter is only valid when IDS or Legacy Mode IPS is enabled.<br />This value may need to be increased if the physical interface is passing VLAN traffic and expected alerts are not being received.');
+
 $form->add($section);
 
 $section = new Form_Section('Networks Suricata Should Inspect and Protect');
@@ -1474,6 +1487,7 @@ events.push(function(){
 			hideCheckbox('blockoffenderskill', true);
 			hideCheckbox('block_drops_only', true);
 			hideSelect('blockoffendersip', true);
+			hideInput('intf_snaplen', true);
 			if (hide) {
 				$('#eve_log_drop').parent().hide();
 			}
@@ -1483,6 +1497,7 @@ events.push(function(){
 		}
 		else {
 			$('#eve_log_drop').parent().hide();
+			hideInput('intf_snaplen', false);
 		}
 	}
 
@@ -1616,6 +1631,7 @@ events.push(function(){
 		disableInput('sgh_mpm_context', disable);
 		disableInput('delayed_detect', disable);
 		disableInput('intf_promisc_mode', disable);
+		disableInput('intf_snaplen', disable);
 		disableInput('fpm_split_any_any', disable);
 		disableInput('fpm_search_optimize', disable);
 		disableInput('fpm_no_stream_inserts', disable);
@@ -1831,6 +1847,7 @@ events.push(function(){
 			hideCheckbox('blockoffenderskill', true);
 			hideCheckbox('block_drops_only', true);
 			hideSelect('blockoffendersip', true);
+			hideInput('intf_snaplen', true);
 			$('#eve_log_drop').parent().show();
 			$('#ips_warn_dlg').modal('show');
 		}
@@ -1838,6 +1855,7 @@ events.push(function(){
 			hideCheckbox('blockoffenderskill', false);
 			hideCheckbox('block_drops_only', false);
 			hideSelect('blockoffendersip', false);
+			hideInput('intf_snaplen', false);
 			hideClass('passlist', false);
 			$('#eve_log_drop').parent().hide();
 			$('#ips_warn_dlg').modal('hide');

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1361,9 +1361,9 @@ $group->add(new Form_Button(
 	'fa-file-text-o'
 ))->removeClass('btn-primary')->addClass('btn-info')->addClass('btn-sm')->setAttribute('data-target', '#passlist')->setAttribute('data-toggle', 'modal');
 
-$group->setHelp('The default Pass List adds local networks, WAN IPs, Gateways, VPNs and VIPs.  Create an Alias to customize.' . 
-				'This option will only be used when block offenders is on.  Choosing "none" will disable Pass List generation ' . 
-				'and is the recommended choice when using Inline IPS Mode.');
+$group->setHelp('The default Pass List adds Gateways, DNS servers and, when Legacy Mode Blocking is used, locally-attached networks, the WAN IP, VPNs and VIPs.  Create a Pass List with an alias to customize.  ' . 
+		'This option will only be used when block offenders is on.  Choosing "none" will disable Pass List generation ' . 
+		'and this is the recommended choice when using Inline IPS Mode.');
 
 $section->add($group);
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1092,7 +1092,7 @@ $group->add(new Form_Checkbox(
 
 
 
-$group->setHelp('Selected which logs should have extended info.');
+$group->setHelp('Select which logs should have extended info.');
 $section->add($group)->addClass('eve_log_info');
 
 $section->addInput(new Form_Select(
@@ -1101,7 +1101,7 @@ $section->addInput(new Form_Select(
 	explode(", ",$pconfig['eve_log_http_extended_headers']),
 	array("accept"=>"accept","accept-charset"=>"accept-charset","accept-datetime"=>"accept-datetime","accept-encoding"=>"accept-encoding","accept-language"=>"accept-language","accept-range"=>"accept-range","age"=>"age","allow"=>"allow","authorization"=>"authorization","cache-control"=>"cache-control","connection"=>"connection","content-encoding"=>"content-encoding","content-language"=>"content-language","content-length"=>"content-length","content-location"=>"content-location","content-md5"=>"content-md5","content-range"=>"content-range","content-type"=>"content-type","cookie"=>"cookie","date"=>"date","dnt"=>"dnt","etags"=>"etags","from"=>"from","last-modified"=>"last-modified","link"=>"link","location"=>"location","max-forwards"=>"max-forwards","origin"=>"origin","pragma"=>"pragma","proxy-authenticate"=>"proxy-authenticate","proxy-authorization"=>"proxy-authorization","range"=>"range","referrer"=>"referrer","refresh"=>"refresh","retry-after"=>"retry-after","server"=>"server","set-cookie"=>"set-cookie","te"=>"te","trailer"=>"trailer","transfer-encoding"=>"transfer-encoding","upgrade"=>"upgrade","vary"=>"vary","via"=>"via","warning"=>"warning","www-authenticate"=>"www-authenticate","x-authenticated-user"=>"x-authenticated-user","x-flash-version"=>"x-flash-version","x-forwarded-proto"=>"x-forwarded-proto","x-requested-with"=>"x-requested-with"),
 	true
-))->setHelp('Select HTTP headers for logging');
+))->setHelp('Select HTTP headers for logging.  Use CTRL + click for multiple selections.');
 
 
 $section->addInput(new Form_Select(
@@ -1110,7 +1110,7 @@ $section->addInput(new Form_Select(
 	explode(", ",$pconfig['eve_log_smtp_extended_fields']),
 	array("bcc"=>"bcc","content-md5"=>"content-md5","date"=>"date","importance"=>"importance","in-reply-to"=>"in-reply-to","message-id"=>"message-id","organization"=>"organization","priority"=>"priority","received"=>"received","references"=>"references","reply-to"=>"reply-to","sensitivity"=>"sensitivity","subject"=>"subject","user-agent"=>"user-agent","x-mailer"=>"x-mailer","x-originating-ip"=>"x-originating-ip"),
 	true
-))->setHelp('Select SMTP fields for logging');
+))->setHelp('Select SMTP fields for logging.  Use CTRL + click for multiple selections.');
 
 
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -231,45 +231,45 @@ $section = new Form_Section('Auto-Generated IP Addresses');
 $section->addInput(new Form_Checkbox(
 	'localnets',
 	'Local Networks',
-	'Add firewall Locally-Attached Networks to the list (excluding WAN).',
+	'Add firewall Locally-Attached Networks to the list (excluding WAN).  Default is checked (but see warning below).',
 	$pconfig['localnets'] == 'yes' ? true:false,
 	'yes'
-));
+))->setHelp('WARNING - when creating a custom Pass List for use with Inline IPS Mode you should uncheck this box to prevent whitelisting all locally-attached network segments! If creating a custom HOME_NET list, then this box should be checked.');
 $section->addInput(new Form_Checkbox(
 	'wanips',
 	'WAN IP',
-	'Add WAN interface IP to the list.',
+	'Add WAN interface IP to the list.  Default is checked (but see warning below).',
 	$pconfig['wanips'] == 'yes' ? true:false,
 	'yes'
-));
+))->setHelp('WARNING - when creating a custom Pass List for use with Inline IPS Mode you should uncheck this box to prevent inadvertent whitelisting all LAN segments when using NAT! If creating a custom HOME_NET list and using NAT, then this box should be checked.');
 $section->addInput(new Form_Checkbox(
 	'wangateips',
 	'WAN Gateways',
-	'Add WAN Gateways to the list.',
+	'Add WAN Gateways to the list.  Default is checked.',
 	$pconfig['wangateips'] == 'yes' ? true:false,
 	'yes'
 ));
 $section->addInput(new Form_Checkbox(
 	'wandnsips',
 	'WAN DNS Servers',
-	'Add WAN DNS servers to the list.',
+	'Add WAN DNS servers to the list.  Default is checked.',
 	$pconfig['wandnsips'] == 'yes' ? true:false,
 	'yes'
 ));
 $section->addInput(new Form_Checkbox(
 	'vips',
 	'Virtual IP Addresses',
-	'Add Virtual IP Addresses to the list.',
+	'Add Virtual IP Addresses to the list.  Default is checked.',
 	$pconfig['vips'] == 'yes' ? true:false,
 	'yes'
 ));
 $section->addInput(new Form_Checkbox(
 	'vpnips',
 	'VPN Addresses',
-	'Add VPN Addresses to the list.',
+	'Add VPN Addresses to the list.  Default is checked (but see warning below).',
 	$pconfig['vpnips'] == 'yes' ? true:false,
 	'yes'
-));
+))->setHelp('WARNING - when creating a custom Pass List for use with Inline IPS Mode you should uncheck this box to prevent whitelisting all VPN segments! If creating a custom HOME_NET list, then this box should be checked.');
 $form->add($section);
 
 $section = new Form_Section('Custom IP Address from Configured Alias');

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
@@ -234,14 +234,14 @@ $section->addInput(new Form_Checkbox(
 	'Add firewall Locally-Attached Networks to the list (excluding WAN).  Default is checked (but see warning below).',
 	$pconfig['localnets'] == 'yes' ? true:false,
 	'yes'
-))->setHelp('WARNING - when creating a custom Pass List for use with Inline IPS Mode you should uncheck this box to prevent whitelisting all locally-attached network segments! If creating a custom HOME_NET list, then this box should be checked.');
+))->setHelp('If creating a custom HOME_NET list, then this box should usually be checked.');
 $section->addInput(new Form_Checkbox(
 	'wanips',
 	'WAN IP',
-	'Add WAN interface IP to the list.  Default is checked (but see warning below).',
+	'Add WAN interface IP to the list.  Default is checked).',
 	$pconfig['wanips'] == 'yes' ? true:false,
 	'yes'
-))->setHelp('WARNING - when creating a custom Pass List for use with Inline IPS Mode you should uncheck this box to prevent inadvertent whitelisting all LAN segments when using NAT! If creating a custom HOME_NET list and using NAT, then this box should be checked.');
+))->setHelp('If creating a custom HOME_NET list and using NAT, then this box should usually be checked.');
 $section->addInput(new Form_Checkbox(
 	'wangateips',
 	'WAN Gateways',
@@ -266,10 +266,10 @@ $section->addInput(new Form_Checkbox(
 $section->addInput(new Form_Checkbox(
 	'vpnips',
 	'VPN Addresses',
-	'Add VPN Addresses to the list.  Default is checked (but see warning below).',
+	'Add VPN Addresses to the list.  Default is checked.',
 	$pconfig['vpnips'] == 'yes' ? true:false,
 	'yes'
-))->setHelp('WARNING - when creating a custom Pass List for use with Inline IPS Mode you should uncheck this box to prevent whitelisting all VPN segments! If creating a custom HOME_NET list, then this box should be checked.');
+))->setHelp('If creating a custom HOME_NET list, then this box should usually be checked.');
 $form->add($section);
 
 $section = new Form_Section('Custom IP Address from Configured Alias');
@@ -279,7 +279,7 @@ $group->add(new Form_Input(
 	'Assigned Alias',
 	'text',
 	$pconfig['address']
-))->setHelp('Enter the name of an existing Alias.')->setAttribute('title', trim(filter_expand_alias($pconfig['address'])));
+))->setHelp('Enter the name of an existing Alias in order to further customize IP addresses included on this Pass List.')->setAttribute('title', trim(filter_expand_alias($pconfig['address'])));
 $group->add(new Form_Button(
 	'btnSelectAlias',
 	'Aliases',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -136,7 +136,12 @@ $categories[] = "User Forced Disabled Rules";
 // option if blocking is enabled.
 if ($a_rule[$id]['blockoffenders'] == 'on') {
 	$categories[] = "User Forced ALERT Action Rules";
-	$categories[] = "User Forced DROP Action Rules";
+
+	// Show custom DROP rules only if using Inline IPS
+	// mode or "Block Drops Only" option.
+	if ($a_rule[$id]['block_drops_only'] == 'on' || $a_rule[$id]['ips_mode'] == 'ips_mode_inline') {
+		$categories[] = "User Forced DROP Action Rules";
+	}
 }
 
 // Only add custom REJECT option if using IPS Inline Mode with blocking enabled

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -43,12 +43,16 @@ elseif (isset($_GET['id']) && is_numericint($_GET['id']))
 	$id = htmlspecialchars($_GET['id']);
 
 // If postback is from system function print_apply_box(),
-// then we won't have our customary $_POST['id'] field set
-// in the response, but the system function will pass back a
-// $_POST[;if'] field we can use instead.
+// then we won't have our customary $_POST['id'] and
+// $_POST['openruleset'] fields set in the response,
+// but the system function will pass back a
+// $_POST['if'] field we can use instead.
 if (is_null($id)) {
 	if (isset($_POST['if'])) {
-		$id = $_POST['if'];
+		// Split the posted string at the '|' delimiter
+		$response = explode('|', $_POST['if']);
+		$id = $response[0];
+		$_POST['openruleset'] = $response[1];
 	}
 	else {
 		$id = 0;
@@ -127,8 +131,18 @@ foreach ($cat_mods as $k => $v) {
 // Add custom Categories list items for User Forced rules
 $categories[] = "User Forced Enabled Rules";
 $categories[] = "User Forced Disabled Rules";
-$categories[] = "User Forced ALERT Action Rules";
-$categories[] = "User Forced DROP Action Rules";
+
+// Only add custom ALERT or DROP Action Rules
+// option if blocking is enabled.
+if ($a_rule[$id]['blockoffenders'] == 'on') {
+	$categories[] = "User Forced ALERT Action Rules";
+	$categories[] = "User Forced DROP Action Rules";
+}
+
+// Only add custom REJECT option if using IPS Inline Mode with blocking enabled
+if ($a_rule[$id]['ips_mode'] == 'ips_mode_inline' && $a_rule[$id]['blockoffenders'] == 'on') {
+	$categories[] = "User Forced REJECT Action Rules";
+}
 
 // Add custom Category to view all Active Rules
 // on the interface.
@@ -193,7 +207,6 @@ if ($currentruleset != 'custom.rules') {
 			$rule_files[$k] = $ruledir . "/" . $v;
 		}
 		$rule_files[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
-		$rule_files[] = "{$suricatacfgdir}/rules/passlist.rules";
 		$rule_files[] = "{$suricatacfgdir}/rules/custom.rules";
 		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule[$id]['rule_sid_on']));
 	}
@@ -207,7 +220,6 @@ if ($currentruleset != 'custom.rules') {
 			$rule_files[$k] = $ruledir . "/" . $v;
 		}
 		$rule_files[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
-		$rule_files[] = "{$suricatacfgdir}/rules/passlist.rules";
 		$rule_files[] = "{$suricatacfgdir}/rules/custom.rules";
 		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule[$id]['rule_sid_off']));
 	}
@@ -216,6 +228,9 @@ if ($currentruleset != 'custom.rules') {
 	}
 	elseif ($currentruleset == "User Forced DROP Action Rules") {
 		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule[$id]['rule_sid_force_drop']));
+	}
+	elseif ($currentruleset == "User Forced REJECT Action Rules") {
+		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule[$id]['rule_sid_force_reject']));
 	}
 	// If it's not a special case, and we can't find
 	// the given rule file, then notify the user.
@@ -237,9 +252,10 @@ $enablesid = suricata_load_sid_mods($a_rule[$id]['rule_sid_on']);
 $disablesid = suricata_load_sid_mods($a_rule[$id]['rule_sid_off']);
 suricata_modify_sids($rules_map, $a_rule[$id]);
 
-/* Load up our alertsid and dropsid arrays with manually changed SID actions */
+/* Load up our rule action arrays with manually changed SID actions */
 $alertsid = suricata_load_sid_mods($a_rule[$id]['rule_sid_force_alert']);
 $dropsid = suricata_load_sid_mods($a_rule[$id]['rule_sid_force_drop']);
+$rejectsid = suricata_load_sid_mods($a_rule[$id]['rule_sid_force_reject']);
 suricata_modify_sids_action($rules_map, $a_rule[$id]);
 
 /* Process AJAX request to view content of a specific rule */
@@ -317,67 +333,139 @@ if (isset($_POST['toggle_state']) && is_numeric($_POST['sid']) && is_numeric($_P
 	// Set a scroll-to anchor location
 	$anchor = "rule_{$gid}_{$sid}";
 }
-elseif (isset($_POST['toggle_action']) && is_numeric($_POST['sid']) && is_numeric($_POST['gid']) && !empty($rules_map)) {
+elseif (isset($_POST['rule_action_save']) && isset($_POST['ruleActionOptions']) && is_numeric($_POST['sid']) && is_numeric($_POST['gid']) && !empty($rules_map)) {
 
 	// Get the GID:SID tags embedded in the clicked rule icon.
 	$gid = $_POST['gid'];
 	$sid = $_POST['sid'];
 
-	// See if the target SID is in our list of modified SIDs,
-	// and toggle it to opposite action if present; otherwise,
-	// add it to the appropriate modified SID list.
-	if (isset($alertsid[$gid][$sid])) {
-		unset($alertsid[$gid][$sid]);
-		$dropsid[$gid][$sid] = "dropsid";
-	}
-	elseif (isset($dropsid[$gid][$sid])) {
-		unset($dropsid[$gid][$sid]);
-		$alertsid[$gid][$sid] = "alertsid";
-	}
-	else {
-		if ($rules_map[$gid][$sid]['action'] == 'drop')
+	// Get the posted rule action
+	$action = $_POST['ruleActionOptions'];
+
+	// Put the target SID in the appropriate lists of modified
+	// SID actions based on the requested action; if default
+	// action is requested, remove the SID from all SID modified
+	// action lists.
+	switch ($action) {
+		case "action_default":
+			$rules_map[$gid][$sid]['action'] = $rules_map[$gid][$sid]['default_action'];
+			if (isset($alertsid[$gid][$sid])) {
+				unset($alertsid[$gid][$sid]);
+			}
+			if (isset($dropsid[$gid][$sid])) {
+				unset($dropsid[$gid][$sid]);
+			}
+			if (isset($rejectsid[$gid][$sid])) {
+				unset($rejectsid[$gid][$sid]);
+			}
+			break;
+
+		case "action_alert":
+			$rules_map[$gid][$sid]['action'] = $rules_map[$gid][$sid]['alert'];
+			if (!is_array($alertsid[$gid])) {
+				$alertsid[$gid] = array();
+			}
+			if (!is_array($alertsid[$gid][$sid])) {
+				$alertsid[$gid][$sid] = array();
+			}
 			$alertsid[$gid][$sid] = "alertsid";
-		else
+			if (isset($dropsid[$gid][$sid])) {
+				unset($dropsid[$gid][$sid]);
+			}
+			if (isset($rejectsid[$gid][$sid])) {
+				unset($rejectsid[$gid][$sid]);
+			}
+			break;
+
+		case "action_drop":
+			$rules_map[$gid][$sid]['action'] = $rules_map[$gid][$sid]['drop'];
+			if (!is_array($dropsid[$gid])) {
+				$dropsid[$gid] = array();
+			}
+			if (!is_array($dropsid[$gid][$sid])) {
+				$dropsid[$gid][$sid] = array();
+			}
 			$dropsid[$gid][$sid] = "dropsid";
+			if (isset($alertsid[$gid][$sid])) {
+				unset($alertsid[$gid][$sid]);
+			}
+			if (isset($rejectsid[$gid][$sid])) {
+				unset($rejectsid[$gid][$sid]);
+			}
+			break;
+
+		case "action_reject":
+			$rules_map[$gid][$sid]['action'] = $rules_map[$gid][$sid]['reject'];
+			if (!is_array($rejectsid[$gid])) {
+				$rejectsid[$gid] = array();
+			}
+			if (!is_array($rejectsid[$gid][$sid])) {
+				$rejectsid[$gid][$sid] = array();
+			}
+			$rejectsid[$gid][$sid] = "rejectsid";
+			if (isset($alertsid[$gid][$sid])) {
+				unset($alertsid[$gid][$sid]);
+			}
+			if (isset($dropsid[$gid][$sid])) {
+				unset($dropsid[$gid][$sid]);
+			}
+			break;
+
+		default:
+			$input_errors[] = gettext("WARNING - unknown rule action of '{$action}' passed in $_POST parameter.  No change made to rule action.");
 	}
 
-	// Write the updated alertsid and dropsid values to the config file.
-	$tmp = "";
-	foreach (array_keys($alertsid) as $k1) {
-		foreach (array_keys($alertsid[$k1]) as $k2)
-			$tmp .= "{$k1}:{$k2}||";
+	if (!$input_errors) {
+		// Write the updated forced rule action values to the config file.
+		$tmp = "";
+		foreach (array_keys($alertsid) as $k1) {
+			foreach (array_keys($alertsid[$k1]) as $k2)
+				$tmp .= "{$k1}:{$k2}||";
+		}
+		$tmp = rtrim($tmp, "||");
+
+		if (!empty($tmp))
+			$a_rule[$id]['rule_sid_force_alert'] = $tmp;
+		else
+			unset($a_rule[$id]['rule_sid_force_alert']);
+
+		$tmp = "";
+		foreach (array_keys($dropsid) as $k1) {
+			foreach (array_keys($dropsid[$k1]) as $k2)
+				$tmp .= "{$k1}:{$k2}||";
+		}
+		$tmp = rtrim($tmp, "||");
+
+		if (!empty($tmp))
+			$a_rule[$id]['rule_sid_force_drop'] = $tmp;
+		else
+			unset($a_rule[$id]['rule_sid_force_drop']);
+
+		$tmp = "";
+		foreach (array_keys($rejectsid) as $k1) {
+			foreach (array_keys($rejectsid[$k1]) as $k2)
+				$tmp .= "{$k1}:{$k2}||";
+		}
+		$tmp = rtrim($tmp, "||");
+
+		if (!empty($tmp))
+			$a_rule[$id]['rule_sid_force_reject'] = $tmp;
+		else
+			unset($a_rule[$id]['rule_sid_force_reject']);
+
+		/* Update the config.xml file. */
+		write_config("Suricata pkg: modified action for rule {$gid}:{$sid} on {$a_rule[$id]['interface']}.");
+
+		// We changed a rule action, remind user to apply the changes
+		mark_subsystem_dirty('suricata_rules');
+
+		// Update our in-memory rules map with the changes just saved
+		// to the Suricata configuration file.
+		suricata_modify_sids_action($rules_map, $a_rule[$id]);
+
+		// Set a scroll-to anchor location
+		$anchor = "rule_{$gid}_{$sid}";
 	}
-	$tmp = rtrim($tmp, "||");
-
-	if (!empty($tmp))
-		$a_rule[$id]['rule_sid_force_alert'] = $tmp;
-	else
-		unset($a_rule[$id]['rule_sid_force_alert']);
-
-	$tmp = "";
-	foreach (array_keys($dropsid) as $k1) {
-		foreach (array_keys($dropsid[$k1]) as $k2)
-			$tmp .= "{$k1}:{$k2}||";
-	}
-	$tmp = rtrim($tmp, "||");
-
-	if (!empty($tmp))
-		$a_rule[$id]['rule_sid_force_drop'] = $tmp;
-	else
-		unset($a_rule[$id]['rule_sid_force_drop']);
-
-	/* Update the config.xml file. */
-	write_config("Suricata pkg: modified action for rule {$gid}:{$sid} on {$a_rule[$id]['interface']}.");
-
-	// We changed a rule action, remind user to apply the changes
-	mark_subsystem_dirty('suricata_rules');
-
-	// Update our in-memory rules map with the changes just saved
-	// to the Suricata configuration file.
-	suricata_modify_sids_action($rules_map, $a_rule[$id]);
-
-	// Set a scroll-to anchor location
-	$anchor = "rule_{$gid}_{$sid}";
 }
 elseif (isset($_POST['disable_all']) && !empty($rules_map)) {
 	// Mark all rules in the currently selected category "disabled".
@@ -480,6 +568,8 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 				unset($alertsid[$k1][$k2]);
 			if (isset($dropsid[$k1][$k2]))
 				unset($dropsid[$k1][$k2]);
+			if (isset($rejectsid[$k1][$k2]))
+				unset($rejectsid[$k1][$k2]);
 		}
 	}
 
@@ -508,7 +598,7 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 	else
 		unset($a_rule[$id]['rule_sid_off']);
 
-	// Write the updated alertsid and dropsid values to the config file.
+	// Write the updated alertsid, dropsid and rejectsid values to the config file.
 	$tmp = "";
 	foreach (array_keys($alertsid) as $k1) {
 		foreach (array_keys($alertsid[$k1]) as $k2)
@@ -532,6 +622,18 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 		$a_rule[$id]['rule_sid_force_drop'] = $tmp;
 	else
 		unset($a_rule[$id]['rule_sid_force_drop']);
+
+	$tmp = "";
+	foreach (array_keys($rejectsid) as $k1) {
+		foreach (array_keys($rejectsid[$k1]) as $k2)
+			$tmp .= "{$k1}:{$k2}||";
+	}
+	$tmp = rtrim($tmp, "||");
+
+	if (!empty($tmp))
+		$a_rule[$id]['rule_sid_force_reject'] = $tmp;
+	else
+		unset($a_rule[$id]['rule_sid_force_reject']);
 
 	// We changed a rule state or action, remind user to apply the changes
 	mark_subsystem_dirty('suricata_rules');
@@ -567,7 +669,6 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 			$rule_files[$k] = $ruledir . "/" . $v;
 		}
 		$rule_files[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
-		$rule_files[] = "{$suricatacfgdir}/rules/passlist.rules";
 		$rule_files[] = "{$suricatacfgdir}/rules/custom.rules";
 		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule[$id]['rule_sid_on']));
 	}
@@ -581,7 +682,6 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 			$rule_files[$k] = $ruledir . "/" . $v;
 		}
 		$rule_files[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
-		$rule_files[] = "{$suricatacfgdir}/rules/passlist.rules";
 		$rule_files[] = "{$suricatacfgdir}/rules/custom.rules";
 		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule[$id]['rule_sid_off']));
 	}
@@ -590,6 +690,9 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 	}
 	elseif ($currentruleset == "User Forced DROP Action Rules") {
 		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule[$id]['rule_sid_force_drop']));
+	}
+	elseif ($currentruleset == "User Forced REJECT Action Rules") {
+		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule[$id]['rule_sid_force_reject']));
 	}
 	// If it's not a special case, and we can't find
 	// the given rule file, then notify the user.
@@ -609,6 +712,7 @@ elseif (isset($_POST['resetall']) && !empty($rules_map)) {
 	unset($a_rule[$id]['rule_sid_off']);
 	unset($a_rule[$id]['rule_sid_force_alert']);
 	unset($a_rule[$id]['rule_sid_force_drop']);
+	unset($a_rule[$id]['rule_sid_force_reject']);
 
 	// We changed a rule state or action, remind user to apply the changes
 	mark_subsystem_dirty('suricata_rules');
@@ -645,7 +749,6 @@ elseif (isset($_POST['resetall']) && !empty($rules_map)) {
 			$rule_files[$k] = $ruledir . "/" . $v;
 		}
 		$rules_file[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
-		$rules_file[] = "{$suricatacfgdir}/rules/passlist.rules";
 		$rules_file[] = "{$suricatacfgdir}/rules/custom.rules";
 		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule[$id]['rule_sid_on']));
 	}
@@ -659,7 +762,6 @@ elseif (isset($_POST['resetall']) && !empty($rules_map)) {
 			$rule_files[$k] = $ruledir . "/" . $v;
 		}
 		$rules_file[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
-		$rules_file[] = "{$suricatacfgdir}/rules/passlist.rules";
 		$rules_file[] = "{$suricatacfgdir}/rules/custom.rules";
 		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule[$id]['rule_sid_off']));
 	}
@@ -668,6 +770,9 @@ elseif (isset($_POST['resetall']) && !empty($rules_map)) {
 	}
 	elseif ($currentruleset == "User Forced DROP Action Rules") {
 		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule[$id]['rule_sid_force_drop']));
+	}
+	elseif ($currentruleset == "User Forced REJECT Action Rules") {
+		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule[$id]['rule_sid_force_reject']));
 	}
 	// If it's not a special case, and we can't find
 	// the given rule file, then notify the user.
@@ -788,7 +893,7 @@ $pgtitle = array(gettext("Suricata"), gettext("Interface ") . $if_friendly, gett
 include_once("head.inc");
 
 if (is_subsystem_dirty('suricata_rules')) {
-	$_POST['if'] = $id;
+	$_POST['if'] = $id . "|" . $currentruleset;
 	print_apply_box(gettext("A change has been made to a rule state or action.") . "<br/>" . gettext("Click APPLY when finished to send the changes to the running configuration."));
 }
 
@@ -986,7 +1091,11 @@ print($section);
 						<td style="padding-left: 8px;"><i class="fa fa-adn text-success"></i></td><td style="padding-left: 4px;"><small><?=gettext('Auto-enabled by SID Mgmt');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-adn text-warning"></i></td><td style="padding-left: 4px;"><small><?=gettext('Action/content modified by SID Mgmt');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-exclamation-triangle text-warning"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is alert');?></small></td>
-						<td style="padding-left: 8px;"><i class="fa fa-thumbs-down text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is drop');?></small></td>
+				<?php if ($a_rule[$id]['ips_mode'] == 'ips_mode_inline' && $a_rule[$id]['blockoffenders'] == 'on') : ?>
+						<td style="padding-left: 8px;"><i class="fa fa-hand-stop-o text-warning"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is reject');?></small></td>
+				<?php else : ?>
+						<td><td></td></td>
+				<?php endif; ?>
 					</tr>
 					<tr>
 						<td></td>
@@ -994,8 +1103,12 @@ print($section);
 						<td style="padding-left: 8px;"><i class="fa fa-times-circle text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Disabled by user');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-adn text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Auto-disabled by SID Mgmt');?></small></td>
 						<td><td></td></td>
-						<td style="padding-left: 8px;"><i class="fa fa-hand-stop-o text-warning"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is reject');?></small></td>
-						<td style="padding-left: 8px;"><i class="fa fa-thumbs-up text-success"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is pass');?></small></td>
+				<?php if ($a_rule[$id]['blockoffenders'] == 'on') : ?>
+						<td style="padding-left: 8px;"><i class="fa fa-thumbs-down text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is drop');?></small></td>
+				<?php else : ?>
+						<td><td></td></td>
+				<?php endif; ?>
+						<td><td></td></td>
 					</tr>
 				</tbody>
 			</table>
@@ -1031,161 +1144,166 @@ print($section);
 			<tbody>
 				<?php
 					$counter = $enable_cnt = $disable_cnt = $user_enable_cnt = $user_disable_cnt = $managed_count = 0;
-					foreach ($rules_map as $k1 => $rulem) {
-						foreach ($rulem as $k2 => $v) {
-							$sid = $k2;
-							$gid = $k1;
-							$ruleset = $currentruleset;
-							$style = "";
-
-							// Apply rule state filters if filtering is enabled
-							if ($filterrules) {
-								if (isset($filterfieldsarray['show_disabled']) && $v['disabled'] == 0) {
-									continue;
-								}
-								elseif (isset($filterfieldsarray['show_enabled']) && $v['disabled'] == 1) {
-									continue;
-								}
+					if (is_array($rules_map) && !empty($rules_map)) {
+						foreach ($rules_map as $k1 => $rulem) {
+							if (!is_array($rulem)) {
+								$rulem = array();
 							}
+							foreach ($rulem as $k2 => $v) {
+								$sid = $k2;
+								$gid = $k1;
+								$ruleset = $currentruleset;
+								$style = "";
 
-							// Determine which icons to display in the first column for rule state.
-							// See if the rule is auto-managed by the SID MGMT tab feature
-							if ($v['managed'] == 1) {
-								if ($v['disabled'] == 1 && $v['state_toggled'] == 1) {
-									$textss = '<span class="text-muted">';
-									$textse = '</span>';
-									$iconb_class = 'class="fa fa-adn text-danger text-left"';
-									$title = gettext("Auto-disabled by settings on SID Mgmt tab");
+								// Apply rule state filters if filtering is enabled
+								if ($filterrules) {
+									if (isset($filterfieldsarray['show_disabled']) && $v['disabled'] == 0) {
+										continue;
+									}
+									elseif (isset($filterfieldsarray['show_enabled']) && $v['disabled'] == 1) {
+										continue;
+									}
 								}
-								elseif ($v['disabled'] == 0 && $v['state_toggled'] == 1) {
+
+								// Determine which icons to display in the first column for rule state.
+								// See if the rule is auto-managed by the SID MGMT tab feature
+								if ($v['managed'] == 1) {
+									if ($v['disabled'] == 1 && $v['state_toggled'] == 1) {
+										$textss = '<span class="text-muted">';
+										$textse = '</span>';
+										$iconb_class = 'class="fa fa-adn text-danger text-left"';
+										$title = gettext("Auto-disabled by settings on SID Mgmt tab");
+									}
+									elseif ($v['disabled'] == 0 && $v['state_toggled'] == 1) {
+										$textss = $textse = "";
+										$iconb_class = 'class="fa fa-adn text-success text-left"';
+										$title = gettext("Auto-enabled by settings on SID Mgmt tab");
+									}
+									$managed_count++;
+								}
+								// See if the rule is in our list of user-disabled overrides
+								if (isset($disablesid[$gid][$sid])) {
+									$textss = "<span class=\"text-muted\">";
+									$textse = "</span>";
+									$disable_cnt++;
+									$user_disable_cnt++;
+									$iconb_class = 'class="fa fa-times-circle text-danger text-left"';
+									$title = gettext("Disabled by user. Click to change rule state");
+								}
+								// See if the rule is in our list of user-enabled overrides
+								elseif (isset($enablesid[$gid][$sid])) {
 									$textss = $textse = "";
-									$iconb_class = 'class="fa fa-adn text-success text-left"';
-									$title = gettext("Auto-enabled by settings on SID Mgmt tab");
+									$enable_cnt++;
+									$user_enable_cnt++;
+									$iconb_class = 'class="fa fa-check-circle text-success text-left"';
+									$title = gettext("Enabled by user. Click to change rules state");
 								}
-								$managed_count++;
-							}
-							// See if the rule is in our list of user-disabled overrides
-							if (isset($disablesid[$gid][$sid])) {
-								$textss = "<span class=\"text-muted\">";
-								$textse = "</span>";
-								$disable_cnt++;
-								$user_disable_cnt++;
-								$iconb_class = 'class="fa fa-times-circle text-danger text-left"';
-								$title = gettext("Disabled by user. Click to toggle to enabled state");
-							}
-							// See if the rule is in our list of user-enabled overrides
-							elseif (isset($enablesid[$gid][$sid])) {
-								$textss = $textse = "";
-								$enable_cnt++;
-								$user_enable_cnt++;
-								$iconb_class = 'class="fa fa-check-circle text-success text-left"';
-								$title = gettext("Enabled by user. Click to toggle to disabled state");
-							}
 
-							// These last two checks handle normal cases of default-enabled or default disabled rules
-							// with no user overrides.
-							elseif (($v['disabled'] == 1) && ($v['state_toggled'] == 0) && (!isset($enablesid[$gid][$sid]))) {
-								$textss = "<span class=\"text-muted\">";
-								$textse = "</span>";
-								$disable_cnt++;
-								$iconb_class = 'class="fa fa-times-circle-o text-danger text-left"';
-								$title = gettext("Disabled by default. Click to toggle to enabled state");
-							}
-							elseif ($v['disabled'] == 0 && $v['state_toggled'] == 0) {
-								$textss = $textse = "";
-								$enable_cnt++;
-								$iconb_class = 'class="fa fa-check-circle-o text-success text-left"';
-								$title = gettext("Enabled by default. Click to toggle to disabled state");
-							}
+								// These last two checks handle normal cases of default-enabled or default disabled rules
+								// with no user overrides.
+								elseif (($v['disabled'] == 1) && ($v['state_toggled'] == 0) && (!isset($enablesid[$gid][$sid]))) {
+									$textss = "<span class=\"text-muted\">";
+									$textse = "</span>";
+									$disable_cnt++;
+									$iconb_class = 'class="fa fa-times-circle-o text-danger text-left"';
+									$title = gettext("Disabled by default. Click to change rule state");
+								}
+								elseif ($v['disabled'] == 0 && $v['state_toggled'] == 0) {
+									$textss = $textse = "";
+									$enable_cnt++;
+									$iconb_class = 'class="fa fa-check-circle-o text-success text-left"';
+									$title = gettext("Enabled by default.");
+								}
 
-							// Determine which icon to display in the second column for rule action
-							if ($v['action'] == 'drop') {
-								$textss = $textse = "";
-								$iconact_class = 'class="fa fa-thumbs-down text-danger text-center"';
-								$title_act = gettext("Rule will drop traffic when triggered.  Click to force alert action instead.");
-							}
-							elseif ($v['action'] == 'pass') {
-								$textss = $textse = "";
-								$iconact_class = 'class="fa fa-thumbs-up text-success text-center"';
-								$title_act = gettext("Rule will pass traffic when triggered.  Click to force alert action instead.");
-							}
-							elseif ($v['action'] == 'reject') {
-								$textss = $textse = "";
-								$iconact_class = 'class="fa fa-hand-stop-o text-warning text-center"';
-								$title_act = gettext("Rule will reject traffic when triggered.  Click to force alert action instead.");
-							}
-							else {
+								// Determine which icon to display in the second column for rule action.
+								// Default to ALERT icon.
 								$textss = $textse = "";
 								$iconact_class = 'class="fa fa-exclamation-triangle text-warning text-center"';
-								$title_act = gettext("Rule will alert on traffic when triggered. Click to force drop action instead.");
-							}
+								$title_act = gettext("Rule will alert on traffic when triggered.");
+								if ($v['action'] == 'drop' && $a_rule[$id]['blockoffenders'] == 'on') {
+									$iconact_class = 'class="fa fa-thumbs-down text-danger text-center"';
+									$title_act = gettext("Rule will drop traffic when triggered.");
+								}
+								elseif ($v['action'] == 'reject' && $a_rule[$id]['ips_mode'] == 'ips_mode_inline' && $a_rule[$id]['blockoffenders'] == 'on') {
+									$iconact_class = 'class="fa fa-hand-stop-o text-warning text-center"';
+									$title_act = gettext("Rule will reject traffic when triggered.");
+								}
+								if ($a_rule[$id]['blockoffenders'] == 'on') {
+									$title_act .= gettext("  Click to change rule action.");
+								}
 
-							// Pick off the first section of the rule (prior to the start of the MSG field),
-							// and then use a REGX split to isolate the remaining fields into an array.
-							$tmp = substr($v['rule'], 0, strpos($v['rule'], "("));
-							$tmp = trim(preg_replace('/^\s*#+\s*/', '', $tmp));
-							$rule_content = preg_split('/[\s]+/', $tmp);
+								// Pick off the first section of the rule (prior to the start of the MSG field),
+								// and then use a REGX split to isolate the remaining fields into an array.
+								$tmp = substr($v['rule'], 0, strpos($v['rule'], "("));
+								$tmp = trim(preg_replace('/^\s*#+\s*/', '', $tmp));
+								$rule_content = preg_split('/[\s]+/', $tmp);
 
-							// Create custom <span> tags for the fields we truncate so we can 
-							// have a "title" attribute for tooltips to show the full string.
-							$srcspan = add_title_attribute($textss, $rule_content[2]);
-							$srcprtspan = add_title_attribute($textss, $rule_content[3]);
-							$dstspan = add_title_attribute($textss, $rule_content[5]);
-							$dstprtspan = add_title_attribute($textss, $rule_content[6]);
+								// Create custom <span> tags for the fields we truncate so we can 
+								// have a "title" attribute for tooltips to show the full string.
+								$srcspan = add_title_attribute($textss, $rule_content[2]);
+								$srcprtspan = add_title_attribute($textss, $rule_content[3]);
+								$dstspan = add_title_attribute($textss, $rule_content[5]);
+								$dstprtspan = add_title_attribute($textss, $rule_content[6]);
 
-							$protocol = $rule_content[1];         //protocol field
-							$source = $rule_content[2];           //source field
-							$source_port = $rule_content[3];      //source port field
-							$destination = $rule_content[5];      //destination field
-							$destination_port = $rule_content[6]; //destination port field
-							$message = suricata_get_msg($v['rule']); // description field
-							$sid_tooltip = gettext("View the raw text for this rule");
-				?>
-							<tr class="text-nowrap">
-								<td><?=$textss; ?>
-									<a id="rule_<?=$gid; ?>_<?=$sid; ?>" href="#" onClick="toggleRule('<?=$sid; ?>', '<?=$gid; ?>');" 
-									<?=$iconb_class; ?> title="<?=$title; ?>"></a><?=$textse; ?>
-				<?php if ($v['managed'] == 1 && $v['modified'] == 1) : ?>
-								<i class="fa fa-adn text-warning text-left" title="<?=gettext('Action or content modified by settings on SID Mgmt tab'); ?>"></i><?=$textse; ?>
-				<?php endif; ?>
-								</td>
+								$protocol = $rule_content[1];         //protocol field
+								$source = $rule_content[2];           //source field
+								$source_port = $rule_content[3];      //source port field
+								$destination = $rule_content[5];      //destination field
+								$destination_port = $rule_content[6]; //destination port field
+								$message = suricata_get_msg($v['rule']); // description field
+								$sid_tooltip = gettext("View the raw text for this rule");
+					?>
+								<tr class="text-nowrap">
+									<td><?=$textss; ?>
+										<a id="rule_<?=$gid; ?>_<?=$sid; ?>" href="#" onClick="toggleRule('<?=$sid; ?>', '<?=$gid; ?>');" 
+										<?=$iconb_class; ?> title="<?=$title; ?>"></a><?=$textse; ?>
+						<?php if ($v['managed'] == 1 && $v['modified'] == 1) : ?>
+										<i class="fa fa-adn text-warning text-left" title="<?=gettext('Action or content modified by settings on SID Mgmt tab'); ?>"></i><?=$textse; ?>
+						<?php endif; ?>
+									</td>
 
-							       <td><?=$textss; ?><a id="rule_<?=$gid; ?>_<?=$sid; ?>_action" href="#" onClick="toggleAction('<?=$sid; ?>', '<?=$gid; ?>');" 
-									<?=$iconact_class; ?> title="<?=$title_act; ?>"></a><?=$textse; ?>
-							       </td>
+						<?php if ($a_rule[$id]['blockoffenders'] == 'on') : ?>
+								       <td><?=$textss; ?><a id="rule_<?=$gid; ?>_<?=$sid; ?>_action" href="#" onClick="toggleAction('<?=$sid; ?>', '<?=$gid; ?>');" 
+										<?=$iconact_class; ?> title="<?=$title_act; ?>"></a><?=$textse; ?>
+								       </td>
+						<?php else : ?>
+								       <td><?=$textss; ?><i <?=$iconact_class; ?> title="<?=$title_act; ?>"></i><?=$textse; ?>
+								       </td>
+						<?php endif; ?>
 
-							       <td ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
-									<?=$textss . $gid . $textse;?>
-							       </td>
-							       <td ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
-									<a href="javascript: void(0)" 
-									onclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');" 
-									title="<?=$sid_tooltip;?>"><?=$textss . $sid . $textse;?></a>
-							       </td>
-							       <td ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
-									<?=$textss . $protocol . $textse;?>
-							       </td>
-							       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
-									<?=$srcspan . $source;?></span>
-							       </td>
-							       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
-									<?=$srcprtspan . $source_port;?></span>
-							       </td>
-							       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
-									<?=$dstspan . $destination;?></span>
-							       </td>
-							       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
-								       <?=$dstprtspan . $destination_port;?></span>
-							       </td>
-								<td style="word-wrap:break-word; white-space:normal" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
-									<?=$textss . $message . $textse;?>
-							       </td>
-							</tr>
+								       <td ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
+										<?=$textss . $gid . $textse;?>
+								       </td>
+								       <td ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
+										<a href="javascript: void(0)" 
+										onclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');" 
+										title="<?=$sid_tooltip;?>"><?=$textss . $sid . $textse;?></a>
+								       </td>
+								       <td ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
+										<?=$textss . $protocol . $textse;?>
+							       	       </td>
+								       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
+										<?=$srcspan . $source;?></span>
+								       </td>
+								       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
+										<?=$srcprtspan . $source_port;?></span>
+								       </td>
+								       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
+										<?=$dstspan . $destination;?></span>
+								       </td>
+								       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
+									       <?=$dstprtspan . $destination_port;?></span>
+								       </td>
+									<td style="word-wrap:break-word; white-space:normal" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
+										<?=$textss . $message . $textse;?>
+								       </td>
+								</tr>
 				<?php
-							$counter++;
+								$counter++;
+							}
 						}
+						unset($rulem, $v);
 					}
-				unset($rulem, $v);
 				?>
 		    </tbody>
 		</table>
@@ -1206,6 +1324,50 @@ print($section);
 	</div>
 </div>
 <?php endif;?>
+
+<!-- Modal Rule SID action selector window -->
+<div class="modal fade" role="dialog" id="sid_action_selector">
+	<div class="modal-dialog">
+		<div class="modal-content">
+			<div class="modal-header">
+				<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+					<span aria-hidden="true">&times;</span>
+				</button>
+				<h3 class="modal-title"><?=gettext("Rule Action Selection")?></h3>
+			</div>
+			<div class="modal-body">
+				<input type="hidden" name="id" id="id" value="<?=$id;?>" />
+				<h4><?=gettext("Choose desired rule action from selections below: ");?></h4>
+				<label class="radio-inline">
+					<input type="radio" name="ruleActionOptions" id="action_default" value="action_default"> <span class = "label label-default">Default</span>
+				</label>
+				<label class="radio-inline">
+					<input type="radio" name="ruleActionOptions" id="action_alert" value="action_alert"> <span class = "label label-warning">ALERT</span>
+				</label>
+				<label class="radio-inline">
+					<input type="radio" name="ruleActionOptions" id="action_drop" value="action_drop"> <span class = "label label-danger">DROP</span>
+				</label>
+
+		<?php if ($a_rule[$id]['ips_mode'] == 'ips_mode_inline' && $a_rule[$id]['blockoffenders'] == 'on') : ?>
+				<label class="radio-inline">
+					<input type="radio" name="ruleActionOptions" id="action_reject" value="action_reject"> <span class = "label label-warning">REJECT</span>
+				</label>
+		<?php endif; ?>
+				<br /><br />
+					<p><?=gettext("Choosing 'Default' will return the rule action to the original value specified by the rule author.  Note this is usually ALERT.");?></p>
+			</div>
+			<div class="modal-footer">
+				<button type="submit" class="btn btn-sm btn-primary" id="rule_action_save" name="rule_action_save" value="<?=gettext("Save");?>" title="<?=gettext("Save changes and close selector");?>">
+					<i class="fa fa-save icon-embed-btn"></i>
+					<?=gettext("Save");?>
+				</button>
+				<button type="button" class="btn btn-sm btn-warning" id="cancel" name="cancel" value="<?=gettext("Cancel");?>" data-dismiss="modal" title="<?=gettext("Abandon changes and quit selector");?>">
+					<?=gettext("Cancel");?>
+				</button>
+			</div>
+		</div>
+	</div>
+</div>
 
 </form>
 
@@ -1239,12 +1401,15 @@ function toggleRule(sid, gid) {
 }
 
 function toggleAction(sid, gid) {
-	$('#toggle_action').remove();
-	$('#sid').val(sid);
-	$('#gid').val(gid);
-	$('#openruleset').val($('#selectbox').val());
-	$('<input name="toggle_action" value="1" />').appendTo($('#iform'));
-	$('#iform').submit();
+	if ($('#rule_'+gid+'_'+sid).hasClass('text-success')) {
+		$('#sid').val(sid);
+		$('#gid').val(gid);
+		$('#openruleset').val($('#selectbox').val());
+		$('#sid_action_selector').modal('show');
+	}
+	else {
+		alert("Rule is disabled, so changing ACTION is meaningless and thus is disabled for this rule.");
+	}
 }
 
 function wopen(url, name)

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -111,6 +111,9 @@ $pgtitle = array(gettext("Suricata"), gettext("Rules File Viewer"));
 
 include("head.inc");
 
+if ($input_errors) {
+	print_input_errors($input_errors);
+}
 if ($savemsg)
 	print_info_box($savemsg);
 
@@ -133,7 +136,7 @@ $section->addInput(new Form_Textarea(
 	'textareaitem',
 	'Rule file',
 	$contents
- ))->setRows(40)->setNoWrap()->setCols(90)->removeClass("form-control");
+ ))->setRows(40)->setNoWrap()->removeClass("form-control")->addClass("col-lg-12");
 
 $form->add($section);
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -414,8 +414,6 @@ else:
 						<th><?=gettext('Ruleset: Snort GPLv2 Community Rules'); ?></th>
 						<th></th>
 						<th></th>
-						<th></th>
-						<th></th>
 					</tr>
 				</thead>
 				<tbody>
@@ -423,19 +421,27 @@ else:
 				<?php if ($cat_mods[$community_rules_file] == 'enabled') : ?>
 					<tr>
 						<td>
-							<i class="fa fa-adn text-success" title="<?=gettext('Auto-disabled by settings on SID Mgmt tab'); ?>"></i>
+							<i class="fa fa-adn text-success" title="<?=gettext('Auto-enabled by settings on SID Mgmt tab'); ?>"></i>
 						</td>
-						<td colspan="5">
+						<td colspan="4">
+						<?php if ($no_community_files): ?>
+							<?php echo gettext("{$msg_community}"); ?>
+						<?php else: ?>
 							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?=gettext('{$msg_community}');?></a>
+						<?php endif; ?>
 						</td>
 					</tr>
 				<?php else: ?>
 					<tr>
 						<td>
-							<i class="fa fa-adn text-danger" title="<?=gettext("Auto-enabled by settings on SID Mgmt tab");?>"><i>
+							<i class="fa fa-adn text-danger" title="<?=gettext("Auto-disabled by settings on SID Mgmt tab");?>"><i>
 						</td>
-						<td colspan="5">
-							<?=gettext("{$msg_community}"); ?>
+						<td colspan="4">
+						<?php if ($no_community_files): ?>
+							<?php echo gettext("{$msg_community}"); ?>
+						<?php else: ?>
+							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext("{$msg_community}"); ?></a>
+						<?php endif; ?>
 						</td>
 					</tr>
 				<?php endif; ?>
@@ -444,8 +450,12 @@ else:
 					<td>
 						<input type="checkbox" name="toenable[]" value="<?=$community_rules_file;?>" checked="checked"/>
 					</td>
-					<td colspan="5">
-						<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?php echo gettext("{$msg_community}"); ?></a>
+					<td colspan="4">
+						<?php if ($no_community_files): ?>
+							<?php echo gettext("{$msg_community}"); ?>
+						<?php else: ?>
+							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?php echo gettext("{$msg_community}"); ?></a>
+						<?php endif; ?>
 					</td>
 				</tr>
 			<?php else: ?>
@@ -453,8 +463,12 @@ else:
 					<td>
 						<input type="checkbox" name="toenable[]" value="<?=$community_rules_file; ?>" />
 					</td>
-					<td colspan="5">
-						<?=gettext("{$msg_community}"); ?>
+					<td colspan="4">
+						<?php if ($no_community_files): ?>
+							<?php echo gettext("{$msg_community}"); ?>
+						<?php else: ?>
+							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext("{$msg_community}"); ?></a>
+						<?php endif; ?>
 					</td>
 				</tr>
 			<?php endif; ?>
@@ -495,10 +509,8 @@ else:
 					<?php if ($snortdownload == 'on' && !$no_snort_files): ?>
 						<th><?=gettext("Enabled"); ?></th>
 						<th><?=gettext('Ruleset: Snort Text Rules');?></th>
-						<th><?=gettext("Enabled"); ?></th>
-						<th><?=gettext('Ruleset: Snort SO Rules');?></th>
 					<?php else: ?>
-						<th colspan="4"><?=gettext("Snort Rules {$msg_snort}"); ?></th>
+						<th colspan="2"><?=gettext("Snort Rules {$msg_snort}"); ?></th>
 					<?php endif; ?>
 					</tr>
 				</thead>
@@ -573,7 +585,7 @@ else:
 						echo "</td>\n";
 						echo "<td>\n";
 						if (empty($CHECKED))
-							echo $file;
+							echo "<a href='suricata_rules_edit.php?id={$id}&openruleset=" . urlencode($file) . "' target='_blank' rel='noopener noreferrer'>{$file}</a>\n";
 						else
 							echo "<a href='suricata_rules.php?id={$id}&openruleset=" . urlencode($file) . "'>{$file}</a>\n";
 						echo "</td>\n";
@@ -604,12 +616,17 @@ else:
 							}
 						}
 						else {
-							echo "	\n<input type='checkbox' name='toenable[]' value='{$file}' {$CHECKED} />\n";
+							if ($CHECKED == "disabled") {
+								echo "	\n<input type='checkbox' name='toenable[]' value='{$file}' {$CHECKED} title='" . gettext('Disabled because an IPS Policy is selected') . "' />\n";
+							}
+							else {
+								echo "	\n<input type='checkbox' name='toenable[]' value='{$file}' {$CHECKED} />\n";
+							}
 						}
 						echo "</td>\n";
 						echo "<td>\n";
 						if (empty($CHECKED) || $CHECKED == "disabled")
-							echo $file;
+							echo "<a href='suricata_rules_edit.php?id={$id}&openruleset=" . urlencode($file) . "' target='_blank' rel='noopener noreferrer'>{$file}</a>\n";
 						else
 							echo "<a href='suricata_rules.php?id={$id}&openruleset=" . urlencode($file) . "'>{$file}</a>\n";
 						echo "</td>\n";
@@ -651,6 +668,12 @@ events.push(function() {
 
 			if (str.substr(0,6) == "snort_") {
 				$(this).attr('disabled', !endis);
+				if (!endis) {
+					$(this).prop('title', 'Disabled because an IPS Policy is selected');
+				}
+				else {
+					$(this).prop('title', '');
+				}
 			}
 		});
 	}

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -89,7 +89,7 @@ if (empty($test))
 if (!file_exists("{$suricatadir}rules/" . GPL_FILE_PREFIX . "community.rules"))
 	$no_community_files = true;
 
-// If a Snort VRT policy is enabled and selected, remove all Snort VRT
+// If a Snort rules policy is enabled and selected, remove all Snort 
 // rules from the configured rule sets to allow automatic selection.
 if ($a_nat[$id]['ips_policy_enable'] == 'on') {
 	if (isset($a_nat[$id]['ips_policy'])) {
@@ -220,7 +220,7 @@ if (isset($_POST["save"])) {
 			$enabled_rulesets_array[] = basename($file);
 	}
 
-	/* Include the Snort VRT rules only if enabled and no IPS policy is set */
+	/* Include the Snort rules only if enabled and no IPS policy is set */
 	if ($snortdownload == 'on' && empty($_POST['ips_policy_enable'])) {
 		$files = glob("{$suricatadir}rules/" . VRT_FILE_PREFIX . "*.rules");
 		foreach ($files as $file)
@@ -345,10 +345,10 @@ else:
 			($a_nat[$id]['ips_policy_enable'] == "on"),
 			'on'
 		);
-		$chkips->setHelp('<span class="text-danger"><strong>' . gettext("Note:  ") . '</strong></span>' . gettext('You must be using the Snort VRT rules to use this option.' . '<br />' .
-					'Selecting this option disables manual selection of Snort VRT categories in the list below, ' .
+		$chkips->setHelp('<span class="text-danger"><strong>' . gettext("Note:  ") . '</strong></span>' . gettext('You must be using the Snort rules to use this option.' . '<br />' .
+					'Selecting this option disables manual selection of Snort rules categories in the list below, ' .
 						'although Emerging Threats categories may still be selected if enabled on the Global Settings tab.  ' .
-						'These will be added to the pre-defined Snort IPS policy rules from the Snort VRT.'));
+						'These will be added to the pre-defined Snort IPS policy rules from the Snort rules set.'));
 		$section->addInput($chkips);
 		$section->addInput(new Form_Select(
 			'ips_policy',
@@ -401,7 +401,7 @@ else:
 			<?php if ($no_community_files)
 				$msg_community = gettext("NOTE: Snort Community Rules have not been downloaded.  Perform a Rules Update to enable them.");
 			      else
-				$msg_community = gettext("Snort GPLv2 Community Rules (VRT certified)");
+				$msg_community = gettext("Snort GPLv2 Community Rules (Talos-certified)");
 			      $community_rules_file = gettext(GPL_FILE_PREFIX . "community.rules");
 			?>
 
@@ -498,7 +498,7 @@ else:
 						<th><?=gettext("Enabled"); ?></th>
 						<th><?=gettext('Ruleset: Snort SO Rules');?></th>
 					<?php else: ?>
-						<th colspan="4"><?=gettext("Snort VRT rules {$msg_snort}"); ?></th>
+						<th colspan="4"><?=gettext("Snort Rules {$msg_snort}"); ?></th>
 					<?php endif; ?>
 					</tr>
 				</thead>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
@@ -90,7 +90,7 @@ if (isset($_POST['upload'])) {
 		$tmp['modtime'] = time();
 		$tmp_fname = $_FILES["sidmods_fileup"]["tmp_name"];
 		$data = file_get_contents($tmp_fname);
-		$tmp['content'] = Base64_encode(str_replace("\r\n", "\n", $data));
+		$tmp['content'] = base64_encode(str_replace("\r\n", "\n", $data));
 
 		// Check for duplicate conflicting list name
 		foreach ($a_list as $list) {
@@ -123,7 +123,7 @@ if (isset($_POST['sidlist_delete']) && isset($a_list[$_POST['sidlist_id']])) {
 }
 
 if (isset($_POST['sidlist_edit']) && isset($a_list[$_POST['sidlist_id']])) {
-	$data = Base64_decode($a_list[$_POST['sidlist_id']]['content']);
+	$data = base64_decode($a_list[$_POST['sidlist_id']]['content']);
 	$sidmodlist_data = htmlspecialchars($data);
 	$sidmodlist_edit_style = "show";
 	$sidmodlist_name = $a_list[$_POST['sidlist_id']]['name'];
@@ -136,7 +136,7 @@ if (isset($_POST['save']) && isset($_POST['sidlist_data']) && isset($_POST['list
 		$tmp = array();
 		$tmp['name'] = $_POST['sidlist_name'];
 		$tmp['modtime'] = time();
-		$tmp['content'] = Base64_encode(str_replace("\r\n", "\n", $_POST['sidlist_data']));
+		$tmp['content'] = base64_encode(str_replace("\r\n", "\n", $_POST['sidlist_data']));
 
 		// If this test is TRUE, then we are adding a new list
 		if ($_POST['listid'] == count($a_list)) {
@@ -231,7 +231,7 @@ if (isset($_POST['sidlist_dnload']) && isset($_POST['sidlist_id'])) {
 	$tmpdirname = "{$g['tmp_path']}/sidmods/";
 	safe_mkdir("{$tmpdirname}");
 
-	file_put_contents($tmpdirname . $file, Base64_decode($a_list[$_POST['sidlist_id']]['content']));
+	file_put_contents($tmpdirname . $file, base64_decode($a_list[$_POST['sidlist_id']]['content']));
 	touch($tmpdirname . $file, $a_list[$_POST['sidlist_id']]['modtime']);	
 
 	if (file_exists($tmpdirname . $file)) {
@@ -274,7 +274,7 @@ if (isset($_POST['sidlist_dnload_all'])) {
 
 	// Walk all saved lists and write them out to individual files
 	foreach($a_list as $list) {
-		file_put_contents($tmpdirname . $list['name'], Base64_decode($list['content']));
+		file_put_contents($tmpdirname . $list['name'], base64_decode($list['content']));
 		touch($tmpdirname . $list['name'], $list['modtime']);	
 	}
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,11 +36,13 @@ if (!is_array($config['installedpackages']['suricata']['rule']))
 	$config['installedpackages']['suricata']['rule'] = array();
 $a_nat = &$config['installedpackages']['suricata']['rule'];
 
-$pconfig['auto_manage_sids'] = $config['installedpackages']['suricata']['config'][0]['auto_manage_sids'];
+if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists']))
+	$config['installedpackages']['suricata']['sid_mgmt_lists'] = array();
+if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists']['item']))
+	$config['installedpackages']['suricata']['sid_mgmt_lists']['item'] = array();
+$a_list = &$config['installedpackages']['suricata']['sid_mgmt_lists']['item'];
 
-// Hard-code the path where SID Mods Lists are stored
-// and disregard any user-supplied path element.
-$sidmods_path = SURICATA_SID_MODS_PATH;
+$pconfig['auto_manage_sids'] = $config['installedpackages']['suricata']['config'][0]['auto_manage_sids'];
 
 // Set default to not show SID modification lists editor controls
 $sidmodlist_edit_style = "display: none;";
@@ -83,44 +85,76 @@ function suricata_is_sidmodslist_active($sidlist) {
 
 if (isset($_POST['upload'])) {
 	if ($_FILES["sidmods_fileup"]["error"] == UPLOAD_ERR_OK) {
-		$tmp_name = $_FILES["sidmods_fileup"]["tmp_name"];
-		$name = basename($_FILES["sidmods_fileup"]["name"]);
-		move_uploaded_file($tmp_name, "{$sidmods_path}{$name}");
+		$tmp = array();
+		$tmp['name'] = basename($_FILES["sidmods_fileup"]["name"]);
+		$tmp['modtime'] = time();
+		$tmp_fname = $_FILES["sidmods_fileup"]["tmp_name"];
+		$data = file_get_contents($tmp_fname);
+		$tmp['content'] = Base64_encode(str_replace("\r\n", "\n", $data));
+
+		// Check for duplicate conflicting list name
+		foreach ($a_list as $list) {
+			if ($list['name'] == $tmp['name']) {
+				$input_errors[] = gettext("A list with that name already exists!  Please choose a different name for the list being uploaded.");
+				break;
+			}
+		}
+		if (!$input_errors) {
+			$a_list[] = $tmp;
+
+			// Write the new configuration
+			write_config("Suricata pkg: Uploaded new automatic SID management list.");
+		}
 	}
 	else
 		$input_errors[] = gettext("Failed to upload file {$_FILES["sidmods_fileup"]["name"]}");
 }
 
-if (isset($_POST['sidlist_delete']) && isset($_POST['sidlist_fname'])) {
-	if (!suricata_is_sidmodslist_active(basename($_POST['sidlist_fname'])))
-		unlink_if_exists($sidmods_path . basename($_POST['sidlist_fname']));
-	else
-		$input_errors[] = gettext("This SID Mods List is currently assigned to an interface and cannot be deleted.");
-}
+if (isset($_POST['sidlist_delete']) && isset($a_list[$_POST['sidlist_id']])) {
+	if (!suricata_is_sidmodslist_active($a_list[$_POST['sidlist_id']]['name'])) {
+		unset($a_list[$_POST['sidlist_id']]);
 
-if (isset($_POST['sidlist_edit']) && isset($_POST['sidlist_fname'])) {
-	$file = $sidmods_path . basename($_POST['sidlist_fname']);
-	$data = file_get_contents($file);
-	if ($data !== FALSE) {
-		$sidmodlist_data = htmlspecialchars($data);
-		$sidmodlist_edit_style = "show";
-		$sidmodlist_name = basename($_POST['sidlist_fname']);
-		unset($data);
+		// Write the new configuration
+		write_config("Suricata pkg: deleted automatic SID management list.");
 	}
 	else {
-		$input_errors[] = gettext("An error occurred reading the file.");
+		$input_errors[] = gettext("This SID Mods List is currently assigned to an interface and cannot be deleted until the assignment is removed.");
 	}
 }
 
-if (isset($_POST['save']) && isset($_POST['sidlist_data'])) {
-	if (strlen(basename($_POST['sidlist_name'])) > 0) {
-		$file = $sidmods_path . basename($_POST['sidlist_name']);
-		$data = str_replace("\r\n", "\n", $_POST['sidlist_data']);
-		file_put_contents($file, $data);
-		unset($data);
+if (isset($_POST['sidlist_edit']) && isset($a_list[$_POST['sidlist_id']])) {
+	$data = Base64_decode($a_list[$_POST['sidlist_id']]['content']);
+	$sidmodlist_data = htmlspecialchars($data);
+	$sidmodlist_edit_style = "show";
+	$sidmodlist_name = $a_list[$_POST['sidlist_id']]['name'];
+	$sidmodlist_id = $_POST['sidlist_id'];
+	unset($data);
+}
+
+if (isset($_POST['save']) && isset($_POST['sidlist_data']) && isset($_POST['listid'])) {
+	if (strlen($_POST['sidlist_name']) > 0) {
+		$tmp = array();
+		$tmp['name'] = $_POST['sidlist_name'];
+		$tmp['modtime'] = time();
+		$tmp['content'] = Base64_encode(str_replace("\r\n", "\n", $_POST['sidlist_data']));
+
+		// If this test is TRUE, then we are adding a new list
+		if ($_POST['listid'] == count($a_list)) {
+			$a_list[] = $tmp;
+
+			// Write the new configuration
+			write_config("Suricata pkg: added new automatic SID management list.");
+		}
+		else {
+			$a_list[$_POST['listid']] = $tmp;
+
+			// Write the new configuration
+			write_config("Suricata pkg: updated automatic SID management list.");
+		}
+		unset($tmp);
 	}
 	else {
-		$input_errors[] = gettext("You must provide a valid filename for the SID Mods List.");
+		$input_errors[] = gettext("You must provide a valid name for the new SID Mods List.");
 		$sidmodlist_edit_style = "display: table-row-group;";
 	}
 }
@@ -190,10 +224,17 @@ if (isset($_POST['save_auto_sid_conf'])) {
 	}
 }
 
-if (isset($_POST['sidlist_dnload']) && isset($_POST['sidlist_fname'])) {
-	$file = $sidmods_path . basename($_POST['sidlist_fname']);
-	if (file_exists($file)) {
-		ob_start(); //important or other posts will fail
+if (isset($_POST['sidlist_dnload']) && isset($_POST['sidlist_id'])) {
+	$file = $a_list[$_POST['sidlist_id']]['name'];
+
+	// Create a temporary directory to hold the list as an individual file
+	$tmpdirname = "{$g['tmp_path']}/sidmods/";
+	safe_mkdir("{$tmpdirname}");
+
+	file_put_contents($tmpdirname . $file, Base64_decode($a_list[$_POST['sidlist_id']]['content']));
+	touch($tmpdirname . $file, $a_list[$_POST['sidlist_id']]['modtime']);	
+
+	if (file_exists($tmpdirname . $file)) {
 		if (isset($_SERVER['HTTPS'])) {
 			header('Pragma: ');
 			header('Cache-Control: ');
@@ -204,19 +245,43 @@ if (isset($_POST['sidlist_dnload']) && isset($_POST['sidlist_fname'])) {
 		header("Content-Type: application/octet-stream");
 		header("Content-length: " . filesize($file));
 		header("Content-disposition: attachment; filename = " . basename($file));
-		ob_end_clean(); //important or other post will fail
-		readfile($file);
+		ob_clean();
+		flush();
+		readfile($tmpdirname . $file);
+
+		// Clean up temporary file if created
+		if (is_dir($tmpdirname)) {
+			rmdir_recursive($tmpdirname);
+		}
+		exit;
 	}
 	else
-		$savemsg = gettext("Unable to locate the file specified!");
+		$savemsg = gettext("Unable to locate the list specified!");
+
+	// Clean up temporary file if created
+	if (is_dir($tmpdirname)) {
+		rmdir_recursive($tmpdirname);
+	}
 }
 
 if (isset($_POST['sidlist_dnload_all'])) {
 	$save_date = date("Y-m-d-H-i-s");
 	$file_name = "suricata_sid_conf_files_{$save_date}.tar.gz";
-	exec("cd {$sidmods_path} && /usr/bin/tar -czf /tmp/{$file_name} *");
+	
+	// Create a temporary directory to hold the lists as individual files
+	$tmpdirname = "{$g['tmp_path']}/sidmods/";
+	safe_mkdir("{$tmpdirname}");
 
-	if (file_exists("/tmp/{$file_name}")) {
+	// Walk all saved lists and write them out to individual files
+	foreach($a_list as $list) {
+		file_put_contents($tmpdirname . $list['name'], Base64_decode($list['content']));
+		touch($tmpdirname . $list['name'], $list['modtime']);	
+	}
+
+	// Zip up all the files into a single tar gzip archive
+	exec("cd {$tmpdirname} && /usr/bin/tar -czf {$g['tmp_path']}/{$file_name} *");
+
+	if (file_exists("{$g['tmp_path']}/{$file_name}")) {
 		ob_start(); //important or other posts will fail
 		if (isset($_SERVER['HTTPS'])) {
 			header('Pragma: ');
@@ -226,23 +291,36 @@ if (isset($_POST['sidlist_dnload_all'])) {
 			header("Cache-Control: private, must-revalidate");
 		}
 		header("Content-Type: application/octet-stream");
-		header("Content-length: " . filesize("/tmp/{$file_name}"));
+		header("Content-length: " . filesize("{$g['tmp_path']}/{$file_name}"));
 		header("Content-disposition: attachment; filename = {$file_name}");
 		ob_end_clean(); //important or other post will fail
-		readfile("/tmp/{$file_name}");
-
-		// Clean up the temp file
-		unlink_if_exists("/tmp/{$file_name}");
+		readfile("{$g['tmp_path']}/{$file_name}");
+		// Remove all the temporary files and directory if created
+		if (is_dir($tmpdirname)) {
+			rmdir_recursive($tmpdirname);
+			unlink_if_exists($g['tmp_path'] . "/" . $file_name);
+		}
+		exit;
 	}
 	else
 		$savemsg = gettext("An error occurred while creating the gzip archive!");
+
+	// Remove all the temporary files and directory if created
+	if (is_dir($tmpdirname)) {
+		rmdir_recursive($tmpdirname);
+		unlink_if_exists($g['tmp_path'] . "/" . $file_name);
+	}
 }
 
-// Get all files in the SID Mods Lists sub-directory as an array
+// Get all the SID Mods Lists as an array
 // Leave this as the last thing before spewing the page HTML
-// so we can pick up any changes made to files in code above.
-$sidmodfiles = return_dir_as_array($sidmods_path);
-$sidmodselections = array_merge(Array( "None" ), $sidmodfiles);
+// so we can pick up any changes made in code above.
+$sidmodlists = $config['installedpackages']['suricata']['sid_mgmt_lists']['item'];
+$sidmodselections = Array();
+$sidmodselections[] = "None";
+foreach ($sidmodlists as $list) {
+	$sidmodselections[] = $list['name'];
+}
 
 $pgtitle = array(gettext("Services"), gettext("Suricata"), gettext("SID Management"));
 include_once("head.inc");
@@ -279,7 +357,7 @@ if ($savemsg) {
 
 <form action="suricata_sid_mgmt.php" method="post" enctype="multipart/form-data" name="iform" id="iform">
 	<input type="hidden" name="MAX_FILE_SIZE" value="100000000" />
-	<input type="hidden" name="sidlist_fname" id="sidlist_fname" value=""/>
+	<input type="hidden" name="sidlist_id" id="sidlist_id" value=""/>
 
 	<div class="panel panel-default">
 		<div class="panel-heading"><h2 class="panel-title"><?=gettext("General Settings")?></h2></div>
@@ -294,13 +372,13 @@ if ($savemsg) {
 						<input type="checkbox" id="auto_manage_sids" name="auto_manage_sids" value="on"
 						<?php if ($pconfig['auto_manage_sids'] == 'on') echo " checked"; ?>
 						onclick="enable_sid_conf();" />
-						<?=gettext("Enable automatic management of rule state and content using configuration files.  Default is Not Checked.")?>
+						<?=gettext("Enable automatic management of rule state and content using SID Management Configuration Lists.  Default is Not Checked.")?>
 					</label>
 					<span class="help-block">
 						<?=gettext("When checked, Suricata will automatically enable/disable/modify text rules upon each update using criteria ") . 
-						gettext("specified in configuration files.  The supported configuration file format is the same as that used ") . 
-						gettext("by PulledPork and Oinkmaster.  See the included sample conf files for usage examples.  ") . 
-						gettext("Either upload existing files to the firewall or create new ones by clicking ADD below."); ?>
+						gettext("specified in SID Management Configuration Lists.  The supported configuration list format is the same as that used ") . 
+						gettext("by PulledPork and Oinkmaster.  See the included sample conf lists for usage examples.  ") . 
+						gettext("Either upload existing configurations to the firewall or create new ones by clicking ADD below."); ?>
 					</span>
 				</div>
 			</div>
@@ -308,7 +386,7 @@ if ($savemsg) {
 	</div>
 
 	<div class="panel panel-default">
-		<div class="panel-heading"><h2 class="panel-title"><?=gettext("SID Management Configuration Files")?></h2></div>
+		<div class="panel-heading"><h2 class="panel-title"><?=gettext("SID Management Configuration Lists")?></h2></div>
 		<div class="panel-body table-responsive">
 			<table class="table table-striped table-hover table-condensed">
 				<tbody>
@@ -317,33 +395,31 @@ if ($savemsg) {
 						<table class="table table-striped table-hover table-condensed">
 							<thead>
 								<tr>
-									<th><?=gettext("SID Mods List File Name"); ?></th>
+									<th><?=gettext("SID Mods List Name"); ?></th>
 									<th><?=gettext("Last Modified Time"); ?></th>
-									<th><?=gettext("File Size"); ?></th>
-									<th><?=gettext("Actions")?>
+									<th><?=gettext("List Actions")?>
 									</th>
 								</tr>
 							</thead>
 							<tbody>
-						<?php foreach ($sidmodfiles as $file): ?>
+						<?php foreach ($sidmodlists as $i => $list): ?>
 							<tr>
-								<td><?=gettext($file); ?></td>
-								<td><?=date('M-d Y g:i a', filemtime("{$sidmods_path}{$file}")); ?></td>
-								<td><?=format_bytes(filesize("{$sidmods_path}{$file}")); ?> </td>
+								<td><?=gettext($list['name']); ?></td>
+								<td><?=date('M-d Y g:i a', $list['modtime'] + 0); ?></td>
 
 								<td>
 									<a name="sidlist_editX[]" id="sidlist_editX[]" type="button" title="<?=gettext('Edit this SID Mods List');?>"
-										onClick='sidfilename="<?=$file;?>"' style="cursor: pointer;">
+										onClick='sidlistid="<?=$i;?>"' style="cursor: pointer;">
 										<i class="fa fa-pencil"></i>
 									</a>
 
 									<a name="sidlist_deleteX[]" id="sidlist_deleteX[]" type="button" title="<?=gettext('Delete this SID Mods List');?>"
-										onClick='sidfilename="<?=$file;?>"' style="cursor: pointer;" text="delete this">
+										onClick='sidlistid="<?=$i;?>"' style="cursor: pointer;">
 										<i class="fa fa-trash" title="<?=gettext('Delete this SID Mods List');?>"></i>
 									</a>
 
 									<a name="sidlist_dnloadX[]" id="sidlist_dnloadX[]" type="button" title="<?=gettext('Download this SID Mods List');?>"
-										onClick='sidfilename="<?=$file;?>"' style="cursor: pointer;">
+										onClick='sidlistid="<?=$i;?>"' style="cursor: pointer;">
 										<i class="fa fa-download" title="<?=gettext('Download this SID Mods List');?>"></i>
 									</a>
 								</td>
@@ -365,7 +441,7 @@ if ($savemsg) {
 							<span aria-hidden="true">&times;</span>
 						</button>
 
-						<h3 class="modal-title" id="myModalLabel"><?=gettext("SID Upload")?></h3>
+						<h3 class="modal-title" id="myModalLabel"><?=gettext("SID Management List Upload")?></h3>
 					</div>
 
 					<div class="modal-body">
@@ -388,11 +464,12 @@ if ($savemsg) {
 							<span aria-hidden="true">&times;</span>
 						</button>
 
-						<h3 class="modal-title" id="myModalLabel"><?=gettext("SID Auto-Management File Editor")?></h3>
+						<h3 class="modal-title" id="myModalLabel"><?=gettext("SID Auto-Management List Editor")?></h3>
 					</div>
 
 					<div class="modal-body">
-						<?=gettext("File Name: ");?>
+						<input type="hidden" name="listid" id="listid" value="<?=$sidmodlist_id;?>" />
+						<?=gettext("List Name: ");?>
 						<input type="text" size="45" class="form-control file" id="sidlist_name" name="sidlist_name" value="<?=$sidmodlist_name;?>" /><br />
 						<button type="submit" class="btn btn-sm btn-primary" id="save" name="save" value="<?=gettext("Save");?>" title="<?=gettext("Save changes and close editor");?>">
 							<i class="fa fa-save icon-embed-btn"></i>
@@ -404,10 +481,6 @@ if ($savemsg) {
 
 						<textarea class="form-control" wrap="off" cols="80" rows="20" name="sidlist_data" id="sidlist_data"
 						><?=$sidmodlist_data;?></textarea>
-
-						<?php echo gettext("Note:"); ?></strong>
-						<br/><?php echo gettext("SID Mods Lists are stored as local files on the firewall and their contents are " .
-						"not saved as part of the firewall configuration file."); ?>
 					</div>
 				</div>
 			</div>
@@ -417,7 +490,8 @@ if ($savemsg) {
 	<nav class="action-buttons">
 
 		<button data-toggle="modal" data-target="#sidlist_editor" role="button" aria-expanded="false" type="button" name="sidlist_new" id="sidlist_new" class="btn btn-success btn-sm" title="<?=gettext('Create a new SID Mods List');?>"
-		onClick="document.getElementById('sidlist_data').value=''; document.getElementById('sidlist_name').value=''; document.getElementById('sidlist_editor').style.display='table-row-group'; document.getElementById('sidlist_name').focus();">
+		onClick="document.getElementById('sidlist_data').value=''; document.getElementById('sidlist_name').value=''; document.getElementById('sidlist_editor').style.display='table-row-group'; document.getElementById('sidlist_name').focus(); 
+			document.getElementById('sidlist_id').value='<?=count($a_list);?>';">
 			<i class="fa fa-plus icon-embed-btn"></i><?=gettext("Add")?>
 		</button>
 
@@ -426,7 +500,7 @@ if ($savemsg) {
 			<?=gettext("Import")?>
 		</button>
 
-		<button type="input" name="sidlist_dnload_all" id="sidlist_dnload_all" class="btn btn-info btn-sm" title="<?=gettext('Download all SID Mods List files in a single gzip archive');?>">
+		<button type="input" name="sidlist_dnload_all" id="sidlist_dnload_all" class="btn btn-info btn-sm" title="<?=gettext('Download all SID Mods Lists in a single gzip archive');?>">
 			<i class="fa fa-download icon-embed-btn"></i>
 			<?=gettext("Download")?>
 		</button>
@@ -434,7 +508,7 @@ if ($savemsg) {
 	</nav>
 
 	<div class="panel panel-default">
-		<div class="panel-heading"><h2 class="panel-title"><?=gettext("Interface SID Management File Assignments")?></h2></div>
+		<div class="panel-heading"><h2 class="panel-title"><?=gettext("Interface SID Management List Assignments")?></h2></div>
 		<div class="panel-body table-responsive">
 			<table class="table table-striped table-hover table-condensed">
 				<thead>
@@ -442,10 +516,10 @@ if ($savemsg) {
 					<th><?=gettext("Rebuild")?></th>
 					<th><?=gettext("Interface")?></th>
 					<th><?=gettext("SID State Order")?></th>
-					<th><?=gettext("Enable SID File")?></th>
-					<th><?=gettext("Disable SID File")?></th>
-					<th><?=gettext("Modify SID File")?></th>
-					<th><?=gettext("Drop SID File")?></th>
+					<th><?=gettext("Enable SID List")?></th>
+					<th><?=gettext("Disable SID List")?></th>
+					<th><?=gettext("Modify SID List")?></th>
+					<th><?=gettext("Drop SID List")?></th>
 				   </tr>
 				</thead>
 				<tbody>
@@ -553,8 +627,8 @@ if ($savemsg) {
 				" In this case you would choose 'disable,enable' for the State Order.  Note that the last action performed takes priority.") .
 		'</p>' .
 		'<p>' .
-			gettext("The Enable SID File, Disable SID File, Modify SID File and Drop SID File drop-down controls specify which rule modification files are run automatically for the interface.  Setting a file control to 'None' disables that modification. " . 
-				"Setting all file controls for an interface to 'None' disables automatic SID state management for the interface.") .
+			gettext("The Enable SID File, Disable SID File, Modify SID File and Drop SID File drop-down controls specify which rule modification lists are run automatically for the interface.  Setting a list control to 'None' disables that modification. " . 
+				"Setting all list controls for an interface to 'None' disables automatic SID state management for the interface.") .
 		'</p>', 'info', false);
 ?>
 </div>
@@ -562,23 +636,31 @@ if ($savemsg) {
 <script type="text/javascript">
 //<![CDATA[
 events.push(function() {
-	sidfilename = "";
 
 	$('[id^=sidlist_editX]').click(function () {
-		$('#sidlist_fname').val(sidfilename);
-		$('<input type="hidden" name="sidlist_edit[]" id="sidlist_edit[]" value="0"/>').appendTo($(form));
+		$('#sidlist_edit').remove();
+		$('#sidlist_delete').remove();
+		$('#sidlist_dnload').remove();
+		$('#sidlist_id').val(sidlistid);
+		$('<input type="hidden" name="sidlist_edit" id="sidlist_edit" value="0"/>').appendTo($(form));
 		$(form).submit();
 	});
 
 	$('[id^=sidlist_deleteX]').click(function () {
-		$('#sidlist_fname').val(sidfilename);
-		$('<input type="hidden" name="sidlist_delete[]" id="sidlist_edit[]" value="0"/>').appendTo($(form));
+		$('#sidlist_edit').remove();
+		$('#sidlist_delete').remove();
+		$('#sidlist_dnload').remove();
+		$('#sidlist_id').val(sidlistid);
+		$('<input type="hidden" name="sidlist_delete" id="sidlist_delete" value="0"/>').appendTo($(form));
 		$(form).submit();
 	});
 
 	$('[id^=sidlist_dnloadX]').click(function () {
-		$('#sidlist_fname').val(sidfilename);
-		$('<input type="hidden" name="sidlist_dnload[]" id="sidlist_edit[]" value="0"/>').appendTo($(form));
+		$('#sidlist_edit').remove();
+		$('#sidlist_delete').remove();
+		$('#sidlist_dnload').remove();
+		$('#sidlist_id').val(sidlistid);
+		$('<input type="hidden" name="sidlist_dnload" id="sidlist_dnload" value="0"/>').appendTo($(form));
 		$(form).submit();
 	});
 


### PR DESCRIPTION
# pfSense-pkg-suricata-4.0.3_2
This update for the Suricata GUI package contains 2 bug fixes and 7 new features.  The underlying binary is unchanged and remains at version 4.0.3.

## New Features:
1. The configuration files associated with automatic SID managment via the SID MGMT tab are deprecated in favor of storing the automatic SID management directives directly in the firewall's configuration file, _config.xml_.  During the installation of the new package, the content of all files found in the **/var/db/suricata/sidmods** directory will be migrated into a list array stored in the firewall configuration file.  The new list names are taken from the filenames read from the directory.  Storing the automatic SID managment directives content as Base64-encoded data within the firewall configuration ensures that the automatic SID management configuration is backed up and restored along with the rest of the firewall configuration.  The ability to upload and download the SID configuration data is retained, but instead of being stored as physical files on the firewall the configuration is written to _config.xml_.

2. On the CATEGORIES tab, hyperlinks are now provided for opening and viewing the content of all rules categories irregardless of whether the category is enabled or not.  Formerly, only "checked" (or enabled) categories could have their contents viewed in a separate window.

3. On the INTERFACE SETTINGS tab a new configurable parameter for **snaplen** has been added.  The default value for the new parameter is 1518 bytes.  Increasing the value of this parameter can be helpful if Suricata is failing to alert on VLAN traffic.  Note that due to a limitation in the Suricata binary, this value is only applicable to Legacy Mode operation.  It has no effect when using Inline IPS Mode.

4. More options are now available to the user for rule action overrides on the RULES and ALERTS tabs.  Rules can be forced to ALERT, DROP or REJECT depending on the IPS operational mode of the interface.  REJECT is only available when using Inline IPS Mode.  Actions are hidden when they are not applicable to the current operational mode.  There is also a new option of "Default" for the action.  Selecting "Default" removes all user overrides and returns the rule action to the vendor's original value.  This is generally "Alert".

5. A series of new choices are availalbe in the **Categories** drop-down selector on the RULES tab.  The new selections are filtered according to the specific operational mode of the interface.  The new selections allow the user to select special filtered views as follows:  "Active Rules", "User-Forced Enabled Rules", "User-Forced Disabled Rules", "User-Forced Alert Rules", "User-Forced Drop Rules" and "User-Forced Reject Rules".  Display of "User-Forced Reject Rules" is only possible when using Inline IPS Mode with blocking enabled.  Display of "User-Forced Drop Rules" requires the interface be using Inline IPS Mode or Legacy Mode with Block-on-Drops-Only enabled.

6. A third rule state option of "Default" has been added to the RULES tab when displaying user override options.  Choosing "Default" for the rule state will remove all user overrides and return the rule's state (enabled or disabled) to the vendor's original value.

7. Add the ability to customize rule actions on the ALERTS tab.  See feature 4 above for details.  An additional icon is displayed in the GID:SID column for each alert that allows user overrides of the action.  When a rule action has been overridden, a special icon is shown to flag the new action.  Pop up tooltips explain the icons.

## Bug Fixes:
1. The default pass list generated during Inline IPS Mode operation was too broad.  Pass Lists really have very limited usefulness with Inline IPS Mode and so the ability to select a pass list when using Inline IPS Mode has been removed.  If you require pass list functionality with Inline IPS Mode, create your own custom PASS rules instead on the RULES tab.  Note that pass list functionality is unchanged when using Legacy Mode operation.

2. The new dynamic service status icons on the INTERFACES tab would sometimes not correctly indicate the Suricata service status.  There was also an error in a control name for the icons associated with Barnyard2 on the INTERFACES tab.