### PR TITLE
pfSense-pkg-suricata-4.0.13_10 -- Bug fix update

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.0.13
-PORTREVISION=	9
+PORTREVISION=	10
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -113,9 +113,12 @@ function suricata_start($suricatacfg, $if_real) {
 
 	$suricatadir = SURICATADIR;
 	$suricata_uuid = $suricatacfg['uuid'];
+	$suricatalogdir = SURICATALOGDIR . "suricata_{$if_real}{$suricata_uuid}";
 	$suricatabindir = SURICATA_PBI_BINDIR;
 
 	if ($suricatacfg['enable'] == 'on') {
+		// Truncate suricata.log file for this interface.
+		file_put_contents("{$suricatalogdir}/suricata.log", '');
 		$run_mode = $suricatacfg['ips_mode'] == 'ips_mode_inline' ? '--netmap' : '-i ' . $if_real;
 		log_error("[Suricata] Suricata START for {$suricatacfg['descr']}({$if_real})...");
 		mwexec_bg("{$suricatabindir}suricata {$run_mode} -D -c {$suricatadir}suricata_{$suricata_uuid}_{$if_real}/suricata.yaml --pidfile {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid");
@@ -3671,6 +3674,7 @@ EOE;
 	fi
 
 	if [ -z \$pid ]; then
+		/bin/cp /dev/null {$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/suricata.log
 		/usr/bin/logger -p daemon.info -i -t SuricataStartup "Suricata START for {$value['descr']}({$suricata_uuid}_{$if_real})..."
 		{$suricatabindir}suricata {$run_mode} -D -c {$suricatadir}suricata_{$suricata_uuid}_{$if_real}/suricata.yaml --pidfile {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid > /dev/null 2>&1
 	fi

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_etiqrisk_update.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_etiqrisk_update.php
@@ -3,11 +3,11 @@
  * suricata_etiqrisk_update.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2018 Rubicon Communications, LLC (Netgate)
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2016 Bill Meeks
+ * Copyright (C) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,6 +73,10 @@ $iprep_path = SURICATA_IPREP_PATH;
 $iqRisk_tmppath = "{$g['tmp_path']}/IQRisk/";
 $success = FALSE;
 
+if (!is_array($config['installedpackages']['suricata']))
+	$config['installedpackages']['suricata'] = array();
+if (!is_array($config['installedpackages']['suricata']['config']))
+	$config['installedpackages']['suricata']['config'] = array();
 if (!is_array($config['installedpackages']['suricata']['config'][0]))
 	$config['installedpackages']['suricata']['config'][0] = array();
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -3,7 +3,7 @@
  * suricata_generate_yaml.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2018 Rubicon Communications, LLC (Netgate)
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
@@ -650,6 +650,8 @@ else
 // Add the OS-specific host policies if configured, otherwise
 // just set default to BSD for all networks.
 $host_os_policy = "";
+if (!is_array($suricatacfg['host_os_policy']))
+	$suricatacfg['host_os_policy'] = array();
 if (!is_array($suricatacfg['host_os_policy']['item']))
 	$suricatacfg['host_os_policy']['item'] = array();
 if (count($suricatacfg['host_os_policy']['item']) < 1)
@@ -692,6 +694,8 @@ else {
 // just set default to IDS for all networks.
 $http_hosts_policy = "";
 $http_hosts_default_policy = "";
+if (!is_array($suricatacfg['libhtp_policy']))
+	$suricatacfg['libhtp_policy'] = array();
 if (!is_array($suricatacfg['libhtp_policy']['item']))
 	$suricatacfg['libhtp_policy']['item'] = array();
 if (count($suricatacfg['libhtp_policy']['item']) < 1) {
@@ -824,6 +828,8 @@ if ($suricatacfg['enable_iprep'] == "on") {
 	$iprep_config .= "reputation-categories-file: {$iprep_path}/{$suricatacfg['iprep_catlist']}\n";
 	$iprep_config .= "reputation-files:";
 
+	if (!is_array($suricatacfg['iplist_files']))
+		$suricatacfg['iplist_files'] = array();
 	if (!is_array($suricatacfg['iplist_files']['item']))
 		$suricatacfg['iplist_files']['item'] = array();
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -3,7 +3,7 @@
  * suricata_migrate_config.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2018 Rubicon Communications, LLC (Netgate)
  * Copyright (C) 2018 Bill Meeks
  * All rights reserved.
  *
@@ -218,6 +218,8 @@ if (!isset($config['installedpackages']['suricata']['config'][0]['u2_archive_log
 foreach ($rule as &$r) {
 
 	// Initialize arrays for supported preprocessors if necessary
+	if (!is_array($r['libhtp_policy']))
+		$r['libhtp_policy'] = array();
 	if (!is_array($r['libhtp_policy']['item']))
 		$r['libhtp_policy']['item'] = array();
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
@@ -3,11 +3,11 @@
  * suricata_ip_reputation.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2018 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2014 Bill Meeks
+ * Copyright (c) 2018 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,6 +40,12 @@ if (is_null($id)) {
 
 if (!is_array($config['installedpackages']['suricata']['rule'])) {
 	$config['installedpackages']['suricata']['rule'] = array();
+}
+if (!is_array($config['installedpackages']['suricata']['rule'][$id])) {
+	$config['installedpackages']['suricata']['rule'][$id] = array();
+}
+if (!is_array($config['installedpackages']['suricata']['rule'][$id]['iplist_files'])) {
+	$config['installedpackages']['suricata']['rule'][$id]['iplist_files'] = array();
 }
 if (!is_array($config['installedpackages']['suricata']['rule'][$id]['iplist_files']['item'])) {
 	$config['installedpackages']['suricata']['rule'][$id]['iplist_files']['item'] = array();


### PR DESCRIPTION
### pfSense-pkg-suricata-4.0.13_10
This GUI package update corrects two bugs.  No new features are added and the underlying Suricata binary remains at version 4.0.5.

**New Features**
None

**Bug Fixes**
1. The _suricata.log_ files for configured interfaces continues to grow in size with each startup.  This file contains Suricata startup logging only (no alerts info).  To prevent continual growth in size of this log, it is now truncated to zero length immediately prior to starting the Suricata binary for each configured interface so that it shows startup data for the most recent session only.  Reference Redmine bug 8607.

2. Reference to an un-initialized array in the Suricata configuration migration code that is executed during a package update causes a run-time error in PHP 7.2.  Three additional sections of other legacy code subject to the same error are also corrected.