### PR TITLE
Fix Automagic for TCP based OpenVPN and for port aliases

### DIFF
--- a/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
+++ b/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
@@ -994,11 +994,7 @@ function openvpn_client_export_find_port_forwards($targetip, $targetport, $targe
                 $proto_short = strtolower(substr($targetproto, 0, 3));
                 if (!isset($natent['disabled']) && ($natent['target'] == $targetip) && ($natent['local-port'] == $targetport) && ($natent['protocol'] == $proto_short)) {
  	        	$dest['proto'] = $targetproto;
-
-			// Could be multiple ports... But we can only use one.
-			$dports = is_port($natent['destination']['port']) ? array($natent['destination']['port']) : filter_expand_alias_array($natent['destination']['port']);
-			$dest['port'] = $dports[0];
-
+			
 			// Could be network or address ...
 			$natif = (!$natent['interface']) ? "wan" : $natent['interface'];
 
@@ -1034,7 +1030,13 @@ function openvpn_client_export_find_port_forwards($targetip, $targetport, $targe
 				}
 			}
 
-			$destinations[] = $dest;
+                        $dports = is_port($natent['destination']['port']) ? array($natent['destination']['port']) : filter_expand_alias_array($natent['destination']['port']);
+ 
+			// Could be multiple ports, we add all of them
+			foreach ($dports as $dport) {
+				$dest['port'] = $dport;
+				$destinations[] = $dest;
+			}
 		}
 	}
 

--- a/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
+++ b/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
@@ -991,8 +991,7 @@ function openvpn_client_export_find_port_forwards($targetip, $targetport, $targe
 
 	foreach ($config['nat']['rule'] as $natent) {
 		$dest = array();
-                $proto_short = strtolower(substr($targetproto, 0, 3));
-                if (!isset($natent['disabled']) && ($natent['target'] == $targetip) && ($natent['local-port'] == $targetport) && ($natent['protocol'] == $proto_short)) {
+                if (!isset($natent['disabled']) && ($natent['target'] == $targetip) && ($natent['local-port'] == $targetport) && ($natent['protocol'] == strtolower(substr($targetproto, 0, 3)))) {
  	        	$dest['proto'] = $targetproto;
 			
 			// Could be network or address ...

--- a/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
+++ b/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
@@ -991,8 +991,9 @@ function openvpn_client_export_find_port_forwards($targetip, $targetport, $targe
 
 	foreach ($config['nat']['rule'] as $natent) {
 		$dest = array();
-		if (!isset($natent['disabled']) && ($natent['target'] == $targetip) && ($natent['local-port'] == $targetport) && ($natent['protocol'] == $targetproto)) {
-			$dest['proto'] = $natent['protocol'];
+                $proto_short = strtolower(substr($targetproto, 0, 3));
+                if (!isset($natent['disabled']) && ($natent['target'] == $targetip) && ($natent['local-port'] == $targetport) && ($natent['protocol'] == $proto_short)) {
+ 	        	$dest['proto'] = $targetproto;
 
 			// Could be multiple ports... But we can only use one.
 			$dports = is_port($natent['destination']['port']) ? array($natent['destination']['port']) : filter_expand_alias_array($natent['destination']['port']);


### PR DESCRIPTION
I stumbled upon two issues with the wonderful Automagic feature:
1) It currently does not create a remote line at all even if you have NAT rules that point to the TCP server.
2) It behaves unexpectedly when dealing with multiple ports inside an alias: it will only use the first one.
This merge request fixes both issues.