### PR TITLE
 pfSense-pkg-pfBlockerNG-devel v2.2.1 fixes

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG-devel/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-pfBlockerNG-devel
-PORTVERSION=	2.1.2
-PORTREVISION=	2
+PORTVERSION=	2.2.1
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2826,26 +2826,40 @@ function pfb_aliastables($mode) {
 }
 
 
-// Collect pfBlockerNG rule names and tracker ids
+// Collect pfBlockerNG rule names and Tracker IDs
 function pfb_filterrules() {
 	global $pfb;
 
-	$rule_list = array();
-	exec("{$pfb['pfctl']} -vv -sr | {$pfb['grep']} 'pfB_'", $results);
+	$rule_list		= array();
+	$rule_list['other']	= array();
+
+	exec("{$pfb['pfctl']} -vvsr 2>&1", $results);
 	if (!empty($results)) {
 		foreach ($results as $result) {
+			if (substr($result, 0, 1) == '@') {
 
-			// Find rule tracker ids
-			$id = strstr($result, '(', FALSE);
-			$id = ltrim(strstr($id, ')', TRUE), '(');
+				$r	= explode(')', $result, 2);
+				$id	= ltrim(strstr($r[0], '(', FALSE), '(');
 
-			// Find rule descriptions
-			$descr = ltrim(stristr($result, '<pfb_', FALSE), '<');
-			$descr = strstr($descr, ':', TRUE);
+				// Find rule descriptions and type for pfBlockerNG Tracker IDs
+				if (strpos($r[1], ' <pfB_') !== FALSE) {
+					$descr	= ltrim(stristr($r[1], '<pfb_', FALSE), '<');
+					$descr	= strstr($descr, ':', TRUE);
+					$type	= strstr(trim($r[1]), ' ', TRUE);
+					if ($type == 'match') {
+						$type = 'unkn(%u)';
+					}
 
-			// Create array of rule description and tracker id
-			$rule_list['id'][] = $id;
-			$rule_list[$id]['name'] = $descr;
+					$rule_list['id'][]	= $id;
+					$rule_list[$id]['name']	= $descr;
+					$rule_list[$id]['type'] = $type;
+				}
+
+				// All other non-pfBlockerNG Tracker IDs
+				else {
+					$rule_list['other'][$id] = '';
+				}
+			}
 		}
 	}
 	return $rule_list;
@@ -3298,7 +3312,7 @@ function pfb_daemon_filterlog() {
 
 	$p_entry 	= '';
 	$line_cnt	= 0;
-	$rule_list	= array();
+	$rule_list	= $rule_list['other'] = array();
 
 	// Parse full filter.log on first run, otherwise only parse new filter.log events
 	if (!file_exists($pfb['ip_blocklog']) && !file_exists($pfb['ip_permitlog']) && !file_exists($pfb['ip_matchlog'])) {
@@ -3387,27 +3401,43 @@ function pfb_daemon_filterlog() {
 			}
 			$d = explode(',', $f[5]);
 
-			// Only collect pfBlockerNG Tracker IDs
-			if (!empty($d[3]) && substr($d[3], 0, 4) == '1770') {
-
-				// Attemp to find the Tracker ID, if not found wait 5secs for filter_reload
+			// Attemp to find the Tracker ID, if not found wait 5secs for filter_reload
+			$other = FALSE;
+			if (!empty($d[3])) {
 				for ($retries = 1; $retries <= 5; $retries++) {
 
-					// Collect pfBlockerNG rule names and Tracker IDs
-					if (!isset($rule_list[$d[3]])) {
+					// Skip known non-pfBlockerNG Tracker IDs
+					if (isset($rule_list['other'][$d[3]])) {
+						$other = TRUE;
+						break;
+					}
+
+					// Break on pfBlockerNG rule Tracker ID and Rule type (block|permit|match)
+					// If the user switched a manual rule from one type to another, the Tracker ID will stay the same
+					// So this comparison will refresh the data on changes
+					if (isset($rule_list[$d[3]]) && $rule_list[$d[3]]['type'] == $d[6]) {
+						break;
+					}
+
+					// Collect updated pfctl Rule data, Host and local IP data
+					else {
 						$rule_list	= pfb_filterrules();
 						$data		= pfb_collect_localip();
 						$pfb_local	= $data[0] ?: array();
 						$pfb_localsub	= $data[1] ?: array();
+
 						$local_hosts    = pfb_collect_localhosts();
-					}
-					else {
-						break;
 					}
 
 					if ($retries < 5) {
 						sleep(5);
+					} else {
+						$other = TRUE;
 					}
+				}
+
+				if ($other) {
+					continue;
 				}
 
 				// Duplicate entry comparison: "Tracker ID/Action/SRC IP/DST IP/DST Port"
@@ -3500,6 +3530,11 @@ function pfb_daemon_filterlog() {
 					// Details:	"Direction/GeoIP/Aliasname/IP evaluated/Feed Name/Resolved Hostname/Client Hostname"
 					$details	= "{$dir},{$geoip},{$pfb_alias},{$pfb_query[1]},{$pfb_query[0]},{$resolved_host},{$hostname}";
 
+					// Reverse Match text
+					if ($d[6] == 'match') {
+						$d[6] = 'unkn(%u)';
+					}
+					
 					if ($d[8] == 4) {
 						// Previous:	"Tracker ID/Action/SRC IP/DST IP/DST Port"
 						$p_entry	= "{$d[3]}{$d[6]}{$d[18]}{$d[19]}{$d[21]}";
@@ -3555,7 +3590,6 @@ function pfb_dnsbl_parse($domain, $src_ip, $req_agent) {
 		$stmt = $db_handle->prepare($db_update);
 		$stmt->bindValue(':domain', $domain, SQLITE3_TEXT);
 		$result = $stmt->execute();
-
 		if ($result) {
 			$dnsbl_cache = $result->fetchArray(SQLITE3_ASSOC);
 		}
@@ -3987,8 +4021,10 @@ function pfb_daemon_queries() {
 		$db_handle = pfb_open_sqlite(3, 'Resolver collect queries');
 		if ($db_handle) {
 			$result = $db_handle->query("SELECT * FROM resolver WHERE row = 0;");
-			while ($stats = $result->fetchArray(SQLITE3_ASSOC)) {
-				$pfb_found = TRUE;
+			if ($result) {
+				while ($stats = $result->fetchArray(SQLITE3_ASSOC)) {
+					$pfb_found = TRUE;
+				}
 			}
 
 			// Create new row

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -423,7 +423,31 @@ if ($ufound) {
 	update_status(" no changes required ... done.\n");
 }
 
+// Move General Tab 'IP settings' to new IP tab
+update_status("Upgrading General Tab -> IP Tab settings...");
+if (!isset($config['installedpackages']['pfblockerngipsettings'])) {
+	$pfb['gconfig'] = &$config['installedpackages']['pfblockerng']['config'][0];
+	$pfb['iconfig'] = &$config['installedpackages']['pfblockerngipsettings']['config'][0];
+
+	$settings = array(	'enable_dup', 'enable_agg', 'suppression', 'enable_log', 'maxmind_locale', 'database_cc',
+				'inbound_interface', 'inbound_deny_action', 'outbound_interface', 'outbound_deny_action',
+				'enable_float', 'pass_order', 'autorule_suffix', 'killstates' );
+
+	foreach ($settings as $setting) {
+		$pfb['iconfig'][$setting] = $pfb['gconfig'][$setting] ?: '';
+		if (isset($pfb['gconfig'][$setting])) {
+			unset($pfb['gconfig'][$setting]);
+		}
+	}
+	update_status(" saving new changes ... done.\n");
+}
+else {
+	update_status(" no changes required ... done.\n");
+}
+
 // Upgrade pfBlockerNGSuppress alias to IPv4 Suppression custom list
+$ufound = FALSE;
+update_status("Upgrading pfBlockerNGSuppress Alias -> IPv4 Suppression Customlist...");
 if (!isset($config['installedpackages']['pfblockerngipsettings']['config'][0]['v4suppression'])) {
 
 	$customlist = '';
@@ -448,27 +472,17 @@ if (!isset($config['installedpackages']['pfblockerngipsettings']['config'][0]['v
 				}
 				$config['installedpackages']['pfblockerngipsettings']['config'][0]['v4suppression'] = base64_encode($customlist) ?: '';
 				// unset($config['aliases']['alias'][$key]);
+				$ufound = TRUE;
 				break;
 			}
 		}
 	}
 }
 
-// Move General Tab 'IP settings' to new IP tab
-if (!isset($config['installedpackages']['pfblockerngipsettings'])) {
-	$pfb['gconfig'] = &$config['installedpackages']['pfblockerng']['config'][0];
-	$pfb['iconfig'] = &$config['installedpackages']['pfblockerngipsettings']['config'][0];
-
-	$settings = array(	'enable_dup', 'enable_agg', 'suppression', 'enable_log', 'maxmind_locale', 'database_cc',
-				'inbound_interface', 'inbound_deny_action', 'outbound_interface', 'outbound_deny_action',
-				'enable_float', 'pass_order', 'autorule_suffix', 'killstates' );
-
-	foreach ($settings as $setting) {
-		$pfb['iconfig'][$setting] = $pfb['gconfig'][$setting] ?: '';
-		if (isset($pfb['gconfig'][$setting])) {
-			unset($pfb['gconfig'][$setting]);
-		}
-	}
+if ($ufound) {
+	update_status(" saving new changes ... done.\n");
+} else {
+	update_status(" no changes required ... done.\n");
 }
 
 // Convert dnsbl_info CSV file to SQLite3 database format

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -168,7 +168,7 @@ pfb_filter_service();
 update_status(" done.\n");
 
 // Create DNSBL service and link required executables
-update_status(" done.\nRemove any existing and create link for DNSBL lighttpd executable...");
+update_status("Remove any existing and create link for DNSBL lighttpd executable...");
 unlink_if_exists('/usr/local/sbin/lighttpd_pfb');
 link('/usr/local/sbin/lighttpd', '/usr/local/sbin/lighttpd_pfb');
 

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -378,10 +378,7 @@ $group->add(new Form_Checkbox(
   ->setHelp('This will create \'Floating\' Firewall permit rules to allow traffic from the Selected Interface(s) to access<br />'
 		. 'the DNSBL VIP on the DNSBL Listening interface. (ICMP and Webserver ports only). This is only required for networks with multiple LAN Segments.');
 
-// Remove Localhost from Interface options
-array_pop($interface_list);
 $int_size = count($interface_list) ?: '1';
-
 $group->add(new Form_Select(
 	'dnsbl_allow_int',
 	NULL,
@@ -899,12 +896,14 @@ $section->addInput(new Form_Textarea(
 $tld_whitelist_text = 'Enter <strong>each specific</strong> Domain and/or Sub-Domains to be Whitelisted.
 			(Used in conjunction with <strong>TLD Blacklist only</strong>)&emsp;
 			<div class="infoblock">
-				Enter one &emsp;<strong>Domain</strong>&emsp; per line, followed by &emsp;<strong>|x.x.x.x</strong>&emsp;
-				(IP Address for Domain or Sub-Domain) &emsp;<br />Examples:<br />
+				Enter one &emsp;<strong>Domain</strong>&emsp;per line<br />Examples:<br />
 				<ul>
-					<li>example.com|x.x.x.x</li>
-					<li>news.example.com|x.x.x.x &emsp;&emsp;(Replace x.x.x.x with associated Domain/Sub-Domain IP Address.</li>
+					<li>example.com</li>
+					<li>example.com|x.x.x.x&emsp;&emsp;(Replace x.x.x.x with associated Domain/Sub-Domain IP Address.</li>
 				</ul>
+				The First option above will collect the IP Address on each Cron run, 
+				while the second option will define a Static IP Address.<br /><br />
+
 				You must Whitelist every Domain or Sub-Domain individually.<br />
 				No Regex Entries and no leading/trailing \'dot\' allowed!<br />
 				You may use "<strong>#</strong>" after any Domain/Sub-Domain to add comments. IE: (example.com|x.x.x.x # TLD Whitelist)<br />

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -98,11 +98,11 @@ if ($_POST) {
 				$mask = strstr($host[0], '/', FALSE);
 
 				if ($mask != '/32' && $mask != '/24') {
-					$input_errors[] = "Invalid mask [ {$host[0]} ]. Mask must be defined as /32 or /24 only.";
+					$input_errors[] = "IPv4 Suppression: Invalid mask [ {$host[0]} ]. Mask must be defined as /32 or /24 only.";
 				}
 
 				if (!is_subnetv4($host[0])) {
-					$input_errors[] = "Invalid IPv4 subnet address defined [ {$host[0]} ]";
+					$input_errors[] = "IPv4 Suppression: Invalid IPv4 subnet address defined [ {$host[0]} ]";
 				}
 			}
 		}

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -163,6 +163,12 @@ $pfb_logtypes = array(	'defaultlogs'	=> array('name'		=> 'Log Files',
 						'logdir'	=> '/usr/local/pkg/pfblockerng/',
 						'download'	=> TRUE,
 						'clear'		=> FALSE
+						),
+			'top1m'		=> array('name'		=> 'TOP1M Whitelist',
+						'ext'		=> array('pfbalexawhitelist.txt'),
+						'logdir'	=> "{$pfb['dbdir']}/",	
+						'download'	=> TRUE,
+						'clear'		=> TRUE
 						)
 		);
 

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -546,9 +546,11 @@ function pfBlockerNG_get_header($mode='') {
 				if ($db_handle) {
 
 					$result = $db_handle->query("SELECT * FROM resolver WHERE row = 0;");
-					while ($qstats = $result->fetchArray(SQLITE3_ASSOC)) {
-						$pfb_found	= TRUE;
-						$resolver[]	= $qstats;
+					if ($result) {
+						while ($qstats = $result->fetchArray(SQLITE3_ASSOC)) {
+							$pfb_found	= TRUE;
+							$resolver[]	= $qstats;
+						}
 					}
 
 					// Create new row


### PR DESCRIPTION
- Ensure that General Tab -> new IP Tab settings are migrated before converting pfBlockerNGSuppress Alias
- Improve installation logging messages
- Improve 'TLD Whitelist' Help Text
- Fix SQLite3 error messages (Call to a member function fetchArray() on boolean)
- Add TOP1M Whitelist final list to Log Viewer
- Fix logging on manual user-defined pfBlockerNG rules as the Tracker ID prefix doesn't start with '1770*'
