### PR TITLE
haproxy-devel, php7 array usage.. drop init() and !isarray(x)x=array() , instead use getarraybyref() where required.

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/Makefile
+++ b/net/pfSense-pkg-haproxy-devel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-haproxy-devel
 PORTVERSION=	0.59
-PORTREVISION=	9
+PORTREVISION=	10
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -504,10 +504,7 @@ function haproxy_get_fileslist() {
 	$result = array();
 	global $config;
 	// create a copy to not modify the original 'keyless' array
-	$a_files = $config['installedpackages']['haproxy']['files']['item'];
-	if (!is_array($a_files)) {
-		$a_files = array();
-	}
+	$a_files = getarraybyref($config, 'installedpackages', 'haproxy', 'files', 'item');
 	foreach($a_files as $file) {
 		$key = $file['name'];
 		$result[$key] = $file;
@@ -658,7 +655,7 @@ EOD;
 
 function haproxy_find_backend($backendname) {
 	global $config;
-	$a_backends = &$config['installedpackages']['haproxy']['ha_pools']['item'];
+	$a_backends = &getarraybyref($config,'installedpackages','haproxy','ha_pools','item');
 	foreach ($a_backends as &$backend) {
 		if ($backend['name'] == $backendname) {
 			return $backend;
@@ -682,26 +679,22 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 	global $config;
 	$frontend = $backendsettings['frontend'];
 	$ipversion = $backendsettings['ipversion'];
-	$a_global = &$config['installedpackages']['haproxy'];
-
-	$a_mailers = &$config['installedpackages']['haproxy']['email_mailers']['item'];
-	$a_resolvers = $config['installedpackages']['haproxy']['dns_resolvers']['item'];
+	$a_global = getarraybyref($config,'installedpackages','haproxy');
+	$a_mailers = getarraybyref($config,'installedpackages','haproxy','email_mailers','item');
+	$a_resolvers = getarraybyref($config,'installedpackages','haproxy','dns_resolvers','item');
+	$a_servers = getarraybyref($pool,'ha_servers','item');
 
 	global $a_checktypes, $a_cookiemode, $a_files_cache, $a_error;
-
 	$server_options = "";
-
-	if (!is_array($pool['ha_servers']['item'])) {
-		$pool['ha_servers']['item'] = array();
-	}
-	$a_servers = &$pool['ha_servers']['item'];
 	$frontendtype = $frontend['type'];
 
 	$idoffset = 0;
-	if ($ipversion == "ipv4")
+	if ($ipversion == "ipv4") {
 		$idoffset += 10000;
-	if ($ipversion == "ipv6")
+	}
+	if ($ipversion == "ipv6") {
 		$idoffset += 20000;
+	}
 	
 	fwrite ($fd, "backend " . $name . "\n");
 	// https is an alias for tcp for clarity purposes
@@ -845,21 +838,20 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 			}
 		}
 
-		if (is_arrayset($pool,'errorfiles','item')) {
-			foreach($pool['errorfiles']['item'] as $errorfile) {
-				if (!is_array($a_files_cache)) {// load only once
-					$a_files_cache = haproxy_get_fileslist();
-				}
-				$file = $errorfile['errorfile'];
-				$errorcodes = explode(",",$errorfile['errorcode']);
-				foreach($errorcodes as $errorcode) {
-					$filename = "$configpath/errorfile_{$name}_{$errorcode}_{$file}";
-					$content = base64_decode($a_files_cache[$file]['content']);
-					$content = str_replace('{errormsg}', $a_error[$errorcode]['descr'], $content);
-					$content = str_replace('{errorcode}', $errorcode, $content);
-					file_put_contents($filename, $content);
-					fwrite ($fd, "\terrorfile\t\t\t" . $errorcode ." " . $filename . "\n");
-				}
+		$errorfiles = getarraybyref($pool,'errorfiles','item');
+		foreach($errorfiles as $errorfile) {
+			if (!is_array($a_files_cache)) {// load only once
+				$a_files_cache = haproxy_get_fileslist();
+			}
+			$file = $errorfile['errorfile'];
+			$errorcodes = explode(",",$errorfile['errorcode']);
+			foreach($errorcodes as $errorcode) {
+				$filename = "$configpath/errorfile_{$name}_{$errorcode}_{$file}";
+				$content = base64_decode($a_files_cache[$file]['content']);
+				$content = str_replace('{errormsg}', $a_error[$errorcode]['descr'], $content);
+				$content = str_replace('{errorcode}', $errorcode, $content);
+				file_put_contents($filename, $content);
+				fwrite ($fd, "\terrorfile\t\t\t" . $errorcode ." " . $filename . "\n");
 			}
 		}
 	}
@@ -1061,7 +1053,7 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 		fwrite ($fd, "\t".$extra."\n");
 	}
 
-	$a_actionitems = $pool['a_actionitems']['item'];
+	$a_actionitems = getarraybyref($pool,'a_actionitems','item');
 	if (!is_array($a_actionitems)) {
 		$a_actionitems = array();
 	}
@@ -1387,12 +1379,7 @@ function haproxy_write_certificate_issuer($filename, $certid) {
 
 function haproxy_uses_ocsp() {
 	global $config;
-
-	$a_frontends = &$config['installedpackages']['haproxy']['ha_backends']['item'];
-	if (!is_array($a_frontends)) {
-		return false;
-	}
-
+	$a_frontends = getarraybyref($config,'installedpackages','haproxy','ha_backends','item');
 	foreach ($a_frontends as $frontend) {
 		if ($frontend['sslocsp'] == 'yes') {
 			return true;
@@ -1470,24 +1457,12 @@ function haproxy_writeconf($configpath) {
 	rmdir_recursive($configpath);
 	@mkdir($configpath, 0755, true);
 
-	$a_global = &$config['installedpackages']['haproxy'];
-	$a_frontends = &$config['installedpackages']['haproxy']['ha_backends']['item'];
-	$a_backends = &$config['installedpackages']['haproxy']['ha_pools']['item'];
-	$a_mailers = &$config['installedpackages']['haproxy']['email_mailers']['item'];
-	$a_resolvers = &$config['installedpackages']['haproxy']['dns_resolvers']['item'];
-	$a_files = &$config['installedpackages']['haproxy']['files']['item'];
-	if (!is_array($a_frontends)) {
-		$a_frontends = array();
-	}
-	if (!is_array($a_backends)) {
-		$a_backends = array();
-	}
-	if (!is_array($a_mailers)) {
-		$a_mailers = array();
-	}
-	if (!is_array($a_resolvers)) {
-		$a_resolvers = array();
-	}
+	$a_global = getarraybyref($config,'installedpackages','haproxy');
+	$a_frontends = getarraybyref($a_global,'ha_backends','item');
+	$a_backends = getarraybyref($a_global,'ha_pools','item');
+	$a_mailers = getarraybyref($a_global,'email_mailers','item');
+	$a_resolvers = getarraybyref($a_global,'dns_resolvers','item');
+	$a_files = getarraybyref($a_global,'files','item');
 
 	$fd = fopen($configfile, "w");
 	fwrite ($fd, "# Automaticaly generated, dont edit manually.\n");
@@ -1705,7 +1680,7 @@ function haproxy_writeconf($configpath) {
 /**/
 			$ca_file = "";
 			$first = true;
-			if (is_array($bind['clientcert_ca']['item'])) {
+			if (is_arrayset($bind,'clientcert_ca','item')) {
 				$filename = "$configpath/clientca_{$bind['name']}.pem";
 				foreach($bind['clientcert_ca']['item'] as $ca) {
 					if (!empty($ca['cert_ca'])) {
@@ -1718,9 +1693,9 @@ function haproxy_writeconf($configpath) {
 			}
 			$crl_file = "";
 			$first = true;
-			if (is_array($bind['clientcert_crl']['item'])) {
+			if (is_arrayset($bind,'clientcert_crl','item')) {
 				$filename = "$configpath/clientcrl_{$bind['name']}.pem";
-				foreach($bind['clientcert_crl']['item'] as $ca) {
+				foreach(getarraybyref($bind, 'clientcert_crl', 'item') as $ca) {
 					haproxy_write_certificate_crl($filename, $ca['cert_crl'], !$first);
 					$first = false;
 				}
@@ -1763,9 +1738,10 @@ function haproxy_writeconf($configpath) {
 
 				$ca_file = "";
 				$first = true;
-				if (is_array($frontend['clientcert_ca']['item'])) {
+				$a_clientcert_ca = getarraybyref($frontend, 'clientcert_ca', 'item');
+				if (count($a_clientcert_ca) > 0) {
 					$filename = "$configpath/clientca_{$frontend['name']}.pem";
-					foreach($frontend['clientcert_ca']['item'] as $ca) {
+					foreach($a_clientcert_ca as $ca) {
 						if (!empty($ca['cert_ca'])) {
 							haproxy_write_certificate_crt($filename, $ca['cert_ca'], false, !$first);
 							$first = false;
@@ -1776,9 +1752,10 @@ function haproxy_writeconf($configpath) {
 				}
 				$crl_file = "";
 				$first = true;
-				if (is_array($frontend['clientcert_crl']['item'])) {
+				$a_clientcert_crl = getarraybyref($frontend, 'clientcert_crl', 'item');
+				if (count($a_clientcert_crl) > 0) {
 					$filename = "$configpath/clientcrl_{$frontend['name']}.pem";
-					foreach($frontend['clientcert_crl']['item'] as $ca) {
+					foreach($a_clientcert_crl as $ca) {
 						haproxy_write_certificate_crl($filename, $ca['cert_crl'], !$first);
 						$first = false;
 					}
@@ -1788,7 +1765,8 @@ function haproxy_writeconf($configpath) {
 				//$ssloptions .= " {$frontend['dcertadv']}";
 				$ssl_crtlist_advanced = empty($frontend['ssl_crtlist_advanced']) ? "" : " {$frontend['ssl_crtlist_advanced']}";
 				$ssloptions .= "{$ssl_crtlist_advanced}{$ca_file}{$crl_file}";
-				foreach($frontend['crtfiles'] as $crtfile) {
+				$a_crtfiles = getarraybyref($frontend['crtfiles']);
+				foreach($a_crtfiles as $crtfile) {
 					if ($frontendname == $frontend['name']) {
 //						continue;// skip primary from the crt-list
 					}
@@ -1858,22 +1836,21 @@ function haproxy_writeconf($configpath) {
 			}
 
 			fwrite ($fd, "\ttimeout client\t\t{$bind['client_timeout']}\n");
-
-			if (is_arrayset($bind,'a_errorfiles','item')) {
-				foreach($bind['a_errorfiles']['item'] as $errorfile) {
-					if (!is_array($a_files_cache)) {// load only once
-						$a_files_cache = haproxy_get_fileslist();
-					}
-					$file = $errorfile['errorfile'];
-					$errorcodes = explode(",",$errorfile['errorcode']);
-					foreach($errorcodes as $errorcode) {
-						$filename = "$configpath/errorfile_{$frontendname}_{$errorcode}_{$file}";
-						$content = base64_decode($a_files_cache[$file]['content']);
-						$content = str_replace('{errormsg}', $a_error[$errorcode]['descr'], $content);
-						$content = str_replace('{errorcode}', $errorcode, $content);
-						file_put_contents($filename, $content);
-						fwrite ($fd, "\terrorfile\t\t\t" . $errorcode ." " . $filename . "\n");
-					}
+			
+			$a_errorfiles = getarraybyref($bind, 'a_errorfiles', 'item');
+			foreach($a_errorfiles as $errorfile) {
+				if (!is_array($a_files_cache)) {// load only once
+					$a_files_cache = haproxy_get_fileslist();
+				}
+				$file = $errorfile['errorfile'];
+				$errorcodes = explode(",",$errorfile['errorcode']);
+				foreach($errorcodes as $errorcode) {
+					$filename = "$configpath/errorfile_{$frontendname}_{$errorcode}_{$file}";
+					$content = base64_decode($a_files_cache[$file]['content']);
+					$content = str_replace('{errormsg}', $a_error[$errorcode]['descr'], $content);
+					$content = str_replace('{errorcode}', $errorcode, $content);
+					file_put_contents($filename, $content);
+					fwrite ($fd, "\terrorfile\t\t\t" . $errorcode ." " . $filename . "\n");
 				}
 			}
 
@@ -1914,10 +1891,7 @@ function haproxy_writeconf($configpath) {
 
 				$a_acl = get_frontend_acls($frontend);
 
-				$a_actionitems = $frontend['a_actionitems']['item'];
-				if (!is_array($a_actionitems)) {
-					$a_actionitems = array();
-				}
+				$a_actionitems = getarraybyref($frontend,'a_actionitems','item');
 				if (!empty($frontend['backend_serverpool'])) {
 					// insert extra use_backend action without a user-condition
 					$item = array();
@@ -2158,13 +2132,12 @@ function frontend_usetransparentbackend($frontend) {
 	if ($backend["transparent_clientip"] == 'yes') {
 		return true;
 	}
-	if (is_array($frontend['a_actionitems']['item'])) {
-		foreach($frontend['a_actionitems']['item'] as $action) {
-			if ($action['action'] == "use_backend") {
-				$backend = haproxy_find_backend($action['use_backendbackend']);
-				if ($backend["transparent_clientip"] == 'yes') {
-					return true;
-				}
+	$actionitems = getarraybyref($frontend,'a_actionitems','item');
+	foreach($actionitems as $action) {
+		if ($action['action'] == "use_backend") {
+			$backend = haproxy_find_backend($action['use_backendbackend']);
+			if ($backend["transparent_clientip"] == 'yes') {
+				return true;
 			}
 		}
 	}
@@ -2173,7 +2146,7 @@ function frontend_usetransparentbackend($frontend) {
 
 function use_transparent_clientip_proxying() {
 	global $config;
-	$a_backends = &$config['installedpackages']['haproxy']['ha_pools']['item'];
+	$a_backends = getarraybyref($config,'installedpackages','haproxy','ha_pools','item');
 	if (is_array($a_backends)) {
 		foreach ($a_backends as $backend) {
 			if ($backend["transparent_clientip"] == 'yes') {
@@ -2185,34 +2158,26 @@ function use_transparent_clientip_proxying() {
 }
 
 function haproxy_get_transparent_backends(){
-	global $config;
-	$a_backends = &$config['installedpackages']['haproxy']['ha_pools']['item'];
+	global $config;	
+	$a_backends = getarraybyref($config, 'installedpackages', 'haproxy', 'ha_pools', 'item');
 	$transparent_backends = array();
-	if (!is_array($a_backends)) {
-		return $transparent_backends;
-	}
 	foreach ($a_backends as $backend) {
 		if ($backend["transparent_clientip"] != 'yes') {
 			continue;
 		}
 		$real_if = get_real_interface($backend["transparent_interface"]);
-		if (!is_array($backend['ha_servers'])) {
-			$backend['ha_servers'] = array();
-		}
-		$a_servers = &$backend['ha_servers']['item'];
-		if (is_array($a_servers)) {
-			foreach($a_servers as $be) {
-				if (!$be['status'] == "inactive" || !is_ipaddr($be['address'])){
-					continue;
-				}
-				$item = array();
-				$item['name'] = $be['name'];
-				$item['interface'] = $real_if;
-				$item['forwardto'] = $be['forwardto'];
-				$item['address'] = $be['address'];
-				$item['port'] = $be['port'];
-				$transparent_backends[] = $item;
+		$a_servers = getarraybyref($backend, 'ha_servers', 'item');
+		foreach($a_servers as $be) {
+			if (!$be['status'] == "inactive" || !is_ipaddr($be['address'])){
+				continue;
 			}
+			$item = array();
+			$item['name'] = $be['name'];
+			$item['interface'] = $real_if;
+			$item['forwardto'] = $be['forwardto'];
+			$item['address'] = $be['address'];
+			$item['port'] = $be['port'];
+			$transparent_backends[] = $item;
 		}
 	}
 	return $transparent_backends;
@@ -2307,25 +2272,24 @@ function haproxy_plugin_certificates($pluginparams) {
 		$result['pkgname'] = "HAProxy";
 		$result['certificatelist'] = array();
 		// return a array of used certificates.
-		if (is_array($config['installedpackages']['haproxy']['ha_backends']['item'])) {
-			foreach($config['installedpackages']['haproxy']['ha_backends']['item'] as &$frontend) {
-				if (get_frontend_uses_ssl($frontend)) {
-					if ($frontend['secondary'] != 'yes' || $frontend['ssloffload']) {
-						// primary or secondary with additional certs checkbox
-						if ($frontend['ssloffloadcert']){
-							$item = array();
-							$cert = $frontend['ssloffloadcert'];
-							$item['usedby'] = $frontend['name'];
-							$result['certificatelist'][$cert][] = $item;
-						}
-						if ($frontend['ha_certificates'] && is_array($frontend['ha_certificates']['item'])) {
-							foreach($frontend['ha_certificates']['item'] as $certref) {
-								if ($certref['ssl_certificate']) {
-									$item = array();
-									$cert = $certref['ssl_certificate'];
-									$item['usedby'] = $frontend['name'];
-									$result['certificatelist'][$cert][] = $item;
-								}
+		$a_frontends = getarraybyref($config,'installedpackages','haproxy','ha_backends','item');
+		foreach($a_frontends as &$frontend) {
+			if (get_frontend_uses_ssl($frontend)) {
+				if ($frontend['secondary'] != 'yes' || $frontend['ssloffload']) {
+					// primary or secondary with additional certs checkbox
+					if ($frontend['ssloffloadcert']){
+						$item = array();
+						$cert = $frontend['ssloffloadcert'];
+						$item['usedby'] = $frontend['name'];
+						$result['certificatelist'][$cert][] = $item;
+					}
+					if ($frontend['ha_certificates'] && is_array($frontend['ha_certificates']['item'])) {
+						foreach($frontend['ha_certificates']['item'] as $certref) {
+							if ($certref['ssl_certificate']) {
+								$item = array();
+								$cert = $certref['ssl_certificate'];
+								$item['usedby'] = $frontend['name'];
+								$result['certificatelist'][$cert][] = $item;
 							}
 						}
 					}
@@ -2333,18 +2297,15 @@ function haproxy_plugin_certificates($pluginparams) {
 			}
 		}
 
-		$a_backends = $config['installedpackages']['haproxy']['ha_pools']['item'];
-		if (is_array($a_backends)) {
-			foreach ($a_backends as $backend) {
-				if (is_array($backend['ha_servers']['item'])) {
-					foreach($backend['ha_servers']['item'] as $srv) {
-						if ($srv['ssl-server-clientcert']) {
-							$item = array();
-							$cert = $srv['ssl-server-clientcert'];
-							$item['usedby'] = $backend['name']."/".$srv['name'];
-							$result['certificatelist'][$cert][] = $item;
-						}
-					}
+		$a_backends = getarraybyref($config,'installedpackages', 'haproxy', 'ha_pools', 'item');
+		foreach ($a_backends as $backend) {
+			$a_servers = getarraybyref($backend,'ha_servers','item');
+			foreach($a_servers as $srv) {
+				if ($srv['ssl-server-clientcert']) {
+					$item = array();
+					$cert = $srv['ssl-server-clientcert'];
+					$item['usedby'] = $backend['name']."/".$srv['name'];
+					$result['certificatelist'][$cert][] = $item;
 				}
 			}
 		}
@@ -2354,7 +2315,7 @@ function haproxy_plugin_certificates($pluginparams) {
 
 function haproxy_carpipismaster($ip) {
 	global $config;
-	foreach($config['virtualip']['vip'] as $carp) {
+	foreach(getarraybyref($config, 'virtualip', 'vip') as $carp) {
 		if ($carp['mode'] != "carp") {
 			continue;
 		}
@@ -2374,7 +2335,7 @@ function haproxy_check_run($reload) {
 	global $config, $g, $haproxy_run_message;
 	haproxy_config_init();
 	$haproxylock = lock("haproxy", LOCK_EX);
-	$a_global = &$config['installedpackages']['haproxy'];
+	$a_global = getarraybyref($config, 'installedpackages', 'haproxy');
 	$configpath = "{$g['varetc_path']}/haproxy";
 
 	if ($reload) {
@@ -2494,7 +2455,7 @@ function killprocesses($processname, $pidfile, $signal = "KILL") {
 
 function haproxy_sync_xmlrpc_settings() {
 	global $config;
-	if (!is_array($config['installedpackages']['haproxysyncpkg'])) {
+	if (!is_arrayset($config, 'installedpackages', 'haproxysyncpkg')) {
 		return false;
 	}
 	// preserve 'old' sync settings, that should not be overwritten by xmlrpc-sync.
@@ -2536,14 +2497,14 @@ function haproxy_xmlrpc_sync_configure() {
 	haproxy_configure(); // Configure HAProxy config files to use the new configuration.
 
 	// sync 2nd and further nodes in the chain if applicable.
-	if (isset($config['installedpackages']['haproxy']['enablesync'])) {
+	if (getarraybyref($config, 'installedpackages', 'haproxy')['enablesync']) {
 		haproxy_do_xmlrpc_sync();
 	}
 }
 
 function get_frontend_id($name) {
 	global $config;
-	$a_frontend = &$config['installedpackages']['haproxy']['ha_backends']['item'];
+	$a_frontend = getarraybyref($config,'installedpackages','haproxy','ha_backends','item');
 	$i = 0;
 	foreach($a_frontend as $frontend)
 	{
@@ -2564,7 +2525,7 @@ function haproxy_is_frontendname($name) {
 
 function get_primaryfrontend($frontend) {
 	global $config;
-	$a_frontend = &$config['installedpackages']['haproxy']['ha_backends']['item'];
+	$a_frontend = getarraybyref($config,'installedpackages','haproxy','ha_backends','item');
 	if ($frontend['secondary'] == 'yes') {
 		$mainfrontend = $a_frontend[get_frontend_id($frontend['primary_frontend'])];
 	} else {
@@ -2579,7 +2540,8 @@ function get_frontend_ipport($frontend, $userfriendly=false) {
 	if (!is_arrayset($mainfrontend,"a_extaddr","item")) {
 		return $result;
 	}
-	foreach($mainfrontend['a_extaddr']['item'] as $extaddr) {
+	$externaladdresses = getarraybyref($mainfrontend,'a_extaddr','item');
+	foreach($externaladdresses  as $extaddr) {
 		if ($extaddr['extaddr'] == 'custom'){
 			$addr = $extaddr['extaddr_custom'];
 		} else {
@@ -2634,7 +2596,7 @@ function get_frontend_bindips($frontend) {
 
 function haproxy_check_config() {
 	global $config;
-	$a_backends = &$config['installedpackages']['haproxy']['ha_backends']['item'];
+	$a_backends = getarraybyref($config,'installedpackages','haproxy','ha_backends','item');
 	$result = false;
 	$activefrontends = array();
 	$issues = array();
@@ -2671,7 +2633,7 @@ function haproxy_check_config() {
 
 function get_haproxy_backends() {
 	global $config;
-	$a_backend = &$config['installedpackages']['haproxy']['ha_pools']['item'];
+	$a_backend = getarraybyref($config,'installedpackages','haproxy','ha_pools','item');
 	$result = array();
 	if (!is_array($a_backend)) {
 		return $result;
@@ -2686,7 +2648,7 @@ function get_haproxy_backends() {
 
 function get_haproxy_frontends($excludeitem = "") {
 	global $config;
-	$a_frontend = &$config['installedpackages']['haproxy']['ha_backends']['item'];
+	$a_frontend = getarraybyref($config,'installedpackages','haproxy','ha_backends','item');
 	$result = array();
 	if (!is_array($a_frontend)) {
 		return $result;
@@ -2771,39 +2733,27 @@ function haproxy_get_cert_acls($cert, $usealternativenames = false) {
 function get_frontend_acls($frontend) {
 	$mainfrontend = get_primaryfrontend($frontend);
 	$result = array();
-	if (!is_array($frontend['ha_acls'])) {
-		$frontend['ha_acls'] = array();
-	}
-	if (!is_array($frontend['ha_acls']['item'])) {
-		$frontend['ha_acls']['item'] = array();
-	}
-	$a_acl = &$frontend['ha_acls']['item'];
-	if (is_array($a_acl))
-	{
-		foreach ($a_acl as $entry) {
-			$acl = haproxy_find_acl($entry['expression']);
-			if (!$acl) {
-				continue;
-			}
-
-			// Filter out acls for different modes
-			if ($acl['mode'] != '' && $acl['mode'] != strtolower($mainfrontend['type'])) {
-				continue;
-			}
-			$not = $entry['not'] == "yes" ? "not: " : "";
-			$acl_item = array();
-			$acl_item['descr'] = $acl['name'] . " " . (isset($acl['novalue']) ? "" : $not . $entry['value']);
-			$acl_item['ref'] = $entry;
-
-			$result[] = $acl_item;
+	$a_acl = getarraybyref($frontend,'ha_acls','item');
+	foreach ($a_acl as $entry) {
+		$acl = haproxy_find_acl($entry['expression']);
+		if (!$acl) {
+			continue;
 		}
+
+		// Filter out acls for different modes
+		if ($acl['mode'] != '' && $acl['mode'] != strtolower($mainfrontend['type'])) {
+			continue;
+		}
+		$not = $entry['not'] == "yes" ? "not: " : "";
+		$acl_item = array();
+		$acl_item['descr'] = $acl['name'] . " " . (isset($acl['novalue']) ? "" : $not . $entry['value']);
+		$acl_item['ref'] = $entry;
+
+		$result[] = $acl_item;
 	}
 
 	if (get_frontend_uses_ssl($frontend)) {
-		$a_acl = &$frontend['ha_acls']['item'];
-		if (!is_array($a_acl)) {
-			$a_acl = array();
-		}
+		$a_acl = getarraybyref($frontend,'ha_acls','item');
 
 		//$poolname = $frontend['backend_serverpool'] . "_" . strtolower($frontend['type']);
 		//$aclname = "SNI_" . $poolname;
@@ -2817,21 +2767,17 @@ function get_frontend_acls($frontend) {
 			$result = array_merge($result, haproxy_get_cert_acls($cert, true));
 		}
 		if (ifset($frontend['ssloffloadacladditional']) == 'yes') {
-			$certs = $frontend['ha_certificates']['item'];
-			if (is_array($certs)) {
-				foreach ($certs as $certref) {
-					$cert = lookup_cert($certref['ssl_certificate']);
-					$result = array_merge($result, haproxy_get_cert_acls($cert));
-				}
+			$certs = getarraybyref($frontend,'ha_certificates','item');
+			foreach ($certs as $certref) {
+				$cert = lookup_cert($certref['ssl_certificate']);
+				$result = array_merge($result, haproxy_get_cert_acls($cert));
 			}
 		}
 		if (ifset($frontend['ssloffloadacladditional_an']) == 'yes') {
-			$certs = $frontend['ha_certificates']['item'];
-			if (is_array($certs)) {
-				foreach ($certs as $certref) {
-					$cert = lookup_cert($certref['ssl_certificate']);
-					$result = array_merge($result, haproxy_get_cert_acls($cert, true));
-				}
+			$certs = getarraybyref($frontend,'ha_certificates','item');
+			foreach ($certs as $certref) {
+				$cert = lookup_cert($certref['ssl_certificate']);
+				$result = array_merge($result, haproxy_get_cert_acls($cert, true));
 			}
 		}
 	}
@@ -2840,54 +2786,43 @@ function get_frontend_acls($frontend) {
 
 function get_backend_acls($backend, $type) {
 	$result = array();
-	if (!is_array($backend['a_acl'])) {
-		$backend['a_acl'] = array();
-	}
-	if (!is_array($backend['a_acl']['item'])) {
-		$backend['a_acl']['item'] = array();
-	}
-	$a_acl = &$backend['a_acl']['item'];
-	if (is_array($a_acl))
-	{
-		foreach ($a_acl as $entry) {
-			$acl = haproxy_find_acl($entry['expression']);
-			if (!$acl) {
-				continue;
-			}
-
-			// Filter out acls for different modes
-			if ($acl['mode'] != '' && $acl['mode'] != $type) {
-				continue;
-			}
-			$not = $entry['not'] == "yes" ? "not: " : "";
-			$acl_item = array();
-			$acl_item['descr'] = $acl['name'] . " " . (isset($acl['novalue']) ? "" : $not . $entry['value']);
-			$acl_item['ref'] = $entry;
-
-			$result[] = $acl_item;
+	$a_acl = getarraybyref($backend,'a_acl','item');
+	foreach ($a_acl as $entry) {
+		$acl = haproxy_find_acl($entry['expression']);
+		if (!$acl) {
+			continue;
 		}
+
+		// Filter out acls for different modes
+		if ($acl['mode'] != '' && $acl['mode'] != $type) {
+			continue;
+		}
+		$not = $entry['not'] == "yes" ? "not: " : "";
+		$acl_item = array();
+		$acl_item['descr'] = $acl['name'] . " " . (isset($acl['novalue']) ? "" : $not . $entry['value']);
+		$acl_item['ref'] = $entry;
+
+		$result[] = $acl_item;
 	}
 	return $result;
 }
 
 function get_backend_id($name) {
 	global $config;
-	$a_backend = &$config['installedpackages']['haproxy']['ha_pools']['item'];
+	$a_backend = getarraybyref($config,'installedpackages','haproxy','ha_pools','item');
 	$i = 0;
-	if (is_array($a_backend)) {
-		foreach ($a_backend as $key => $backend) {
-			if ($backend['name'] == $name) {
-				return $i;
-			}
-			$i++;
+	foreach ($a_backend as $key => $backend) {
+		if ($backend['name'] == $name) {
+			return $i;
 		}
+		$i++;
 	}
 	return null;
 }
 
 function get_backend($name) {
 	global $config;
-	$a_backend = &$config['installedpackages']['haproxy']['ha_pools']['item'];
+	$a_backend = &getarraybyref($config,'installedpackages','haproxy','ha_pools','item');
 	$id = get_backend_id($name);
 	if (is_numeric($id)) {
 		return $a_backend[$id];
@@ -2897,7 +2832,7 @@ function get_backend($name) {
 
 function use_frontend_as_unixsocket($name) {
 	global $config;
-	$a_backends = getarraybyref($config['installedpackages']['haproxy'],'ha_pools','item');
+	$a_backends = getarraybyref($config, 'installedpackages', 'haproxy', 'ha_pools', 'item');
 	foreach ($a_backends as $backend) {
 		$a_servers = getarraybyref($backend,'ha_servers','item');
 		if (is_array($a_servers)) {
@@ -2948,6 +2883,9 @@ function haproxy_find_create_certificate($certificatename) {
 
 function haproxy_config_init(){
 	global $config;
+	return; 
+	// this dont work.. i cant know who is calling my functions and uninitialilzing my arrays in between..
+/*	
 	if (!is_array($config['installedpackages'])) {
 		$config['installedpackages'] = array();
 	}
@@ -2985,13 +2923,14 @@ function haproxy_config_init(){
 	if (!is_array($haproxycfg['files']['item'])) {
 		$haproxycfg['files']['item'] = array();
 	}
+ */
 }
 
 function config_id() {
 	global $config;
-	$haproxycfg = &$config['installedpackages']['haproxy'];
+	$a_backends = &getarraybyref($config,'installedpackages','haproxy','ha_pools','item');
 	$id = 100;
-	foreach($haproxycfg['ha_pools']['item'] as &$backend) {
+	foreach($a_backends as &$backend) {
 		if (!is_numeric($backend['id'])) {
 			while(find_server_by_id($id) || find_backend_by_id($id)) {
 				// find unused id..
@@ -2999,15 +2938,14 @@ function config_id() {
 			}
 			$backend['id'] = $id;
 		}
-		if (is_array($backend['ha_servers']['item'])) {
-			foreach($backend['ha_servers']['item'] as &$server) {
-				if (!is_numeric($server['id'])) {
-					while(find_server_by_id($id) || find_backend_by_id($id)) {
-						// find unused id..
-						$id++;
-					}
-					$server['id'] = $id;
+		$a_servers = &getarraybyref($backend,'ha_servers','item');
+		foreach($a_servers as &$server) {
+			if (!is_numeric($server['id'])) {
+				while(find_server_by_id($id) || find_backend_by_id($id)) {
+					// find unused id..
+					$id++;
 				}
+				$server['id'] = $id;
 			}
 		}
 	}
@@ -3015,19 +2953,17 @@ function config_id() {
 
 function find_frontends_using_backend($backendname) {
 	global $config;
-	$a_backends = $config['installedpackages']['haproxy']['ha_backends']['item'];
+	$a_backends = getarraybyref($config,'installedpackages','haproxy','ha_backends','item');
 	$result = array();
 	foreach ($a_backends as $frontend) {
 		$used = false;
 		if($frontend['backend_serverpool'] == $backendname) {
 			$used = true;
 		}
-		$actions = $frontend['a_actionitems']['item'];
-		if (is_array($actions)) {
-			foreach($actions as $action) {
-				if ($action["action"] == "use_backend" && $action['use_backendbackend'] == $backendname) {
-					$used = true;
-				}
+		$actions = getarraybyref($frontend,'a_actionitems','item');
+		foreach($actions as $action) {
+			if ($action["action"] == "use_backend" && $action['use_backendbackend'] == $backendname) {
+				$used = true;
 			}
 		}
 		if ($used) {
@@ -3039,13 +2975,12 @@ function find_frontends_using_backend($backendname) {
 
 function find_server_by_id($id) {
 	global $config;
-	$haproxycfg = &$config['installedpackages']['haproxy'];
-	foreach($haproxycfg['ha_pools']['item'] as &$backend) {
-		if (is_array($backend['ha_servers']['item'])) {
-			foreach($backend['ha_servers']['item'] as &$server) {
-				if ($server['id'] == $id) {
-					return $server;
-				}
+	$a_backends = &getarraybyref($config,'installedpackages','haproxy','ha_pools','item');
+	foreach($a_backends as &$backend) {
+		$a_servers = getarraybyref($backend,'ha_servers','item');
+		foreach($a_servers as &$server) {
+			if ($server['id'] == $id) {
+				return $server;
 			}
 		}
 	}
@@ -3054,8 +2989,8 @@ function find_server_by_id($id) {
 
 function find_backend_by_id($id) {
 	global $config;
-	$haproxycfg = &$config['installedpackages']['haproxy'];
-	foreach($haproxycfg['ha_pools']['item'] as &$backend) {
+	$a_backends = &getarraybyref($config,'installedpackages','haproxy','ha_pools','item');
+	foreach($a_backends as &$backend) {
 		if ($backend['id'] == $id) {
 			return $backend;
 		}
@@ -3065,17 +3000,16 @@ function find_backend_by_id($id) {
 
 function rename_backend_references($oldvalue, $newvalue) {
 	global $config;
-	$a_frontends = &$config['installedpackages']['haproxy']['ha_backends']['item'];
+	$a_frontends = &getarraybyref($config,'installedpackages','haproxy','ha_backends','item');
 	foreach ($a_frontends as &$frontend) {
 		if ($frontend['backend_serverpool'] == $oldvalue) {
 			$frontend['backend_serverpool'] = $newvalue;
 		}
-		if (is_array($frontend['a_actionitems']['item'])) {
-			foreach($frontend['a_actionitems']['item'] as &$item) {
-				if ($item['action'] == "use_backend") {
-					if ($item['use_backendbackend'] == $oldvalue) {
-						$item['use_backendbackend'] = $newvalue;
-					}
+		$a_actionitems = getarraybyref($frontend,'a_actionitems','item');
+		foreach($a_actionitems as &$item) {
+			if ($item['action'] == "use_backend") {
+				if ($item['use_backendbackend'] == $oldvalue) {
+					$item['use_backendbackend'] = $newvalue;
 				}
 			}
 		}

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy_utils.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy_utils.inc
@@ -102,25 +102,6 @@ if(!function_exists('is_arrayset')){
 	}
 }
 
-function &getarraybyref(&$array) {
-	if (!isset($array)) {
-		return false;
-	}
-	if (!is_array($array)) {
-		$array = array();
-	}
-	$item = &$array;
-	$arg = func_get_args();
-	for($i = 1; $i < count($arg); $i++) {
-		$itemindex = $arg[$i];
-		if (!is_array($item[$itemindex])) {
-			$item[$itemindex] = array();
-		}
-		$item = &$item[$itemindex];
-	}
-	return $item;
-}
-
 function haproxy_compareByName($a, $b) {
 	return strcasecmp($a['name'], $b['name']);
 }

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_files.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_files.php
@@ -28,8 +28,8 @@ require_once("haproxy/pkg_haproxy_tabs.inc");
 
 haproxy_config_init();
 
-$a_files = &$config['installedpackages']['haproxy']['files']['item'];
-$a_pools = &$config['installedpackages']['haproxy']['ha_pools']['item'];
+$a_files = &getarraybyref($config,'installedpackages','haproxy','files','item');
+$a_pools = &getarraybyref($config,'installedpackages','haproxy','ha_pools','item');
 
 $fields_files = array();
 $fields_files[0]['name']="name";
@@ -74,18 +74,17 @@ if ($_POST) {
 
 		// replace references in backends to renamed 'files'
 		foreach($a_pools as &$backend) {
-			if (is_arrayset($backend,'errorfiles','item')) {
-				foreach($backend['errorfiles']['item'] as &$errorfile) {
-					$found = false;
-					foreach($a_files as $key => $file) {
-						if ($errorfile['errorfile'] == $key) {
-							$errorfile['errorfile'] = $file['name'];
-							$found = true;
-						}
+			$a_errorfiles = getarraybyref($backend, 'errorfiles', 'item');
+			foreach($a_errorfiles as &$errorfile) {
+				$found = false;
+				foreach($a_files as $key => $file) {
+					if ($errorfile['errorfile'] == $key) {
+						$errorfile['errorfile'] = $file['name'];
+						$found = true;
 					}
-					if (!$found) {
-						$input_errors[] = "Errorfile marked for deletion: " . $errorfile['errorfile'] . " which is used in backend " . $backend['name'];
-					}
+				}
+				if (!$found) {
+					$input_errors[] = "Errorfile marked for deletion: " . $errorfile['errorfile'] . " which is used in backend " . $backend['name'];
 				}
 			}
 		}

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_global.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_global.php
@@ -124,8 +124,9 @@ if ($_POST) {
 			$config['installedpackages']['haproxy']['localstatsport'] = $_POST['localstatsport'] ? $_POST['localstatsport'] : false;
 			$config['installedpackages']['haproxy']['advanced'] = $_POST['advanced'] ? base64_encode($_POST['advanced']) : false;
 			$config['installedpackages']['haproxy']['nbproc'] = $_POST['nbproc'] ? $_POST['nbproc'] : false;
-			foreach($simplefields as $stat)
+			foreach($simplefields as $stat) {
 				$config['installedpackages']['haproxy'][$stat] = $_POST[$stat];
+			}
 
 			// flag for Status/Services to show when the package is 'disabled' so no start button is shown.
 			if ($_POST['enable']) {

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
@@ -41,8 +41,8 @@ if (!function_exists("cert_get_purpose")) {
 
 haproxy_config_init();
 
-$a_backend = &$config['installedpackages']['haproxy']['ha_backends']['item'];
-$a_pools = $config['installedpackages']['haproxy']['ha_pools']['item'];
+$a_backend = &getarraybyref($config,'installedpackages','haproxy','ha_backends','item');
+$a_pools = getarraybyref($config,'installedpackages','haproxy','ha_pools','item');
 uasort($a_pools, 'haproxy_compareByName');
 
 global $simplefields;
@@ -365,8 +365,9 @@ if ($_POST) {
 	}
 
 	/* Ensure that our pool names are unique */
-	for ($i=0; isset($config['installedpackages']['haproxy']['ha_backends']['item'][$i]); $i++) {
-		if (($_POST['name'] == $config['installedpackages']['haproxy']['ha_backends']['item'][$i]['name']) && ($i != $id)) {
+	$a_frontends = getarraybyref($config, 'installedpackages', 'haproxy', 'ha_backends', 'item');
+	for ($i=0; isset($a_frontends[$i]); $i++) {
+		if (($_POST['name'] == $a_frontends[$i]['name']) && ($i != $id)) {
 			$input_errors[] = gettext("This frontend name has already been used. Frontend names must be unique.")." $i != $id";
 		}
 	}

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pool_edit.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pool_edit.php
@@ -30,7 +30,7 @@ require_once("haproxy/pkg_haproxy_tabs.inc");
 
 haproxy_config_init();
 
-$a_pools = &$config['installedpackages']['haproxy']['ha_pools']['item'];
+$a_pools = &getarraybyref($config, 'installedpackages', 'haproxy', 'ha_pools', 'item');
 
 $a_files = haproxy_get_fileslist();
 
@@ -410,8 +410,9 @@ if ($_POST) {
 		$input_errors[] = "The field 'Stats Node' contains invalid characters. Should be a string with digits(0-9), letters(A-Z, a-z), hyphen(-) or underscode(_)";
 	}
 	/* Ensure that our pool names are unique */
-	for ($i=0; isset($config['installedpackages']['haproxy']['ha_pools']['item'][$i]); $i++) {
-		if (($_POST['name'] == $config['installedpackages']['haproxy']['ha_pools']['item'][$i]['name']) && ($i != $id)) {
+	$a_backends = getarraybyref($config, 'installedpackages', 'haproxy', 'ha_pools', 'item');
+	for ($i=0; isset($a_backends[$i]); $i++) {
+		if (($_POST['name'] == $a_backends[$i]['name']) && ($i != $id)) {
 			$input_errors[] = "This pool name has already been used.  Pool names must be unique.";
 		}
 	}

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pools.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pools.php
@@ -29,8 +29,8 @@ require_once("haproxy/pkg_haproxy_tabs.inc");
 
 haproxy_config_init();
 
-$a_pools = &$config['installedpackages']['haproxy']['ha_pools']['item'];
-$a_backends = &$config['installedpackages']['haproxy']['ha_backends']['item'];
+$a_pools = &getarraybyref($config,'installedpackages','haproxy','ha_pools','item');
+$a_backends = &getarraybyref($config,'installedpackages','haproxy','ha_backends','item');
 
 if ($_POST['apply']) {
 	$result = haproxy_check_and_run($savemsg, true);


### PR DESCRIPTION
haproxy-devel, php7 array usage.. drop init() and !isarray(x)x=array() , instead use getarraybyref() where required.