### PR TITLE
pfSense-pkg-snort-3.2.9.7_1 - Port new GUI features added previously to Suricata package

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	3.2.9.7
+PORTREVISION=   1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -3,7 +3,7 @@
  * snort.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2018 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
  * Copyright (c) 2013-2018 Bill Meeks
  * All rights reserved.
@@ -1303,18 +1303,24 @@ function snort_load_rules_map($rules_path) {
 	 *  map[gid][sid]['rule']['category']['action']['disabled']['managed']['flowbits']
 	 *
 	 *  where:
-	 *   gid      = Generator ID from rule, or 1 if general text 
-	 *              rule
-	 *   sid      = Signature ID from rule
-         *   rule     = Complete rule text
-	 *   category = File name of file containing the rule
-	 *   action   = alert, drop, reject or pass
-	 *   disabled = 1 if rule is disabled (commented out), 0 if 
-	 *              rule is enabled
-	 *    managed = 1 if rule is auto-managed by SID MGMT process,
-	 *              0 if not auto-managed 
-	 *   flowbits = Array of applicable flowbits if rule contains 
-	 *              flowbits options
+	 *   gid            = Generator ID from rule, or 1 if general text rule
+	 *   sid            = Signature ID from rule
+         *   rule           = Complete rule text
+	 *   category       = File name of file containing the rule
+	 *   action         = alert, drop, reject or pass
+	 *   disabled       = 1 if rule is disabled (commented out), 0 if 
+	 *                    rule is enabled
+	 *   default_state  = 1 if rule is default enabled, 0 if default disabled
+	 *   default_action = alert, drop, reject or pass  
+	 *   state_toggled  = 1 if rule was toggled by SID MGMT process,
+	 *                    0 if not toggled
+	 *   managed        = 1 if rule is auto-managed by SID MGMT process,
+	 *                    0 if not auto-managed 
+	 *   modified       = 1 if rule action or content is modified by SID MGMT or
+	 *                      IPS Policy process,
+	 *                    0 if not modified
+	 *   flowbits       = Array of applicable flowbits if rule contains 
+	 *                    flowbits options
 	 ************************************************************************************/
 
 	/* First check if we were passed a directory, a single file   */
@@ -1398,6 +1404,9 @@ function snort_load_rules_map($rules_path) {
 				$map_ref[$gid][$sid] = array();
 			$map_ref[$gid][$sid]['rule'] = $rule;
 			$map_ref[$gid][$sid]['category'] = basename($file, ".rules");
+			$map_ref[$gid][$sid]['state_toggled'] = 0;
+			$map_ref[$gid][$sid]['modified'] = 0;
+			$map_ref[$gid][$sid]['managed'] = 0;
 
 			if (preg_match('/^\s*\#+/', $rule))
 				$map_ref[$gid][$sid]['disabled'] = 1;
@@ -1406,10 +1415,23 @@ function snort_load_rules_map($rules_path) {
 
 			/* Grab the rule action (this is for a future option) */
 			$matches = array();
-			if (preg_match('/^\s*#*\s*(alert|log|pass|drop|reject|sdrop)/i', $rule, $matches))
+			if (preg_match('/^\s*#*\s*(alert|log|pass|drop|reject|sdrop)/i', $rule, $matches)) {
 				$map_ref[$gid][$sid]['action'] = $matches[1];
-			else
+				$map_ref[$gid][$sid]['default_action'] = $matches[1];
+			}
+			else {
 				$map_ref[$gid][$sid]['action'] = "";
+			}
+
+			// Determine if default state is "disabled"
+			// or "enabled".
+			if (preg_match('/^\s*\#+/', $rule)) {
+				$map_ref[$gid][$sid]['disabled'] = 1;
+				$map_ref[$gid][$sid]['default_state'] = 0;
+			} else {
+				$map_ref[$gid][$sid]['disabled'] = 0;
+				$map_ref[$gid][$sid]['default_state'] = 1;
+			}
 
 			/* Grab any associated flowbits from the rule.     */
 			$map_ref[$gid][$sid]['flowbits'] = snort_get_flowbits($rule);
@@ -3094,6 +3116,67 @@ EOD;
 	/* Write out barnyard2_conf text string to disk */
 	@file_put_contents("{$snortcfgdir}/barnyard2.conf", $barnyard2_conf_text);
 	unset($barnyard2_conf_text);
+}
+
+function snort_get_filtered_rules($rules, $filter) {
+
+	/************************************************/
+	/* This function returns a rules_map array of   */
+	/* of rules filtered using the GID:SID pairs    */
+	/* found in the passed filter criteria array.   */
+	/*                                              */
+	/*   $rules --> file, a directory or an array   */
+	/*              containing rules files to scan  */
+	/*                                              */
+	/*  $filter --> array of GID:SID pairs to use   */
+	/*              for filtering returned rules    */
+	/*              map array.                      */
+	/*                                              */
+	/*  Returns --> rules_map array                 */
+	/************************************************/
+
+	$tmp_map = array();
+	$filtered_map = array();
+
+	// If the filter array is empty, just
+	// return an empty result to save time
+	// since nothing would match.
+	if (empty($filter)) {
+		return $filtered_map;
+	}
+
+	// Load up all the rules from the location passed
+	$tmp_map = snort_load_rules_map($rules);
+
+	// Now walk the loaded filter list and copy
+	// matching GID:SID rules from the target list
+	// over to the filtered array.
+	foreach ($filter as $k1 => $rulem) {
+		foreach($rulem as $k2 => $v) {
+			if (isset($tmp_map[$k1][$k2])) {
+				if (!is_array($filtered_map[$k1])) {
+					$filtered_map[$k1] = array();
+				}
+				if (!is_array($filtered_map[$k1][$k2])) {
+					$filtered_map[$k1][$k2] = array();
+				}
+				$filtered_map[$k1][$k2]['rule'] = $tmp_map[$k1][$k2]['rule'];
+				$filtered_map[$k1][$k2]['category'] = $tmp_map[$k1][$k2]['category'];
+				$filtered_map[$k1][$k2]['action'] = $tmp_map[$k1][$k2]['action'];
+				$filtered_map[$k1][$k2]['modified'] = $tmp_map[$k1][$k2]['modified'];
+				$filtered_map[$k1][$k2]['disabled'] = $tmp_map[$k1][$k2]['disabled'];
+				$filtered_map[$k1][$k2]['flowbits'] = $tmp_map[$k1][$k2]['flowbits'];
+				$filtered_map[$k1][$k2]['managed'] = $tmp_map[$k1][$k2]['managed'];
+				$filtered_map[$k1][$k2]['state_toggled'] = $tmp_map[$k1][$k2]['state_toggled'];
+				$filtered_map[$k1][$k2]['default_state'] = $tmp_map[$k1][$k2]['default_state'];
+				$filtered_map[$k1][$k2]['default_action'] = $tmp_map[$k1][$k2]['default_action'];
+			}
+		}
+	}
+
+	// Clean up and return the filtered list of rules
+	unset($tmp_map);
+	return $filtered_map;
 }
 
 function snort_prepare_rule_files($snortcfg, $snortcfgdir) {

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -1861,42 +1861,69 @@ function snort_write_enforcing_rules_file($rule_map, $rule_path) {
 	}
 }
 
-function snort_parse_sidconf_file($sidconf_file) {
+function snort_parse_sidconf_file($sidconf_file,$split_lines=TRUE) {
 
 	/**********************************************/
-	/* This function loads and processes the file */
-	/* specified by '$sidconf_file'.  The file is */
+	/* This function loads and processes the list */
+	/* specified by '$sidconf_file'.  The list is */
 	/* assumed to contain valid instructions for  */
 	/* matching rule SIDs as supported by the     */
 	/* Oinkmaster and PulledPork utilities.       */
 	/*                                            */
-	/*  $sidconf_file ==> full path and name of   */
-	/*                    file to process         */
+	/*  $sidconf_file ==> name of SID Mgmt        */
+	/*                    list to process         */
+	/*                                            */
+	/*  $split_lines ==> determines whether lines */
+	/*                   should be split at       */
+	/*                   commas into multiple     */
+	/*                   sid modification	      */
 	/*                                            */
 	/*        Returns ==> an array containing     */
 	/*                    SID modifier tokens     */
 	/**********************************************/
 
+	global $config;
 	$buf = "";
 	$sid_mods = array();
+	$list = array();
 
-	$fd = fopen("{$sidconf_file}", "r");
-	if ($fd == FALSE) {
-		log_error("[Snort] Failed to open SID MGMT file '{$sidconf_file}' for processing.");
-		return $sid_mods;
+	// Find the list we need
+	if (!is_array($config['installedpackages']['snortglobal']['sid_mgmt_lists'])) {
+		$config['installedpackages']['snortglobal']['sid_mgmt_lists'] = array();
+	}
+	if (!is_array($config['installedpackages']['snortglobal']['sid_mgmt_lists']['item'])) {
+		$config['installedpackages']['snortglobal']['sid_mgmt_lists']['item'] = array();
+	}
+	foreach($config['installedpackages']['snortglobal']['sid_mgmt_lists']['item'] as $item) {
+		if ($item['name'] == $sidconf_file) {
+			$list = $item;
+			break;
+		}
 	}
 
-	// Read and parse the conf file line-by-line
+	// Decode the list contents into a PHP temp buffer
+	// we can read like a normal file.
+	$fd = fopen("php://temp", "r+");
+	if ($fd == FALSE) {
+		log_error("[Snort] Failed to open SID MGMT list '{$sidconf_file}' for processing.");
+		return $sid_mods;
+	}
+	fwrite($fd, base64_decode($list['content']));
+	rewind($fd);
+
+	// Read and parse the conf list line-by-line
 	while (($buf = fgets($fd)) !== FALSE) {
 		$line = array();
 
 		// Skip any lines that may be just spaces.
-		if (trim($buf, " \r\n") == "")
+		if (trim($buf, " \r\n") == "") {
 			continue;
+		}
 
 		// Skip line with leading "#" since it's a comment
-		if (preg_match('/^\s*#/', $buf))
+		if (preg_match('/^\s*#/', $buf)) {
 			continue;
+		}
 
 		// Trim off any trailing comment
 		$line = explode("#", $buf);
@@ -1904,35 +1931,73 @@ function snort_parse_sidconf_file($sidconf_file) {
 		// Trim leading and trailing spaces plus newline and any carriage returns
 		$buf = trim($line[0], ' \r\n');
 
-		// Now split the SID mod arguments at the commas, if more than one
-		// per line, and add to our $sid_mods array.
-		$line = explode(",", $buf);
-		foreach ($line as $ent)
-			$sid_mods[] = trim($ent);
+		if ($split_lines) {
+			// If split mode split the SID mod arguments at the commas, if more than one
+			// per line, and add to our $sid_mods array.
+			$line = explode(",", $buf);
+			foreach ($line as $ent) {
+				$sid_mods[] = trim($ent);
+			}
+		}
+		else{
+			//Otherwise add 1 line as 1 modification to the $sid_mods array
+			$sid_mods[] = $buf;
+		}
 	}
 
 	// Close the file, release unneeded memory and return
 	// the array of SID mod tokens parsed from the file.
 	fclose($fd);
-	unset($line, $buf);
+	unset($list, $line, $buf);
 	return $sid_mods;
+}
+
+function snort_sid_mgmt_list_exist($sid_mgmt_list) {
+
+	/****************************************************/
+	/* This function tests whether or not the passed    */
+	/* automatic SID MGMT list exists in the config     */
+	/* file for the firewall.                           */
+	/*                                                  */
+	/*   $sid_mgmt_list ==> name of SID Mgmt List       */
+	/*                                                  */
+	/*          Returns ==> TRUE if list exists, or     */
+	/*                      FALSE if not found          */
+	/*                                                  */
+	/****************************************************/
+
+	global $config, $g;
+
+	if (!is_array($config['installedpackages']['snortglobal']['sid_mgmt_lists'])) {
+		$config['installedpackages']['snortglobal']['sid_mgmt_lists'] = array();
+	}
+	if (!is_array($config['installedpackages']['snortglobal']['sid_mgmt_lists']['item'])) {
+		$config['installedpackages']['snortglobal']['sid_mgmt_lists']['item'] = array();
+	}
+
+	foreach($config['installedpackages']['snortglobal']['sid_mgmt_lists']['item'] as $list) {
+		if ($list['name'] == $sid_mgmt_list) {
+			return TRUE;
+		}
+	}
+	return FALSE;
 }
 
 function snort_sid_mgmt_auto_categories($snortcfg, $log_results = FALSE) {
 
 	/****************************************************/
-	/* This function parses any auto-SID conf files     */
+	/* This function parses any auto-SID conf lists     */
 	/* configured for the interface and returns an      */
 	/* array of rule categories adjusted from the       */
 	/* ['enabled_rulesets'] element in the config for   */
 	/* the interface in accordance with the contents    */
-	/* of the SID Mgmt conf files.                      */
+	/* of the SID Mgmt conf lists.                      */
 	/*                                                  */
 	/* The returned array shows which files should be   */
 	/* removed and which should be added to the list    */
 	/* used when building the enforcing ruleset.        */
 	/*                                                  */
-	/*  $snortcfg ==> pointer to interface              */
+	/*  $snortcfg    ==> pointer to interface           */
 	/*                   configuration info             */
 	/*  $log_results ==> [optional] log results to      */
 	/*                   'sid_changes.log' in the       */
@@ -1953,7 +2018,6 @@ function snort_sid_mgmt_auto_categories($snortcfg, $log_results = FALSE) {
 	/****************************************************/
 
 	global $config;
-	$snort_sidmods_dir = SNORT_SID_MODS_PATH;
 	$sid_mods = array();
 	$enables = array();
 	$disables = array();
@@ -1984,40 +2048,43 @@ function snort_sid_mgmt_auto_categories($snortcfg, $log_results = FALSE) {
 		case "disable_enable":
 			if (!empty($snortcfg['disable_sid_file'])) {
 				if ($log_results == TRUE)
-					error_log(gettext("Processing disable_sid file: {$snortcfg['disable_sid_file']}\n"), 3, $log_file);
+					error_log(gettext("Processing disable_sid list: {$snortcfg['disable_sid_file']}\n"), 3, $log_file);
 
 				// Attempt to open the 'disable_sid_file' for the interface
-				if (!file_exists("{$snort_sidmods_dir}{$snortcfg['disable_sid_file']}")) {
-					log_error(gettext("[Snort] Error - unable to open 'disable_sid_file' \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
-					if ($log_results == TRUE)
-						error_log(gettext("Unable to open disable_sid file \"{$snortcfg['disable_sid_file']}\".\n"), 3, $log_file);
+				// Verify the assigned SID Mgmt List still exists in the firewall configuration
+				if (!snort_sid_mgmt_list_exist($snortcfg['disable_sid_file'])) {
+					log_error(gettext("[Snort] Error - unable to open disable_sid list \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+					if ($log_results == TRUE) {
+						error_log(gettext("Unable to find disable_sid list \"{$snortcfg['disable_sid_file']}\".\n"), 3, $log_file);
+					}
+				} else {
+					$sid_mods = snort_parse_sidconf_file($snortcfg['disable_sid_file']);
 				}
-				else
-					$sid_mods = snort_parse_sidconf_file("{$snort_sidmods_dir}{$snortcfg['disable_sid_file']}");
 
 				if (!empty($sid_mods))
 					$disables = snort_get_auto_category_mods($enabled_cats, $sid_mods, "disable", $log_results, $log_file);
 				elseif ($log_results == TRUE && !empty($log_file)) {
-					error_log(gettext("WARNING: no valid SID match tokens found in file \"{$snortcfg['disable_sid_file']}\".\n"), 3, $log_file);
+					error_log(gettext("WARNING: no valid SID match tokens found in list \"{$snortcfg['disable_sid_file']}\".\n"), 3, $log_file);
 				}
 			}
 			if (!empty($snortcfg['enable_sid_file'])) {
 				if ($log_results == TRUE)
-					error_log(gettext("Processing enable_sid file: {$snortcfg['enable_sid_file']}\n"), 3, $log_file);
+					error_log(gettext("Processing enable_sid list: {$snortcfg['enable_sid_file']}\n"), 3, $log_file);
 
 				// Attempt to open the 'enable_sid_file' for the interface
-				if (!file_exists("{$snort_sidmods_dir}{$snortcfg['enable_sid_file']}")) {
-					log_error(gettext("[Snort] Error - unable to open 'enable_sid_file' \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
-					if ($log_results == TRUE)
-						error_log(gettext("Unable to open enable_sid file \"{$snortcfg['enable_sid_file']}\".\n"), 3, $log_file);
+				if (!snort_sid_mgmt_list_exist($snortcfg['enable_sid_file'])) {
+					log_error(gettext("[snort] Error - unable to open enable_sid list \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+					if ($log_results == TRUE) {
+						error_log(gettext("Unable to find enable_sid list \"{$snortcfg['enable_sid_file']}\".\n"), 3, $log_file);
+					}
+				} else {
+					$sid_mods = snort_parse_sidconf_file($snortcfg['enable_sid_file']);
 				}
-				else
-					$sid_mods = snort_parse_sidconf_file("{$snort_sidmods_dir}{$snortcfg['enable_sid_file']}");
 
-				if (!empty($sid_mods))
+				if (!empty($sid_mods)) {
 					$enables = snort_get_auto_category_mods($enabled_cats, $sid_mods, "enable", $log_results, $log_file);
-				elseif ($log_results == TRUE && !empty($log_file)) {
-					error_log(gettext("WARNING: no valid SID match tokens found in file \"{$snortcfg['enable_sid_file']}\".\n"), 3, $log_file);
+				} elseif ($log_results == TRUE && !empty($log_file)) {
+					error_log(gettext("WARNING: no valid SID match tokens found in list \"{$snortcfg['enable_sid_file']}\".\n"), 3, $log_file);
 				}
 			}
 			break;
@@ -2025,40 +2092,44 @@ function snort_sid_mgmt_auto_categories($snortcfg, $log_results = FALSE) {
 		case "enable_disable":
 			if (!empty($snortcfg['enable_sid_file'])) {
 				if ($log_results == TRUE)
-					error_log(gettext("Processing enable_sid file: {$snortcfg['enable_sid_file']}\n"), 3, $log_file);
+					error_log(gettext("Processing enable_sid list: {$snortcfg['enable_sid_file']}\n"), 3, $log_file);
 
 				// Attempt to open the 'enable_sid_file' for the interface
-				if (!file_exists("{$snort_sidmods_dir}{$snortcfg['enable_sid_file']}")) {
-					log_error(gettext("[Snort] Error - unable to open 'enable_sid_file' \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
-					if ($log_results == TRUE)
-						error_log(gettext("Unable to open enable_sid file \"{$snortcfg['enable_sid_file']}\".\n"), 3, $log_file);
+				if (!snort_sid_mgmt_list_exist($snortcfg['enable_sid_file'])) {
+					log_error(gettext("[Snort] Error - unable to find enable_sid list \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+					if ($log_results == TRUE) {
+						error_log(gettext("Unable to open enable_sid list \"{$snortcfg['enable_sid_file']}\".\n"), 3, $log_file);
+					}
+				} else {
+					$sid_mods = snort_parse_sidconf_file($snortcfg['enable_sid_file']);
 				}
-				else
-					$sid_mods = snort_parse_sidconf_file("{$snort_sidmods_dir}{$snortcfg['enable_sid_file']}");
 
-				if (!empty($sid_mods))
+				if (!empty($sid_mods)) {
 					$enables = snort_get_auto_category_mods($enabled_cats, $sid_mods, "enable", $log_results, $log_file);
-				elseif ($log_results == TRUE && !empty($log_file)) {
-					error_log(gettext("WARNING: no valid SID match tokens found in file \"{$snortcfg['enable_sid_file']}\".\n"), 3, $log_file);
+				} elseif ($log_results == TRUE && !empty($log_file)) {
+					error_log(gettext("WARNING: no valid SID match tokens found in list \"{$snortcfg['enable_sid_file']}\".\n"), 3, $log_file);
 				}
 			}
 			if (!empty($snortcfg['disable_sid_file'])) {
-				if ($log_results == TRUE)
-					error_log(gettext("Processing disable_sid file: {$snortcfg['disable_sid_file']}\n"), 3, $log_file);
+				if ($log_results == TRUE) {
+					error_log(gettext("Processing disable_sid list: {$snortcfg['disable_sid_file']}\n"), 3, $log_file);
+				}
 
 				// Attempt to open the 'disable_sid_file' for the interface
-				if (!file_exists("{$snort_sidmods_dir}{$snortcfg['disable_sid_file']}")) {
-					log_error(gettext("[Snort] Error - unable to open 'disable_sid_file' \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
-					if ($log_results == TRUE)
-						error_log(gettext("Unable to open disable_sid file \"{$snortcfg['disable_sid_file']}\".\n"), 3, $log_file);
+				if (!snort_sid_mgmt_list_exist($snortcfg['disable_sid_file'])) {
+					log_error(gettext("[Snort] Error - unable to open disable_sid list \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+					if ($log_results == TRUE) {
+						error_log(gettext("Unable to find disable_sid list \"{$snortcfg['disable_sid_file']}\".\n"), 3, $log_file);
+					}
 				}
-				else
-					$sid_mods = snort_parse_sidconf_file("{$snort_sidmods_dir}{$snortcfg['disable_sid_file']}");
+				else {
+					$sid_mods = snort_parse_sidconf_file($snortcfg['disable_sid_file']);
+				}
 
-				if (!empty($sid_mods))
+				if (!empty($sid_mods)) {
 					$disables = snort_get_auto_category_mods($enabled_cats, $sid_mods, "disable", $log_results, $log_file);
-				elseif ($log_results == TRUE && !empty($log_file)) {
-					error_log(gettext("WARNING: no valid SID match tokens found in file \"{$snortcfg['disable_sid_file']}\".\n"), 3, $log_file);
+				} elseif ($log_results == TRUE && !empty($log_file)) {
+					error_log(gettext("WARNING: no valid SID match tokens found in list \"{$snortcfg['disable_sid_file']}\".\n"), 3, $log_file);
 				}
 			}
 			break;
@@ -2473,16 +2544,16 @@ function snort_modify_sid_content(&$rule_map, $sid_mods, $log_results = FALSE, $
 function snort_process_enablesid(&$rule_map, $snortcfg, $log_results = FALSE, $log_file = NULL) {
 
 	/**********************************************/
-	/* This function loads and processes the file */
+	/* This function loads and processes the list */
 	/* specified by 'enable_sid_file' for the     */
-	/* interface.  The file is assumed to be a    */
-	/* valid enablesid.conf file containing       */
+	/* interface.  The list is assumed to be a    */
+	/* valid enablesid.conf list containing       */
 	/* instructions for enabling matching rule    */
 	/* SIDs.                                      */
 	/*                                            */
 	/*     $rule_map ==> reference to array of    */
 	/*                   current rules            */
-	/*  $snortcfg ==> interface config params     */
+	/*  $snortcfg    ==> interface config params  */
 	/*  $log_results ==> [optional] 'yes' to log  */
 	/*                   results to $log_file     */
 	/*     $log_file ==> full path and filename   */
@@ -2492,7 +2563,6 @@ function snort_process_enablesid(&$rule_map, $snortcfg, $log_results = FALSE, $l
 	/*                   $rule_map array          */
 	/**********************************************/
 
-	$snort_sidmods_dir = SNORT_SID_MODS_PATH;
 	$snortlogdir = SNORTLOGDIR;
 	$sid_mods = array();
 
@@ -2500,9 +2570,9 @@ function snort_process_enablesid(&$rule_map, $snortcfg, $log_results = FALSE, $l
 	if (empty($rule_map))
 		return;
 
-	// Attempt to open the 'enable_sid_file' for the interface
-	if (!file_exists("{$snort_sidmods_dir}{$snortcfg['enable_sid_file']}")) {
-		log_error(gettext("[Snort] Error - unable to open 'enable_sid_file' \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+	// Verify the 'enable_sid' list for the interface exists
+	if (!snort_sid_mgmt_list_exist($snortcfg['enable_sid_file'])) {
+		log_error(gettext("[Snort] Error - unable to find enable_sid list \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 		return;
 	}
 	else
@@ -2511,7 +2581,7 @@ function snort_process_enablesid(&$rule_map, $snortcfg, $log_results = FALSE, $l
 	if (!empty($sid_mods))
 		snort_modify_sid_state($rule_map, $sid_mods, "enable", $log_results, $log_file);
 	elseif ($log_results == TRUE && !empty($log_file)) {
-		error_log(gettext("WARNING: no valid SID match tokens found in file \"{$snortcfg['enable_sid_file']}\".\n"), 3, $log_file);
+		error_log(gettext("WARNING: no valid SID match tokens found in list \"{$snortcfg['enable_sid_file']}\".\n"), 3, $log_file);
 	}
 
 	unset($sid_mods);
@@ -2520,16 +2590,16 @@ function snort_process_enablesid(&$rule_map, $snortcfg, $log_results = FALSE, $l
 function snort_process_disablesid(&$rule_map, $snortcfg, $log_results = FALSE, $log_file = NULL) {
 
 	/**********************************************/
-	/* This function loads and processes the file */
+	/* This function loads and processes the list */
 	/* specified by 'disable_sid_file' for the    */
-	/* interface.  The file is assumed to be a    */
-	/* valid disablesid.conf file containing      */
+	/* interface.  The list is assumed to be a    */
+	/* valid disablesid.conf list containing      */
 	/* instructions for disabling matching rule   */
 	/* SIDs.                                      */
 	/*                                            */
 	/*     $rule_map ==> reference to array of    */
 	/*                   current rules            */
-	/*  $snortcfg ==> interface config params     */
+	/*  $snortcfg    ==> interface config params  */
 	/*  $log_results ==> [optional] 'yes' to log  */
 	/*                   results to $log_file     */
 	/*     $log_file ==> full path and filename   */
@@ -2539,7 +2609,6 @@ function snort_process_disablesid(&$rule_map, $snortcfg, $log_results = FALSE, $
 	/*                   $rule_map array          */
 	/**********************************************/
 
-	$snort_sidmods_dir = SNORT_SID_MODS_PATH;
 	$snortlogdir = SNORTLOGDIR;
 	$sid_mods = array();
 
@@ -2547,13 +2616,14 @@ function snort_process_disablesid(&$rule_map, $snortcfg, $log_results = FALSE, $
 	if (empty($rule_map))
 		return;
 
-	// Attempt to open the 'disable_sid_file' for the interface
-	if (!file_exists("{$snort_sidmods_dir}{$snortcfg['disable_sid_file']}")) {
-		log_error(gettext("[Snort] Error - unable to open 'disable_sid_file' \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+	// Verify the 'disable_sid' list for the interface exists
+	if (!snort_sid_mgmt_list_exist($snortcfg['disable_sid_file'])) {
+		log_error(gettext("[Snort] Error - unable to find disable_sid list \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 		return;
 	}
-	else
+	else {
 		$sid_mods = snort_parse_sidconf_file("{$snort_sidmods_dir}{$snortcfg['disable_sid_file']}");
+	}
 
 	if (!empty($sid_mods))
 		snort_modify_sid_state($rule_map, $sid_mods, "disable", $log_results, $log_file);
@@ -2567,16 +2637,16 @@ function snort_process_disablesid(&$rule_map, $snortcfg, $log_results = FALSE, $
 function snort_process_modifysid(&$rule_map, $snortcfg, $log_results = FALSE, $log_file = NULL) {
 
 	/**********************************************/
-	/* This function loads and processes the file */
+	/* This function loads and processes the list */
 	/* specified by 'modify_sid_file' for the     */
-	/* interface.  The file is assumed to be a    */
-	/* valid modifysid.conf file containing       */
+	/* interface.  The list is assumed to be a    */
+	/* valid modifysid.conf list containing       */
 	/* instructions for modifying matching rule   */
 	/* SIDs.                                      */
 	/*                                            */
 	/*     $rule_map ==> reference to array of    */
 	/*                   current rules            */
-	/*  $snortcfg ==> interface config params     */
+	/*  $snortcfg    ==> interface config params  */
 	/*  $log_results ==> [optional] 'yes' to log  */
 	/*                   results to $log_file     */
 	/*     $log_file ==> full path and filename   */
@@ -2586,7 +2656,6 @@ function snort_process_modifysid(&$rule_map, $snortcfg, $log_results = FALSE, $l
 	/*                   $rule_map array          */
 	/**********************************************/
 
-	$snort_sidmods_dir = SNORT_SID_MODS_PATH;
 	$snortlogdir = SNORTLOGDIR;
 	$sid_mods = array();
 
@@ -2594,13 +2663,13 @@ function snort_process_modifysid(&$rule_map, $snortcfg, $log_results = FALSE, $l
 	if (empty($rule_map))
 		return;
 
-	// Attempt to open the 'modify_sid_file' for the interface
-	if (!file_exists("{$snort_sidmods_dir}{$snortcfg['modify_sid_file']}")) {
-		log_error(gettext("[Snort] Error - unable to open 'modify_sid_file' \"{$snortcfg['modify_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+	// Verify the 'modify_sid' list for the interface exists
+	if (!snort_sid_mgmt_list_exist($snortcfg['modify_sid_file'])) {
+		log_error(gettext("[Snort] Error - unable to find modify_sid list \"{$snortcfg['modify_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 		return;
+	} else {
+		$sid_mods = snort_parse_sidconf_file($snortcfg['modify_sid_file'],FALSE);
 	}
-	else
-		$sid_mods = snort_parse_sidconf_file("{$snort_sidmods_dir}{$snortcfg['modify_sid_file']}");
 
 	if (!empty($sid_mods))
 		snort_modify_sid_content($rule_map, $sid_mods, $log_results, $log_file);
@@ -2616,7 +2685,7 @@ function snort_auto_sid_mgmt(&$rule_map, $snortcfg, $log_results = FALSE) {
 	/**************************************************/
 	/* This function modifies the rules in the        */
 	/* passed rule_map array based on values in the   */
-	/* files 'enable_sid_file', 'disable_sid_file'    */
+	/* lists 'enable_sid_file', 'disable_sid_file'    */
 	/* and 'modify_sid_file' for the interface.       */
 	/*                                                */
 	/* If auto-mgmt of SIDs is enabled via the        */
@@ -2658,17 +2727,17 @@ function snort_auto_sid_mgmt(&$rule_map, $snortcfg, $log_results = FALSE) {
 			case "disable_enable":
 				if (!empty($snortcfg['disable_sid_file'])) {
 					if ($log_results == TRUE)
-						error_log(gettext("Processing disable_sid file: {$snortcfg['disable_sid_file']}\n"), 3, $log_file);
+						error_log(gettext("Processing disable_sid list: {$snortcfg['disable_sid_file']}\n"), 3, $log_file);
 					snort_process_disablesid($rule_map, $snortcfg, $log_results, $log_file);
 				}
 				if (!empty($snortcfg['enable_sid_file'])) {
 					if ($log_results == TRUE)
-						error_log(gettext("Processing enable_sid file: {$snortcfg['enable_sid_file']}\n"), 3, $log_file);
+						error_log(gettext("Processing enable_sid list: {$snortcfg['enable_sid_file']}\n"), 3, $log_file);
 					snort_process_enablesid($rule_map, $snortcfg, $log_results, $log_file);
 				}
 				if (!empty($snortcfg['modify_sid_file'])) {
 					if ($log_results == TRUE)
-						error_log(gettext("Processing modify_sid file: {$snortcfg['modify_sid_file']}\n"), 3, $log_file);
+						error_log(gettext("Processing modify_sid list: {$snortcfg['modify_sid_file']}\n"), 3, $log_file);
 					snort_process_modifysid($rule_map, $snortcfg, $log_results, $log_file);
 				}
 				$result = TRUE;
@@ -2677,17 +2746,17 @@ function snort_auto_sid_mgmt(&$rule_map, $snortcfg, $log_results = FALSE) {
 			case "enable_disable":
 				if (!empty($snortcfg['enable_sid_file'])) {
 					if ($log_results == TRUE)
-						error_log(gettext("Processing enable_sid file: {$snortcfg['enable_sid_file']}\n"), 3, $log_file);
+						error_log(gettext("Processing enable_sid list: {$snortcfg['enable_sid_file']}\n"), 3, $log_file);
 					snort_process_enablesid($rule_map, $snortcfg, $log_results, $log_file);
 				}
 				if (!empty($snortcfg['disable_sid_file'])) {
 					if ($log_results == TRUE)
-						error_log(gettext("Processing disable_sid file: {$snortcfg['disable_sid_file']}\n"), 3, $log_file);
+						error_log(gettext("Processing disable_sid list: {$snortcfg['disable_sid_file']}\n"), 3, $log_file);
 					snort_process_disablesid($rule_map, $snortcfg, $log_results, $log_file);
 				}
 				if (!empty($snortcfg['modify_sid_file'])) {
 					if ($log_results == TRUE)
-						error_log(gettext("Processing modify_sid file: {$snortcfg['modify_sid_file']}\n"), 3, $log_file);
+						error_log(gettext("Processing modify_sid list: {$snortcfg['modify_sid_file']}\n"), 3, $log_file);
 					snort_process_modifysid($rule_map, $snortcfg, $log_results, $log_file);
 				}
 				$result = TRUE;

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -2426,6 +2426,7 @@ function snort_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results = F
 					$rule_map[$k1][$k2]['rule'] = ltrim($rule_map[$k1][$k2]['rule'], " \t#");
 					$rule_map[$k1][$k2]['disabled'] = 0;
 					$rule_map[$k1][$k2]['managed'] = 1;
+					$rule_map[$k1][$k2]['state_toggled'] = 1;
 					$changecount++;
 					$modcount++;
 				}
@@ -2433,6 +2434,7 @@ function snort_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results = F
 					$rule_map[$k1][$k2]['rule'] = "# " . $rule_map[$k1][$k2]['rule'];
 					$rule_map[$k1][$k2]['disabled'] = 1;
 					$rule_map[$k1][$k2]['managed'] = 1;
+					$rule_map[$k1][$k2]['state_toggled'] = 1;
 					$changecount++;
 					$modcount++;
 				}

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules_edit.php
@@ -3,7 +3,7 @@
  * snort_rules_edit.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2018 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
@@ -75,7 +75,7 @@ if (substr($file, 0, 10) == "IPS Policy") {
 		$wrap_flag = "soft";
 	}
 	else {
-		$contents = "# Suricata IPS Policy - " . ucfirst(trim(substr($file, strpos($file, "-")+1))) . "\n\n";
+		$contents = "# Snort IPS Policy - " . ucfirst(trim(substr($file, strpos($file, "-")+1))) . "\n\n";
 		foreach (array_keys($rules_map) as $k1) {
 			foreach (array_keys($rules_map[$k1]) as $k2) {
 				$contents .= "# Category: " . $rules_map[$k1][$k2]['category'] . "   SID: {$k2}\n";
@@ -108,7 +108,7 @@ elseif (file_exists("{$snortdir}/rules/{$file}"))
 else
 	$input_errors[] = gettext("Unable to open file: {$displayfile}");
 
-$pgtitle = array(gettext("Suricata"), gettext("Rules File Viewer"));
+$pgtitle = array(gettext("Snort"), gettext("Rules File Viewer"));
 
 include("head.inc");
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules_edit.php
@@ -3,10 +3,11 @@
  * snort_rules_edit.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2004-2016 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2008-2009 Robert Zelaya
- * Copyright (c) 2014 Bill Meeks
- * Copyright (c) 2006-2009 Volker Theile
+ * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2003-2004 Manuel Kasper
+ * Copyright (c) 2005 Bill Marquette
+ * Copyright (c) 2009 Robert Zelaya Sr. Developer
+ * Copyright (c) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,7 +34,7 @@ if (isset($_GET['id']) && is_numericint($_GET['id']))
 
 // If we were not passed a valid index ID, close the pop-up and exit
 if (is_null($id)) {
-	echo '<html><body link="#000000" vlink="#000000" alink="#000000">';
+	echo '<html><body>';
 	echo '<script language="javascript" type="text/javascript">';
 	echo 'window.close();</script>';
 	echo '</body></html>';
@@ -58,8 +59,10 @@ $wrap_flag = "off";
 // Correct displayed file title if necessary
 if ($file == "Auto-Flowbit Rules")
 	$displayfile = FLOWBITS_FILENAME;
+elseif ($file == "snort.rules")
+	$displayfile = "Currently Active Rules";
 else
-	$displayfile = $file;
+	$displayfile = strip_tags($file);
 
 // Read the contents of the argument passed to us.
 // It may be an IPS policy string, an individual SID,
@@ -72,7 +75,7 @@ if (substr($file, 0, 10) == "IPS Policy") {
 		$wrap_flag = "soft";
 	}
 	else {
-		$contents = "# Snort IPS Policy - " . ucfirst(trim(substr($file, strpos($file, "-")+1))) . "\n\n";
+		$contents = "# Suricata IPS Policy - " . ucfirst(trim(substr($file, strpos($file, "-")+1))) . "\n\n";
 		foreach (array_keys($rules_map) as $k1) {
 			foreach (array_keys($rules_map[$k1]) as $k2) {
 				$contents .= "# Category: " . $rules_map[$k1][$k2]['category'] . "   SID: {$k2}\n";
@@ -87,10 +90,11 @@ elseif (isset($_GET['sid']) && is_numericint($_GET['sid']) && isset($_GET['gid']
 	// If flowbit rule, point to interface-specific file
 	if ($file == "Auto-Flowbit Rules")
 		$rules_map = snort_load_rules_map("{$snortcfgdir}/rules/" . FLOWBITS_FILENAME);
-	elseif (file_exists("{$snortdir}/preproc_rules/{$file}"))
-		$rules_map = snort_load_rules_map("{$snortdir}/preproc_rules/{$file}");
+	elseif ($file == "snort.rules")
+		$rules_map = snort_load_rules_map("{$snortcfgdir}/rules/snort.rules");
 	else
 		$rules_map = snort_load_rules_map("{$snortdir}/rules/{$file}");
+
 	$contents = $rules_map[$_GET['gid']][trim($_GET['sid'])]['rule'];
 	$wrap_flag = "soft";
 }
@@ -100,46 +104,43 @@ elseif ($file == "Auto-Flowbit Rules")
 // Is it a rules file in the ../rules/ directory?
 elseif (file_exists("{$snortdir}/rules/{$file}"))
 	$contents = file_get_contents("{$snortdir}/rules/{$file}");
-// Is it a rules file in the ../preproc_rules/ directory?
-elseif (file_exists("{$snortdir}/preproc_rules/{$file}"))
-	$contents = file_get_contents("{$snortdir}/preproc_rules/{$file}");
-// Is it a disabled preprocessor auto-rules-disable file?
-elseif (file_exists("{$snortlogdir}/{$file}"))
-	$contents = file_get_contents("{$snortlogdir}/{$file}");
 // It is not something we can display, so exit.
 else
-	$contents = gettext("Unable to open file: {$displayfile}");
+	$input_errors[] = gettext("Unable to open file: {$displayfile}");
 
-$pgtitle = array(gettext("Snort"), gettext("File Viewer"));
-?>
+$pgtitle = array(gettext("Suricata"), gettext("Rules File Viewer"));
 
-<?php include("head.inc");?>
+include("head.inc");
 
-<table width="100%" border="0" cellpadding="0" cellspacing="0">
-<tr>
-	<td class="tabcont">
-		<table width="100%" cellpadding="0" cellspacing="6" bgcolor="#eeeeee">
-		<tr>
-			<td class="pgtitle" colspan="2">Snort: Rules Viewer</td>
-		</tr>
-		<tr>
-			<td width="20%">
-				<input type="button" class="formbtn" value="Return" onclick="window.close()">
-			</td>
-			<td align="right">
-				<b><?php echo gettext("Rules File: ") . '</b>&nbsp;' . $displayfile; ?>&nbsp;&nbsp;&nbsp;&nbsp;
-			</td>
-		</tr>
-		<tr>
-			<td valign="top" class="label" colspan="2">
-			<div style="background: #eeeeee; width:100%; height:100%;" id="textareaitem"><!-- NOTE: The opening *and* the closing textarea tag must be on the same line. -->
-			<textarea style="width:100%; height:100%;" wrap="<?=$wrap_flag?>" rows="33" cols="80" name="code2"><?=$contents;?></textarea>
-			</div>
-			</td>
-		</tr>
-		</table>
-	</td>
-</tr>
-</table>
+if ($input_errors) {
+	print_input_errors($input_errors);
+}
+if ($savemsg)
+	print_info_box($savemsg);
 
-<?php require_once("foot.inc"); ?>
+$form = new Form(false);
+
+$section = new Form_Section('Rules file: ' . $displayfile);
+
+$btnclear = new Form_Button(
+	'close',
+	'Close'
+);
+
+$btnclear->addClass('btn-primary');
+$btnclear->setType('button');
+$btnclear->setOnclick('window.close()');
+
+$section->addInput($btnclear);
+
+$section->addInput(new Form_Textarea(
+	'textareaitem',
+	'Rule file',
+	$contents
+ ))->setRows(40)->setNoWrap()->removeClass("form-control")->addClass("col-lg-12");
+
+$form->add($section);
+
+print($form);
+
+include("foot.inc");?>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
@@ -601,17 +601,17 @@ if ($snortdownload == "on") {
 							// make sure we include a hidden field to reference it 
 							// so we do not unset it during a post-back.
 							if (in_array($file, $enabled_rulesets_array))
-								echo "<input type='hidden' name='toenable[]' value='{$file}' />\n";
+								echo '<input type="hidden" name="toenable[]" value="' . $file . '" />' . "\n";
 							if ($cat_mods[$file] == 'enabled') {
 								$CHECKED = "enabled";
-								echo "	\n<i class=\"fa fa-adn text-success\" title=\"" . gettext('Auto-enabled by settings on SID Mgmt tab') . "></i>\n";
+								echo "	\n" . '<i class="fa fa-adn text-success" title="' . gettext('Auto-enabled by settings on SID Mgmt tab') . '"></i>' . "\n";
 							}
 							else {
-								echo "	\n<i class=\"fa fa-adn text-danger\" title=\"" . gettext('Auto-disabled by settings on SID Mgmt tab') . "></i>\n";
+								echo "	\n" . '<i class="fa fa-adn text-danger" title="' . gettext('Auto-disabled by settings on SID Mgmt tab') . '"></i>' . "\n";
 							}
 						}
 						else {
-							echo "	\n<input type=\"checkbox\" name=\"toenable[]\" value=\"{$file}\" {$CHECKED} />\n";
+							echo "	\n" . '<input type="checkbox" name="toenable[]" value="' . $file . '"' . $CHECKED . " />\n";
 						}
 						echo "</td>\n";
 						echo "<td>\n";
@@ -637,17 +637,17 @@ if ($snortdownload == "on") {
 							$CHECKED = "";
 						if (isset($cat_mods[$file])) {
 							if (in_array($file, $enabled_rulesets_array))
-								echo "<input type='hidden' name='toenable[]' value='{$file}' />\n";
+								echo '<input type="hidden" name="toenable[]" value="' . $file . '" />' . "\n";
 							if ($cat_mods[$file] == 'enabled') {
 								$CHECKED = "enabled";
-								echo "	\n<i class=\"fa fa-adn text-success\" title=\"" . gettext('Auto-enabled by settings on SID Mgmt tab') . "></i>\n";
+								echo "	\n" . '<i class="fa fa-adn text-success" title="' . gettext('Auto-enabled by settings on SID Mgmt tab') . '"></i>' . "\n";
 							}
 							else {
-								echo "	\n<i class=\"fa fa-adn text-danger\" title=\"" . gettext('Auto-disabled by settings on SID Mgmt tab') . "></i>\n";
+								echo "	\n" . '<i class="fa fa-adn text-danger" title="' . gettext('Auto-disabled by settings on SID Mgmt tab') . '"></i>' . "\n";
 							}
 						}
 						else {
-							echo "	\n<input type='checkbox' name='toenable[]' value='{$file}' {$CHECKED} />\n";
+							echo "	\n" . '<input type="checkbox" name="toenable[]" value="' . $file . '"' . $CHECKED . " />\n";
 						}
 						echo "</td>\n";
 						echo "<td>\n";
@@ -673,17 +673,17 @@ if ($snortdownload == "on") {
 							$CHECKED = "";
 						if (isset($cat_mods[$file])) {
 							if (in_array($file, $enabled_rulesets_array))
-								echo "<input type='hidden' name='toenable[]' value='{$file}' />\n";
+								echo '<input type="hidden" name="toenable[]" value="' . $file . '" />' . "\n";
 							if ($cat_mods[$file] == 'enabled') {
 								$CHECKED = "enabled";
-								echo "	\n<i class=\"fa fa-adn text-success\" title=\"" . gettext('Auto-enabled by settings on SID Mgmt tab') . "></i>\n";
+								echo "	\n" . '<i class="fa fa-adn text-success" title="' . gettext('Auto-enabled by settings on SID Mgmt tab') . '"></i>' . "\n";
 							}
 							else {
-								echo "	\n<i class=\"fa fa-adn text-danger\" title=\"" . gettext('Auto-disabled by settings on SID Mgmt tab') . "></i>\n";
+								echo "	\n" . '<i class="fa fa-adn text-danger" title="' . gettext('Auto-disabled by settings on SID Mgmt tab') . '"></i>' . "\n";
 							}
 						}
 						else {
-							echo "	\n<input type='checkbox' name='toenable[]' value='{$file}' {$CHECKED} />\n";
+							echo "	\n" . '<input type="checkbox" name="toenable[]" value="{$file}"' . '"' .  $CHECKED . " />\n";
 						}
 						echo "</td>\n";
 						echo "<td>\n";
@@ -706,19 +706,17 @@ if ($snortdownload == "on") {
 							$CHECKED = "";
 					if (isset($cat_mods[$file])) {
 						if (in_array($file, $enabled_rulesets_array))
-							echo "<input type='hidden' name='toenable[]' value='{$file}' />\n";
+							echo '<input type="hidden" name="toenable[]" value="' . $file . '" />' . "\n";
 					if ($cat_mods[$file] == 'enabled') {
 							$CHECKED = "enabled";
-						echo "  \n<i class=\"fa fa-adn text-success\" title=\"" . gettext('Auto-enabled by settings on SID Mgmt
-tab') . "></i>\n";
+						echo "  \n" . '<i class="fa fa-adn text-success" title="' . gettext('Auto-enabled by settings on SID Mgmt tab') . '"></i>' . "\n";
 					}
 					else {
-					echo "  \n<i class=\"fa fa-adn text-danger\" title=\"" . gettext('Auto-disabled by settings on SID Mgmt
-tab') . "></i>\n";
+						echo "  \n" . '<i class="fa fa-adn text-danger" title="' . gettext('Auto-disabled by settings on SID Mgmt tab') . '"></i>' . "\n";
 					}
 				}
 				else {
-					echo "  \n<input type=\"checkbox\" name=\"toenable[]\" value=\"{$file}\" {$CHECKED} />\n";
+					echo "  \n" . '<input type="checkbox" name="toenable[]" value="' . $file . '"' . $CHECKED . " />\n";
 				}
 				echo "</td>\n";
 				echo "<td>\n";

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
@@ -419,7 +419,7 @@ if ($snortdownload == "on") {
 			<table class="table table-striped table-hover table-condensed">
 				<thead>
 					<tr>
-						<th><?=gettext("Enabled"); ?></th>
+						<th><?=gettext("Enable"); ?></th>
 						<th><?=gettext('Ruleset: Snort GPLv2 Community Rules'); ?></th>
 						<th></th>
 						<th></th>
@@ -432,19 +432,27 @@ if ($snortdownload == "on") {
 				<?php if ($cat_mods[$community_rules_file] == 'enabled') : ?>
 					<tr>
 						<td>
-							<i class="fa fa-adn text-success" title="<?=gettext('Auto-disabled by settings on SID Mgmt tab'); ?>"></i>
+							<i class="fa fa-adn text-success" title="<?=gettext('Auto-enabled by settings on SID Mgmt tab'); ?>"></i>
 						</td>
 						<td colspan="5">
-							<a href='snort_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?=gettext('{$msg_community}');?></a>
+							<?php if ($no_community_files): ?>
+								<?php echo gettext("{$msg_community}"); ?>
+							<?php else: ?>
+								<a href='snort_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?=gettext('{$msg_community}');?></a>
+							<?php endif; ?>
 						</td>
 					</tr>
 				<?php else: ?>
 					<tr>
 						<td>
-							<i class="fa fa-adn text-danger" title="<?=gettext("Auto-enabled by settings on SID Mgmt tab");?>"><i>
+							<i class="fa fa-adn text-danger" title="<?=gettext("Auto-disabled by settings on SID Mgmt tab");?>"><i>
 						</td>
 						<td colspan="5">
-							<?=gettext("{$msg_community}"); ?>
+							<?php if ($no_community_files): ?>
+								<?php echo gettext("{$msg_community}"); ?>
+							<?php else: ?>
+								<a href='snort_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext("{$msg_community}"); ?></a>
+							<?php endif; ?>
 						</td>
 					</tr>
 				<?php endif; ?>
@@ -454,7 +462,11 @@ if ($snortdownload == "on") {
 						<input type="checkbox" name="toenable[]" value="<?=$community_rules_file;?>" checked="checked"/>
 					</td>
 					<td colspan="5">
-						<a href='snort_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?php echo gettext("{$msg_community}"); ?></a>
+						<?php if ($no_community_files): ?>
+							<?php echo gettext("{$msg_community}"); ?>
+						<?php else: ?>
+							<a href='snort_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?php echo gettext("{$msg_community}"); ?></a>
+						<?php endif; ?>
 					</td>
 				</tr>
 			<?php else: ?>
@@ -463,7 +475,11 @@ if ($snortdownload == "on") {
 						<input type="checkbox" name="toenable[]" value="<?=$community_rules_file; ?>" />
 					</td>
 					<td colspan="5">
-						<?=gettext("{$msg_community}"); ?>
+						<?php if ($no_community_files): ?>
+							<?php echo gettext("{$msg_community}"); ?>
+						<?php else: ?>
+							<a href='snort_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext("{$msg_community}"); ?></a>
+						<?php endif; ?>
 					</td>
 				</tr>
 			<?php endif; ?>
@@ -495,24 +511,24 @@ if ($snortdownload == "on") {
 				<thead>
 					<tr>
 					<?php if ($emergingdownload == 'on' && !$no_emerging_files): ?>
-						<th><?=gettext("Enabled"); ?></th>
+						<th><?=gettext("Enable"); ?></th>
 						<th><?=gettext('Ruleset: ET Open Rules');?></th>
 					<?php elseif ($etpro == 'on' && !$no_emerging_files): ?>
-						<th><?=gettext("Enabled"); ?></th>
+						<th><?=gettext("Enable"); ?></th>
 						<th><?=gettext('Ruleset: ET Pro Rules');?></th>
 					<?php else: ?>
 						<th colspan="2"><?=gettext("{$et_type} rules {$msg_emerging}"); ?></th>
 					<?php endif; ?>
 					<?php if ($snortdownload == 'on' && !$no_snort_files): ?>
-						<th><?=gettext("Enabled"); ?></th>
+						<th><?=gettext("Enable"); ?></th>
 						<th><?=gettext('Ruleset: Snort Text Rules');?></th>
-						<th><?=gettext("Enabled"); ?></th>
+						<th><?=gettext("Enable"); ?></th>
 						<th><?=gettext('Ruleset: Snort SO Rules');?></th>
 					<?php else: ?>
 						<th colspan="4"><?=gettext("Snort Subscriber rules {$msg_snort}"); ?></th>
 					<?php endif; ?>
 					<?php if ($openappid_rulesdownload == 'on' && !$no_openappid_files): ?>
-						<th><?=gettext("Enabled"); ?></th>
+						<th><?=gettext("Enable"); ?></th>
 						<th><?=gettext('Ruleset: Snort OPENAPPI Rules');?></th>
 						<?php else: ?>
 						<th colspan="4"><?=gettext("Snort OPENAPPID rules {$msg_snort}"); ?></th>
@@ -600,7 +616,7 @@ if ($snortdownload == "on") {
 						echo "</td>\n";
 						echo "<td>\n";
 						if (empty($CHECKED))
-							echo $file;
+							echo "<a href='snort_rules_edit.php?id={$id}&openruleset=" . urlencode($file) . "' target='_blank' rel='noopener noreferrer'>{$file}</a>\n";
 						else
 							echo "<a href='snort_rules.php?id={$id}&openruleset=" . urlencode($file) . "'>{$file}</a>\n";
 						echo "</td>\n";
@@ -636,7 +652,7 @@ if ($snortdownload == "on") {
 						echo "</td>\n";
 						echo "<td>\n";
 						if (empty($CHECKED) || $CHECKED == "disabled")
-							echo $file;
+							echo "<a href='snort_rules_edit.php?id={$id}&openruleset=" . urlencode($file) . "' target='_blank' rel='noopener noreferrer'>{$file}</a>\n";
 						else
 							echo "<a href='snort_rules.php?id={$id}&openruleset=" . urlencode($file) . "'>{$file}</a>\n";
 						echo "</td>\n";
@@ -672,7 +688,7 @@ if ($snortdownload == "on") {
 						echo "</td>\n";
 						echo "<td>\n";
 						if (empty($CHECKED) || $CHECKED == "disabled")
-							echo $file;
+							echo "<a href='snort_rules_edit.php?id={$id}&openruleset=" . urlencode($file) . "' target='_blank' rel='noopener noreferrer'>{$file}</a>\n";
 						else
 							echo "<a href='snort_rules.php?id={$id}&openruleset=" . urlencode($file) . "'>{$file}</a>\n";
 						echo "</td>\n";
@@ -707,7 +723,7 @@ tab') . "></i>\n";
 				echo "</td>\n";
 				echo "<td>\n";
 				if (empty($CHECKED))
-					echo $file;
+					echo "<a href='snort_rules_edit.php?id={$id}&openruleset=" . urlencode($file) . "' target='_blank' rel='noopener noreferrer'>{$file}</a>\n";
 				else
 					echo "<a href='snort_rules.php?id={$id}&openruleset=" . urlencode($file) . "'>{$file}</a>\n";
 				echo "</td>\n";
@@ -737,16 +753,24 @@ tab') . "></i>\n";
 
 		function enable_change()
 		{
- 			var endis = !(($('#ips_policy_enable').prop('checked')));
-			disableInput('ips_policy', endis);
+		var endis = !($('#ips_policy_enable').prop('checked'));
 
-		 	for (var i = 0; i < document.iform.elements.length; i++) {
-			    if (document.iform.elements[i].type == 'checkbox') {
-			       var str = document.iform.elements[i].value;
-			       if (str.substr(0,6) == "snort_")
-        			  document.iform.elements[i].disabled = !(endis);
-			    }
- 			}
+		hideInput('ips_policy', endis);
+		hideInput('ips_policy_mode', endis);
+
+		$('input[type="checkbox"]').each(function() {
+			var str = $(this).val();
+
+			if (str.substr(0,6) == "snort_") {
+				$(this).attr('disabled', !endis);
+				if (!endis) {
+					$(this).prop('title', 'Disabled because an IPS Policy is selected');
+				}
+				else {
+					$(this).prop('title', '');
+				}
+			}
+		});
 		}
 
 	events.push(function(){

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
@@ -160,45 +160,37 @@ if (isset($_POST['save_auto_sid_conf'])) {
 	$config['installedpackages']['snortglobal']['auto_manage_sids'] = $pconfig['auto_manage_sids'] ? "on" : "off";
 
 	// Grab the SID Mods config for the interfaces from the form's controls array
-	foreach ($_POST['sid_state_order'] as $k => $v) {
-		$a_nat[$k]['sid_state_order'] = $v;
-	}
-	foreach ($_POST['enable_sid_file'] as $k => $v) {
-		if ($v == "None") {
-			unset($a_nat[$k]['enable_sid_file']);
-			continue;
+	if (is_array($_POST['sid_state_order'])) {
+		foreach ($_POST['sid_state_order'] as $k => $v) {
+			$a_nat[$k]['sid_state_order'] = $v;
 		}
-		$a_nat[$k]['enable_sid_file'] = $v;
 	}
-	foreach ($_POST['disable_sid_file'] as $k => $v) {
-		if ($v == "None") {
-			unset($a_nat[$k]['disable_sid_file']);
-			continue;
+	if (is_array($_POST['enable_sid_file'])) {
+		foreach ($_POST['enable_sid_file'] as $k => $v) {
+			if ($v == "None") {
+				unset($a_nat[$k]['enable_sid_file']);
+				continue;
+			}
+			$a_nat[$k]['enable_sid_file'] = $v;
 		}
-		$a_nat[$k]['disable_sid_file'] = $v;
 	}
-	foreach ($_POST['modify_sid_file'] as $k => $v) {
-		if ($v == "None") {
-			unset($a_nat[$k]['modify_sid_file']);
-			continue;
+	if (is_array($_POST['disable_sid_file'])) {
+		foreach ($_POST['disable_sid_file'] as $k => $v) {
+			if ($v == "None") {
+				unset($a_nat[$k]['disable_sid_file']);
+				continue;
+			}
+			$a_nat[$k]['disable_sid_file'] = $v;
 		}
-		$a_nat[$k]['modify_sid_file'] = $v;
 	}
-
-	foreach ($_POST['drop_sid_file'] as $k => $v) {
-		if ($v == "None") {
-			unset($a_nat[$k]['drop_sid_file']);
-			continue;
+	if (is_array($_POST['modify_sid_file'])) {
+		foreach ($_POST['modify_sid_file'] as $k => $v) {
+			if ($v == "None") {
+				unset($a_nat[$k]['modify_sid_file']);
+				continue;
+			}
+			$a_nat[$k]['modify_sid_file'] = $v;
 		}
-		$a_nat[$k]['drop_sid_file'] = $v;
-	}
-
-	foreach ($_POST['reject_sid_file'] as $k => $v) {
-		if ($v == "None") {
-			unset($a_nat[$k]['reject_sid_file']);
-			continue;
-		}
-		$a_nat[$k]['reject_sid_file'] = $v;
 	}
 
 	// Write the new configuration
@@ -333,13 +325,7 @@ include_once("head.inc");
 /* Display Alert message, under form tag or no refresh */
 if ($input_errors)
 	print_input_errors($input_errors);
-?>
 
-<form action="snort_sid_mgmt.php" method="post" enctype="multipart/form-data" name="iform" id="iform" class="form-horizontal">
-	<input type="hidden" name="MAX_FILE_SIZE" value="100000000" />
-	<input type="hidden" name="sidlist_id" id="sidlist_id" value=""/>
-
-<?php
 if ($savemsg) {
 	/* Display save message */
 	print_info_box($savemsg);
@@ -358,7 +344,13 @@ $tab_array[] = array(gettext("SID Mgmt"), true, "/snort/snort_sid_mgmt.php");
 $tab_array[] = array(gettext("Log Mgmt"), false, "/snort/snort_log_mgmt.php");
 $tab_array[] = array(gettext("Sync"), false, "/pkg_edit.php?xml=snort/snort_sync.xml");
 display_top_tabs($tab_array, true);
+?>
 
+<form action="snort_sid_mgmt.php" method="post" enctype="multipart/form-data" name="iform" id="iform" class="form-horizontal">
+	<input type="hidden" name="MAX_FILE_SIZE" value="100000000" />
+	<input type="hidden" name="sidlist_id" id="sidlist_id" value=""/>
+
+<?php
 $section = new Form_Section('SID Management General Settings');
 $group = new Form_Group('Enable Automatic SID State Management');
 $group->add(new Form_Checkbox(
@@ -415,6 +407,7 @@ print($section);
 								</td>
 							</tr>
 						<?php endforeach; ?>
+							</tbody>
 						</table>
 					</td>
 				</tr>
@@ -578,19 +571,17 @@ print($section);
 			   <?php endforeach; ?>
 				</tbody>
 			</table>
-			</div>
 		</div>
-
+	</div>
+	<div>
 		<button type="submit" id="save_auto_sid_conf" name="save_auto_sid_conf" class="btn btn-primary" value="<?=gettext("Save");?>" title="<?=gettext("Save SID Management configuration");?>" >
 			<i class="fa fa-save icon-embed-btn"></i>
 			<?=gettext("Save");?>
 		</button>
 		&nbsp;&nbsp;<?=gettext("Remember to save changes before exiting this page"); ?>
-
 	</div>
 </form>
 </br />
-
 	<div class="infoblock">
 	<?php
 		print_info_box(


### PR DESCRIPTION
### pfSense-pkg-snort v3.2.9.7_1
This update to the Snort GUI package ports in three new features added previously to the Suricata package.

**New Features**
1. Create hyperlinks for all rule category files on the CATEGORIES tab so that both enabled and not enabled files can be viewed.  Enabled rule category contents are shown by switching to the RULES tab.  Disabled rule category contents are shown in a modal pop-up window.
2. Provide mechanism to view the list of "user-forced disabled" or "user-forced enabled" or "Active Rules" rules on the RULES tab.
3. Migrate storage of SID management files to the firewall _config.xml_ file using Base64 encoding so they stay with the firewall configuration and can be easily backed up as well.