### PR TITLE
Resolves #7905 - Asynchronous Authentication Plugin

### DIFF
--- a/security/pfSense/Makefile
+++ b/security/pfSense/Makefile
@@ -76,7 +76,8 @@ php56_RUN_DEPENDS=	${PHP_PKGNAMEPREFIX}suhosin>=0:security/php-suhosin \
 			${PHP_PKGNAMEPREFIX}pfSense-module>=0:devel/${PHP_PKGNAMEPREFIX}pfSense-module
 php72_RUN_DEPENDS=	${PHP_PKGNAMEPREFIX}pfSense-module>=0:devel/php-pfSense-module@${PHP_FLAVOR}
 
-LIB_DEPENDS=	libltdl.so:devel/libltdl
+LIB_DEPENDS=	libltdl.so:devel/libltdl \
+		openvpn-plugin-auth-script.so:security/openvpn-auth-script
 
 USES=		kmod php:flavors
 


### PR DESCRIPTION
Adds the library /usr/local/lib/openvpn/plugins/openvpn-plugin-auth-script.so as a dependency to the security/pfSense package. This ensures that the openvpn plugin is built and present on the system to support the following pull request to mainline pfsense:
https://github.com/pfsense/pfsense/pull/3908

Note that this depends on the port security/openvpn-auth-script which has not yet been pulled in from upstream FreeBSD. I'm unsure how that process is typically handled so I didn't include the files this pull request.