### PR TITLE
pkg telegraf fix prefix string inside config

### DIFF
--- a/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.inc
+++ b/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.inc
@@ -107,7 +107,7 @@ EOD;
 		$cfg .= "[[outputs.graphite]]\n";
 		$cfg .= "\tservers = [\"" . $telegraf_conf['graphite_server'] . "\"]\n";
 		if (!empty($telegraf_conf['graphite_prefix'])) {
-			$cfg .= "\tprefix = " . $telegraf_conf['graphite_prefix'] . "\n";
+			$cfg .= "\tprefix = \"" . $telegraf_conf['graphite_prefix'] . "\"\n";
 		} else {
 			$cfg .= "\tprefix = \"monitor\"\n";
 		}


### PR DESCRIPTION
current code will generate an invalid config if a prefix is used