### PR TITLE
acme, add challenge alias feature for dns validation with CNAME (for 2.4.3 )

### DIFF
--- a/security/pfSense-pkg-acme/Makefile
+++ b/security/pfSense-pkg-acme/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-acme
-PORTVERSION=	0.3.1
-PORTREVISION=	1
+PORTVERSION=	0.3.2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
@@ -655,6 +655,12 @@ $acme_domain_validation_method['dns_zilore'] = array('name' => "DNS-Zilore",
 			'description' =>"Fill in the Zilore API Key"
 		)
 	));
+$acme_domain_validation_method['anydns'] = array('name' => "notforuser",
+	'fields' => array(
+		'challengealias' => array('name'=>"challengealias",'columnheader'=>"Enable DNS alias mode",'type'=>"textbox",
+			'description' => '(Optional) Adds the --challenge-alias flag to the acme.sh call.<br/>To use a CNAME for _acme-challenge.importantDomain.tld to direct the acme validation to a different (sub)domain _acme-challenge.aliasDomainForValidationOnly.tld, configure the alternate domain here.<br/>More information can be found <a href="https://github.com/Neilpang/acme.sh/wiki/DNS-alias-mode" target="_new">here</a>.'
+		)
+	));
 
 //TODO add more challenge validation types
 /* 
@@ -815,14 +821,25 @@ function & get_certificate($name) {
 		return $acmesh->registeraccount($key);
 	}
 
-	function renew_all_certificates() {
-		global $config;
-		$a_global = &$config['installedpackages']['acme'];
-		if (is_array($a_global['certificates']['item'])) {
-			foreach($a_global['certificates']['item'] as $certificate) {
-				echo "Checking if renewal is needed for: {$certificate['name']}\n";
-				issue_certificate($certificate['name']);
+	function renew_all_certificates($force = false) {
+		global $config;		
+		$a_certificates = getarraybyref($config, 'installedpackages', 'acme', 'certificates', 'item');
+		$errors = "";
+		foreach($a_certificates as $certificate) {
+			if ($certificate['status'] != 'active') {
+				echo "Certificate renewal certificate {$certificate['name']} is set to: disabled\n";
+				continue;
 			}
+			echo "Checking if renewal is needed for: {$certificate['name']}\n";
+			$res = issue_certificate($certificate['name'], $force);
+			if (!$res) {
+				$errmsg = "ACME, Failed to renew certificate for {$certificate['name']}";
+				syslog(LOG_WARNING, $errmsg);
+				$errors .= "{$errmsg}\n";
+			}
+		}
+		if (!empty($errors)) {
+			notify_all_remote($errors);
 		}
 	}
 	
@@ -914,11 +931,12 @@ function & get_certificate($name) {
 	}
 		
 	function issue_certificate($id, $force = false, $renew = false) {
+		$result = true;
 		$certificate = & get_certificate($id);
 		if (!$force) {
 			if ($certificate['status'] != 'active') {
 				echo "Certificate renewal for this certificate is set to: disabled\n";
-				return;
+				return $result;
 			}
 
 			$renewafterdays = is_numericint($certificate['renewafter']) ? $certificate['renewafter'] : 60;	
@@ -939,21 +957,29 @@ function & get_certificate($name) {
 			syslog(LOG_NOTICE, "Acme, renewing certificate: {$id}");
 			echo "Renewing certificate \n";
 			$domainstosign = array();
-			$method = "";
 			if (is_array($certificate['a_domainlist']['item'])) {
 				foreach($certificate['a_domainlist']['item'] as $domain) {
 					if ($domain['status'] == 'disable') {
 						continue;
 					}
-					$domainstosign[] = $domain['name'];
 					$method = $domain['method'];
+					$newdomain = new acme_sh_domain($domain['name'], $method);
+					if ($method == "dns_nsupdate") {
+						$newdomain->setnsupdateparameters(
+								$domain["{$method}nsupdate_server"],
+								$domain["{$method}nsupdate_keyname"],
+								$domain["{$method}nsupdate_keyalgo"],
+								$domain["{$method}nsupdate_key"]
+						);
+					}
+					if (substr($method, 0, 4) == "dns_") {
+						$newdomain->setchallengealias($domain["anydns"."challengealias"]);
+					}
+					$domainstosign[] = $newdomain;
 					$envvariables = array();
 					global $acme_domain_validation_method;
 					foreach($acme_domain_validation_method[$method]['fields'] as $key => $field) {
 						$envvariables[$key] = $domain["{$method}{$field['name']}"];
-						if ($method == "dns_nsupdate") {
-							$extras[$domain['name']][$key] = $domain["{$method}{$field['name']}"];
-						}
 					}
 				}
 			}
@@ -966,13 +992,15 @@ function & get_certificate($name) {
 			
 			global $a_acmeserver;
 			$url = $a_acmeserver[$acmeserver]['url'];
-			$certificatepsk = getCertificatePSK($url, $certificate, $domainstosign[0]);
+			$certificatepsk = getCertificatePSK($url, $certificate, $domainstosign[0]->domainname);
 			$acmesh = new acme_sh($certificate['name'], $url);
 			$action = $renew == true ? "renew" : "issue";
 			$acmesh->dnssleep = $certificate['dnssleep'];
+			$acmesh->challengealias = $certificate['challengealias'];
 			$acmesh->ocspstaple = $certificate['ocspstaple'];
-			$acmesh->signCertificate($action, $accountkey, $certificatepsk, $domainstosign, $method, $envvariables, $extras);
+			$result = $acmesh->signCertificate($action, $accountkey, $certificatepsk, $domainstosign, $envvariables);
 		}
+		return $result;
 	}
 	
 	function challenge_response_put($certificatename, $domain, $token, $payload) {
@@ -990,7 +1018,7 @@ function & get_certificate($name) {
 			echo "webroot\n";
 			$directory = $domain_info['webrootfolder'];
 			if(!file_exists($directory) && !@mkdir($directory, 0755, true)) {
-				throw new \RuntimeException("Couldn't create directory to expose challenge: ${tokenPath}");
+				throw new \RuntimeException("Couldn't create directory: '{$directory}' to expose challenge for certificate: {$certificatename}.");
 			}
 			$tokenPath = $directory . "/" . $token;
 			file_put_contents($tokenPath, $payload);

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_command.sh
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_command.sh
@@ -7,8 +7,24 @@ include_once("acme.inc");
 
 $command = $argv[1];
 
+$force = false;
+$perform = "";
+$certname = "";
+for($i = 0; $i < count($argv); $i++){
+	if ($argv[$i] == '-force') {
+		$force = true;
+	}
+	if (substr($argv[$i],0,9) == '-perform=') {
+		$perform = substr($argv[$i],9);
+	}
+	if (substr($argv[$i],0,10) == '-certname=') {
+		$certname = substr($argv[$i],10);
+	}
+}
+
 if ($command == "renewall") {
-	renew_all_certificates();
+	renew_all_certificates($force);
+	return;
 }
 
 if ($command == "importcert") {
@@ -59,6 +75,7 @@ if ($command == "importcert") {
 		}
 	}
 	acme_write_all_certificates();
+	return;
 }
 
 if ($command == "deploykey") {
@@ -67,6 +84,7 @@ if ($command == "deploykey") {
 	$token = $argv[4];
 	$payload = $argv[5];
 	challenge_response_put($certificatename, $domain, $token, $payload);
+	return;
 }
 
 if ($command == "removekey") {
@@ -74,4 +92,22 @@ if ($command == "removekey") {
 	$domain = $argv[3];
 	$token = $argv[4];
 	challenge_response_cleanup($certificatename, $domain, $token);
+	return;
 }
+
+if ($perform == "issue" && !empty($certname)) {
+	issue_certificate($certname, $force);
+	return;
+}
+if ($perform == "renew" && !empty($certname)) {
+	issue_certificate($certname, $force, true);
+	return;
+}
+
+echo "Use acme_command.sh like this:\n";
+echo "  acme_command.sh renewall\n";
+echo "  acme_command.sh importcert MyCertificate DomainName CertKeyPath CertPath CaCertPath CertFullChainPath\n";
+echo "  acme_command.sh deploykey MyCertificate DomainName Token Payload\n";
+echo "  acme_command.sh removekey MyCertificate DomainName Token\n";
+echo "  acme_command.sh -- -perform=issue -certname=MyCertificate [-force]\n";
+echo "  acme_command.sh -- -perform=renew -certname=MyCertificate [-force]\n";

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_htmllist.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_htmllist.inc
@@ -79,9 +79,11 @@ class HtmlList
 			}
 			foreach($fields as $item) {
 				$itemname = $item['name'];
-				$value[$itemname] = $_POST[$this->tablename.$itemname.$x];
-				if ($item['type'] == 'textarea') {
-					$value[$itemname] = base64_encode($value[$itemname]);
+				if (!empty($_POST[$this->tablename.$itemname.$x])) {
+					$value[$itemname] = $_POST[$this->tablename.$itemname.$x];
+					if ($item['type'] == 'textarea') {
+						$value[$itemname] = base64_encode($value[$itemname]);
+					}
 				}
 				$add_item |= isset($_POST[$this->tablename.$itemname.$x]);
 			}

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_sh.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_sh.inc
@@ -20,6 +20,29 @@
  */
 
 namespace pfsense_pkg\acme;
+
+class acme_sh_domain {
+	public $domainname;
+	public $method;
+	public $challengealias;
+	public $NSUPDATE_SERVER;
+	public $NSUPDATE_KEYNAME;
+	public $NSUPDATE_KEYALGO;
+	public $NSUPDATE_KEY;
+	function __construct($domainname, $method) {
+		$this->domainname = $domainname;
+		$this->method = $method;
+	}
+	function setchallengealias($challengealias) {
+		$this->challengealias = $challengealias;
+	}
+	function setnsupdateparameters($server, $keyname, $keyalgo, $key) {
+		$this->NSUPDATE_SERVER = $server;
+		$this->NSUPDATE_KEYNAME = $keyname;
+		$this->NSUPDATE_KEYALGO = $keyalgo;
+		$this->NSUPDATE_KEY = $key;
+	}
+}
 	
 class acme_sh {
 
@@ -126,30 +149,12 @@ class acme_sh {
 		return $privateKey;
 	}
 	
-	function signCertificate($action, $accountkey, $certificatepsk, $domainstosign, $api = null, $envvariables = null, $extras = null) {
+	function signCertificate($action, $accountkey, $certificatepsk, $domainstosign, $envvariables = null) {
 		// $action = issue / renew
 		global $acme_domain_validation_method;
 		file_put_contents("{$this->path_account}/account.key", base64_decode($accountkey));
+
 		$cmdparameters = "";
-		if ($api && substr($api, 0, 4 ) === "dns_") {
-			if ($api == "dns_manual") {
-				$cmdapi = "";
-				$cmdparameters .= " --yes-I-know-dns-manual-mode-enough-go-ahead-please ";
-			} else {
-				$cmdapi = escapeshellarg($api);
-			}
-			$cmdparameters .= " --dns {$cmdapi} ";
-		} elseif ($api == "standalone") {
-			$port = empty($envvariables['port']) ? 80 : $envvariables['port'];
-			$listen = ($envvariables['ipv6'] == "yes") ? "--listen-v6" : "--listen-v4";
-			$cmdparameters = " --standalone {$listen} --httpport " . escapeshellarg($port);
-		} elseif ($api == "standalonetls") {
-			$port = empty($envvariables['port']) ? 443 : $envvariables['port'];
-			$listen = ($envvariables['ipv6'] == "yes") ? "--listen-v6" : "--listen-v4";
-			$cmdparameters = " --tls {$listen} --tlsport " . escapeshellarg($port);
-		} else {
-			$cmdparameters = " --webroot pfSenseacme";
-		}
 		if (is_numericint($this->dnssleep)) {
 			$cmdparameters .= " --dnssleep " . escapeshellarg($this->dnssleep);
 		}
@@ -157,7 +162,7 @@ class acme_sh {
 			$cmdparameters .= " --ocsp-must-staple ";
 		}
 		
-		$Le_Domain = $domainstosign[0];
+		$Le_Domain = $domainstosign[0]->domainname;
 		$certpath = "{$this->acmeconf}{$Le_Domain}/";
 		safe_mkdir($certpath);
 		$CERT_KEY_PATH = "{$certpath}{$Le_Domain}.key";
@@ -175,33 +180,6 @@ class acme_sh {
 		file_put_contents($reloadfile, $reloadcmd);
 		chmod($reloadfile, 0755);
 
-		if ($api == "dns_nsupdate") {
-			/* Prefix to use as a base for server/key/private files */
-			$nsupdatefileprefix = "{$certpath}nsupdate";
-			foreach (array_keys($extras) as $nsupdatedomain) {
-				$acmechalengedom = (substr($nsupdatedomain, 0, 2) === "*.") ? substr($nsupdatedomain, 2) : $nsupdatedomain;
-				file_put_contents("{$nsupdatefileprefix}_acme-challenge.{$acmechalengedom}.server", $extras[$nsupdatedomain]['NSUPDATE_SERVER']);
-				$envvariables['NSUPDATE_SERVER'] = $nsupdatefileprefix;
-				$nsupdatekey = base64_decode($extras[$nsupdatedomain]['NSUPDATE_KEY']);
-
-				/* Set a default key algo of HMAC-MD5 if the key type is invalid. */
-				$key_algo = empty($extras[$nsupdatedomain]['NSUPDATE_KEYALGO']) || !array_key_exists($extras[$nsupdatedomain]['NSUPDATE_KEYALGO'], $acme_domain_validation_method['dns_nsupdate']['fields']['NSUPDATE_KEYALGO']['items']) ? '157' : $extras[$nsupdatedomain]['NSUPDATE_KEYALGO'];
-
-				$key_name = empty($extras[$nsupdatedomain]['NSUPDATE_KEYNAME']) ? "_acme-challenge.{$acmechalengedom}" : rtrim($extras[$nsupdatedomain]['NSUPDATE_KEYNAME'], '.');
-
-				/* Use ddns-confgen format key */
-				$keydata = <<<EOD
-key "{$key_name}." {
-	algorithm {$acme_domain_validation_method['dns_nsupdate']['fields']['NSUPDATE_KEYALGO']['items'][$key_algo]['name']};
-	secret "{$nsupdatekey}";
-};
-
-EOD;
-				file_put_contents("{$nsupdatefileprefix}_acme-challenge.{$acmechalengedom}.key", $keydata);
-			}
-			$envvariables['NSUPDATE_KEY'] = $nsupdatefileprefix;
-		}
-
 		$hookcontent_httpapi  = <<<EOF
 pfSenseacme_add() {
   /usr/local/pkg/acme/acme_command.sh "deploykey" "{$this->name}" "\$1" "\$2" "\$3"
@@ -216,13 +194,69 @@ EOF;
 		file_put_contents($hookfile_httpapi, $hookcontent_httpapi);
 		chmod($hookfile_httpapi, 0755);
 		
-		$certpath = "{$this->acmeconf}{$domainstosign[0]}";
+		$certpath = "{$this->acmeconf}{$domainstosign[0]->domainname}";
 		safe_mkdir($certpath);
-		file_put_contents("{$certpath}/{$domainstosign[0]}.key", $certificatepsk);
+		file_put_contents("{$certpath}/{$domainstosign[0]->domainname}.key", $certificatepsk);
 		$domainstr = "";
 		foreach($domainstosign as $domain) {
-			$domainstr .= " -d " . escapeshellarg($domain);
+			$api = $domain->method; 
+			$domainstr .= " -d " . escapeshellarg($domain->domainname);
+			if (!empty($domain->method)) {
+				$domainparameters = "";
+				if ($api && substr($api, 0, 4 ) === "dns_") {
+					if (!empty($domain->challengealias)) {
+						$domainstr .= " --challenge-alias " . escapeshellarg($domain->challengealias);
+					}
+					if ($api == "dns_manual") {
+						$cmdapi = "";
+						$domainparameters .= " --yes-I-know-dns-manual-mode-enough-go-ahead-please ";
+					} else {
+						$cmdapi = escapeshellarg($api);
+					}
+					$domainparameters .= " --dns {$cmdapi} ";
+				} elseif ($api == "standalone") {
+					$port = empty($envvariables['port']) ? 80 : $envvariables['port'];
+					$listen = ($envvariables['ipv6'] == "yes") ? "--listen-v6" : "--listen-v4";
+					$domainparameters = " --standalone {$listen} --httpport " . escapeshellarg($port);
+				} elseif ($api == "standalonetls") {
+					$port = empty($envvariables['port']) ? 443 : $envvariables['port'];
+					$listen = ($envvariables['ipv6'] == "yes") ? "--listen-v6" : "--listen-v4";
+					$domainparameters = " --tls {$listen} --tlsport " . escapeshellarg($port);
+				} else {
+					$domainparameters = " --webroot pfSenseacme";
+				}
+				$domainstr .= $domainparameters;
+			}
+			if ($domain->method == "dns_nsupdate") {
+				/* Prefix to use as a base for server/key/private files */
+				$nsupdatefileprefix = "{$certpath}nsupdate";
+				$envvariables['NSUPDATE_SERVER'] = $nsupdatefileprefix;
+				$envvariables['NSUPDATE_KEY'] = $nsupdatefileprefix;
+				$nsupdatedomain = $domain->domainname;
+				if (!empty($domain->challengealias)) {
+					$nsupdatedomain = $domain->challengealias;
+				}
+
+
+				$acmechalengedom = (substr($nsupdatedomain, 0, 2) === "*.") ? substr($nsupdatedomain, 2) : $nsupdatedomain;
+				file_put_contents("{$nsupdatefileprefix}_acme-challenge.{$acmechalengedom}.server", $domain->NSUPDATE_SERVER);
+				$nsupdatekey = base64_decode($domain->NSUPDATE_KEY);
+
+				/* Set a default key algo of HMAC-MD5 if the key type is invalid. */
+				$key_algo = empty($domain->NSUPDATE_KEYALGO) || !array_key_exists($domain->NSUPDATE_KEYALGO, $acme_domain_validation_method['dns_nsupdate']['fields']['NSUPDATE_KEYALGO']['items']) ? '157' : $domain->NSUPDATE_KEYALGO;
+				$key_name = empty($domain->NSUPDATE_KEYNAME) ? "_acme-challenge.{$acmechalengedom}" : rtrim($domain->NSUPDATE_KEYNAME, '.');
+
+				/* Use ddns-confgen format key */
+				$keydata = <<<EOD
+key "{$key_name}." {
+	algorithm {$acme_domain_validation_method['dns_nsupdate']['fields']['NSUPDATE_KEYALGO']['items'][$key_algo]['name']};
+	secret "{$nsupdatekey}";
+};
+EOD;
+				file_put_contents("{$nsupdatefileprefix}_acme-challenge.{$acmechalengedom}.key", $keydata);
+			}
 		}
+		
 		$this->execacmesh(""
 			. " --{$action} {$domainstr}"
 			. " --home " . escapeshellarg($this->acmeconf)
@@ -234,7 +268,7 @@ EOF;
 			. " --log " . escapeshellarg("{$this->acmeconf}acme_issuecert.log")
 			//. " > {$this->acmeconf}issue.log 2>&1"
 			, $envvariables);
-		$cer = "{$certpath}/{$domainstosign[0]}.cer";
+		$cer = "{$certpath}/{$domainstosign[0]->domainname}.cer";
 		if (file_exists($cer)) {
 			if ($action == "renew") {
 				/* Renew action will not automatically run the reload command! */

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_utils.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_utils.inc
@@ -53,6 +53,27 @@ if(!function_exists('is_arrayset')){
 	}
 }
 
+if (!function_exists('getarraybyref')) {
+	function &getarraybyref(&$array) {
+		if (!isset($array)) {
+			return false;
+		}
+		if (!is_array($array)) {
+			$array = array();
+		}
+		$item = &$array;
+		$arg = func_get_args();
+		for($i = 1; $i < count($arg); $i++) {
+			$itemindex = $arg[$i];
+			if (!is_array($item[$itemindex])) {
+				$item[$itemindex] = array();
+			}
+			$item = &$item[$itemindex];
+		}
+		return $item;
+	}
+}
+
 function array_moveitemsbefore(&$items, $before, $selected) {
 	// generic function to move array items before the set item by their numeric indexes.
 	

--- a/security/pfSense-pkg-acme/files/usr/local/www/acme/acme_certificates.php
+++ b/security/pfSense-pkg-acme/files/usr/local/www/acme/acme_certificates.php
@@ -31,16 +31,13 @@ require_once("acme/pkg_acme_tabs.inc");
 
 $changedesc = "Services: Acme: Certificates";
 
-if (!is_array($config['installedpackages']['acme']['certificates']['item'])) {
-	$config['installedpackages']['acme']['certificates']['item'] = array();
-}
-$a_certifcates = &$config['installedpackages']['acme']['certificates']['item'];
+$a_certificates = &getarraybyref($config, 'installedpackages', 'acme', 'certificates', 'item');
 
 if($_POST['action'] == "toggle") {
 	$id = $_POST['id'];
 	echo "$id|";
-	if (isset($a_certifcates[get_certificate_id($id)])) {
-		$item = &$a_certifcates[get_certificate_id($id)];
+	if (isset($a_certificates[get_certificate_id($id)])) {
+		$item = &$a_certificates[get_certificate_id($id)];
 		if ($item['status'] != "disabled"){
 			$item['status'] = 'disabled';
 			echo "0|";
@@ -59,7 +56,7 @@ if($_POST['action'] == "toggle") {
 if($_POST['action'] == "issuecert") {
 	$id = $_POST['id'];
 	echo $id . "\n";
-	if (isset($a_certifcates[get_certificate_id($id)])) {
+	if (isset($a_certificates[get_certificate_id($id)])) {
 		issue_certificate($id, true);
 	}
 	exit;
@@ -67,7 +64,7 @@ if($_POST['action'] == "issuecert") {
 if($_POST['action'] == "renewcert") {
 	$id = $_POST['id'];
 	echo $id . "\n";
-	if (isset($a_certifcates[get_certificate_id($id)])) {
+	if (isset($a_certificates[get_certificate_id($id)])) {
 		issue_certificate($id, true, true);
 	}
 	exit;
@@ -85,7 +82,7 @@ if ($_POST) {
 				$selected[] = get_certificate_id($selection);
 			}
 			foreach ($selected as $itemnr) {
-				unset($a_certifcates[$itemnr]);
+				unset($a_certificates[$itemnr]);
 				$deleted = true;
 			}
 			if ($deleted) {
@@ -116,7 +113,7 @@ if ($_POST) {
 			foreach($_POST['rule'] as $selection) {
 				$selected[] = get_certificate_id($selection);
 			}
-			array_moveitemsbefore($a_certifcates, $moveto, $selected);
+			array_moveitemsbefore($a_certificates, $moveto, $selected);
 		
 			touch($d_acmeconfdirty_path);
 			write_config($changedesc);			
@@ -127,9 +124,9 @@ if ($_POST) {
 if ($_GET['act'] == "del") {
 	$id = $_GET['id'];
 	$id = get_certificate_id($id);
-	if (isset($a_certifcates[$id])) {
+	if (isset($a_certificates[$id])) {
 		if (!$input_errors) {
-			unset($a_certifcates[$id]);
+			unset($a_certificates[$id]);
 			$changedesc .= " Item delete";
 			write_config($changedesc);
 			touch($d_acmeconfdirty_path);
@@ -186,7 +183,7 @@ display_top_tabs_active($acme_tab_array['acme'], "certificates");
 				</thead>
 				<tbody class="user-entries">
 <?php
-		foreach ($a_certifcates as $certificate) {
+		foreach ($a_certificates as $certificate) {
 			$certificatename = $certificate['name'];
 			$disabled = $certificate['status'] != 'active';
 			?>
@@ -248,7 +245,7 @@ display_top_tabs_active($acme_tab_array['acme'], "certificates");
 				<a href="acme_certificates_edit.php?id=<?=$certificatename;?>">
 					<?=acmeicon("edit", gettext("edit"))?>
 				</a>
-				<a href="acme_certificates.php?act=del&amp;id=<?=$certificatename;?>" onclick="return confirm('Do you really want to delete this entry?')">
+				<a href="acme_certificates.php?act=del&amp;id=<?=$certificatename;?>">
 					<?=acmeicon("delete", gettext("delete"))?>
 				</a>
 				<a href="acme_certificates_edit.php?dup=<?=$certificatename;?>">
@@ -263,15 +260,15 @@ display_top_tabs_active($acme_tab_array['acme'], "certificates");
 		</div>
 	</div>
 	<nav class="action-buttons">
-		<a href="acme_certificates_edit.php" role="button" class="btn btn-sm btn-success" title="<?=gettext('Add backend to the end of the list')?>">
+		<a href="acme_certificates_edit.php" role="button" class="btn btn-sm btn-success" title="<?=gettext('Add certificate to the end of the list')?>">
 			<i class="fa fa-plus icon-embed-btn"></i>
 			<?=gettext("Add");?>
 		</a>
-		<button name="del_x" type="submit" class="btn btn-danger btn-sm" value="<?=gettext("Delete selected backends"); ?>" title="<?=gettext('Delete selected backends')?>">
-			<i class="fa fa-trash icon-embed-btn no-confirm"></i>
+		<button name="del_x" type="submit" class="btn btn-danger btn-sm" value="<?=gettext("Delete selected certificates"); ?>" title="<?=gettext('Delete selected certificates')?>">
+			<i class="fa fa-trash icon-embed-btn"></i>
 			<?=gettext("Delete"); ?>
 		</button>
-		<button type="submit" id="order-store" name="order-store" class="btn btn-sm btn-primary" value="store changes" disabled title="<?=gettext('Save backend order')?>">
+		<button type="submit" id="order-store" name="order-store" class="btn btn-sm btn-primary" value="store changes" disabled title="<?=gettext('Save certificate order')?>">
 			<i class="fa fa-save icon-embed-btn no-confirm"></i>
 			<?=gettext("Save")?>
 		</button>

--- a/security/pfSense-pkg-acme/files/usr/local/www/acme/acme_certificates_edit.php
+++ b/security/pfSense-pkg-acme/files/usr/local/www/acme/acme_certificates_edit.php
@@ -28,10 +28,7 @@ require_once("acme/acme_utils.inc");
 require_once("acme/acme_htmllist.inc");
 require_once("acme/pkg_acme_tabs.inc");
 
-if (!is_array($config['installedpackages']['acme']['certificates']['item'])) {
-	$config['installedpackages']['acme']['certificates']['item'] = array();
-}
-$a_certificates = &$config['installedpackages']['acme']['certificates']['item'];
+$a_certificates = &getarraybyref($config,'installedpackages','acme','certificates','item');
 
 if (isset($_POST['id'])) {
 	$id = $_POST['id'];
@@ -79,9 +76,9 @@ $fields_domains[2]['columnheader']="Method";
 $fields_domains[2]['colwidth']="15%";
 $fields_domains[2]['type']="select";
 $fields_domains[2]['size']="100px";
-$fields_domains[2]['items']=&$acme_domain_validation_method;
 
-$fields_domains_details=array();
+$fields_domains_details = array();
+$methods = array();
 foreach($acme_domain_validation_method as $key => $action) {
 	if (is_array($action['fields'])) {
 		foreach($action['fields'] as $field) {
@@ -92,7 +89,13 @@ foreach($acme_domain_validation_method as $key => $action) {
 			$fields_domains_details[$name] = $item;
 		}
 	}
+	if ($action['name'] != 'notforuser') {
+		$methods[$key] = array();
+		$methods[$key]['name'] = $action['name'];
+	}
 }
+$fields_domains[2]['items'] = $methods;
+
 $domainslist = new HtmlList("table_domains", $fields_domains);
 $domainslist->keyfield = "name";
 $domainslist->fields_details = $fields_domains_details;
@@ -254,8 +257,8 @@ if ($_POST) {
 	if($certificate['name'] != "") {
 		$changedesc .= " modified certificate: '{$certificate['name']}'";
 	}
-	$certificate['a_domainlist']['item'] = $a_domains;
-	$certificate['a_actionlist']['item'] = $a_actions;
+	getarraybyref($certificate, 'a_domainlist')['item'] = $a_domains;
+	getarraybyref($certificate, 'a_actionlist')['item'] = $a_actions;
 
 	$certificate['keypaste'] = base64_encode($_POST['keypaste']);
 	global $simplefields;
@@ -399,7 +402,6 @@ $section->addInput(new \Form_Input(
 	['min' => '1', 'max' => '3600']
 ))->setHelp('When using a DNS validation method configure how much time to wait before attempting verification after the txt records are added. Defaults to 120 seconds.');
 
-
 $section->addInput(new \Form_StaticText(
 	'Actions list', 
 	"Used to restart webserver processes after this certificate has been renewed<br/>" .
@@ -463,17 +465,17 @@ print $form;
 			var table = d.getElementById(tableId);
 			
 			for(var actionkey in showhide_domainfields) {
+				var showfield = actionkey === actiontype ? '' : 'none';
+				if (actiontype.startsWith('dns_') && actionkey === 'anydns') {
+					showfield = '';
+				}
 				var fields = showhide_domainfields[actionkey]['fields'];
 				for(var fieldkey in fields){
 					var fieldname = fields[fieldkey]['name'];
 					var rowid = "tr_edititemdetails_"+rowNr+"_"+actionkey+fieldname;
 					var element = d.getElementById(rowid);
 					if (element) {
-						if (actionkey === actiontype) {
-							element.style.display = '';
-						} else {
-							element.style.display = 'none';
-						}
+						element.style.display = showfield;
 					}
 				}
 			}


### PR DESCRIPTION
acme, add challenge alias feature for dns validation with CNAME (https://redmine.pfsense.org/issues/8613)
-support different validation methods within the domains for 1 certificate
-add notification and syslog message when renewal fails
-minor gui improvements