### PR TITLE
pfBlockerNG v2.1.2_3 - Add tag for DEVEL/REL conflicts

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG/Makefile
@@ -13,7 +13,7 @@ COMMENT=	pfSense package pfBlockerNG
 
 LICENSE=	APACHE20
 
-CONFLICTS=	pfBlockerNG-devel
+CONFLICTS=	pfSense-pkg-pfBlockerNG-devel
 
 USES=		php
 RUN_DEPENDS=	${LOCALBASE}/bin/geoiplookup:net/GeoIP \

--- a/net/pfSense-pkg-pfBlockerNG/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-pfBlockerNG
 PORTVERSION=	2.1.2
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -12,6 +12,8 @@ MAINTAINER=	coreteam@pfsense.org
 COMMENT=	pfSense package pfBlockerNG
 
 LICENSE=	APACHE20
+
+CONFLICTS=	pfBlockerNG-devel
 
 USES=		php
 RUN_DEPENDS=	${LOCALBASE}/bin/geoiplookup:net/GeoIP \


### PR DESCRIPTION
Added a makefile CONFLICT tag to avoid users from installing both DEVEL and REL versions at the same time.