### PR TITLE
pfSense-pkg-snort-3.2.9.8 -- Snort GUI package update

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-snort
-PORTVERSION=	3.2.9.7
-PORTREVISION=   2
+PORTVERSION=	3.2.9.8
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -56,6 +56,9 @@ $snort_version = SNORT_BIN_VERSION;
 
 // Create a collapsed version string for use in the tarball filename
 $snortver = str_replace(".", "", SNORT_BIN_VERSION);
+// Make sure the rules file version is at least 5 characters in length
+// by adding trailing zeros if required.
+$snortver = str_pad($snortver, 5, '0', STR_PAD_RIGHT);
 $snort_filename = "snortrules-snapshot-{$snortver}.tar.gz";
 $snort_filename_md5 = "{$snort_filename}.md5";
 $snort_rule_url = VRT_DNLD_URL;

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -34,15 +34,23 @@ if (!defined("SNORTDIR"))
 if (!defined("SNORTLOGDIR"))
 	define("SNORTLOGDIR", "{$g['varlog_path']}/snort");
 if (!defined("SNORT_BIN_VERSION")) {
-	// Grab the Snort binary version programmatically
+	// Grab the Snort binary version programmatically by
+	// running the binary with the command-line argument
+	// to display the version information.
 	$snortbindir = SNORT_PBI_BINDIR;
-	$snortver = exec_command("{$snortbindir}/snort -V 2>&1 |/usr/bin/grep Version | /usr/bin/cut -c20-27");
-	$snortver = trim($snortver);
-	if (!empty($snortver))
-		define("SNORT_BIN_VERSION", $snortver);
-	else
-		define("SNORT_BIN_VERSION", "2.9.11.1");
+	$snortver = exec_command("{$snortbindir}/snort -V 2>&1 |/usr/bin/grep Version | /usr/bin/cut -c20-31");
+
+	// Extract just the numbers and decimal point
+	// delimiters at the front of the version string.
+	$matches = array();
+	if (preg_match('/^[^\s]+/', $snortver, $matches)) {
+		define("SNORT_BIN_VERSION", $matches[0]);
+	}
+	else {
+		define("SNORT_BIN_VERSION", "2.9.12");
+	}
 }
+
 if (!defined("SNORT_SID_MODS_PATH"))
 	define('SNORT_SID_MODS_PATH', "{$g['vardb_path']}/snort/sidmods/");
 if (!defined("SNORT_IPREP_PATH"))

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
@@ -683,7 +683,7 @@ if ($snortdownload == "on") {
 							}
 						}
 						else {
-							echo "	\n" . '<input type="checkbox" name="toenable[]" value="{$file}"' . '"' .  $CHECKED . " />\n";
+							echo "	\n" . '<input type="checkbox" name="toenable[]" value="' . $file . '"' . $CHECKED . " />\n";
 						}
 						echo "</td>\n";
 						echo "<td>\n";


### PR DESCRIPTION
### pfSense-pkg-snort-3.2.9.8
This update of the Snort GUI package provides support for version 2.9.12 of the Snort binary and also corrects a bug on the CATEGORIES tab that prevented the saving of Shared Object rules selections.

**New Features**
1.  Support for the latest 2.9.12 version of the Snort binary


**Bug Fixes**
1.  Share Object rule selections on the CATEGORIES tab cannot be saved.
