### PR TITLE
Add port specification to BIND package

### DIFF
--- a/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.inc
+++ b/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.inc
@@ -116,7 +116,7 @@ function bind_sync() {
 	// Create rndc
 	$rndc_confgen = "/usr/local/sbin/rndc-confgen";
 	$rndc_port = $bind['controlport'] == "" ? "953" : $bind['controlport'];
-	$rndc_confgen_opts = "-p$rndc_port";
+	$rndc_confgen_opts = "-p " . escapeshellarg($rndc_port);
 	if (!file_exists(BIND_LOCALBASE."/etc/rndc-confgen.pfsense") && file_exists($rndc_confgen)) {
 		exec("$rndc_confgen $rndc_confgen_opts ", $rndc_conf);
 		$confgen_file = "";
@@ -235,13 +235,13 @@ EOD;
 
 	$bind_listenport = $bind['listenport'] == "" ? "53" : $bind['listenport'];
 	if (array_key_exists("ipv6allow", $config['system'])) {
-		$bind_conf .= "\tlisten-on-v6 port $bind_listenport { $bind_listenonv6 };\n";
+		$bind_conf .= "\tlisten-on-v6 port {$bind_listenport} { {$bind_listenonv6} };\n";
 	}
-	$bind_conf .= "\tlisten-on port $bind_listenport { $bind_listenon };\n";
+	$bind_conf .= "\tlisten-on port {$bind_listenport} { {$bind_listenon} };\n";
 
 	// Forwarder config
 	if ($bind_forwarder == 'on') {
-		$bind_conf .= "\tforwarders { $forwarder_ips };\n";
+		$bind_conf .= "\tforwarders { {$forwarder_ips} };\n";
 	}
 	if ($bind_notify == 'on') {
 		$bind_conf .= "\tnotify yes;\n";

--- a/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.inc
+++ b/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.inc
@@ -112,10 +112,13 @@ function bind_sync() {
 
 	global $config;
 	conf_mount_rw();
+	$bind = $config['installedpackages']['bind']['config'][0];
 	// Create rndc
 	$rndc_confgen = "/usr/local/sbin/rndc-confgen";
+	$rndc_port = $bind['controlport'] == "" ? "953" : $bind['controlport'];
+	$rndc_confgen_opts = "-p$rndc_port";
 	if (!file_exists(BIND_LOCALBASE."/etc/rndc-confgen.pfsense") && file_exists($rndc_confgen)) {
-		exec("$rndc_confgen ", $rndc_conf);
+		exec("$rndc_confgen $rndc_confgen_opts ", $rndc_conf);
 		$confgen_file = "";
 		foreach ($rndc_conf as $line) {
 			$confgen_file .= "{$line}\n";
@@ -128,6 +131,9 @@ function bind_sync() {
 		$rndc_conf = file(BIND_LOCALBASE . "/etc/rndc-confgen.pfsense");
 		$confgen = "rndc.conf";
 		foreach ($rndc_conf as $line) {
+			if (preg_match("/\bport \d+\b/", $line)) {
+				$line = preg_replace("/\bport \d+\b/", "port {$rndc_port}", $line);
+			}
 			if ($confgen == "rndc.conf") {
 				if (!preg_match("/^#/", $line)) {
 					$rndc_file .= $line;
@@ -144,7 +150,6 @@ function bind_sync() {
 		}
 	}
 
-	$bind = $config['installedpackages']['bind']['config'][0];
 	if (is_array($config['installedpackages']['bindzone'])) {
 		$bindzone = $config['installedpackages']['bindzone']['config'];
 	} else {
@@ -227,10 +232,12 @@ EOD;
 	$bind_listenonv6 = $bind_listenonv6 == "" ? "none;" : $bind_listenonv6;
 	$bind_listenon = $bind_listenon == "" ? "none;" : $bind_listenon;
 	// Print "<pre>$bind_listenonv6 $bind_listenon";
+
+	$bind_listenport = $bind['listenport'] == "" ? "53" : $bind['listenport'];
 	if (array_key_exists("ipv6allow", $config['system'])) {
-		$bind_conf .= "\tlisten-on-v6 { $bind_listenonv6 };\n";
+		$bind_conf .= "\tlisten-on-v6 port $bind_listenport { $bind_listenonv6 };\n";
 	}
-	$bind_conf .= "\tlisten-on { $bind_listenon };\n";
+	$bind_conf .= "\tlisten-on port $bind_listenport { $bind_listenon };\n";
 
 	// Forwarder config
 	if ($bind_forwarder == 'on') {

--- a/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.xml
+++ b/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.xml
@@ -67,6 +67,7 @@
 		</tab>
 
 	</tabs>
+	<advanced_options>enabled</advanced_options>
 	<fields>
 		<field>
 			<type>listtopic</type>
@@ -303,8 +304,32 @@
 			<size>80</size>
 		</field>
 		<field>
-			<type>listtopic</type>
-			<name>Custom Options</name>
+			<fielddescr>Listen port</fielddescr>
+			<fieldname>listenport</fieldname>
+			<description>
+				<![CDATA[
+				TCP and UDP port BIND listens for queries on. Remember to create firewall rules to allow queries on this port.<br />
+				Must be changed if also running DNS Forwarder or Resolver on this Firewall.
+				]]>
+			</description>
+			<type>input</type>
+			<size>5</size>
+			<default_value>53</default_value>
+			<advancedfield/>
+		</field>
+		<field>
+			<fielddescr>Control port</fielddescr>
+			<fieldname>controlport</fieldname>
+			<description>
+				<![CDATA[
+				TCP port BIND listens for control requests on (localhost only).<br />
+				Must be changed if also running DNS Forwarder or Resolver on this Firewall.
+				]]>
+			</description>
+			<type>input</type>
+			<size>5</size>
+			<default_value>953</default_value>
+			<advancedfield/>
 		</field>
 		<field>
 			<fielddescr>Custom Options</fielddescr>
@@ -319,10 +344,7 @@
 			<cols>65</cols>
 			<rows>5</rows>
 			<encoding>base64</encoding>
-		</field>
-		<field>
-			<type>listtopic</type>
-			<name>Global Settings</name>
+			<advancedfield/>
 		</field>
 		<field>
 			<fielddescr>Global Settings</fielddescr>
@@ -337,6 +359,7 @@
 			<cols>65</cols>
 			<rows>5</rows>
 			<encoding>base64</encoding>
+			<advancedfield/>
 		</field>
 	</fields>
 	<custom_php_resync_config_command>


### PR DESCRIPTION
Able to specify BIND DNS port and control port,
which default to 53 and 953 respectively.

Slightly restructured the BIND package settings
screen to have an "Advanced Options" panel where
the new port settings are and also moved "Custom Options"
and "Global Settings" overrides to this panel.