### PR TITLE
Handle multiple lcdproc clients

### DIFF
--- a/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc.inc
+++ b/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc.inc
@@ -480,7 +480,7 @@ function sync_package_lcdproc() {
 
 		/* Generate rc file start and stop */
 		$stop = <<<EOD
-if [ `pgrep -f lcdproc_client.ph` ];then
+if [ `pgrep -f -o lcdproc_client.ph` ];then
 		pkill -f lcdproc_client.ph
 		sleep 1
 fi

--- a/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc.inc
+++ b/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc.inc
@@ -480,7 +480,7 @@ function sync_package_lcdproc() {
 
 		/* Generate rc file start and stop */
 		$stop = <<<EOD
-if [ `pgrep -f -o lcdproc_client.ph` ];then
+if [ `pgrep -fo lcdproc_client.ph` ];then
 		pkill -f lcdproc_client.ph
 		sleep 1
 fi

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid_antivirus.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid_antivirus.inc
@@ -450,12 +450,16 @@ function squid_antivirus_install_config_files() {
 		$cicap_r[2] = "MaxServers 20";
 		$cicap_m[3] = "@MaxRequestsPerChild\s+0@";
 		$cicap_r[3] = "MaxRequestsPerChild 1000";
+		$cicap_m[4] = "@ListenAddress\s+127.0.0.1@";
+		$cicap_r[4] = "# ListenAddress 127.0.0.1";
+		$cicap_m[5] = "@Port\s+1344@";
+		$cicap_r[5] = "Port 127.0.0.1:1344";
 		/* XXX: Bug #4615
 		 * Do NOT move the C-ICAP log anywhere, ever! It breaks C-ICAP in completely inexplicable ways,
 		 * such as Error: [No Error] or 500 response codes.
 		 */
-		$cicap_m[4] = "@DebugLevel\s1@";
-		$cicap_r[4] = "DebugLevel 0";
+		$cicap_m[6] = "@DebugLevel\s1@";
+		$cicap_r[6] = "DebugLevel 0";
 		if (!file_put_contents("{$cf}.pfsense", preg_replace($cicap_m, $cicap_r, $sample_file), LOCK_EX)) {
 			log_error("[squid] Could not save patched '{$cf}.pfsense' template file!");
 		}


### PR DESCRIPTION
Return only one argument from pgrep to avoid breaking [ ]. Without that the client processes are not killed if there is more than one client resulting in an ever increasing number of clients. This happens all too often.