### PR TITLE
Add HAProxy monitor to Telegraf

### DIFF
--- a/net-mgmt/pfSense-pkg-Telegraf/Makefile
+++ b/net-mgmt/pfSense-pkg-Telegraf/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-Telegraf
-PORTVERSION=	0.7
+PORTVERSION=	0.8
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.inc
+++ b/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.inc
@@ -84,6 +84,18 @@ function telegraf_resync_config() {
 
 EOD;
 
+	/* HAProxy Monitor Configuration */
+	if ($telegraf_conf["haproxy_enable"]) {
+		$ha_port = 2200;
+		if ($telegraf_conf["haproxy_port"]) {
+			$ha_port = $telegraf_conf["haproxy_port"];	
+		}
+
+		$cfg .= "\n[[inputs.haproxy]]\n";
+		$cfg .= "\tservers = [\"http://127.0.0.1:" . $ha_port . "/haproxy/haproxy_stats.php?haproxystats=1\"]\n";
+		$cfg .= "\n";
+	}
+
 	if ((is_array($telegraf_conf['telegraf_output']) && in_array("influxdb", $telegraf_conf['telegraf_output'])) || $telegraf_conf['telegraf_output'] == "influxdb") {
 		$cfg .= "[[outputs.influxdb]]\n";
 		$cfg .= "\turls = [\"" . $telegraf_conf['influx_server'] . "\"]\n";
@@ -119,6 +131,15 @@ EOD;
 			$cfg .= "\ttimeout = 2\n";
 		}
 	}
+
+	/* Raw additional configuration options */
+ 	if ($telegraf_conf["telegraf_raw_config"]) {
+		#$telegraf_conf["telegraf_raw_config"] = $_POST["telegraf_raw_config"];
+		$cfg .= "\n# Additional Raw Options\n";
+		$cfg .= $_POST["telegraf_raw_config"];
+		$cfg .= "\n";
+	}
+
 	$conffile = "/usr/local/etc/telegraf.conf";
 	file_put_contents($conffile, $cfg);
 

--- a/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.xml
+++ b/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.xml
@@ -114,6 +114,27 @@
             <type>input</type>
             <description>Timeout when submitting data to Graphite</description>
         </field>
+        <field>
+            <fielddescr>HAProxy</fielddescr>
+            <fieldname>haproxy_enable</fieldname>
+            <type>checkbox</type>
+            <description>Enable HAProxy Status Reporting</description>
+            <enablefields>haproxy_port</enablefields>
+        </field>
+        <field>
+           <fielddescr>HAProxy Port (optional)</fielddescr>
+           <fieldname>haproxy_port</fieldname>
+           <type>input</type>
+           <description>Port number where HAProxy status is available (default: 2200)</description>
+        </field>
+        <field>
+            <fielddescr>Additional configuration for Telegraf</fielddescr>
+            <fieldname>telegraf_raw_config</fieldname>
+            <type>textarea</type>
+            <size>80</size>
+            <encoding>base64</encoding>
+            <description>Additional directives for telegraf.conf.</description>
+        </field>
     </fields>
     <custom_php_resync_config_command>
         telegraf_resync_config();


### PR DESCRIPTION
Add configuration to Telegraf plugin to connect and monitor HAProxy package. Also add "extra" field that gets added to `/usr/local/etc/telegraf.conf` to allow adding other Telegraf options that are not yet supported in the UI.