### PR TITLE
Add check_swap

### DIFF
--- a/net-mgmt/pfSense-pkg-nrpe/Makefile
+++ b/net-mgmt/pfSense-pkg-nrpe/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-nrpe
-PORTVERSION=	3.0
+PORTVERSION=	4.0
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-nrpe/Makefile
+++ b/net-mgmt/pfSense-pkg-nrpe/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-nrpe
-PORTVERSION=	4.0
+PORTVERSION=	3.1
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-nrpe/files/usr/local/pkg/nrpe.inc
+++ b/net-mgmt/pfSense-pkg-nrpe/files/usr/local/pkg/nrpe.inc
@@ -84,6 +84,12 @@ function nrpe_custom_php_install_command() {
 				'command' => 'check_procs',
 				'warning' => '150',
 				'critical' => '200'
+			),
+			6 => array(
+				'name' => 'check_swap',
+				'command' => 'check_swap',
+				'warning' => '50%',
+				'critical' => '25%'
 			)
 		);
 	}


### PR DESCRIPTION
It feels like the check_swap command should be one of the default nrpe commands. I ran into some issues with my swap filling up and I had no notification until my pfsense started to fail and nothing could be done except a hard reboot.

Redmine issue: https://redmine.pfsense.org/issues/8756