### PR TITLE
Move key-direction infront of tls-auth for old network-manager-openvp…

### DIFF
--- a/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
+++ b/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
@@ -464,7 +464,7 @@ EOF;
 					$tls_directive = "tls-auth";
 					$tls_keydir = "key-direction 1{$nl}";
 				}
-				$conf .= "<{$tls_directive}>{$nl}" . trim(base64_decode($settings['tls'])) . "{$nl}</{$tls_directive}>{$nl}{$tls_keydir}";
+				$conf .= "{$tls_keydir}<{$tls_directive}>{$nl}" . trim(base64_decode($settings['tls'])) . "{$nl}</{$tls_directive}>{$nl}";
 			}
 			return $conf;
 		// "yealink" creates: "/client.tar"


### PR DESCRIPTION
OpenVPN configs generated by pfsense currently do not work in network-manager-openvpn of Ubuntu 16.04 because of a bug: https://bugs.launchpad.net/ubuntu/+source/network-manager-openvpn/+bug/1643282
One could argue that pfsense generates a perfectly valid config thus no change is needed but Ubuntu 16.04 is still very widespread and supported until 2021 and it does seem to affect many users (the error message is really unclear).