### PR TITLE
haproxy-devel, version bump to 0.56 including a variety of new features and fixes

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/Makefile
+++ b/net/pfSense-pkg-haproxy-devel/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-haproxy-devel
-PORTVERSION=	0.55
-PORTREVISION=	2
+PORTVERSION=	0.56
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -1191,7 +1191,12 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 				if (count($servers) > 1) {
 					$servername .= "_" . $counter;
 				}
+				if (is_numeric($be['istemplate'])) {
+					$istemplate = " {$be['istemplate']}";
+					fwrite ($fd, "\tserver-template\t\t\t" . $servername . $istemplate . " " . $server . "$ssl$cookie$checkinter$checkport$agentcheck $isbackup$weight$maxconn$cafile$crlfile$verifynone$verifyhost$crtfile$server_options{$advanced_txt} {$be['advanced']}\n");
+				} else {
 					fwrite ($fd, "\tserver\t\t\t" . $servername . " " . $server . "$ssl$cookie$checkinter$checkport$agentcheck $isbackup$weight$maxconn$cafile$crlfile$verifynone$verifyhost$crtfile$server_options{$advanced_txt} {$be['advanced']}\n");
+				}
 				$counter++;
 			}
 		}
@@ -1973,7 +1978,7 @@ function haproxy_writeconf($configpath) {
 						
 						if ($actionid == "use_backend") {							
 							if (empty($condition)) {
-								$config_usedefaultbackends .= "\tdefault_backend {$parameter}{$condition}\n";
+								$config_usedefaultbackends .= "\tdefault_backend {$parameter}\n";
 							} else {
 								if (!empty($actionitem['acl'])){
 									$config_usebackends .= $action;

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -888,7 +888,7 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 	}
 	fwrite ($fd, "\ttimeout server\t\t" . $pool['server_timeout'] . "\n");
 
-	if (empty($pool['retries'])) {
+	if (!is_numeric($pool['retries'])) {
 		$pool['retries'] = 3;
 	}
 	fwrite ($fd, "\tretries\t\t\t" . $pool['retries'] . "\n");
@@ -2841,4 +2841,30 @@ function haproxy_find_create_certificate($certificatename) {
 	cert_import($cert, $crt, $prv);
 	$a_cert[] = $cert;
 	return $cert;
+}
+
+function haproxy_config_init(){
+	global $config;
+	if (!is_array($config['installedpackages']['haproxy'])) {
+		$config['installedpackages']['haproxy'] = array();
+	}
+	$haproxycfg = &$config['installedpackages']['haproxy'];
+	if (!is_array($haproxycfg['email_mailers']['item'])) {
+		$haproxycfg['email_mailers']['item'] = array();
+	}
+	if (!is_array($haproxycfg['dns_resolvers']['item'])) {
+		$haproxycfg['dns_resolvers']['item'] = array();
+	}
+	if (!is_array($haproxycfg['ha_backends']['item'])) {
+		$haproxycfg['ha_backends']['item'] = array();
+	}
+	if (!is_array($haproxycfg['ha_pools']['item'])) {
+		$haproxycfg['ha_pools']['item'] = array();
+	}
+	if (!is_array($haproxycfg['ha_pools']['item'])) {
+		$haproxycfg['ha_pools']['item'] = array();
+	}
+	if (!is_array($haproxycfg['files']['item'])) {
+		$haproxycfg['files']['item'] = array();
+	}
 }

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -44,25 +44,25 @@ $a_frontendmode['health'] = array('name' => "health", 'shortname' => "health");
 global $a_acltypes;
 $a_acltypes = array();
 $a_acltypes["host_starts_with"] = array('name' => 'Host starts with:',
-				'mode' => 'http', 'syntax' => 'hdr_beg(host) -i %1$s');
+				'mode' => 'http', 'syntax' => 'var(txn.txnhost) -m beg -i %1$s', 'advancedoptions' => "http-request set-var(txn.txnhost) hdr(host)");
 $a_acltypes["host_ends_with"] = array('name' => 'Host ends with:',
-				'mode' =>'http', 'syntax' => 'hdr_end(host) -i %1$s');
+				'mode' =>'http', 'syntax' => 'var(txn.txnhost) -m end -i %1$s', 'advancedoptions' => "http-request set-var(txn.txnhost) hdr(host)");
 $a_acltypes["host_matches"] = array('name' => 'Host matches:',
-				'mode' =>'http', 'syntax' => 'hdr(host) -i %1$s');
+				'mode' =>'http', 'syntax' => 'var(txn.txnhost) -m str -i %1$s', 'advancedoptions' => "http-request set-var(txn.txnhost) hdr(host)");
 $a_acltypes["host_regex"] = array('name' => 'Host regex:',
-				'mode' =>'http', 'syntax' => 'hdr_reg(host) -i %1$s');
+				'mode' =>'http', 'syntax' => 'var(txn.txnhost) -m reg -i %1$s', 'advancedoptions' => "http-request set-var(txn.txnhost) hdr(host)");
 $a_acltypes["host_contains"] = array('name' => 'Host contains:',
-				'mode' => 'http', 'syntax' => 'hdr_sub(host) -i %1$s');
+				'mode' => 'http', 'syntax' => 'var(txn.txnhost) -m sub -i %1$s', 'advancedoptions' => "http-request set-var(txn.txnhost) hdr(host)");
 $a_acltypes["path_starts_with"] = array('name' => 'Path starts with:',
-				'mode' => 'http', 'syntax' => 'path_beg -i %1$s');
+				'mode' => 'http', 'syntax' => 'var(txn.txnpath) -m beg -i %1$s', 'advancedoptions' => "http-request set-var(txn.txnpath) hdr(path)");
 $a_acltypes["path_ends_with"] = array('name' => 'Path ends with:',
-				'mode' => 'http', 'syntax' => 'path_end -i %1$s');
+				'mode' => 'http', 'syntax' => 'var(txn.txnpath) -m end -i %1$s', 'advancedoptions' => "http-request set-var(txn.txnpath) hdr(path)");
 $a_acltypes["path_matches"] = array('name' => 'Path matches:',
-				'mode' => 'http', 'syntax' => 'path -i %1$s');
+				'mode' => 'http', 'syntax' => 'var(txn.txnpath) -m str -i %1$s', 'advancedoptions' => "http-request set-var(txn.txnpath) hdr(path)");
 $a_acltypes["path_regex"] = array('name' => 'Path regex:',
-				'mode' => 'http', 'syntax' => 'path_reg -i %1$s');
+				'mode' => 'http', 'syntax' => 'var(txn.txnpath) -m reg -i %1$s', 'advancedoptions' => "http-request set-var(txn.txnpath) hdr(path)");
 $a_acltypes["path_contains"] = array('name' => 'Path contains:',
-				'mode' => 'http', 'syntax' => 'path_sub -i %1$s');
+				'mode' => 'http', 'syntax' => 'var(txn.txnpath) -m sub -i %1$s', 'advancedoptions' => "http-request set-var(txn.txnpath) hdr(path)");
 $a_acltypes["url_parameter"] = array('name' => 'Url parameter contains:',
 				'mode' => 'http', 'syntax' => 'url_param({parameter}) -i %1$s',
 	'fields' => array(
@@ -252,7 +252,7 @@ $a_action["use_backend"] = array('name' => "Use Backend", 'mode' => '', 'syntax'
 	));
 $a_action["use_server"] = array('name' => "Use Server", 'mode' => '', 'syntax' => 'use-server {server}', 'usage' => 'backend',
 	'fields' => array(
-		'server' => array('name'=>"server",'columnheader'=>"Server",'type'=>"select",'size'=>"50",'mask'=>'server')
+		'server' => array('name'=>"server",'columnheader'=>"Server",'type'=>"textbox",'size'=>"50",'mask'=>'server')
 	));
 //
 $a_action["custom"] = array('name' => "Custom", 'mode' => '', 'syntax' => '{customaction}',
@@ -309,6 +309,23 @@ $a_action["http-request_replace-value"] = array('name' => "http-request header r
 		array('name'=>"find",'columnheader'=>"Find regex",'type'=>"textbox",'size'=>"50",'mask'=>'match-regex'),
 		array('name'=>"replace",'columnheader'=>"Replace by",'type'=>"textbox",'size'=>"50",'mask'=>'replace-fmt')
 	));
+
+$a_action["http-request_set-method"] = array('name' => "http-request set method", 'mode'=> 'http', 'syntax' => 'http-request set-method {fmt}',
+	'fields' => array(
+		array('name'=>"fmt",'columnheader'=>"New logformat value",'type'=>"textbox",'size'=>"50",'mask'=>'logformat')
+	));
+$a_action["http-request_set-path"] = array('name' => "http-request set path", 'mode'=> 'http', 'syntax' => 'http-request set-path {fmt}',
+	'fields' => array(
+		array('name'=>"fmt",'columnheader'=>"New logformat value",'type'=>"textbox",'size'=>"50",'mask'=>'logformat')
+	));
+$a_action["http-request_set-query"] = array('name' => "http-request set query", 'mode'=> 'http', 'syntax' => 'http-request set-query {fmt}',
+	'fields' => array(
+		array('name'=>"fmt",'columnheader'=>"New logformat value",'type'=>"textbox",'size'=>"50",'mask'=>'logformat')
+	));
+$a_action["http-request_set-uri"] = array('name' => "http-request set uri", 'mode'=> 'http', 'syntax' => 'http-request set-uri {fmt}',
+	'fields' => array(
+		array('name'=>"fmt",'columnheader'=>"New logformat value",'type'=>"textbox",'size'=>"50",'mask'=>'logformat')
+	));
 //
 $a_action["http-response_allow"] = array('name' => "http-response allow", 'mode'=> 'http', 'syntax' => 'http-response allow');
 $a_action["http-response_deny"] = array('name' => "http-response deny", 'mode'=> 'http', 'syntax' => 'http-response deny');
@@ -343,6 +360,11 @@ $a_action["http-response_replace-value"] = array('name' => "http-response header
 		array('name'=>"name",'columnheader'=>"Headername",'type'=>"textbox",'size'=>"50",'mask'=>'headername'),
 		array('name'=>"find",'columnheader'=>"Find regex",'type'=>"textbox",'size'=>"50",'mask'=>'match-regex'),
 		array('name'=>"replace",'columnheader'=>"Replace by",'type'=>"textbox",'size'=>"50",'mask'=>'replace-fmt')
+	));
+$a_action["http-response_set-status"] = array('name' => "http-response set status", 'mode'=> 'http', 'syntax' => 'http-response set-status {status} {reason}',
+	'fields' => array(
+		array('name'=>"status",'columnheader'=>"Status",'type'=>"textbox",'size'=>"50",'mask'=>'text'),
+		array('name'=>"reason",'columnheader'=>"Reason",'type'=>"textbox",'size'=>"50",'mask'=>'text','prefix'=>'reason')
 	));
 //
 $a_action["tcp-request_connection_accept"] = array('name' => "tcp-request connection accept", 'mode'=> '', 'syntax' => 'tcp-request connection accept');
@@ -429,7 +451,7 @@ function haproxy_addressoralias_to_list($address_or_alias) {
 		if ($alias_type == "host") {
 			$result = explode(' ',$alias);
 		}
-	} else {
+		} else {
 		$result[] = $address_or_alias;
 	}
 	return $result;
@@ -439,9 +461,9 @@ function haproxy_hostoralias_to_list($host_or_alias) {
 	if (is_alias($host_or_alias)){
 		$result = filter_expand_alias_array($host_or_alias);
 	} else {
-		$result = array();
+	$result = array();
 		$result[] = $host_or_alias;
-	}
+			}
 	return $result;
 }
 
@@ -889,6 +911,7 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 	if (!is_array($a_acl)) {
 		$a_acl = array();
 	}
+	$advancedextra = array();
 	// ACL's
 	foreach ($a_acl as $entry) {
 		$aclitem = $entry['ref'];
@@ -908,7 +931,7 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 			$inspectdelay = $acltype['inspect-delay'];
 		}
 		if ($acltype['advancedoptions'] != '') {
-			$advancedextra[$acltype['syntax']] = $acltype['advancedoptions']."\n";
+			$advancedextra[$acltype['advancedoptions']] = $acltype['advancedoptions'];
 		}
 		if ($acltype['require_client_cert']) {
 			$needs_clientcert[$aclname] = true;
@@ -947,6 +970,9 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 	foreach($config_acls as $acl => $dummy) {
 		fwrite ($fd, $acl);
 	}
+	foreach($advancedextra as $extra) {
+		fwrite ($fd, "\t".$extra."\n");
+	}
 
 	$a_actionitems = $pool['a_actionitems']['item'];
 	if (!is_array($a_actionitems)) {
@@ -975,6 +1001,9 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 						$a_pendingpl[$backendname]['ipversion'] = $ipversion;
 					}*/
 					$parameter = $backendname;
+				}
+				if (!empty($parameter)) {
+					$parameter = $field['prefix'] . " ". $parameter;
 				}
 				$action_cfg = str_replace("{{$fieldname}}", $parameter, $action_cfg);
 			}
@@ -1138,7 +1167,7 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 				if (count($servers) > 1) {
 					$servername .= "_" . $counter;
 				}
-				fwrite ($fd, "\tserver\t\t\t" . $servername . " " . $server . "$ssl$cookie$checkinter$checkport$agentcheck $isbackup$weight$maxconn$cafile$crlfile$verifynone$verifyhost$crtfile$server_options{$advanced_txt} {$be['advanced']}\n");
+					fwrite ($fd, "\tserver\t\t\t" . $servername . " " . $server . "$ssl$cookie$checkinter$checkport$agentcheck $isbackup$weight$maxconn$cafile$crlfile$verifynone$verifyhost$crtfile$server_options{$advanced_txt} {$be['advanced']}\n");
 				$counter++;
 			}
 		}
@@ -1829,7 +1858,7 @@ function haproxy_writeconf($configpath) {
 							$inspectdelay = $acltype['inspect-delay'];
 						}
 						if ($acltype['advancedoptions'] != '') {
-							$advancedextra[$acltype['syntax']] = $acltype['advancedoptions']."\n";
+							$advancedextra[$acltype['advancedoptions']] = $acltype['advancedoptions'];
 						}
 						if ($acltype['require_client_cert']) {
 							$needs_clientcert[$aclname] = true;
@@ -1889,6 +1918,9 @@ function haproxy_writeconf($configpath) {
 										$a_pendingpl[$backendname]['ipversion'] = $ipversion;
 									}
 									$parameter = $backendname;
+								}
+								if (!empty($parameter)) {
+									$parameter = $field['prefix'] . " ". $parameter;
 								}
 								$action_cfg = str_replace("{{$fieldname}}", $parameter, $action_cfg);
 							}

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -436,34 +436,58 @@ function haproxy_portoralias_to_list($port_or_alias) {
 		return $portresult;
 	}
 }
-function haproxy_addressoralias_to_list($address_or_alias) {
+
+function haproxy_expand_alias_array($address_or_alias) {
 	global $aliastable;
 	$result = array();
-	$alias_type = alias_get_type($address_or_alias);
-	if (!empty($alias_type)) {
-		$alias = $aliastable[$address_or_alias];
+	$items = explode(' ', $address_or_alias);
+	
+	$i = 0;
+	while($i < count($items)) {
+		$item = $items[$i];
+		$alias_type = alias_get_type($item);
+		$alias = $aliastable[$item];
 		if ($alias_type == "url") {
-			$result = explode(' ',$alias);
+			$items = array_merge($items, explode(' ',$alias));
 		} else
 		if ($alias_type == "network") {
-			//$result = explode(' ',$alias);
+			$items = array_merge($items, explode(' ',$alias));
 		} else
 		if ($alias_type == "host") {
-			$result = explode(' ',$alias);
-		}
+			$items = array_merge($items, explode(' ',$alias));
 		} else {
-		$result[] = $address_or_alias;
+			$result[] = $item;
+		}
+		$i++;
+	}
+	return $result;
+}
+
+function haproxy_filter_alias_array($list, $ip=false, $subnet=false, $hostname=false, $convertiptosubnet=false) {
+	$result = array();
+	foreach($list as $item) {
+		if ($ip && $ipv = is_ipaddr($item)) {
+			if ($convertiptosubnet) {
+				if ($ipv == 4) {
+					$item .= "/32";
+				} elseif ($ipv == 6) {
+					$item .= "/128";
+				}
+			}
+			$result[] = $item;
+		} elseif ($subnet && is_subnet($item)) {
+			$result[] = $item;
+		} elseif ($hostname && is_hostname($item)) {
+			$result[] = $item;
+		}
 	}
 	return $result;
 }
 
 function haproxy_hostoralias_to_list($host_or_alias) {
-	if (is_alias($host_or_alias)){
-		$result = filter_expand_alias_array($host_or_alias);
-	} else {
-	$result = array();
-		$result[] = $host_or_alias;
-			}
+	//used by source_ip acl
+	$items = haproxy_expand_alias_array($host_or_alias);
+	$result = haproxy_filter_alias_array($items, true, true);
 	return $result;
 }
 
@@ -2491,8 +2515,8 @@ function get_frontend_bindips($frontend) {
 		if (isset($extaddr['extaddr']) && $extaddr['extaddr'] != "custom") {
 			$a_ip[] = haproxy_interface_ip($extaddr['extaddr']);
 		} else {						
-			$iporalias = $extaddr['extaddr_custom'];
-			$a_ip = haproxy_addressoralias_to_list($iporalias);
+			$items = haproxy_expand_alias_array($extaddr['extaddr_custom']);
+			$a_ip = haproxy_filter_alias_array($items, true);
 		}
 		foreach($a_ip as $ip) {
 			$portsnumeric = group_ports(haproxy_portoralias_to_list($extaddr['extaddr_port']));

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -1026,7 +1026,7 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 					}*/
 					$parameter = $backendname;
 				}
-				if (!empty($parameter)) {
+				if (!empty($parameter) && !empty($field['prefix'])) {
 					$parameter = $field['prefix'] . " ". $parameter;
 				}
 				$action_cfg = str_replace("{{$fieldname}}", $parameter, $action_cfg);
@@ -1948,7 +1948,7 @@ function haproxy_writeconf($configpath) {
 									}
 									$parameter = $backendname;
 								}
-								if (!empty($parameter)) {
+								if (!empty($parameter) && !empty($field['prefix'])) {
 									$parameter = $field['prefix'] . " ". $parameter;
 								}
 								$action_cfg = str_replace("{{$fieldname}}", $parameter, $action_cfg);

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy_htmllist.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy_htmllist.inc
@@ -79,9 +79,11 @@ class HaproxyHtmlList
 			}
 			foreach($fields as $item) {
 				$itemname = $item['name'];
-				$value[$itemname] = $_POST[$this->tablename.$itemname.$x];
-				if ($item['type'] == 'textarea') {
-					$value[$itemname] = base64_encode($value[$itemname]);
+				if (!empty($_POST[$this->tablename.$itemname.$x])) {
+					$value[$itemname] = $_POST[$this->tablename.$itemname.$x];
+					if ($item['type'] == 'textarea') {
+						$value[$itemname] = base64_encode($value[$itemname]);
+					}
 				}
 				$add_item |= isset($_POST[$this->tablename.$itemname.$x]);
 			}

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy_socketinfo.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy_socketinfo.inc
@@ -151,10 +151,10 @@ function haproxy_get_clients($show_traffic = false){// "show sess"
 			$session_data = haproxy_socket_command("show sess {$client['sessid']}");
 			$client['session_data'] = $session_data;
 			
-			$req = explode(" ",$session_data[12]);
+			$req = explode(" ",$session_data[13]);
 			$x = explode("=",$req[7]);
 			$client['session_datareq'] = $x[1];
-			$res = explode(" ",$session_data[15]);
+			$res = explode(" ",$session_data[16]);
 			$x = explode("=",$res[7]);
 			$client['session_datares'] = $x[1];
 		}

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy_utils.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy_utils.inc
@@ -520,3 +520,47 @@ function haproxy_keyvalue_array($hap_array) {
 	}
 	return $result;
 }
+
+function haproxy_js_css() {
+	echo <<<PRE
+	function getCSSrule(cssID) {
+		var ss = document.styleSheets;
+		for (var i=0; i<ss.length; i++) {
+			var rules;
+			try {
+				rules = ss[i].cssRules || ss[i].rules;
+			} catch(e) {
+				// some plugins add 3rd party stylesheets, FF throws an SecurityError when trying to access those rules.
+				if(e.name !== "SecurityError") {
+					throw e;
+				}
+			}
+			if (rules) {
+				for (var j=0; j<rules.length; j++) {
+					if (rules[j].selectorText === cssID) {
+						return rules[j];
+					}
+				}
+			}
+		}
+		return null;
+	}
+	
+	function setCSSdisplay(cssID, display) {
+		rule = getCSSrule(cssID);
+		if (rule) {
+			rule.style.display = display ? "" : "none";
+		}
+	}
+	
+	function toggleCSSdisplay(cssID)
+	{
+		rule = getCSSrule(cssID);
+		if (rule) {
+			rule.style.display = rule.style.display === "none" ? "" : "none";
+		}
+	}
+	
+PRE;
+
+}

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_files.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_files.php
@@ -26,11 +26,9 @@ require_once("haproxy/haproxy.inc");
 require_once("haproxy/haproxy_htmllist.inc");
 require_once("haproxy/pkg_haproxy_tabs.inc");
 
+haproxy_config_init();
 $a_files = &$config['installedpackages']['haproxy']['files']['item'];
-if (!is_array($a_files)) $a_files = array();
 $a_pools = &$config['installedpackages']['haproxy']['ha_pools']['item'];
-if (!is_array($a_pools)) $a_pools = array();
-
 
 $fields_files = array();
 $fields_files[0]['name']="name";

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_global.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_global.php
@@ -76,8 +76,7 @@ $mailerslist->keyfield = "name";
 $resolverslist = new HaproxyHtmlList("table_resolvers", $fields_resolvers);
 $resolverslist->keyfield = "name";
 
-if (!is_array($config['installedpackages']['haproxy'])) 
-	$config['installedpackages']['haproxy'] = array();
+haproxy_config_init();
 
 if ($_POST) {
 	unset($input_errors);
@@ -144,13 +143,7 @@ if ($_POST) {
 }
 
 $a_mailers = $config['installedpackages']['haproxy']['email_mailers']['item'];
-if (!is_array($a_mailers)) {
-	$a_mailers = array();
-}
 $a_resolvers = $config['installedpackages']['haproxy']['dns_resolvers']['item'];
-if (!is_array($a_resolvers)) {
-	$a_resolvers = array();
-}
 
 $pconfig['enable'] = isset($config['installedpackages']['haproxy']['enable']);
 $pconfig['terminate_on_reload'] = isset($config['installedpackages']['haproxy']['terminate_on_reload']);

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners.php
@@ -432,7 +432,7 @@ function js_callback(req) {
 					<a href="haproxy_listeners_edit.php?id=<?=$frontendname;?>">
 						<?=haproxyicon("edit", gettext("edit frontend"))?>
 					</a>
-					<a href="haproxy_listeners.php?act=del&amp;id=<?=$frontendname;?>" onclick="return confirm('Do you really want to delete this entry?')">
+					<a href="haproxy_listeners.php?act=del&amp;id=<?=$frontendname;?>">
 						<?=haproxyicon("delete", gettext("delete frontend"))?>
 					</a>
 					<a href="haproxy_listeners_edit.php?dup=<?=$frontendname;?>">
@@ -448,16 +448,16 @@ function js_callback(req) {
 		</div>
 	</div>
 	<nav class="action-buttons">
-		<a href="haproxy_listeners_edit.php" role="button" class="btn btn-sm btn-success" title="<?=gettext('Add backend to the end of the list')?>">
+		<a href="haproxy_listeners_edit.php" role="button" class="btn btn-sm btn-success" title="<?=gettext('Add frontend to the end of the list')?>">
 			<i class="fa fa-level-down icon-embed-btn"></i>
 			<?=gettext("Add");?>
 		</a>
-		<button name="del_x" type="submit" class="btn btn-danger btn-sm" value="<?=gettext("Delete selected backends"); ?>" title="<?=gettext('Delete selected backends')?>">
-			<i class="fa fa-trash icon-embed-btn no-confirm"></i>
+		<button name="del_x" type="submit" class="btn btn-danger btn-sm no-confirm" value="<?=gettext("Delete selected frontends"); ?>" title="<?=gettext('Delete selected frontends')?>">
+			<i class="fa fa-trash icon-embed-btn"></i>
 			<?=gettext("Delete"); ?>
 		</button>
-		<button type="submit" id="order-store" name="order-store" class="btn btn-sm btn-primary" value="store changes" disabled title="<?=gettext('Save backend order')?>">
-			<i class="fa fa-save icon-embed-btn no-confirm"></i>
+		<button type="submit" id="order-store" name="order-store" class="btn btn-sm btn-primary no-confirm" value="store changes" disabled title="<?=gettext('Save backend order')?>">
+			<i class="fa fa-save icon-embed-btn"></i>
 			<?=gettext("Save")?>
 		</button>
 	</nav>

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
@@ -500,6 +500,8 @@ $primaryfrontends = get_haproxy_frontends($excludefrontend);
 </head>
 
 <script type="text/javascript">
+	<?php haproxy_js_css(); ?>
+		
 	function htmllist_get_select_options(tableId, fieldname, itemstable) {
 		if (tableId === 'table_acls' && fieldname === 'expression') {
 			var type;
@@ -521,18 +523,7 @@ $primaryfrontends = get_haproxy_frontends($excludefrontend);
 		}
 		return itemstable;
 	}
-
-	function setCSSdisplay(cssID, display) {
-		var ss = document.styleSheets;
-		for (var i=0; i<ss.length; i++) {
-			var rules = ss[i].cssRules || ss[i].rules;
-			for (var j=0; j<rules.length; j++) {
-				if (rules[j].selectorText === cssID) {
-					rules[j].style.display = display ? "" : "none";
-				}
-			}
-		}
-	}
+		
 	function updatevisibility()	{
 		d = document;
 		ssl = false;

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
@@ -171,6 +171,11 @@ $fields_externalAddress[4]['colwidth']="20%";
 $fields_externalAddress[4]['type']="textbox";
 $fields_externalAddress[4]['size']="30";
 
+foreach ($a_action as $key => $value) {
+	if (!empty($value['usage']) && !stristr('frontend', $value['usage'])) {
+		unset($a_action[$key]);
+	}
+}
 $fields_actions=array();
 $fields_actions[0]['name']="action";
 $fields_actions[0]['columnheader']="Action";
@@ -233,7 +238,7 @@ foreach($a_acltypes as $key => $action) {
 			$item = $field;
 			$name = $key . $item['name'];
 			$item['name'] = $name;
-			$item['columnheader'] = $field['name'];
+			$item['columnheader'] = $field['columnheader'];
 			$item['customdrawcell'] = customdrawcell_actions;
 			$fields_acl_details[$name] = $item;
 		}
@@ -446,6 +451,9 @@ if ($_POST) {
 		
 		foreach($simplefields as $stat) {
 			update_if_changed($stat, $backend[$stat], $_POST[$stat]);
+			if (empty($backend[$stat])) {
+				unset($backend[$stat]);
+			}
 		}
 		
 		update_if_changed("advanced", $backend['advanced'], base64_encode($_POST['advanced']));

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
@@ -39,15 +39,9 @@ if (!function_exists("cert_get_purpose")) {
 }
 /**/
 
-if (!is_array($config['installedpackages']['haproxy']['ha_backends']['item'])) {
-	$config['installedpackages']['haproxy']['ha_backends']['item'] = array();
-}
-
+haproxy_config_init();
 $a_backend = &$config['installedpackages']['haproxy']['ha_backends']['item'];
 $a_pools = $config['installedpackages']['haproxy']['ha_pools']['item'];
-if (!is_array($a_pools)) {
-	$a_pools = array();
-}
 uasort($a_pools, haproxy_compareByName);
 
 global $simplefields;

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pool_edit.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pool_edit.php
@@ -180,6 +180,12 @@ $fields_servers_details[7]['description']="Advanced, Allows for adding custom HA
 $fields_servers_details[7]['colwidth']="15%";
 $fields_servers_details[7]['type']="textbox";
 $fields_servers_details[7]['size']="80";
+$fields_servers_details[8]['name']="istemplate";
+$fields_servers_details[8]['columnheader']="DNS template count";
+$fields_servers_details[8]['description']="If set configures this server item as a template to provision servers from dns/srv responses.";
+$fields_servers_details[8]['colwidth']="15%";
+$fields_servers_details[8]['type']="textbox";
+$fields_servers_details[8]['size']="80";
 
 $fields_errorfile = array();
 $fields_errorfile[0]['name']="errorcode";
@@ -227,6 +233,11 @@ $fields_aclSelectionList[3]['colwidth']="35%";
 $fields_aclSelectionList[3]['type']="textbox";
 $fields_aclSelectionList[3]['size']="35";
 
+foreach ($a_action as $key => $value) {
+	if (!empty($value['usage']) && !stristr('backend', $value['usage'])) {
+		unset($a_action[$key]);
+	}
+}
 $fields_actions=array();
 $fields_actions[0]['name']="action";
 $fields_actions[0]['columnheader']="Action";
@@ -269,7 +280,7 @@ foreach($a_acltypes as $key => $action) {
 			$item = $field;
 			$name = $key . $item['name'];
 			$item['name'] = $name;
-			$item['columnheader'] = $field['name'];
+			$item['columnheader'] = $field['columnheader'];
 			$item['customdrawcell'] = customdrawcell_actions;
 			$fields_acl_details[$name] = $item;
 		}

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pool_edit.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pool_edit.php
@@ -28,10 +28,7 @@ require_once("haproxy/haproxy_utils.inc");
 require_once("haproxy/haproxy_htmllist.inc");
 require_once("haproxy/pkg_haproxy_tabs.inc");
 
-if (!is_array($config['installedpackages']['haproxy']['ha_pools']['item'])) {
-	$config['installedpackages']['haproxy']['ha_pools']['item'] = array();
-}
-
+haproxy_config_init();
 $a_pools = &$config['installedpackages']['haproxy']['ha_pools']['item'];
 
 $a_files = haproxy_get_fileslist();

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pool_edit.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pool_edit.php
@@ -537,36 +537,13 @@ foreach($simplefields as $field){
   </style>
 </head>
 <script type="text/javascript">
+	<?php haproxy_js_css(); ?>
+
 	function clearcombo(){
 	  for (var i=document.iform.serversSelect.options.length-1; i>=0; i--){
 		document.iform.serversSelect.options[i] = null;
 	  }
 	  document.iform.serversSelect.selectedIndex = -1;
-	}
-
-	function setCSSdisplay(cssID, display)
-	{
-		var ss = document.styleSheets;
-		for (var i=0; i<ss.length; i++) {
-			var rules = ss[i].cssRules || ss[i].rules;
-			for (var j=0; j<rules.length; j++) {
-				if (rules[j].selectorText === cssID) {
-					rules[j].style.display = display ? "" : "none";
-				}
-			}
-		}
-	}
-	function toggleCSSdisplay(cssID)
-	{
-		var ss = document.styleSheets;
-		for (var i=0; i<ss.length; i++) {
-			var rules = ss[i].cssRules || ss[i].rules;
-			for (var j=0; j<rules.length; j++) {
-				if (rules[j].selectorText === cssID) {
-					rules[j].style.display = rules[j].style.display === "none" ? "" : "none";
-				}
-			}
-		}
 	}
 	
 	function updatevisibility()

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pools.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pools.php
@@ -193,7 +193,7 @@ haproxy_display_top_tabs_active($haproxy_tab_array['haproxy'], "backend");
 					<a href="haproxy_pool_edit.php?id=<?=$i;?>">
 						<?=haproxyicon("edit", gettext("edit backend"))?>
 					</a>
-					<a href="haproxy_pools.php?act=del&amp;id=<?=$i;?>" onclick="return confirm('Do you really want to delete this entry?')">
+					<a href="haproxy_pools.php?act=del&amp;id=<?=$i;?>">
 						<?=haproxyicon("delete", gettext("delete backend"))?>
 					</a>
 					<a href="haproxy_pool_edit.php?dup=<?=$i;?>">

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/widgets/widgets/haproxy.widget.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/widgets/widgets/haproxy.widget.php
@@ -210,7 +210,7 @@ foreach ($backends as $be => $bedata) {
 			if ($show_clients == "YES") {
 				foreach ($clients as $cli => $clidata) {
 					if ($clidata['be'] == $bedata['pxname'] && $clidata['srv'] == $srvdata['svname']) {
-						print "<tr><td class=\"listlr\"><div class='text-success'>&nbsp;&nbsp;<i>".$clidata['src']."</i></div>&nbsp;<a href=\"diag_dns.php?host=".$clidata['srcip']."\" title=\"Reverse Resolve with DNS\">".$log."</a></td>";
+						print "<tr><td class=\"listlr\"><div class='text-success'>&nbsp;&nbsp;<i>".$clidata['src']."</i>&nbsp;<a href=\"diag_dns.php?host=".$clidata['srcip']."\" title=\"Reverse Resolve with DNS\">".$log."</a></div></td>";
 						if ($show_clients_traffic == "YES") {
 							$clientstraffic[0] = format_bytes($clidata['session_datareq']);
 							$clientstraffic[1] = format_bytes($clidata['session_datares']);


### PR DESCRIPTION
- fix widget client traffic statistics / layout
- fix host/path acls for http-response actions
- fix processing of fixed ips and subnets that are mentioned in a alias and skip any dns names that might also be there
- skip saving empty options from action/acl/other htmllists
- add support for server-template definition for automatic server discovery
- several small improvements to the webgui

p.s. please update haproxy-devel binaries also to 1.8.7 (not strictly required for these changes, but it includes several stability fixes)