### PR TITLE
pfSense-pkg-snort-3.2.9.8_4 -- Fix display of MD5 checksum for downloaded rules

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	3.2.9.8
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
@@ -28,6 +28,12 @@ $snortdir = SNORTDIR;
 $snortbinver = SNORT_BIN_VERSION;
 $snortbinver = str_replace(".", "", $snortbinver);
 
+// Make sure the rules version is at least 5 characters in length
+// by adding trailing zeros if required.
+if (strlen($snortbinver) < 5) {
+	$snortbinver = str_pad($snortbinver, 5, '0', STR_PAD_RIGHT);
+}
+
 $snort_rules_file = "snortrules-snapshot-{$snortbinver}.tar.gz";
 $snort_community_rules_filename = SNORT_GPLV2_DNLD_FILENAME;
 $snort_openappid_filename = SNORT_OPENAPPID_DNLD_FILENAME;


### PR DESCRIPTION
### pfSense-pkg-snort-3.2.9.8_4
This update corrects a cosmetic display issue on the UPDATES tab whereby the MD5 checksum for the downloaded Snort Subsriber Rules is shown as "Not Downloaded".  This is due to changes in the file version string that came with Snort 2.9.12.

**New Features**
None

**Bug Fixes**
1.  Snort Subscriber Rules MD5 checksum always displays as "Not Downloaded" when in fact the correct file is present on the system.