### PR TITLE
Added Buypass CA ACME, and fix on registering email

### DIFF
--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
@@ -1,7 +1,7 @@
 <?php
 /*
  * acme.inc
- * 
+ *
  * part of pfSense (https://www.pfsense.org/)
  * Copyright (c) 2016 PiBa-NL
  * All rights reserved.
@@ -179,6 +179,9 @@ $a_acmeserver['letsencrypt-production'] = array('name' => "Let's Encrypt Product
 );
 $a_acmeserver['letsencrypt-production-2'] = array('name' => "Let's Encrypt Production ACME v2 (Applies rate limits to certificate requests)",
     'url' => 'https://acme-v02.api.letsencrypt.org'
+);
+$a_acmeserver['buypass-production'] = array('name' => "BuyPass Production ACME v2 (Applies rate limits to certificate requests)",
+    'url' => 'https://api.buypass.com/acme'
 );
 /*$a_acmeserver['dummy'] = array('name' => "dummy",
     'url' => 'https://example.org'
@@ -763,7 +766,7 @@ $acme_domain_validation_method['anydns'] = array('name' => "notforuser",
 	));
 
 //TODO add more challenge validation types
-/* 
+/*
 $acme_domain_validation_method['http-post'] = array('name' => "http-post",
 	'fields' => array(
 		'url' => array('name'=>"url",'columnheader'=>"Url",'type'=>"textbox",'size'=>"50",
@@ -854,7 +857,7 @@ function get_itembyname($a_array, $name) {
 			$i++;
 		}
 	}
-	return null;	
+	return null;
 }
 
 function get_accountkey_id($name) {
@@ -906,23 +909,23 @@ function & get_certificate($name) {
 	return null;
 }
 
-	function generateAccountKey($name, $ca) {
-		$acmesh = new acme_sh($name, $ca);
+	function generateAccountKey($name, $ca, $email = "") {
+		$acmesh = new acme_sh($name, $ca, $email);
 		return $acmesh->generateAccountKey();
 	}
-	
-	function generateDomainKey($name, $ca, $domain, $keylength) {
-		$acmesh = new acme_sh($name, $ca);
+
+	function generateDomainKey($name, $ca, $domain, $keylength, $email = "") {
+		$acmesh = new acme_sh($name, $ca, $email);
 		return $acmesh->generateDomainKey($domain, $keylength);
 	}
-	
+
 	function registerAcmeAccountKey($name, $ca, $key, $email = "") {
 		$acmesh = new acme_sh($name, $ca, $email);
 		return $acmesh->registeraccount($key);
 	}
 
 	function renew_all_certificates($force = false) {
-		global $config;		
+		global $config;
 		$a_certificates = getarraybyref($config, 'installedpackages', 'acme', 'certificates', 'item');
 		$errors = "";
 		foreach($a_certificates as $certificate) {
@@ -942,7 +945,7 @@ function & get_certificate($name) {
 			notify_all_remote($errors);
 		}
 	}
-	
+
 	function getCertificatePSK($ca, $certificate, $domain) {
 		$certificatename = $certificate['name'];
 		$cert = lookup_cert_by_name($certificatename);
@@ -974,7 +977,7 @@ function & get_certificate($name) {
 
 		return base64_decode($cert['prv']);
 	}
-	
+
 	function saveCACertificateToStore($crt) {
 		global $config;
 		$crt_enc = base64_encode($crt);
@@ -995,11 +998,11 @@ function & get_certificate($name) {
 		$a_ca[] = $cert;
 		syslog(LOG_NOTICE, "Acme, storing new CA: {$subject}");
 	}
-	
+
 	function storeCertificateCer($certificatename, $keyfile, $cerfile, $fullchainfile) {
 		global $config;
 		$certupdated = false;
-		
+
 		$key = file_get_contents($keyfile);
 		$crt = file_get_contents($cerfile);
 		$fullchain = "";
@@ -1026,10 +1029,10 @@ function & get_certificate($name) {
 				}
 			}
 		}
-		
+
 		return $certupdated;
 	}
-		
+
 	function issue_certificate($id, $force = false, $renew = false) {
 		$result = true;
 		$certificate = & get_certificate($id);
@@ -1039,7 +1042,7 @@ function & get_certificate($name) {
 				return $result;
 			}
 
-			$renewafterdays = is_numericint($certificate['renewafter']) ? $certificate['renewafter'] : 60;	
+			$renewafterdays = is_numericint($certificate['renewafter']) ? $certificate['renewafter'] : 60;
 			$timetorenew = false;
 			$now = new \DateTime();
 			$lastrenewal = new \DateTime();
@@ -1052,7 +1055,7 @@ function & get_certificate($name) {
 				echo "Renewal number of days not yet reached.\n";
 			}
 		}
-		
+
 		if ($timetorenew || $force) {
 			syslog(LOG_NOTICE, "Acme, renewing certificate: {$id}");
 			echo "Renewing certificate \n";
@@ -1086,17 +1089,18 @@ function & get_certificate($name) {
 					}
 				}
 			}
-			
+
 			echo "account: {$certificate['acmeaccount']} \n";
 			$account = get_accountkey($certificate['acmeaccount']);
 			$acmeserver = $account['acmeserver'];
 			$accountkey = $account['accountkey'];
+			$email = $account['email'];
 			echo "server: $acmeserver \n";
-			
+
 			global $a_acmeserver;
 			$url = $a_acmeserver[$acmeserver]['url'];
 			$certificatepsk = getCertificatePSK($url, $certificate, $domainstosign[0]->domainname);
-			$acmesh = new acme_sh($certificate['name'], $url);
+			$acmesh = new acme_sh($certificate['name'], $url, $email);
 			$action = $renew == true ? "renew" : "issue";
 			$acmesh->dnssleep = $certificate['dnssleep'];
 			$acmesh->challengealias = $certificate['challengealias'];
@@ -1105,11 +1109,11 @@ function & get_certificate($name) {
 		}
 		return $result;
 	}
-	
+
 	function challenge_response_put($certificatename, $domain, $token, $payload) {
 		$acmecert = get_certificate($certificatename);
 		global $ftpconn;
-		
+
 		echo "\nchallenge_response_put $certificatename, $domain\n";
 		foreach($acmecert['a_domainlist']['item'] as $domainitem) {
 			if($domainitem['name'] == $domain){
@@ -1140,7 +1144,7 @@ function & get_certificate($name) {
 				echo 'FTP Attempt Failed: ',  $e->getMessage(), "\n";
 			}
 		}
-	}	
+	}
 
 	function challenge_response_cleanup($certificatename, $domain, $token) {
 		global $ftpconn;

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_sh.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_sh.inc
@@ -1,7 +1,7 @@
 <?php
 /*
  * acme_sh.inc
- * 
+ *
  * part of pfSense (https://www.pfsense.org/)
  * Copyright (c) 2016 PiBa-NL
  * All rights reserved.
@@ -43,7 +43,7 @@ class acme_sh_domain {
 		$this->NSUPDATE_KEY = $key;
 	}
 }
-	
+
 class acme_sh {
 
 	private $accountconfig;
@@ -52,7 +52,7 @@ class acme_sh {
 	private $debug = true;
 	public $dnssleep;
 	public $ocspstaple;
-	
+
 	private function execacmesh($command, $envvariables = null) {
 		$command = "/usr/local/pkg/acme/acme.sh " . $command;
 		if ($this->debug) {
@@ -86,14 +86,14 @@ class acme_sh {
 		}
 		return $return_value;
 	}
-	
-	function __construct($name, $ca) {
+
+	function __construct($name, $ca, $email) {
 		$this->name = $name;
-		$this->init($ca, $name);
+		$this->init($ca, $name, $email);
 	}
-	
-	function init($ca, $name) {
-		$conf = "ACME_DIRECTORY='{$ca}/directory'\n";
+
+	function init($ca, $name, $email) {
+		$conf = "ACME_DIRECTORY='{$ca}/directory'\nACCOUNT_EMAIL='{$email}'\n";
 		$cahost = parse_url($ca, PHP_URL_HOST);
 		$acmeconf = "/tmp/acme/{$name}/";
 		$this->acmeconf = $acmeconf;
@@ -102,7 +102,7 @@ class acme_sh {
 		$this->accountconfig = "{$this->acmeconf}accountconf.conf";
 		file_put_contents("{$this->accountconfig}", $conf);
 	}
-	
+
 	function generateAccountKey() {
 		unlink_if_exists("{$this->path_account}/account.key");
 		$this->debug = false;
@@ -115,7 +115,7 @@ class acme_sh {
 		$privateKey = file_get_contents("{$this->path_account}/account.key");
 		return $privateKey;
 	}
-	
+
 	function registeraccount($key) {
 		file_put_contents("{$this->path_account}/account.key", $key);
 		$result = $this->execacmesh(""
@@ -126,7 +126,7 @@ class acme_sh {
 				. " --log " . escapeshellarg($this->acmeconf."acme_issuecert.log"));
 		return $result == 0;
 	}
-	
+
 	function generateDomainKey($domain, $keylength) {
 		global $a_keylength;
 		$pathadd = "";
@@ -135,7 +135,7 @@ class acme_sh {
 		}
 		$certpath = "{$this->acmeconf}{$domain}{$pathadd}";
 		safe_mkdir($certpath);
-		
+
 		unlink_if_exists("{$certpath}/{$domain}.key");
 		$this->execacmesh(""
 				. " --home " . escapeshellarg($this->acmeconf)
@@ -148,7 +148,7 @@ class acme_sh {
 		$privateKey = file_get_contents("{$certpath}/{$domain}.key");
 		return $privateKey;
 	}
-	
+
 	function signCertificate($action, $accountkey, $certificatepsk, $domainstosign, $envvariables = null) {
 		// $action = issue / renew
 		global $acme_domain_validation_method;
@@ -161,7 +161,7 @@ class acme_sh {
 		if ($this->ocspstaple == "yes") {
 			$cmdparameters .= " --ocsp-must-staple ";
 		}
-		
+
 		$Le_Domain = $domainstosign[0]->domainname;
 		$certpath = "{$this->acmeconf}{$Le_Domain}/";
 		safe_mkdir($certpath);
@@ -193,13 +193,13 @@ EOF;
 		$hookfile_httpapi = "{$this->acmeconf}httpapi/pfSenseacme.sh";
 		file_put_contents($hookfile_httpapi, $hookcontent_httpapi);
 		chmod($hookfile_httpapi, 0755);
-		
+
 		$certpath = "{$this->acmeconf}{$domainstosign[0]->domainname}";
 		safe_mkdir($certpath);
 		file_put_contents("{$certpath}/{$domainstosign[0]->domainname}.key", $certificatepsk);
 		$domainstr = "";
 		foreach($domainstosign as $domain) {
-			$api = $domain->method; 
+			$api = $domain->method;
 			$domainstr .= " -d " . escapeshellarg($domain->domainname);
 			if (!empty($domain->method)) {
 				$domainparameters = "";
@@ -256,7 +256,7 @@ EOD;
 				file_put_contents("{$nsupdatefileprefix}_acme-challenge.{$acmechalengedom}.key", $keydata);
 			}
 		}
-		
+
 		$this->execacmesh(""
 			. " --{$action} {$domainstr}"
 			. " --home " . escapeshellarg($this->acmeconf)


### PR DESCRIPTION
Added support for Buypass Go ACME
https://www.buypass.com/ssl/products/acme
which also recently has been added as working in acme.sh.

Also this CA requires the email address, so fixed so it's written to accountconf.conf, which it seemed not to do in the existing code.
