### PR TITLE
pfSense-pkg-pfBlockerNG-devel -  Fix previous PHPv7 commits.

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG-devel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-pfBlockerNG-devel
 PORTVERSION=	2.2.5
-PORTREVISION=	9
+PORTREVISION=	10
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -141,18 +141,6 @@ if (!$alert_summary) {
 		$config['installedpackages']['pfblockerngdnsblsettings']['config'][0] = array();
 	}
 
-	if (!is_array($config['installedpackages']['pfblockerngipsettings']['config'][0]['v4suppression'])) {
-		$config['installedpackages']['pfblockerngipsettings']['config'][0]['v4suppression'] = array();
-	}
-
-	if (!is_array($config['installedpackages']['pfblockerngipsettings']['config'][0]['suppression'])) {
-		$config['installedpackages']['pfblockerngipsettings']['config'][0]['suppression'] = array();
-	}
-
-	if (!is_array($config['installedpackages']['pfblockerngipsettings']['config'][0]['tldexclusion'])) {
-		$config['installedpackages']['pfblockerngipsettings']['config'][0]['tldexclusion'] = array();
-	}
-
 	foreach (array('ipsuppression', 'dnsblwhitelist', 'tldexclusion') as $key => $type) {
 		if ($key == 0) {
 			$clists[$type]['base64'] = &$config['installedpackages']['pfblockerngipsettings']['config'][0]['v4suppression'];


### PR DESCRIPTION
The following settings 'v4suppression', 'suppression' and 'tldexclusion' are not arrays.