### PR TITLE
Implements #8490 - "pfSense-pkg-acme: acme_certificates_edit.php - Ad…

### DIFF
--- a/security/pfSense-pkg-acme/Makefile
+++ b/security/pfSense-pkg-acme/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-acme
-PORTVERSION=	0.2.8
+PORTVERSION=	0.2.9
 PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
@@ -676,11 +676,12 @@ $acme_newcertificateactions = array(
 #end
 
 $a_keylength = array();
-$a_keylength['2048'] = array('name' => "2048");
-$a_keylength['3072'] = array('name' => "3072");
-$a_keylength['4096'] = array('name' => "4096");
-$a_keylength['ec-256'] = array('name' => "ec-256", 'ecc' => true);
-$a_keylength['ec-384'] = array('name' => "ec-384", 'ecc' => true);
+$a_keylength['2048'] = array('name' => "2048-bit RSA");
+$a_keylength['3072'] = array('name' => "3072-bit RSA");
+$a_keylength['4096'] = array('name' => "4096-bit RSA");
+$a_keylength['ec-256'] = array('name' => "256-bit ECDSA", 'ecc' => true);
+$a_keylength['ec-384'] = array('name' => "384-bit ECDSA", 'ecc' => true);
+$a_keylength['custom'] = array('name' => "Custom...");
 
 function set_cronjob() {
 	global $config;
@@ -795,19 +796,31 @@ function & get_certificate($name) {
 		$certificatename = $certificate['name'];
 		$cert = lookup_cert_by_name($certificatename);
 		if (!is_array($cert)) {
-			echo "\n getCertificatePSK creating new cert";
 			global $config;
 			$a_cert =& $config['cert'];
 			$cert = array();
 			$cert['refid'] = uniqid();
 			$cert['descr'] = $certificatename;
-			$accountkey = generateDomainKey($certificatename, $ca, $domain, $certificate['keylength']);
-			$cert['prv'] = base64_encode($accountkey);
+			// If keylength is set to 'custom', just use the user-pasted key
+			// instead of generating a new one
+			if ($certificate['keylength'] != 'custom') {
+				echo "\n getCertificatePSK creating new key";
+				$privatekey = generateDomainKey($certificatename, $ca, $domain, $certificate['keylength']);
+				$cert['prv'] = base64_encode($privatekey);
+			} else {
+				echo "\n getCertificatePSK using custom key";
+				$cert['prv'] = $certificate['keypaste']; // (already base64-encoded)
+			}
 			$a_cert[] = $cert;
 			echo "\n{$cert['prv']}";
 			$desc = "Acme: Add new certificate & key.";
 			write_config($desc);
+		} elseif (   $certificate['keylength'] == 'custom'
+				  && $cert['prv'] != $certificate['keypaste']) {
+			echo "\n getCertificatePSK updating custom key";
+			$cert['prv'] = $certificate['keypaste']; // (already base64-encoded)
 		}
+
 		return base64_decode($cert['prv']);
 	}
 	
@@ -890,7 +903,7 @@ function & get_certificate($name) {
 		
 		if ($timetorenew || $force) {
 			syslog(LOG_NOTICE, "Acme, renewing certificate: {$id}");
-			echo "Renewing certificate";
+			echo "Renewing certificate \n";
 			$domainstosign = array();
 			$method = "";
 			if (is_array($certificate['a_domainlist']['item'])) {

--- a/security/pfSense-pkg-acme/files/usr/local/www/acme/acme_certificates_edit.php
+++ b/security/pfSense-pkg-acme/files/usr/local/www/acme/acme_certificates_edit.php
@@ -146,11 +146,13 @@ function customdrawcell_actions($object, $item, $itemvalue, $editable, $itemname
 		echo $itemvalue;
 	}
 }
+
 if (isset($id) && $a_certificates[$id]) {
 	$a_domains = $a_certificates[$id]['a_domainlist']['item'];
 	$a_actions = $a_certificates[$id]['a_actionlist']['item'];
 
 	$pconfig["lastrenewal"] = $a_certificates[$id]["lastrenewal"];
+	$pconfig['keypaste'] = base64_decode($a_certificates[$id]['keypaste']);
 	foreach($simplefields as $stat) {
 		$pconfig[$stat] = $a_certificates[$id][$stat];
 	}
@@ -183,6 +185,24 @@ if ($_POST) {
 		$input_errors[] = "The field 'Name' contains invalid characters.";
 	}
 	
+	// If the "Custom..." option was selected in the "Private Key" dropdown...
+	if ($_POST['keylength'] == 'custom') {
+		// ...then the "Custom Private Key" field is required.
+		$reqdfields = explode(' ', 'keypaste');
+		$reqdfieldsn = explode(',', 'Custom Private Key');
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
+
+		if (   isset($_POST['keypaste'])
+			&& (   strpos($_POST['keypaste'], 'BEGIN PRIVATE KEY') === false
+			    || strpos($_POST['keypaste'], 'END PRIVATE KEY') === false)) {
+			$input_errors[] = "The Custom Private Key does not appear to be valid.";
+		}
+	} else {
+		// ...otherwise, the "Custom Private Key" field will be ignored, so
+		// clear its contents to avoid triggering update_if_changed() below.
+		$_POST['keypaste'] = '';
+	}
+
 	if ($_POST['stats_enabled']) {
 		$reqdfields = explode(" ", "name stats_uri");
 		$reqdfieldsn = explode(",", "Name,Stats Uri");		
@@ -242,10 +262,12 @@ if ($_POST) {
 	$certificate['a_domainlist']['item'] = $a_domains;
 	$certificate['a_actionlist']['item'] = $a_actions;
 
+	$certificate['keypaste'] = base64_encode($_POST['keypaste']);
 	global $simplefields;
 	foreach($simplefields as $stat) {
 		update_if_changed($stat, $certificate[$stat], $_POST[$stat]);
 	}
+
 	if (isset($id) && $a_certificates[$id]) {
 		$a_certificates[$id] = $certificate;
 	} else {
@@ -342,13 +364,20 @@ $section->addInput(new \Form_Select(
 	form_name_array($a_accountkeys)
 ));
 
-$a_accountkeys = &$config['installedpackages']['acme']['accountkeys']['item'];
 $section->addInput(new \Form_Select(
 	'keylength',
-	'Key Size',
+	'Private Key',
 	$pconfig['keylength'],
-	form_name_array($a_keylength)
+	form_keyvalue_array($a_keylength)
 ));
+
+$section->addInput(new \Form_Textarea(
+	'keypaste',
+	'Custom Private Key',
+	$pconfig['keypaste']
+))->setNoWrap()
+	->setAttribute('placeholder', "-----BEGIN PRIVATE KEY-----\nBASE64-ENCODED DATA\n-----END PRIVATE KEY-----")
+	->setHelp('Paste a private key in X.509 PEM format here.');
 
 $section->addInput(new \Form_Checkbox(
 	'ocspstaple',
@@ -362,8 +391,8 @@ $section->addInput(new \Form_StaticText(
 	"List all domain names that should be included in the certificate here, and how to validate ownership by use of a webroot or dns challenge<br/>"
 	. "Examples:<br/>"
 	. "Domainname: www.example.com<br/>"
-	. "Method: Webroot ,Rootfolder: /usr/local/www/.well-known/acme-challenge/<br/>"
-	. "Method: Webroot ,Rootfolder: /tmp/haproxy_chroot/haproxywebroot/.well-known/acme-challenge/"
+	. "Method: Webroot, Rootfolder: /usr/local/www/.well-known/acme-challenge/<br/>"
+	. "Method: Webroot, Rootfolder: /tmp/haproxy_chroot/haproxywebroot/.well-known/acme-challenge/"
 	. $domainslist->Draw($a_domains)
 ));
 
@@ -373,7 +402,7 @@ $section->addInput(new \Form_Input(
 	'number',
 	$pconfig['dnssleep'],
 	['min' => '1', 'max' => '3600']
-))->setHelp('When using a DNS validation method configure how much time to wait before atempting verification after the txt records are added. Defaults to 120 seconds.');
+))->setHelp('When using a DNS validation method configure how much time to wait before attempting verification after the txt records are added. Defaults to 120 seconds.');
 
 
 $section->addInput(new \Form_StaticText(
@@ -466,6 +495,20 @@ events.push(function() {
 	*/
 	$('[id^=table_domainsmethod]').change();
 	updatevisibility();
+
+	// Update visibility of Custom Private Key field,
+	// based upon selection in Private Key drop-down
+	function keylength_change() {
+		hideInput('keypaste', $('#keylength').val() != "custom");
+	}
+
+	// Update page display state on keylength selection change
+	$('#keylength').change(function () {
+		keylength_change();
+	});
+
+	// Set initial page display state
+	keylength_change();
 });
 //]]>
 </script>


### PR DESCRIPTION
…d ability to specify (vs generate) private key"

This is required to allow certificates to work in environments where HPKP is deployed across subdomains.

UI (Services / Acme / Certificates / Edit Certificate Options:
==============================================================

* Added "Custom..." option at the end of the Key Size drop-down.

* Renamed this field from "Key Size" to "Private Key", since it now contains both generate and paste-custom options.

* Selecting "Custom..." from the list adds (makes visible) a "Custom Private Key" textarea field in the next section.

* Selecting any other of the other (key-size) options from the Private Key drop-down hides the "Custom Private Key"
  field again.

* Key sizes in the drop-down have been renamed for clarity, e.g. "2048" => "2048-bit RSA", "ec-384" => "384-bit ECDSA", etc.

* Fixed a few typos/misspellings in the files I worked on (e.g. "atempting" => "attempting")

Back End:
=========

* Like other user-entered X.509 PEM formatted data, the user-entered Custom Private Key text is stored base64_encoded
  in the configuration.

* The private-key-generation logic is skipped when the user pastes in their private key.

* When visible, "Custom Private Key" is a required field, and is also verified to contain "-----BEGIN PRIVATE KEY-----"
  and "-----END PRIVATE KEY-----" strings.

Additional Notes:
=================

* security/pfSense-pkg-acme/Makefile

  - I bumped the version number from 0.2.8 to 0.2.9. If you're using semver (i.e. last digit is bug fixes), then that
    should probably be 0.3.0.

* security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc:795 - getCertificatePSK function

  - This function appears to be the locus of a bug (needs investigating): Once a private key has been generated for
    a certificate, it will not be re-generated when the certificate is edited, even if a user changes the key-size.

  - This function is misnamed; it doesn't get a Pre-Shared Key, it generates a private key.