### PR TITLE
Suricata GUI Package -- Fix display of user-modified filtered rules on RULES tab.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.0.13
-PORTREVISION=	8
+PORTREVISION=	9
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -3266,8 +3266,12 @@ function suricata_get_filtered_rules($rules, $filter) {
 	foreach ($filter as $k1 => $rulem) {
 		foreach($rulem as $k2 => $v) {
 			if (isset($tmp_map[$k1][$k2])) {
-				$filtered_map[$k1] = array();
-				$filtered_map[$k1][$k2] = array();
+				if (!is_array($filtered_map[$k1])) {
+					$filtered_map[$k1] = array();
+				}
+				if (!is_array($filtered_map[$k1][$k2])) {
+					$filtered_map[$k1][$k2] = array();
+				}
 				$filtered_map[$k1][$k2]['rule'] = $tmp_map[$k1][$k2]['rule'];
 				$filtered_map[$k1][$k2]['category'] = $tmp_map[$k1][$k2]['category'];
 				$filtered_map[$k1][$k2]['action'] = $tmp_map[$k1][$k2]['action'];


### PR DESCRIPTION
### pfSense-pkg-suricata-4.0.13_9
This updates corrects the filtered display of those rules on the RULES tab whose state (enabled or disabled) has been user-forced.

**New Features**
None

**Bug Fixes**
1. When selecteting "User-Forced Enabled" or "User-Forced Disabled" rules for display on the RULES tab only a single rule is displayed.