### PR TITLE
pfSense-pkg-suricata-4.0.4_1

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.0.4
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -2363,8 +2363,8 @@ function suricata_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results 
 	/*                  tokens                    */
 	/*      $action ==> modification action for   */
 	/*                  matching SID targets:     */
-	/*                  'enable', 'disable' or    */
-	/*		    'drop'.
+	/*                  'enable', 'disable',      */
+	/*		    'drop' or 'reject'.       */
 	/* $log_results ==> [optional] 'yes' to log   */
 	/*                   results to $log_file     */
 	/*    $log_file ==> full path and filename    */
@@ -2381,6 +2381,7 @@ function suricata_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results 
 
 	$sids = array();
 	$log_action = '';
+	$log_what = '';
 
 	// If no rules in $rule_map or mods in $sid_mods,
 	// then nothing to do.
@@ -2393,15 +2394,23 @@ function suricata_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results 
 	switch ($action) {
 
 		case "enable":
+			$log_what = 'state';
 			$log_action = 'enabled';
 			break;
 
 		case "disable":
+			$log_what = 'state';
 			$log_action = 'disabled';
 			break;
 
 		case "drop":
+			$log_what = 'action';
 			$log_action = 'drop';
+			break;
+
+		case "reject":
+			$log_what = 'action';
+			$log_action = 'reject';
 			break;
 
 		default:
@@ -2537,13 +2546,23 @@ function suricata_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results 
 						$modcount++;
 					}
 				}
+				elseif ($action == 'reject' && $rule_map[$k1][$k2]['action'] != 'reject') {
+					if ($tmp = preg_replace('/\s*alert\s*/', 'reject ', $rule_map[$k1][$k2]['rule'], 1)) {
+						$rule_map[$k1][$k2]['rule'] = $tmp;
+						$rule_map[$k1][$k2]['action'] = 'reject';
+						$rule_map[$k1][$k2]['managed'] = 1;
+						$rule_map[$k1][$k2]['modified'] = 1;
+						$changecount++;
+						$modcount++;
+					}
+				}
 			}
 		}
 	}
 
 	if ($log_results == TRUE && !empty($log_file)) {
 		error_log(gettext("    Found {$modcount} matching SIDs in the active rules.\n"), 3, $log_file);
-		error_log(gettext("    Changed state for {$changecount} SIDs to '{$log_action}'.\n"), 3, $log_file);
+		error_log(gettext("    Changed {$log_what} for {$changecount} SIDs to '{$log_action}'.\n"), 3, $log_file);
 	}
 
 	// Return the array of matching SIDs
@@ -2850,6 +2869,53 @@ function suricata_process_dropsid(&$rule_map, $suricatacfg, $log_results = FALSE
 	unset($sid_mods);
 }
 
+function suricata_process_rejectsid(&$rule_map, $suricatacfg, $log_results = FALSE, $log_file = NULL) {
+
+	/**********************************************/
+	/* This function loads and processes the list */
+	/* specified by 'reject_sid_file' for the     */
+	/* interface.  The list is assumed to be a    */
+	/* valid rejectsid.conf list containing       */
+	/* instructions for modifying the action for  */
+	/* matching rule SIDs.                        */
+	/*                                            */
+	/*     $rule_map ==> reference to array of    */
+	/*                   current rules            */
+	/*  $suricatacfg ==> interface config params  */
+	/*  $log_results ==> [optional] 'yes' to log  */
+	/*                   results to $log_file     */
+	/*     $log_file ==> full path and filename   */
+	/*                   of log file to write to  */
+	/*                                            */
+	/*     On Return ==> suitably modified        */
+	/*                   $rule_map array          */
+	/**********************************************/
+
+	$suricatalogdir = SURICATALOGDIR;
+	$sid_mods = array();
+
+	// If no rules in $rule_map, then nothing to do
+	if (empty($rule_map)) {
+		return;
+	}
+
+	// Verify the 'reject_sid' list for the interface exists
+	if (!suricata_sid_mgmt_list_exist($suricatacfg['reject_sid_file'])) {
+		log_error(gettext("[Suricata] Error - unable to find reject_sid list \"{$suricatacfg['reject_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+		return;
+	} else {
+		$sid_mods = suricata_parse_sidconf_file($suricatacfg['reject_sid_file']);
+	}
+
+	if (!empty($sid_mods)) {
+		suricata_modify_sid_state($rule_map, $sid_mods, "reject", $log_results, $log_file);
+	} elseif ($log_results == TRUE && !empty($log_file)) {
+		error_log(gettext("WARNING: no valid SID match tokens found in list \"{$suricatacfg['reject_sid_file']}\".\n"), 3, $log_file);
+	}
+
+	unset($sid_mods);
+}
+
 function suricata_auto_sid_mgmt(&$rule_map, $suricatacfg, $log_results = FALSE) {
 
 	/**************************************************/
@@ -2915,11 +2981,17 @@ function suricata_auto_sid_mgmt(&$rule_map, $suricatacfg, $log_results = FALSE) 
 					}
 					suricata_process_modifysid($rule_map, $suricatacfg, $log_results, $log_file);
 				}
-				if (!empty($suricatacfg['drop_sid_file'])) {
+				if (!empty($suricatacfg['drop_sid_file']) && ($suricatacfg['blockoffenders'] == 'on' && ($suricatacfg['block_drops_only'] == 'on' || $suricatacfg['ips_mode'] == 'ips_mode_inline'))) {
 					if ($log_results == TRUE) {
 						error_log(gettext("Processing drop_sid list: {$suricatacfg['drop_sid_file']}\n"), 3, $log_file);
 					}
 					suricata_process_dropsid($rule_map, $suricatacfg, $log_results, $log_file);
+				}
+				if (!empty($suricatacfg['reject_sid_file']) && $suricatacfg['blockoffenders'] == 'on' && $suricatacfg['ips_mode'] == 'ips_mode_inline') {
+					if ($log_results == TRUE) {
+						error_log(gettext("Processing reject_sid list: {$suricatacfg['reject_sid_file']}\n"), 3, $log_file);
+					}
+					suricata_process_rejectsid($rule_map, $suricatacfg, $log_results, $log_file);
 				}
 				$result = TRUE;
 				break;
@@ -2943,11 +3015,17 @@ function suricata_auto_sid_mgmt(&$rule_map, $suricatacfg, $log_results = FALSE) 
 					}
 					suricata_process_modifysid($rule_map, $suricatacfg, $log_results, $log_file);
 				}
-				if (!empty($suricatacfg['drop_sid_file'])) {
+				if (!empty($suricatacfg['drop_sid_file']) && ($suricatacfg['blockoffenders'] == 'on' && ($suricatacfg['block_drops_only'] == 'on' || $suricatacfg['ips_mode'] == 'ips_mode_inline'))) {
 					if ($log_results == TRUE) {
 						error_log(gettext("Processing drop_sid list: {$suricatacfg['drop_sid_file']}\n"), 3, $log_file);
 					}
 					suricata_process_dropsid($rule_map, $suricatacfg, $log_results, $log_file);
+				}
+				if (!empty($suricatacfg['reject_sid_file']) && $suricatacfg['blockoffenders'] == 'on' && $suricatacfg['ips_mode'] == 'ips_mode_inline') {
+					if ($log_results == TRUE) {
+						error_log(gettext("Processing reject_sid list: {$suricatacfg['reject_sid_file']}\n"), 3, $log_file);
+					}
+					suricata_process_rejectsid($rule_map, $suricatacfg, $log_results, $log_file);
 				}
 				$result = TRUE;
 				break;
@@ -3073,8 +3151,24 @@ function suricata_modify_sids_action(&$rule_map, $suricatacfg) {
 
 	/* Load up our SID forced action arrays with manually changed SID actions */
 	$alertsid = suricata_load_sid_mods($suricatacfg['rule_sid_force_alert']);
-	$dropsid = suricata_load_sid_mods($suricatacfg['rule_sid_force_drop']);
-	$rejectsid = suricata_load_sid_mods($suricatacfg['rule_sid_force_reject']);
+
+	/* DROP is only applicable when blocking offenders is enabled and when    */
+	/* 'block drops only' is enabled, or when using Inline IPS Mode.          */
+	if ($suricatacfg['blockoffenders'] == 'on' && ($suricatacfg['block_drops_only'] == 'on' || $suricatacfg['ips_mode'] == 'ips_mode_inline')) {
+		$dropsid = suricata_load_sid_mods($suricatacfg['rule_sid_force_drop']);
+	}
+	else {
+		$dropsid = array();
+	}
+
+	/* REJECT is only applicable when blocking offenders is enabled and when  */
+	/* Inline IPS Mode is also enabled.                                       */
+	if ($suricatacfg['blockoffenders'] == 'on' && $suricatacfg['ips_mode'] == 'ips_mode_inline') {
+		$rejectsid = suricata_load_sid_mods($suricatacfg['rule_sid_force_reject']);
+	}
+	else {
+		$rejectsid = array();
+	}
 
 	/* Change action for any rules that need to be */
 	/* forced to "alert" with alertsid mods.       */
@@ -3305,7 +3399,13 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 		// Check if a pre-defined Snort VRT policy is selected. If so,
 		// add all the VRT policy rules to our enforcing rule set.
 		if ($suricatacfg['ips_policy_enable'] == 'on' && !empty($suricatacfg['ips_policy'])) {
-			$policy_rules = suricata_load_vrt_policy($suricatacfg['ips_policy'], $suricatacfg['ips_policy_mode'], $all_rules);
+			if ($suricatacfg['blockoffenders'] == 'on' && ($suricatacfg['ips_mode'] == 'ips_mode_inline' || $suricatacfg['block_drops_only'] == 'on')) {
+				$policy_mode = $suricatacfg['ips_policy_mode'];
+			}
+			else {
+				$policy_mode = 'alert';
+			}
+			$policy_rules = suricata_load_vrt_policy($suricatacfg['ips_policy'], $policy_mode, $all_rules);
 			foreach ($policy_rules as $k1 => $policy) {
 				foreach ($policy as $k2 => $p) {
 					if (!is_array($enabled_rules[$k1])) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -50,13 +50,27 @@ $snortcommunityrules = $config['installedpackages']['suricata']['config'][0]['sn
 $tmpfname = "{$g['tmp_path']}/suricata_rules_up";
 
 /* Snort Rules filenames and URL */
-$snort_filename_md5 = "{$snort_filename}.md5";
-$snort_rule_url = VRT_DNLD_URL;
+if ($config['installedpackages']['suricata']['config'][0]['enable_snort_custom_url'] == 'on') {
+	$snort_rule_url = trim(substr($config['installedpackages']['suricata']['config'][0]['snort_custom_url'], 0, strrpos($config['installedpackages']['suricata']['config'][0]['snort_custom_url'], '/') + 1));
+	$snort_filename = trim(substr($config['installedpackages']['suricata']['config'][0]['snort_custom_url'], strrpos($config['installedpackages']['suricata']['config'][0]['snort_custom_url'], '/') + 1));
+	$snort_filename_md5 = "{$snort_filename}.md5";
+}
+else {
+	$snort_filename_md5 = "{$snort_filename}.md5";
+	$snort_rule_url = VRT_DNLD_URL;
+}
 
 /* Snort GPLv2 Community Rules filenames and URL */
-$snort_community_rules_filename = GPLV2_DNLD_FILENAME;
-$snort_community_rules_filename_md5 = GPLV2_DNLD_FILENAME . ".md5";
-$snort_community_rules_url = GPLV2_DNLD_URL;
+if ($config['installedpackages']['suricata']['config'][0]['enable_gplv2_custom_url'] == 'on') {
+	$snort_community_rules_filename = trim(substr($config['installedpackages']['suricata']['config'][0]['gplv2_custom_url'], strrpos($config['installedpackages']['suricata']['config'][0]['gplv2_custom_url'], '/') + 1));
+	$snort_community_rules_filename_md5 = $snort_community_rules_filename . ".md5";
+	$snort_community_rules_url = trim(substr($config['installedpackages']['suricata']['config'][0]['gplv2_custom_url'], 0, strrpos($config['installedpackages']['suricata']['config'][0]['gplv2_custom_url'], '/') + 1));
+}
+else {
+	$snort_community_rules_filename = GPLV2_DNLD_FILENAME;
+	$snort_community_rules_filename_md5 = GPLV2_DNLD_FILENAME . ".md5";
+	$snort_community_rules_url = GPLV2_DNLD_URL;
+}
 
 /* Mount the Suricata conf directories R/W so we can modify files there */
 if (!is_subsystem_dirty('mount')) {
@@ -66,23 +80,39 @@ if (!is_subsystem_dirty('mount')) {
 
 /* Set up Emerging Threats rules filenames and URL */
 if ($etpro == "on") {
-	$emergingthreats_filename = ETPRO_DNLD_FILENAME;
-	$emergingthreats_filename_md5 = ETPRO_DNLD_FILENAME . ".md5";
-	$emergingthreats_url = ETPRO_BASE_DNLD_URL;
-	$emergingthreats_url .= "{$etproid}/suricata-{$suri_eng_ver}/";
 	$et_name = "Emerging Threats Pro";
-	$et_md5_remove = ET_DNLD_FILENAME . ".md5";
+	if ($config['installedpackages']['suricata']['config'][0]['enable_etpro_custom_url'] == 'on') {
+		$emergingthreats_url = trim(substr($config['installedpackages']['suricata']['config'][0]['etpro_custom_rule_url'], 0, strrpos($config['installedpackages']['suricata']['config'][0]['etpro_custom_rule_url'], '/') + 1));
+		$emergingthreats_filename = trim(substr($config['installedpackages']['suricata']['config'][0]['etpro_custom_rule_url'], strrpos($config['installedpackages']['suricata']['config'][0]['etpro_custom_rule_url'], '/') + 1));
+		$emergingthreats_filename_md5 = $emergingthreats_filename . ".md5";
+		$et_md5_remove = ET_DNLD_FILENAME . ".md5";
+	}
+	else {
+		$emergingthreats_filename = ETPRO_DNLD_FILENAME;
+		$emergingthreats_filename_md5 = ETPRO_DNLD_FILENAME . ".md5";
+		$emergingthreats_url = ETPRO_BASE_DNLD_URL;
+		$emergingthreats_url .= "{$etproid}/suricata-{$suri_eng_ver}/";
+		$et_md5_remove = ET_DNLD_FILENAME . ".md5";
+	}
 	unlink_if_exists("{$suricatadir}{$et_md5_remove}");
 }
 else {
-	$emergingthreats_filename = ET_DNLD_FILENAME;
-	$emergingthreats_filename_md5 = ET_DNLD_FILENAME . ".md5";
-	$emergingthreats_url = ET_BASE_DNLD_URL;
-	// If using Snort rules with ET, then we should use the open-nogpl ET rules
-	$emergingthreats_url .= $vrt_enabled == "on" ? "open-nogpl/" : "open/";
-	$emergingthreats_url .= "suricata-{$suri_eng_ver}/";
 	$et_name = "Emerging Threats Open";
-	$et_md5_remove = ETPRO_DNLD_FILENAME . ".md5";
+	if ($config['installedpackages']['suricata']['config'][0]['enable_etopen_custom_url'] == 'on') {
+		$emergingthreats_url = trim(substr($config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url'], 0, strrpos($config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url'], '/') + 1));
+		$emergingthreats_filename = trim(substr($config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url'], strrpos($config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url'], '/') + 1));
+		$emergingthreats_filename_md5 = $emergingthreats_filename . ".md5";
+		$et_md5_remove = ETPRO_DNLD_FILENAME . ".md5";
+	}
+	else {
+		$emergingthreats_filename = ET_DNLD_FILENAME;
+		$emergingthreats_filename_md5 = ET_DNLD_FILENAME . ".md5";
+		$emergingthreats_url = ET_BASE_DNLD_URL;
+		// If using Snort rules with ET, then we should use the open-nogpl ET rules
+		$emergingthreats_url .= $vrt_enabled == "on" ? "open-nogpl/" : "open/";
+		$emergingthreats_url .= "suricata-{$suri_eng_ver}/";
+		$et_md5_remove = ETPRO_DNLD_FILENAME . ".md5";
+	}
 	unlink_if_exists("{$suricatadir}{$et_md5_remove}");
 }
 
@@ -257,19 +287,17 @@ function suricata_check_rule_md5($file_url, $file_dst, $desc = "") {
 	/**********************************************************/
 
 	global $last_curl_error, $update_errors;
-
 	$suricatadir = SURICATADIR;
 	$filename_md5 = basename($file_dst);
 
 	suricata_update_status(gettext("Downloading {$desc} md5 file..."));
-	error_log(gettext("\tDownloading {$desc} md5 file {$filename_md5}...\n"), 3, SURICATA_RULES_UPD_LOGFILE);
+	error_log(gettext("\tDownloading {$desc} md5 file...\n"), 3, SURICATA_RULES_UPD_LOGFILE);
 	$rc = suricata_download_file_url($file_url, $file_dst);
 
 	// See if download from URL was successful
 	if ($rc === true) {
 		suricata_update_status(gettext(" done.") . "\n");
 		error_log("\tChecking {$desc} md5 file...\n", 3, SURICATA_RULES_UPD_LOGFILE);
-
 		// check md5 hash in new file against current file to see if new download is posted
 		if (file_exists("{$suricatadir}{$filename_md5}")) {
 			$md5_check_new = file_get_contents($file_dst);
@@ -376,8 +404,12 @@ safe_mkdir("{$suricatalogdir}");
 
 /* See if we need to automatically clear the Update Log based on 1024K size limit */
 if (file_exists(SURICATA_RULES_UPD_LOGFILE)) {
-	if (1048576 < filesize(SURICATA_RULES_UPD_LOGFILE))
-		unlink_if_exists("{SURICATA_RULES_UPD_LOGFILE}");
+	if (1048576 < filesize(SURICATA_RULES_UPD_LOGFILE)) {
+		file_put_contents(SURICATA_RULES_UPD_LOGFILE, "");
+	}
+}
+else {
+	file_put_contents(SURICATA_RULES_UPD_LOGFILE, "");
 }
 
 /* Log start time for this rules update */
@@ -399,15 +431,16 @@ if ($emergingthreats == 'on') {
 
 /*  Check for and download any new Snort rule sigs */
 if ($snortdownload == 'on') {
+	$snort_custom_url = config['installedpackages']['suricata']['config'][0]['enable_snort_custom_url'] == 'on' ? TRUE : FALSE;
 	if (empty($snort_filename)) {
 		log_error(gettext("No snortrules-snapshot filename has been set on Snort pkg GLOBAL SETTINGS tab.  Snort rules cannot be updated."));
 		error_log(gettext("\tWARNING-- No snortrules-snapshot filename set on GLOBAL SETTINGS tab. Snort rules cannot be updated!\n"), 3, SURICATA_RULES_UPD_LOGFILE);
 		$snortdownload = 'off';
 	}
-	elseif (suricata_check_rule_md5("{$snort_rule_url}{$snort_filename_md5}?oinkcode={$oinkid}", "{$tmpfname}/{$snort_filename_md5}", "Snort VRT rules")) {
+	elseif (suricata_check_rule_md5("{$snort_rule_url}{$snort_filename_md5}" . ($snort_custom_url ? "" : "?oinkcode={$oinkid}"), "{$tmpfname}/{$snort_filename_md5}", "Snort VRT rules")) {
 		/* download snortrules file */
 		$file_md5 = trim(file_get_contents("{$tmpfname}/{$snort_filename_md5}"));
-		if (!suricata_fetch_new_rules("{$snort_rule_url}{$snort_filename}?oinkcode={$oinkid}", "{$tmpfname}/{$snort_filename}", $file_md5, "Snort rules"))
+		if (!suricata_fetch_new_rules("{$snort_rule_url}{$snort_filename}" . ($snort_custom_url ? "" : "?oinkcode={$oinkid}"), "{$tmpfname}/{$snort_filename}", $file_md5, "Snort rules"))
 			$snortdownload = 'off';
 	}
 	else

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,7 @@
  */
 
 require_once("guiconfig.inc");
+require_once("/usr/local/pkg/suricata/suricata_defs.inc");
 require_once("/usr/local/pkg/suricata/suricata.inc");
 
 /* Define some locally required variables from Suricata constants */
@@ -34,7 +35,6 @@ $snortdownload = $config['installedpackages']['suricata']['config'][0]['enable_v
 $emergingthreats = $config['installedpackages']['suricata']['config'][0]['enable_etopen_rules'];
 $etpro = $config['installedpackages']['suricata']['config'][0]['enable_etpro_rules'];
 $snortcommunityrules = $config['installedpackages']['suricata']['config'][0]['snortcommunityrules'];
-$snort_rules_file = $config['installedpackages']['suricata']['config'][0]['snort_rules_file'];
 
 /* Get last update information if available */
 if (!empty($config['installedpackages']['suricata']['config'][0]['last_rule_upd_time']))
@@ -46,15 +46,37 @@ if (!empty($config['installedpackages']['suricata']['config'][0]['last_rule_upd_
 else
 	$last_rule_upd_status = gettext("Unknown");
 
-$snort_community_rules_filename = GPLV2_DNLD_FILENAME;
-
-if ($etpro == "on") {
-	$emergingthreats_filename = ETPRO_DNLD_FILENAME;
-	$et_name = "Emerging Threats Pro Rules";
+// Check for any custom URLs and extract custom filenames
+// if present, else use package default values.
+if ($config['installedpackages']['suricata']['config'][0]['enable_snort_custom_url'] == 'on') {
+	$snort_rules_file = trim(substr($config['installedpackages']['suricata']['config'][0]['snort_custom_url'], strrpos($config['installedpackages']['suricata']['config'][0]['snort_custom_url'], '/') + 1));
 }
 else {
-	$emergingthreats_filename = ET_DNLD_FILENAME;
+	$snort_rules_file = $config['installedpackages']['suricata']['config'][0]['snort_rules_file'];
+}
+if ($config['installedpackages']['suricata']['config'][0]['enable_gplv2_custom_url'] == 'on') {
+	$snort_community_rules_filename = trim(substr($config['installedpackages']['suricata']['config'][0]['gplv2_custom_url'], strrpos($config['installedpackages']['suricata']['config'][0]['gplv2_custom_url'], '/') + 1));
+}
+else {
+	$snort_community_rules_filename = GPLV2_DNLD_FILENAME;
+}
+if ($etpro == "on") {
+	$et_name = "Emerging Threats Pro Rules";
+	if ($config['installedpackages']['suricata']['config'][0]['enable_etpro_custom_url'] == 'on') {
+		$emergingthreats_filename = trim(substr($config['installedpackages']['suricata']['config'][0]['etpro_custom_rule_url'], strrpos($config['installedpackages']['suricata']['config'][0]['etpro_custom_rule_url'], '/') + 1));
+	}
+	else {
+		$emergingthreats_filename = ETPRO_DNLD_FILENAME;
+	}
+}
+else {
 	$et_name = "Emerging Threats Open Rules";
+	if ($config['installedpackages']['suricata']['config'][0]['enable_etopen_custom_url'] == 'on') {
+		$emergingthreats_filename = trim(substr($config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url'], strrpos($config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url'], '/') + 1));
+	}
+	else {
+		$emergingthreats_filename = ET_DNLD_FILENAME;
+	}
 }
 
 /* quick md5 chk of downloaded rules */
@@ -99,8 +121,9 @@ if ($snortcommunityrules == 'on' && file_exists("{$suricatadir}{$snort_community
 
 /* Check for postback to see if we should clear the update log file. */
 if ($_POST['clear']) {
-	if (file_exists("{$suricata_rules_upd_log}"))
-		unlink_if_exists("{$suricata_rules_upd_log}");
+	if (file_exists(SURICATA_RULES_UPD_LOGFILE)) {
+		file_put_contents(SURICATA_RULES_UPD_LOGFILE, "");
+	}
 }
 
 if ($_REQUEST['updatemode']) {
@@ -146,15 +169,20 @@ if ($_REQUEST['ajax'] == 'status') {
 }
 
 /* check for logfile */
-if (file_exists("{$suricata_rules_upd_log}"))
-	$suricata_rules_upd_log_chk = 'yes';
-else
+if (file_exists("{$suricata_rules_upd_log}")) {
+	if (filesize("{$suricata_rules_upd_log}") > 0) {
+		$suricata_rules_upd_log_chk = 'yes';
+	}
+}
+else {
 	$suricata_rules_upd_log_chk = 'no';
+}
 
 if ($_POST['view']&& $suricata_rules_upd_log_chk == 'yes') {
-	$contents = @file_get_contents($suricata_rules_upd_log);
-	if (empty($contents))
+	$contents = file_get_contents($suricata_rules_upd_log);
+	if ($contents === FALSE) {
 		$input_errors[] = gettext("Unable to read log file: {$suricata_rules_upd_log}");
+	}
 }
 
 if ($_POST['hide'])

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -37,21 +37,29 @@ if (!empty($_POST)) {
 }
 else {
 	$pconfig['enable_vrt_rules'] = $config['installedpackages']['suricata']['config'][0]['enable_vrt_rules'] == "on" ? 'on' : 'off';
-	$pconfig['oinkcode'] = $config['installedpackages']['suricata']['config'][0]['oinkcode'];
-	$pconfig['etprocode'] = $config['installedpackages']['suricata']['config'][0]['etprocode'];
+	$pconfig['oinkcode'] = htmlentities($config['installedpackages']['suricata']['config'][0]['oinkcode']);
+	$pconfig['etprocode'] = htmlentities($config['installedpackages']['suricata']['config'][0]['etprocode']);
 	$pconfig['enable_etopen_rules'] = $config['installedpackages']['suricata']['config'][0]['enable_etopen_rules'] == "on" ? 'on' : 'off';
 	$pconfig['enable_etpro_rules'] = $config['installedpackages']['suricata']['config'][0]['enable_etpro_rules'] == "on" ? 'on' : 'off';
 	$pconfig['rm_blocked'] = $config['installedpackages']['suricata']['config'][0]['rm_blocked'];
 	$pconfig['autoruleupdate'] = $config['installedpackages']['suricata']['config'][0]['autoruleupdate'];
-	$pconfig['autoruleupdatetime'] = $config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'];
+	$pconfig['autoruleupdatetime'] = htmlentities($config['installedpackages']['suricata']['config'][0]['autoruleupdatetime']);
 	$pconfig['live_swap_updates'] = $config['installedpackages']['suricata']['config'][0]['live_swap_updates'] == "on" ? 'on' : 'off';
 	$pconfig['log_to_systemlog'] = $config['installedpackages']['suricata']['config'][0]['log_to_systemlog'] == "on" ? 'on' : 'off';
 	$pconfig['log_to_systemlog_facility'] = $config['installedpackages']['suricata']['config'][0]['log_to_systemlog_facility'];
 	$pconfig['forcekeepsettings'] = $config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] == "on" ? 'on' : 'off';
 	$pconfig['snortcommunityrules'] = $config['installedpackages']['suricata']['config'][0]['snortcommunityrules'] == "on" ? 'on' : 'off';
-	$pconfig['snort_rules_file'] = $config['installedpackages']['suricata']['config'][0]['snort_rules_file'];
+	$pconfig['snort_rules_file'] = htmlentities($config['installedpackages']['suricata']['config'][0]['snort_rules_file']);
 	$pconfig['autogeoipupdate'] = $config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] == "off" ? 'off' : 'on';
 	$pconfig['hide_deprecated_rules'] = $config['installedpackages']['suricata']['config'][0]['hide_deprecated_rules'] == "on" ? 'on' : 'off';
+	$pconfig['enable_etopen_custom_url'] = $config['installedpackages']['suricata']['config'][0]['enable_etopen_custom_url'] == "on" ? 'on' : 'off';
+	$pconfig['enable_etpro_custom_url'] = $config['installedpackages']['suricata']['config'][0]['enable_etpro_custom_url'] == "on" ? 'on' : 'off';
+	$pconfig['enable_snort_custom_url'] = $config['installedpackages']['suricata']['config'][0]['enable_snort_custom_url'] == "on" ? 'on' : 'off';
+	$pconfig['enable_gplv2_custom_url'] = $config['installedpackages']['suricata']['config'][0]['enable_gplv2_custom_url'] == "on" ? 'on' : 'off';
+	$pconfig['etopen_custom_rule_url'] = htmlentities($config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url']);
+	$pconfig['etpro_custom_rule_url'] = htmlentities($config['installedpackages']['suricata']['config'][0]['etpro_custom_rule_url']);
+	$pconfig['snort_custom_url'] = htmlentities($config['installedpackages']['suricata']['config'][0]['snort_custom_url']);
+	$pconfig['gplv2_custom_url'] = htmlentities($config['installedpackages']['suricata']['config'][0]['gplv2_custom_url']);
 }
 
 // Do input validation on parameters
@@ -75,6 +83,18 @@ if ($_POST['enable_vrt_rules'] == "on" && empty($_POST['oinkcode']))
 if ($_POST['enable_etpro_rules'] == "on" && empty($_POST['etprocode']))
 		$input_errors[] = "You must supply a subscription code in the box provided in order to enable Emerging Threats Pro rules!";
 
+if ($_POST['enable_etopen_custom_url'] == "on" && empty(trim(html_entity_decode($_POST['etopen_custom_rule_url']))))
+		$input_errors[] = "'Use Custom ET Open Rule download URL' is checked, but the ET Open Custom URL field is blank!";
+
+if ($_POST['enable_etpro_custom_url'] == "on" && empty(trim(html_entity_decode($_POST['etpro_custom_rule_url']))))
+		$input_errors[] = "'Use Custom ET Pro Rule download URL' is checked, but the ET Pro Custom URL field is blank!";
+
+if ($_POST['enable_snort_custom_url'] == "on" && empty(trim(html_entity_decode($_POST['snort_custom_url']))))
+		$input_errors[] = "'Use Custom Snort Rule download URL' is checked, but the Snort Custom URL field is blank!";
+
+if ($_POST['enable_gplv2_custom_url'] == "on" && empty(trim(html_entity_decode($_POST['gplv2_custom_url']))))
+		$input_errors[] = "'Use Custom Snort GPLv2 Rule download URL' is checked, but the Snort GPLv2 Custom URL field is blank!";
+
 /* if no errors move foward with save */
 if (!$input_errors) {
 	if ($_POST["save"]) {
@@ -85,6 +105,10 @@ if (!$input_errors) {
 		$config['installedpackages']['suricata']['config'][0]['enable_etpro_rules'] = $_POST['enable_etpro_rules'] ? 'on' : 'off';
 		$config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] = $_POST['autogeoipupdate'] ? 'on' : 'off';
 		$config['installedpackages']['suricata']['config'][0]['hide_deprecated_rules'] = $_POST['hide_deprecated_rules'] ? 'on' : 'off';
+		$config['installedpackages']['suricata']['config'][0]['enable_etopen_custom_url'] = $_POST['enable_etopen_custom_url'] ? 'on' : 'off';
+		$config['installedpackages']['suricata']['config'][0]['enable_etpro_custom_url'] = $_POST['enable_etpro_custom_url'] ? 'on' : 'off';
+		$config['installedpackages']['suricata']['config'][0]['enable_snort_custom_url'] = $_POST['enable_snort_custom_url'] ? 'on' : 'off';
+		$config['installedpackages']['suricata']['config'][0]['enable_gplv2_custom_url'] = $_POST['enable_gplv2_custom_url'] ? 'on' : 'off';
 
 		// If any rule sets are being turned off, then remove them
 		// from the active rules section of each interface.  Start
@@ -127,11 +151,15 @@ if (!$input_errors) {
 			suricata_remove_dead_rules();
 		}
 
-		$config['installedpackages']['suricata']['config'][0]['snort_rules_file'] = $_POST['snort_rules_file'];
-		$config['installedpackages']['suricata']['config'][0]['oinkcode'] = $_POST['oinkcode'];
-		$config['installedpackages']['suricata']['config'][0]['etprocode'] = $_POST['etprocode'];
+		$config['installedpackages']['suricata']['config'][0]['snort_rules_file'] = html_entity_decode($_POST['snort_rules_file']);
+		$config['installedpackages']['suricata']['config'][0]['oinkcode'] = html_entity_decode($_POST['oinkcode']);
+		$config['installedpackages']['suricata']['config'][0]['etprocode'] = html_entity_decode($_POST['etprocode']);
 		$config['installedpackages']['suricata']['config'][0]['rm_blocked'] = $_POST['rm_blocked'];
 		$config['installedpackages']['suricata']['config'][0]['autoruleupdate'] = $_POST['autoruleupdate'];
+		$config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url'] = trim(html_entity_decode($_POST['etopen_custom_rule_url']));
+		$config['installedpackages']['suricata']['config'][0]['etpro_custom_rule_url'] = trim(html_entity_decode($_POST['etpro_custom_rule_url']));
+		$config['installedpackages']['suricata']['config'][0]['snort_custom_url'] = trim(html_entity_decode($_POST['snort_custom_url']));
+		$config['installedpackages']['suricata']['config'][0]['gplv2_custom_url'] = trim(html_entity_decode($_POST['gplv2_custom_url']));
 
 		/* Check and adjust format of Rule Update Starttime string to add colon and leading zero if necessary */
 		if ($_POST['autoruleupdatetime']) {
@@ -140,7 +168,7 @@ if (!$input_errors) {
 				$tmp = str_pad($_POST['autoruleupdatetime'], 4, "0", STR_PAD_LEFT);
 				$_POST['autoruleupdatetime'] = substr($tmp, 0, 2) . ":" . substr($tmp, -2);
 			}
-			$config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'] = str_pad($_POST['autoruleupdatetime'], 4, "0", STR_PAD_LEFT);
+			$config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'] = str_pad(html_entity_decode($_POST['autoruleupdatetime']), 4, "0", STR_PAD_LEFT);
 		}
 		$config['installedpackages']['suricata']['config'][0]['log_to_systemlog'] = $_POST['log_to_systemlog'] ? 'on' : 'off';
 		$config['installedpackages']['suricata']['config'][0]['log_to_systemlog_facility'] = $_POST['log_to_systemlog_facility'];
@@ -204,33 +232,85 @@ display_top_tabs($tab_array, true);
 
 $form = new Form;
 $section = new Form_Section('Please Choose The Type Of Rules You Wish To Download');
-$section->addInput(new Form_Checkbox(
+
+$group = new Form_Group('Install ETOpen Emerging Threats rules');
+$group->add(new Form_Checkbox(
 	'enable_etopen_rules',
 	'Install ETOpen Emerging Threats rules',
-	'ETOpen is an open source set of Suricata rules whose coverage is more limited than ETPro.',
+	'ETOpen is a free open source set of Suricata rules whose coverage is more limited than ETPro.',
 	$pconfig['enable_etopen_rules'] == 'on' ? true:false,
 	'on'
 ));
-$section->addInput(new Form_Checkbox(
+$group->add(new Form_Checkbox(
+	'enable_etopen_custom_url',
+	'Enable ETOpen Custom Download URL',
+	'Use a custom URL for ETOpen downloads',
+	$pconfig['enable_etopen_custom_url'] == 'on' ? true:false,
+	'on'
+));
+$group->setHelp('Enabling the custom URL option will force the use of a custom user-supplied URL when downloading ETOpen rules.');
+$section->add($group);
+$section->addInput(new Form_Input(
+	'etopen_custom_rule_url',
+	'ETOpen Custom Rule Download URL',
+	'text',
+	$pconfig['etopen_custom_rule_url']
+))->setHelp('You must provide the complete URL including the filename!  The code will assume a matching filename exists at the same URL with an additional extension of ".md5".');
+
+$group = new Form_Group('Install ETPro Emerging Threats rules');
+$group->add(new Form_Checkbox(
 	'enable_etpro_rules',
 	'Install ETPro Emerging Threats rules',
 	'ETPro for Suricata offers daily updates and extensive coverage of current malware threats.',
 	$pconfig['enable_etpro_rules'] == 'on' ? true:false,
 	'on'
-))->setHelp('The ETPro rules contain all of the ETOpen rules, so the ETOpen rules are not required and are disabled when the ETPro rules are selected. <a href="https://www.proofpoint.com/us/products/et-pro-ruleset">Sign Up for an ETPro Account</a>');
+));
+$group->add(new Form_Checkbox(
+	'enable_etpro_custom_url',
+	'Enable ETPro Custom Download URL',
+	'Use a custom URL for ETPro rule downloads',
+	$pconfig['enable_etpro_custom_url'] == 'on' ? true:false,
+	'on'
+));
+$group->setHelp('The ETPro rules contain all of the ETOpen rules, so the ETOpen rules are not required and are disabled when the ETPro rules are selected. ' . 
+		'<a href="https://www.proofpoint.com/us/products/et-pro-ruleset">Sign Up for an ETPro Account</a>.  Enabling the custom URL option will force the use of a custom user-supplied URL when downloading ETPro rules.');
+$section->add($group);
+$section->addInput(new Form_Input(
+	'etpro_custom_rule_url',
+	'ETPro Custom Rule Download URL',
+	'text',
+	$pconfig['etpro_custom_rule_url']
+))->setHelp('You must provide the complete URL including the filename!  The code will assume a matching filename exists at the same URL with an additional extension of ".md5".');
 $section->addInput(new Form_Input(
 	'etprocode',
 	'ETPro Subscription Configuration Code',
 	'text',
 	$pconfig['etprocode']
 ))->setHelp('Obtain an ETPro subscription code and paste it here.');
-$section->addInput(new Form_Checkbox(
+
+$group = new Form_Group('Install Snort rules');
+$group->add(new Form_Checkbox(
 	'enable_vrt_rules',
 	'Install Snort rules',
 	'Snort free Registered User or paid Subscriber rules',
 	$pconfig['enable_vrt_rules'] == 'on' ? true:false,
 	'on'
 ))->setHelp('<a href="https://www.snort.org/users/sign_up">Sign Up for a free Registered User Rules Account</a><br /><a href="https://www.snort.org/products">Sign Up for paid Snort Subscriber Rule Set (by Talos)</a>');
+$group->add(new Form_Checkbox(
+	'enable_snort_custom_url',
+	'Enable Snort Custom Download URL',
+	'Use a custom URL for Snort rule downloads',
+	$pconfig['enable_snort_custom_url'] == 'on' ? true:false,
+	'on'
+));
+$group->setHelp('Enabling the custom URL option will force the use of a custom user-supplied URL when downloading Snort Subscriber rules.');
+$section->add($group);
+$section->addInput(new Form_Input(
+	'snort_custom_url',
+	'Snort Rules Custom Download URL',
+	'text',
+	$pconfig['snort_custom_url']
+))->setHelp('You must provide the complete URL including the filename!  The code will assume a matching filename exists at the same URL with an additional extension of ".md5".');
 $section->addInput(new Form_Input(
 	'snort_rules_file',
 	'Snort Rules Filename',
@@ -243,13 +323,32 @@ $section->addInput(new Form_Input(
 	'text',
 	$pconfig['oinkcode']
 ))->setHelp('Obtain a snort.org Oinkmaster code and paste it here.');
-$section->addInput(new Form_Checkbox(
+
+$group = new Form_Group('Install Snort GPLv2 Community rules');
+$group->add(new Form_Checkbox(
 	'snortcommunityrules',
 	'Install Snort GPLv2 Community rules',
-	'The Snort Community Ruleset is a GPLv2 Talos-certified ruleset that is distributed free of charge without any Snort Subscriber License restrictions. This ruleset is updated daily and is a subset of the subscriber ruleset.',
+	'The Snort Community Ruleset is a GPLv2 Talos-certified ruleset that is distributed free of charge without any Snort Subscriber License restrictions.',
 	$pconfig['snortcommunityrules'] == 'on' ? true:false,
 	'on'
-))->setHelp('If you are a Snort Subscriber Rules customer (paid subscriber), the community ruleset is already built into your download of the Snort Subscriber rules, and there is no benefit in adding this rule set separately.');
+));
+$group->add(new Form_Checkbox(
+	'enable_gplv2_custom_url',
+	'Enable Snort GPLv2 Custom Download URL',
+	'Use a custom URL for Snort GPLv2 rule downloads',
+	$pconfig['enable_gplv2_custom_url'] == 'on' ? true:false,
+	'on'
+));
+$group->setHelp('This ruleset is updated daily and is a subset of the subscriber ruleset.  If you are a Snort Subscriber Rules customer (paid subscriber), ' .
+		'the community ruleset is already built into your download of the Snort Subscriber rules, and there is no benefit in adding this rule set separately.');
+$section->add($group);
+$section->addInput(new Form_Input(
+	'gplv2_custom_url',
+	'Snort GPLv2 Custom Rule Download URL',
+	'text',
+	$pconfig['gplv2_custom_url']
+))->setHelp('You must provide the complete URL including the filename!  The code will assume a matching filename exists at the same URL with an additional extension of ".md5".');
+
 $section->addInput(new Form_Checkbox(
 	'hide_deprecated_rules',
 	'Hide Deprecated Rules Categories',
@@ -339,21 +438,60 @@ events.push(function(){
 		var hide = ! $('#enable_vrt_rules').prop('checked');
 		hideInput('snort_rules_file', hide);
 		hideInput('oinkcode', hide);
+		$('#enable_snort_custom_url').prop('disabled', hide);
+		if (!hide && $('#enable_snort_custom_url').prop('checked')) {
+			hideInput('snort_custom_url', false);
+		}
+		else {
+			hideInput('snort_custom_url', true);
+		}
 	}
 
 	function enable_et_rules() {
 		var hide = $('#enable_etopen_rules').prop('checked');
+		$('#enable_etopen_custom_url').prop('disabled', !hide);
+		if (hide && $('#enable_etopen_custom_url').prop('checked')) {
+			hideInput('etopen_custom_rule_url', false);
+		}
+		else {
+			hideInput('etopen_custom_rule_url', true);
+		}
 		if (hide && $('#enable_etpro_rules').prop('checked')) {
 			hideInput('etprocode', hide);
+			hideInput('etpro_custom_rule_url', hide);
 			$('#enable_etpro_rules').prop('checked', false);
+			$('#enable_etpro_custom_url').prop('disabled', hide);
 		}
 	}
 
 	function enable_etpro_rules() {
 		var hide = ! $('#enable_etpro_rules').prop('checked');
-		hideInput('etprocode', hide);
-		if (!hide && $('#enable_etopen_rules').prop('checked'))
+		$('#enable_etpro_custom_url').prop('disabled', hide);
+		if (!hide && $('#enable_etpro_custom_url').prop('checked')) {
+			hideInput('etpro_custom_rule_url', false);
+			hideInput('etprocode', true);
+		}
+		else {
+			hideInput('etpro_custom_rule_url', true);
+			hideInput('etprocode', false);
+
+		}
+		if (!hide && $('#enable_etopen_rules').prop('checked')) {
 			$('#enable_etopen_rules').prop('checked', false);
+			$('#enable_etopen_custom_url').prop('disabled', !hide);
+			hideInput('etopen_custom_rule_url', !hide);
+		}
+	}
+
+	function enable_gplv2_rules() {
+		var hide = ! $('#snortcommunityrules').prop('checked');
+		$('#enable_gplv2_custom_url').prop('disabled', hide);
+		if (!hide && $('#enable_gplv2_custom_url').prop('checked')) {
+			hideInput('gplv2_custom_url', false);
+		}
+		else {
+			hideInput('gplv2_custom_url', true);
+		}
 	}
 
 	function enable_change_rules_upd(val) {
@@ -374,14 +512,44 @@ events.push(function(){
 		enable_snort_vrt();
 	});
 
+	// When 'enable_snort_custom_url' is clicked, toggle the custom URL control
+	$('#enable_snort_custom_url').click(function() {
+		var hide = ! $('#enable_snort_custom_url').prop('checked');
+		hideInput('snort_custom_url', hide);
+	});
+
 	// When 'enable_etopen_rules' is clicked, uncheck ETPro and hide the ETPro Code text control
 	$('#enable_etopen_rules').click(function() {
 		enable_et_rules();
 	});
 
+	// When 'enable_etopen_custom_url' is clicked, toggle the custom URL control
+	$('#enable_etopen_custom_url').click(function() {
+		var hide = ! $('#enable_etopen_custom_url').prop('checked');
+		hideInput('etopen_custom_rule_url', hide);
+	});
+
 	// When 'enable_etpro_rules' is clicked, uncheck ET Open checkbox control and show code
 	$('#enable_etpro_rules').click(function() {
 		enable_etpro_rules();
+	});
+
+	// When 'enable_etpro_custom_url' is clicked, toggle the custom URL control
+	$('#enable_etpro_custom_url').click(function() {
+		var hide = ! $('#enable_etpro_custom_url').prop('checked');
+		hideInput('etpro_custom_rule_url', hide);
+		hideInput('etprocode', !hide);
+	});
+
+	// When 'snortcommunityrules' is clicked, toggle the custom URL control
+	$('#snortcommunityrules').click(function() {
+		enable_gplv2_rules();
+	});
+
+	// When 'enable_gplv2_custom_url' is clicked, toggle the custom URL control
+	$('#enable_gplv2_custom_url').click(function() {
+		var hide = ! $('#enable_gplv2_custom_url').prop('checked');
+		hideInput('gplv2_custom_url', hide);
 	});
 
 	// When 'autoruleupdate' is set to never, disable 'autoruleupdatetime'
@@ -398,6 +566,7 @@ events.push(function(){
 	enable_snort_vrt();
 	enable_et_rules();
 	enable_etpro_rules();
+	enable_gplv2_rules();
 	enable_change_rules_upd($('#autoruleupdate').prop('selectedIndex'));
 	toggle_log_to_systemlog();
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
@@ -196,6 +196,14 @@ if (isset($_POST['save_auto_sid_conf'])) {
 		$a_nat[$k]['drop_sid_file'] = $v;
 	}
 
+	foreach ($_POST['reject_sid_file'] as $k => $v) {
+		if ($v == "None") {
+			unset($a_nat[$k]['reject_sid_file']);
+			continue;
+		}
+		$a_nat[$k]['reject_sid_file'] = $v;
+	}
+
 	// Write the new configuration
 	write_config("Suricata pkg: updated automatic SID management settings.");
 
@@ -520,16 +528,17 @@ if ($savemsg) {
 					<th><?=gettext("Disable SID List")?></th>
 					<th><?=gettext("Modify SID List")?></th>
 					<th><?=gettext("Drop SID List")?></th>
+					<th><?=gettext("Reject SID List")?></th>
 				   </tr>
 				</thead>
 				<tbody>
 			   <?php foreach ($a_nat as $k => $natent): ?>
 				<tr>
-					<td>
+					<td class="text-center">
 						<input type="checkbox" name="torestart[]" id="torestart[]" value="<?=$k;?>" title="<?=gettext("Apply new configuration and rebuild rules for this interface when saving");?>" />
 					</td>
-					<td class="listbg"><?=convert_friendly_interface_to_friendly_descr($natent['interface']); ?></td>
-					<td class="listr" align="center">
+					<td><?=convert_friendly_interface_to_friendly_descr($natent['interface']); ?></td>
+					<td>
 						<select name="sid_state_order[<?=$k?>]" class="form-control" id="sid_state_order[<?=$k?>]">
 							<?php
 								foreach (array("disable_enable" => "Disable, Enable", "enable_disable" => "Enable, Disable") as $key => $order) {
@@ -586,18 +595,42 @@ if ($savemsg) {
 						</select>
 					</td>
 					<td>
-						<select name="drop_sid_file[<?=$k?>]" class="form-control" id="drop_sid_file[<?=$k?>]">
-							<?php
-								foreach ($sidmodselections as $choice) {
-									if ($choice == $natent['drop_sid_file'])
-										echo "<option value='{$choice}' selected>";
-									else
-										echo "<option value='{$choice}'>";
+						<?php if ($natent['blockoffenders'] == 'on' && ($natent['ips_mode'] == 'ips_mode_inline' || $natent['block_drops_only'] == 'on')) : ?>
+							<select name="drop_sid_file[<?=$k?>]" class="form-control" id="drop_sid_file[<?=$k?>]">
+								<?php
+									foreach ($sidmodselections as $choice) {
+										if ($choice == $natent['drop_sid_file'])
+											echo "<option value='{$choice}' selected>";
+										else
+											echo "<option value='{$choice}'>";
 
-									echo htmlspecialchars(gettext($choice)) . '</option>';
-								}
-							?>
-						</select>
+										echo htmlspecialchars(gettext($choice)) . '</option>';
+									}
+								?>
+							</select>
+						<?php else : ?>
+							<input type="hidden" name="drop_sid_file[<?=$k?>]" id="drop_sid_file[<?=$k?>]" value="<?=isset($natent['drop_sid_file']) ? $natent['drop_sid_file'] : 'none';?>">
+							<span class="text-center"><?=gettext("Not Applicable")?></span>
+						<?php endif; ?>
+					</td>
+					<td>
+						<?php if ($natent['blockoffenders'] == 'on' && $natent['ips_mode'] == 'ips_mode_inline') : ?>
+							<select name="reject_sid_file[<?=$k?>]" class="form-control" id="reject_sid_file[<?=$k?>]">
+								<?php
+									foreach ($sidmodselections as $choice) {
+										if ($choice == $natent['reject_sid_file'])
+											echo "<option value='{$choice}' selected>";
+										else
+											echo "<option value='{$choice}'>";
+
+										echo htmlspecialchars(gettext($choice)) . '</option>';
+									}
+								?>
+							</select>
+						<?php else : ?>
+							<input type="hidden" name="reject_sid_file[<?=$k?>]" id="reject_sid_file[<?=$k?>]" value="<?=isset($natent['reject_sid_file']) ? $natent['reject_sid_file'] : 'none';?>">
+							<span class="text-center"><?=gettext("Not Applicable")?></span>
+						<?php endif; ?>
 					</td>
 				</tr>
 			   <?php endforeach; ?>


### PR DESCRIPTION
# pfSense-pkg-suricata v4.0.4_1
This update adds two new features to the GUI package.  The underlying Suricata binary version is 4.0.4.
## New Features
1.  Add the ability to use custom user-supplied rules update URLs for downloading rules updates.  See Redmine Feature Request #8362.  This is primarily useful for organizations with many firewalls where it is desirable to fetch rule update archives from the rule vendor and then store them on a central internal server for distribution to the organization's internal firewalls.
2.  Add the ability to use a _rejectsid.conf_ configuration on SID MGMT to duplicate what _dropsid.conf_ does except the rule action is changed to REJECT.