### PR TITLE
Properly check domain when registering DHCP static mappings

### DIFF
--- a/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.inc
+++ b/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.inc
@@ -573,8 +573,7 @@ EOD;
 										}
 									} else {
 										$parts = array_reverse(explode('.', $domain));
-										$diff = array_diff_assoc($parts, $zoneparts);
-										if (count($diff) == 0) {
+										if ($parts === $zoneparts) {
 											$zone_conf .= "{$host['hostname']}\tIN A\t{$host['ipaddr']}\n";
 										}
 									}


### PR DESCRIPTION
Use of the PHP function "array_diff_assoc" results in any zone which is
a subdomain of a given static DHCP mapping domain being populated with
said mapping. In other words, a static DHCP mapping with a domain of
"domain.com" would appear in any zone that is a subdomain of it, such
as "sub1.domain.com" or "sub2.sub1.domain.com".

This fix changes the logic to perform a direct domain comparison so
that only the zone matching the exact domain specified in a given
static DHCP mapping will be populated with such a mapping entry.

Redmine issue: https://redmine.pfsense.org/issues/8619