### PR TITLE
haproxy-devel, fix transparent backend ipfw rule, (broke with typo in a php7 fix..)

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/Makefile
+++ b/net/pfSense-pkg-haproxy-devel/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-haproxy-devel
 PORTVERSION=	0.59
+PORTREVISION=	1
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -2248,7 +2248,7 @@ function haproxy_get_transparent_backends(){
 			continue;
 		}
 		$real_if = get_real_interface($backend["transparent_interface"]);
-		if (!is_array($backend['ha_serveres'])) {
+		if (!is_array($backend['ha_servers'])) {
 			$backend['ha_servers'] = array();
 		}
 		$a_servers = &$backend['ha_servers']['item'];


### PR DESCRIPTION
haproxy-devel, fix transparent backend ipfw rule, (broke with typo in a php7 fix..)
please also apply to 2.4.3