### PR TITLE
pfSense-pkg-snort-3.2.9.8_5  -- Include built-in rules when filtering for user-forced rules

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	3.2.9.8
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty


### PR DESCRIPTION
### pfSense-pkg-snort v3.2.9.8_5
This update for the Snort GUI package includes the built-in Snort preprocessor and decoder rules when filtering and displaying user-forced rules on the RULES tab.  Previously, user disabled preprocessor or decoder rules would not be shown when filtering the rules to display user-forced disabled (or enabled) rules.