### PR TITLE
Switch menu linked tab

### DIFF
--- a/sysutils/pfSense-pkg-syslog-ng/Makefile
+++ b/sysutils/pfSense-pkg-syslog-ng/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-syslog-ng
 PORTVERSION=	1.15
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.xml
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.xml
@@ -33,7 +33,7 @@
 		<name>Syslog-ng</name>
 		<tooltiptext>Setup Syslog-ng</tooltiptext>
 		<section>Services</section>
-		<url>/syslog-ng_log_viewer.php</url>
+		<url>/pkg_edit.php?xml=syslog-ng.xml&amp;id=0</url>
 	</menu>
 	<service>
 		<name>syslog-ng</name>


### PR DESCRIPTION
Open the settings tab from the menu to prevent GUI issues that the log view tab can cause.