### PR TITLE
Update package to avoid conflict with remote access systems that require the old default username/password such as Synology.

### DIFF
--- a/sysutils/pfSense-pkg-nut/Makefile
+++ b/sysutils/pfSense-pkg-nut/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-nut
 PORTVERSION=	2.7.4
-PORTREVISION=	6
+PORTREVISION=	7
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,9 +13,7 @@ COMMENT=	Network UPS Tools
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	${LOCALBASE}/sbin/upsd:sysutils/nut \
-		${LOCALBASE}/sbin/upsmon:sysutils/nut \
-		${LOCALBASE}/sbin/upsdrvctl:sysutils/nut
+RUN_DEPENDS=	nut>=0:sysutils/nut
 
 NO_BUILD=	yes
 NO_MTREE=	yes
@@ -27,16 +25,12 @@ do-extract:
 	${MKDIR} ${WRKSRC}
 
 do-install:
-	${MKDIR} ${STAGEDIR}${PREFIX}/pkg
 	${MKDIR} ${STAGEDIR}${PREFIX}/pkg/nut
 	${MKDIR} ${STAGEDIR}/etc/inc/priv
-	${MKDIR} ${STAGEDIR}${PREFIX}/www
 	${MKDIR} ${STAGEDIR}${PREFIX}/www/shortcuts
 	${MKDIR} ${STAGEDIR}${PREFIX}/www/widgets/widgets
 	${MKDIR} ${STAGEDIR}${PREFIX}/www/widgets/include
 	${MKDIR} ${STAGEDIR}${DATADIR}
-	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/nut.xml \
-		${STAGEDIR}${PREFIX}/pkg
 	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/nut.xml \
 		${STAGEDIR}${PREFIX}/pkg
 	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/nut/nut.inc \

--- a/sysutils/pfSense-pkg-nut/files/usr/local/pkg/nut/nut.inc
+++ b/sysutils/pfSense-pkg-nut/files/usr/local/pkg/nut/nut.inc
@@ -229,7 +229,7 @@ function nut_sync_config() {
 			$upsdfile .= "\n\n" . base64_decode($nut_config['upsd_conf']) . "\n";
 		}
 
-		$user = "monuser";
+		$user = "local-monitor";
 		$pass = bin2hex(openssl_random_pseudo_bytes(10));
 		$monitor = $nut_config['name'] . " 1 " . $user . " " . $pass . " master";
 


### PR DESCRIPTION
Rename local user from "monuser" to "local-monitor" to avoid conflict with remote access systems that require the old default username/password.