### PR TITLE
pfSense-pkg-suricata v4.1.2_1 -- Update to allow non-Rust enabled platform support (armv6 and aarch64).

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.1.2
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -20,6 +21,8 @@ NO_MTREE=	yes
 
 SUB_FILES=	pkg-install pkg-deinstall
 SUB_LIST=	PORTNAME=${PORTNAME}
+
+.include <bsd.port.pre.mk>
 
 do-extract:
 	${MKDIR} ${WRKSRC}
@@ -140,5 +143,8 @@ do-install:
 		${STAGEDIR}${DATADIR}
 	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
 		${STAGEDIR}${DATADIR}/info.xml
+.if ${ARCH} == "armv6" || ${ARCH} == "aarch64"
+	cd ${FILESDIR}/arm && ${COPYTREE_SHARE} . ${STAGEDIR}
+.endif
 
-.include <bsd.port.mk>
+.include <bsd.port.post.mk>

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -1,0 +1,312 @@
+<?php
+/*
+ * suricata_check_cron_misc.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2019 Bill Meeks
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once("/usr/local/pkg/suricata/suricata.inc");
+
+global $g, $config;
+
+function suricata_check_dir_size_limit($suricataloglimitsize) {
+
+	/********************************************************
+	 * This function checks the total size of the Suricata  *
+	 * logging sub-directory structure and prunes the files *
+	 * for all Suricata interfaces if the size exceeds the  *
+	 * passed limit.                                        *
+	 *                                                      *
+	 * On Entry: $surictaaloglimitsize = dir size limit     *
+	 *                                   in megabytes       *
+	 ********************************************************/
+
+	global $g, $config;
+
+	// Convert Log Limit Size setting from MB to KB
+	$suricataloglimitsizeKB = round($suricataloglimitsize * 1024);
+	$suricatalogdirsizeKB = suricata_Getdirsize(SURICATALOGDIR);
+
+	if ($suricatalogdirsizeKB > 0 && $suricatalogdirsizeKB > $suricataloglimitsizeKB) {
+		log_error(gettext("[Suricata] Log directory size exceeds configured limit of " . number_format($suricataloglimitsize) . " MB set on Global Settings tab. Starting cleanup of Suricata logs."));
+		conf_mount_rw();
+
+		// Initialize an array of the log files we want to prune
+		$logs = array ( "alerts.log", "block.log", "dns.log", "eve.json", "http.log", "files-json.log", "sid_changes.log", "stats.log", "tls.log" );
+
+		// Clean-up the rotated logs for each configured Suricata instance
+		foreach ($config['installedpackages']['suricata']['rule'] as $value) {
+			$if_real = get_real_interface($value['interface']);
+			$suricata_uuid = $value['uuid'];
+			$suricata_log_dir = SURICATALOGDIR . "suricata_{$if_real}{$suricata_uuid}";
+			log_error(gettext("[Suricata] Cleaning logs for {$value['descr']} ({$if_real})..."));
+			suricata_post_delete_logs($suricata_uuid);
+
+			foreach ($logs as $file) {
+				// Cleanup any rotated logs
+				log_error(gettext("[Suricata] Deleting rotated log files except last for {$value['descr']} ({$if_real}) $file..."));
+				$filelist = glob("{$suricata_log_dir}/{$file}.*");
+				// Keep most recent file
+				unset($filelist[count($filelist) - 1]);
+				foreach ($filelist as $file) {
+					unlink_if_exists($file);
+				}
+				unset($filelist);
+			}
+
+			// Check for any captured stored files and clean them up
+			unlink_if_exists("{$suricata_log_dir}/files/*");
+
+			// Check for any captured stored TLS certs and clean them up
+			unlink_if_exists("{$suricata_log_dir}/certs/*");
+		}
+
+		if (suricata_Getdirsize(SURICATALOGDIR) < $suricataloglimitsizeKB) {
+			goto cleanupExit;
+		}
+
+		// Cleanup any rotated logs not caught above
+		log_error(gettext("[Suricata] Deleting any additional rotated log files..."));
+		unlink_if_exists("{$suricata_log_dir}/suricata_*/*.log.*");
+		unlink_if_exists("{$suricata_log_dir}/suricata_*/*.json.*");
+
+		if (suricata_Getdirsize(SURICATALOGDIR) < $suricataloglimitsizeKB) {
+			goto cleanupExit;
+		}
+
+		// Clean-up active logs for each configured Suricata instance
+		foreach ($config['installedpackages']['suricata']['rule'] as $value) {
+			$if_real = get_real_interface($value['interface']);
+			$suricata_uuid = $value['uuid'];
+			$suricata_log_dir = SURICATALOGDIR . "suricata_{$if_real}{$suricata_uuid}";
+			if (suricata_Getdirsize(SURICATALOGDIR) < $suricataloglimitsizeKB) {
+				goto cleanupExit;
+			}
+
+			foreach ($logs as $file) {
+				// Truncate the log file if it exists
+				if (file_exists("{$suricata_log_dir}/{$file}")) {
+					try {
+						file_put_contents("{$suricata_log_dir}/{$file}", "");
+					} catch (Exception $e) {
+						log_error("[Suricata] Failed to truncate file '{$suricata_log_dir}/{$file}' -- error was {$e->getMessage()}");
+					}
+				}
+
+				if (suricata_Getdirsize(SURICATALOGDIR) < $suricataloglimitsizeKB) {
+					goto cleanupExit;
+				}
+			}
+
+			if (suricata_Getdirsize(SURICATALOGDIR) < $suricataloglimitsizeKB) {
+				goto cleanupExit;
+			}
+		}
+
+		// Truncate the Rules Update Log file if it exists
+		if (file_exists(SURICATA_RULES_UPD_LOGFILE)) {
+			log_error(gettext("[Suricata] Truncating the Rules Update Log file..."));
+			@file_put_contents(SURICATA_RULES_UPD_LOGFILE, "");
+		}
+
+		cleanupExit:
+		// This is needed if suricata is run as suricata user
+		mwexec('/bin/chmod 660 /var/log/suricata/*', true);
+		conf_mount_ro();
+		log_error(gettext("[Suricata] Automatic clean-up of Suricata logs completed."));
+	}
+}
+
+function suricata_check_rotate_log($log_file, $log_limit, $retention) {
+
+	/********************************************************
+	 * This function checks the passed log file against     *
+	 * the passed size limit and rotates the log file if    *
+	 * necessary.  It also checks the age of previously     *
+	 * rotated logs and removes those older than the        *
+	 * rentention  parameter.                               *
+	 *                                                      *
+	 * On Entry: $log_file  -> full pathname/filename of    *
+	 *                         log file to check            *
+	 *           $log_limit -> size of file in bytes to     *
+	 *                         trigger rotation. Zero       *
+	 *                         means no rotation.           *
+	 *           $retention -> retention period in hours    *
+	 *                         for rotated logs. Zero       *
+	 *                         means never remove.          *
+	 ********************************************************/
+
+	// Check the current log to see if it needs rotating.
+	// If it does, rotate it and put the current time
+	// on the end of the filename as UNIX timestamp.
+	if (!file_exists($log_file))
+		return;
+	if (($log_limit > 0) && (filesize($log_file) >= $log_limit)) {
+		$newfile = $log_file . "." . date('Y_md_Hi');
+		try {
+			copy($log_file, $newfile);
+			file_put_contents($log_file, "");
+		} catch (Exception $e) {
+			log_error("[Suricata] Failed to rotate file '{$log_file}' -- error was {$e->getMessage()}");
+		}
+	}
+
+	// Check previously rotated logs to see if time to
+	// delete any older than the retention period.
+	// Rotated logs have a UNIX timestamp appended to
+	// filename.
+	if ($retention > 0) {
+		$now = time();
+		$rotated_files = glob("{$log_file}.*");
+		foreach ($rotated_files as $file) {
+			if (($now - filemtime($file)) > ($retention * 3600))
+				unlink_if_exists($file);
+		}
+		unset($rotated_files);
+	}
+}
+
+/*************************
+ * Start of main code    *
+ *************************/
+
+// If firewall is booting, do nothing
+if ($g['booting'] == true)
+	return;
+
+// If no interfaces defined, there is nothing to clean up
+if (!is_array($config['installedpackages']['suricata']['rule']))
+	return;
+
+$logs = array ();
+
+// Build an arry of files to check and limits to check them against from our saved configuration
+$logs['alerts.log']['limit'] = $config['installedpackages']['suricata']['config'][0]['alert_log_limit_size'];
+$logs['alerts.log']['retention'] = $config['installedpackages']['suricata']['config'][0]['alert_log_retention'];
+$logs['block.log']['limit'] = $config['installedpackages']['suricata']['config'][0]['block_log_limit_size'];
+$logs['block.log']['retention'] = $config['installedpackages']['suricata']['config'][0]['block_log_retention'];
+$logs['dns.log']['limit'] = $config['installedpackages']['suricata']['config'][0]['dns_log_limit_size'];
+$logs['dns.log']['retention'] = $config['installedpackages']['suricata']['config'][0]['dns_log_retention'];
+$logs['eve.json']['limit'] = $config['installedpackages']['suricata']['config'][0]['eve_log_limit_size'];
+$logs['eve.json']['retention'] = $config['installedpackages']['suricata']['config'][0]['eve_log_retention'];
+$logs['files-json.log']['limit'] = $config['installedpackages']['suricata']['config'][0]['files_json_log_limit_size'];
+$logs['files-json.log']['retention'] = $config['installedpackages']['suricata']['config'][0]['files_json_log_retention'];
+$logs['http.log']['limit'] = $config['installedpackages']['suricata']['config'][0]['http_log_limit_size'];
+$logs['http.log']['retention'] = $config['installedpackages']['suricata']['config'][0]['http_log_retention'];
+$logs['sid_changes.log']['limit'] = $config['installedpackages']['suricata']['config'][0]['sid_changes_log_limit_size'];
+$logs['sid_changes.log']['retention'] = $config['installedpackages']['suricata']['config'][0]['sid_changes_log_retention'];
+$logs['stats.log']['limit'] = $config['installedpackages']['suricata']['config'][0]['stats_log_limit_size'];
+$logs['stats.log']['retention'] = $config['installedpackages']['suricata']['config'][0]['stats_log_retention'];
+$logs['tls.log']['limit'] = $config['installedpackages']['suricata']['config'][0]['tls_log_limit_size'];
+$logs['tls.log']['retention'] = $config['installedpackages']['suricata']['config'][0]['tls_log_retention'];
+
+// Check log limits and retention in the interface logging directories if enabled
+if ($config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 'on') {
+	foreach ($config['installedpackages']['suricata']['rule'] as $value) {
+		$if_real = get_real_interface($value['interface']);
+		$suricata_log_dir = SURICATALOGDIR . "suricata_{$if_real}{$value['uuid']}";
+		foreach ($logs as $k => $p) {
+			suricata_check_rotate_log("{$suricata_log_dir}/{$k}", $p['limit']*1024, $p['retention']);
+		}
+
+		// Prune any aged-out Barnyard2 archived logs if any exist
+		if (is_dir("{$suricata_log_dir}/barnyard2/archive") &&
+		    $config['installedpackages']['suricata']['config'][0]['u2_archive_log_retention'] > 0) {
+			$now = time();
+			$files = glob("{$suricata_log_dir}/barnyard2/archive/unified2.alert.*");
+			$prune_count = 0;
+			foreach ($files as $f) {
+				if (($now - filemtime($f)) > ($config['installedpackages']['suricata']['config'][0]['u2_archive_log_retention'] * 3600)) {
+					$prune_count++;
+					unlink_if_exists($f);
+				}
+			}
+			if ($prune_count > 0)
+				log_error(gettext("[Suricata] Barnyard2 archived logs cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/barnyard2/archive/..."));
+			unset($files);
+		}
+
+		// Prune aged-out File Store files if any exist
+		if (is_dir("{$suricata_log_dir}/files") &&
+		    $config['installedpackages']['suricata']['config'][0]['file_store_retention'] > 0) {
+			$now = time();
+			$files = glob("{$suricata_log_dir}/files/file.*");
+			$prune_count = 0;
+			foreach ($files as $f) {
+				if (($now - filemtime($f)) > ($config['installedpackages']['suricata']['config'][0]['file_store_retention'] * 3600)) {
+					$prune_count++;
+					unlink_if_exists($f);
+				}
+			}
+			if ($prune_count > 0)
+				log_error(gettext("[Suricata] File Store cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/files/..."));
+			unset($files);
+		}
+
+		// Prune aged-out TLS Certs Store files if any exist
+		if (is_dir("{$suricata_log_dir}/certs") &&
+		    $config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'] > 0) {
+			$now = time();
+			$files = glob("{$suricata_log_dir}/certs/*.*");
+			$prune_count = 0;
+			foreach ($files as $f) {
+				if (($now - filemtime($f)) > ($config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'] * 3600)) {
+					$prune_count++;
+					unlink_if_exists($f);
+				}
+			}
+			if ($prune_count > 0)
+				log_error(gettext("[Suricata] TLS Certs Store cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/certs/..."));
+			unset($files);
+		}
+
+		// Prune any pcap log files over configured limit
+		$files = glob("{$suricata_log_dir}/log.pcap.*");
+		if (count($files) > $value['max_pcap_log_files']) {
+			$over = count($files) - $value['max_pcap_log_files'];
+			$remove_files = array();
+			while ($over > 0) {
+				$remove_files[] = array_shift($files);
+				$over--;
+			}
+			$prune_count = 0;
+			foreach ($remove_files as $f) {
+				$prune_count++;
+				unlink_if_exists($f);
+			}
+			if ($prune_count > 0)
+				log_error(gettext("[Suricata] Packet Capture log cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/..."));
+			unset($files, $remove_files);
+		}
+
+		// Send the running Suricata instance on this interface a SIGHUP signal
+		// so it will re-open the log files we rotated and truncated.
+		if (isvalidpid("{$g['varrun_path']}/suricata_{$if_real}{$value['uuid']}.pid")) {
+			mwexec_bg("/bin/pkill -SIGHUP -F {$g['varrun_path']}/suricata_{$if_real}{$value['uuid']}.pid");
+		}
+	}
+}
+
+// Check the overall log directory limit (if enabled) and prune if necessary
+if ($config['installedpackages']['suricata']['config'][0]['suricataloglimit'] == 'on')
+	suricata_check_dir_size_limit($config['installedpackages']['suricata']['config'][0]['suricataloglimitsize']);
+
+?>

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -1,0 +1,1004 @@
+<?php
+/*
+ * suricata_generate_yaml.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2019 Bill Meeks
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Create required Suricata directories if they don't exist
+$suricata_dirs = array( $suricatadir, $suricatacfgdir, "{$suricatacfgdir}/rules",
+	"{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}" );
+foreach ($suricata_dirs as $dir) {
+	if (!is_dir($dir))
+		safe_mkdir($dir);
+}
+
+// Copy required generic files to the interface sub-directory
+$config_files = array( "classification.config", "reference.config", "gen-msg.map", "unicode.map" );
+foreach ($config_files as $file) {
+	if (file_exists("{$suricatadir}{$file}"))
+		@copy("{$suricatadir}{$file}", "{$suricatacfgdir}/{$file}");
+}
+
+// Read the configuration parameters for the passed interface
+// and construct appropriate string variables for use in the
+// suricata.yaml template include file.
+
+// Set HOME_NET and EXTERNAL_NET for the interface
+$home_net_list = suricata_build_list($suricatacfg, $suricatacfg['homelistname']);
+$home_net = implode(",", $home_net_list);
+$home_net = trim($home_net);
+$external_net = "";
+if (!empty($suricatacfg['externallistname']) && $suricatacfg['externallistname'] != 'default') {
+	$external_net_list = suricata_build_list($suricatacfg, $suricatacfg['externallistname'], false, true);
+	$external_net = implode(",", $external_net_list);
+	$external_net = "[" . trim($external_net) . "]";
+}
+else {
+	$external_net = "[";
+	foreach ($home_net_list as $ip)
+		$external_net .= "!{$ip},";
+	$external_net = trim($external_net, ', ') . "]";
+}
+
+// Set the PASS LIST and write its contents to disk,
+// but only if using Legacy Mode blocking. Otherwise,
+// just create an empty placeholder file.
+unlink_if_exists("{$suricatacfgdir}/rules/passlist.rules");
+$suri_passlist = "{$suricatacfgdir}/passlist";
+if ($suricatacfg['ips_mode'] == 'ips_mode_legacy' && $suricatacfg['blockoffenders'] == 'on' && $suricatacfg['passlistname'] != 'none') {
+	$plist = suricata_build_list($suricatacfg, $suricatacfg['passlistname'], true);
+	@file_put_contents("{$suricatacfgdir}/passlist", implode("\n", $plist));
+}
+else {
+	file_put_contents("{$suricatacfgdir}/passlist", '');
+}
+
+// Set default and user-defined variables for SERVER_VARS and PORT_VARS
+$suricata_servers = array (
+	"dns_servers" => "\$HOME_NET", "smtp_servers" => "\$HOME_NET", "http_servers" => "\$HOME_NET",
+	"sql_servers" => "\$HOME_NET", "telnet_servers" => "\$HOME_NET", "dnp3_server" => "\$HOME_NET",
+	"dnp3_client" => "\$HOME_NET", "modbus_server" => "\$HOME_NET", "modbus_client" => "\$HOME_NET",
+	"enip_server" => "\$HOME_NET", "enip_client" => "\$HOME_NET", "ftp_servers" => "\$HOME_NET", "ssh_servers" => "\$HOME_NET", 
+	"aim_servers" => "64.12.24.0/23,64.12.28.0/23,64.12.161.0/24,64.12.163.0/24,64.12.200.0/24,205.188.3.0/24,205.188.5.0/24,205.188.7.0/24,205.188.9.0/24,205.188.153.0/24,205.188.179.0/24,205.188.248.0/24", 
+	"sip_servers" => "\$HOME_NET"
+);
+$addr_vars = "";
+	foreach ($suricata_servers as $alias => $avalue) {
+		if (!empty($suricatacfg["def_{$alias}"]) && is_alias($suricatacfg["def_{$alias}"])) {
+			$avalue = trim(filter_expand_alias($suricatacfg["def_{$alias}"]));
+			$avalue = preg_replace('/\s+/', ',', trim($avalue));
+		}
+		$addr_vars .= "    " . strtoupper($alias) . ": \"{$avalue}\"\n";
+	}
+$addr_vars = trim($addr_vars);
+if(is_array($config['system']['ssh']) && isset($config['system']['ssh']['port']))
+        $ssh_port = $config['system']['ssh']['port'];
+else
+        $ssh_port = "22";
+$suricata_ports = array(
+	"ftp_ports" => "21", 
+	"http_ports" => "80", 
+	"oracle_ports" => "1521", 
+	"ssh_ports" => $ssh_port, 
+	"shellcode_ports" => "!80", 
+	"DNP3_PORTS" => "20000", 
+	"file_data_ports" => "\$HTTP_PORTS,110,143", 
+	"sip_ports" => "5060,5061,5600"
+);
+$port_vars = "";
+	foreach ($suricata_ports as $alias => $avalue) {
+		if (!empty($suricatacfg["def_{$alias}"]) && is_alias($suricatacfg["def_{$alias}"])) {
+			$avalue = trim(filter_expand_alias($suricatacfg["def_{$alias}"]));
+			$avalue = preg_replace('/\s+/', ',', trim($avalue));
+		}
+		$port_vars .= "    " . strtoupper($alias) . ": \"{$avalue}\"\n";
+	}
+$port_vars = trim($port_vars);
+
+// Define a Suppress List (Threshold) if one is configured
+$suppress = suricata_find_list($suricatacfg['suppresslistname'], 'suppress');
+if (!empty($suppress)) {
+	$suppress_data = str_replace("\r", "", base64_decode($suppress['suppresspassthru']));
+	@file_put_contents("{$suricatacfgdir}/threshold.config", $suppress_data);
+}
+else
+	@file_put_contents("{$suricatacfgdir}/threshold.config", "");
+
+// Add interface-specific performance and detection engine settings
+if (!empty($suricatacfg['runmode']))
+	$runmode = $suricatacfg['runmode'];
+else
+	$runmode = "autofp";
+
+if (!empty($suricatacfg['max_pending_packets']))
+	$max_pend_pkts = $suricatacfg['max_pending_packets'];
+else
+	$max_pend_pkts = 1024;
+
+if (!empty($suricatacfg['detect_eng_profile']))
+	$detect_eng_profile = $suricatacfg['detect_eng_profile'];
+else
+	$detect_eng_profile = "medium";
+
+if (!empty($suricatacfg['sgh_mpm_context']))
+	$sgh_mpm_ctx = $suricatacfg['sgh_mpm_context'];
+else
+	$sgh_mpm_ctx = "auto";
+
+if (!empty($suricatacfg['mpm_algo']))
+	$mpm_algo = $suricatacfg['mpm_algo'];
+else
+	$mpm_algo = "auto";
+
+if (!empty($suricatacfg['inspect_recursion_limit']) || $suricatacfg['inspect_recursion_limit'] == '0')
+	$inspection_recursion_limit = $suricatacfg['inspect_recursion_limit'];
+else
+	$inspection_recursion_limit = "";
+
+if ($suricatacfg['delayed_detect'] == 'on')
+	$delayed_detect = "yes";
+else
+	$delayed_detect = "no";
+
+if ($suricatacfg['intf_promisc_mode'] == 'on')
+	$intf_promisc_mode = "yes";
+else
+	$intf_promisc_mode = "no";
+
+if (!empty($suricatacfg['intf_snaplen'])) {
+	$intf_snaplen = $suricatacfg['intf_snaplen'];
+}
+else {
+	$intf_snaplen = "1518";
+}
+
+// Add interface-specific blocking settings
+if ($suricatacfg['blockoffenders'] == 'on' && $suricatacfg['ips_mode'] == 'ips_mode_legacy')
+	$suri_blockoffenders = "yes";
+else
+	$suri_blockoffenders = "no";
+
+if ($suricatacfg['blockoffenderskill'] == 'on')
+	$suri_killstates = "yes";
+else
+	$suri_killstates = "no";
+
+if ($suricatacfg['block_drops_only'] == 'on')
+	$suri_blockdrops = "yes";
+else
+	$suri_blockdrops = "no";
+
+if ($suricatacfg['blockoffendersip'] == 'src')
+	$suri_blockip = 'SRC';
+elseif ($suricatacfg['blockoffendersip'] == 'dst')
+	$suri_blockip = 'DST';
+else
+	$suri_blockip = 'BOTH';
+
+$suri_pf_table = SURICATA_PF_TABLE;
+
+// Add interface-specific logging settings
+if ($suricatacfg['alertsystemlog'] == 'on')
+	$alert_syslog = "yes";
+else
+	$alert_syslog = "no";
+
+if (!empty($suricatacfg['alertsystemlog_facility']))
+	$alert_syslog_facility = $suricatacfg['alertsystemlog_facility'];
+else
+	$alert_syslog_facility = "local5";
+
+if (!empty($suricatacfg['alertsystemlog_priority']))
+	$alert_syslog_priority = $suricatacfg['alertsystemlog_priority'];
+else
+	$alert_syslog_priority = "Info";
+
+if ($suricatacfg['enable_stats_log'] == 'on')
+	$stats_log_enabled = "yes";
+else
+	$stats_log_enabled = "no";
+
+if (!empty($suricatacfg['stats_upd_interval']))
+	$stats_upd_interval = $suricatacfg['stats_upd_interval'];
+else
+	$stats_upd_interval = "10";
+
+if ($suricatacfg['enable_dns_log'] == 'on')
+	$dns_log_enabled = "yes";
+else
+	$dns_log_enabled = "no";
+
+if ($suricatacfg['append_dns_log'] == 'on')
+	$dns_log_append = "yes";
+else
+	$dns_log_append = "no";
+
+if ($suricatacfg['append_stats_log'] == 'on')
+	$stats_log_append = "yes";
+else
+	$stats_log_append = "no";
+
+if ($suricatacfg['enable_http_log'] == 'on')
+	$http_log_enabled = "yes";
+else
+	$http_log_enabled = "no";
+
+if ($suricatacfg['append_http_log'] == 'on')
+	$http_log_append = "yes";
+else
+	$http_log_append = "no";
+
+if ($suricatacfg['http_log_extended'] == 'on')
+	$http_log_extended = "yes";
+else
+	$http_log_extended = "no";
+
+if ($suricatacfg['enable_tls_log'] == 'on')
+	$tls_log_enabled = "yes";
+else
+	$tls_log_enabled = "no";
+
+if ($suricatacfg['enable_tls_store'] == 'on')
+	$tls_store_enabled = "yes";
+else
+	$tls_store_enabled = "no";
+
+if ($suricatacfg['tls_log_extended'] == 'on')
+	$tls_log_extended = "yes";
+else
+	$tls_log_extended = "no";
+
+if ($suricatacfg['enable_json_file_log'] == 'on')
+	$json_log_enabled = "yes";
+else
+	$json_log_enabled = "no";
+
+if ($suricatacfg['append_json_file_log'] == 'on')
+	$json_log_append = "yes";
+else
+	$json_log_append = "no";
+
+if ($suricatacfg['enable_tracked_files_magic'] == 'on')
+	$json_log_magic = "yes";
+else
+	$json_log_magic = "no";
+
+if ($suricatacfg['tracked_files_hash'] != 'none')
+	$json_log_hash = "force-hash: [{$suricatacfg['tracked_files_hash']}]";
+else
+	$json_log_hash = "#force-hash: [md5]";
+	
+if ($suricatacfg['enable_file_store'] == 'on') {
+	$file_store_enabled = "yes";
+	if (!file_exists("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/file.waldo"))
+		@file_put_contents("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/file.waldo", "");
+	$file_store_waldo = "waldo: file.waldo";
+}
+else {
+	$file_store_enabled = "no";
+	$file_store_waldo = "#waldo: file.waldo";
+}
+
+if ($suricatacfg['enable_pcap_log'] == 'on')
+	$pcap_log_enabled = "yes";
+else
+	$pcap_log_enabled = "no";
+
+if (!empty($suricatacfg['max_pcap_log_size']))
+	$pcap_log_limit_size = $suricatacfg['max_pcap_log_size'];
+else
+	$pcap_log_limit_size = "32";
+
+if (!empty($suricatacfg['max_pcap_log_files']))
+	$pcap_log_max_files = $suricatacfg['max_pcap_log_files'];
+else
+	$pcap_log_max_files = "1000";
+
+// Unified2 Alert Log Settings
+if ($suricatacfg['barnyard_enable'] == 'on')
+	$barnyard2_enabled = "yes";
+else
+	$barnyard2_enabled = "no";
+
+if (isset($config['installedpackages']['suricata']['config'][0]['unified2_log_limit']))
+	$unified2_log_limit = "{$config['installedpackages']['suricata']['config'][0]['unified2_log_limit']}mb";
+else
+	$unified2_log_limit = "32mb";
+
+if (isset($suricatacfg['barnyard_sensor_id']))
+	$unified2_sensor_id = $suricatacfg['barnyard_sensor_id'];
+else
+	$unified2_sensor_id = "0";
+
+// Unified2 X-Forwarded-For logging options
+if ($suricatacfg['barnyard_xff_logging'] == 'on') {
+	$unified2_xff_output = "xff:";
+	$unified2_xff_output .= "\n        enabled: yes";
+	if (!empty($suricatacfg['barnyard_xff_mode']))
+		$unified2_xff_output .= "\n        mode: {$suricatacfg['barnyard_xff_mode']}";
+	else
+		$unified2_xff_output .= "\n        mode: extra-data";
+	if (!empty($suricatacfg['barnyard_xff_deployment']))
+		$unified2_xff_output .= "\n        deployment: {$suricatacfg['barnyard_xff_deployment']}";
+	else
+		$unified2_xff_output .= "\n        deployment: reverse";
+	if (!empty($suricatacfg['barnyard_xff_header']))
+		$unified2_xff_output .= "\n        header: {$suricatacfg['barnyard_xff_header']}";
+	else
+		$unified2_xff_output .= "\n        header: X-Forwarded-For";
+}
+else {
+	$unified2_xff_output = "xff:";
+	$unified2_xff_output .= "\n        enabled: no";
+}
+
+// EVE JSON log output settings
+if ($suricatacfg['enable_eve_log'] == 'on')
+	$enable_eve_log = "yes";
+else
+	$enable_eve_log = "no";
+
+if (!empty($suricatacfg['eve_output_type']))
+	$eve_output_type = $suricatacfg['eve_output_type'];
+else
+	$eve_output_type = "regular";
+
+// EVE SYSLOG output settings
+if (!empty($suricatacfg['eve_systemlog_facility']))
+	$eve_systemlog_facility = $suricatacfg['eve_systemlog_facility'];
+else
+	$eve_systemlog_facility = "local1";
+
+if (!empty($suricatacfg['eve_systemlog_priority']))
+	$eve_systemlog_priority = $suricatacfg['eve_systemlog_priority'];
+else
+	$eve_systemlog_priority = "info";
+
+// EVE REDIS output settings
+if (!empty($suricatacfg['eve_redis_server']))
+	$eve_redis_output = "\n        server: ". $suricatacfg['eve_redis_server'];
+else
+	$eve_redis_output = "\n        server: 127.0.0.1";
+
+if (!empty($suricatacfg['eve_redis_port']))
+	$eve_redis_output .= "\n        port: " . $suricatacfg['eve_redis_port'];
+
+if (!empty($suricatacfg['eve_redis_mode']))
+	$eve_redis_output .= "\n        mode: " . $suricatacfg['eve_redis_mode'];
+
+if (!empty($suricatacfg['eve_redis_key']))
+	$eve_redis_output .= "\n        key: \"" . $suricatacfg['eve_redis_key'] ."\"";
+
+// EVE X-Forwarded-For settings
+if ($suricatacfg['eve_log_alerts_xff'] == 'on'){
+	$eve_xff_enabled = "yes";
+	$eve_xff_mode = $suricatacfg['eve_log_alerts_xff_mode'];
+	$eve_xff_deployment = $suricatacfg['eve_log_alerts_xff_deployment'];
+	$eve_xff_header = $suricatacfg['eve_log_alerts_xff_header'];
+}
+else {
+	$eve_xff_enabled = "no";
+	$eve_xff_mode = $suricatacfg['eve_log_alerts_xff_mode'];
+	$eve_xff_deployment = $suricatacfg['eve_log_alerts_xff_deployment'];
+	$eve_xff_header = $suricatacfg['eve_log_alerts_xff_header'];
+}
+
+// EVE log output included information
+$eve_out_types = "";
+
+if (($suricatacfg['eve_log_alerts'] == 'on')) {
+	$eve_out_types .= "\n        - alert:";
+	$eve_out_types .= "\n            payload: ".($suricatacfg['eve_log_alerts_payload'] == 'on' || $suricatacfg['eve_log_alerts_payload'] == 'only-base64' ?'yes':'no ')."              # enable dumping payload in Base64";
+	$eve_out_types .= "\n            payload-buffer-size: 4kb  # max size of payload buffer to output in eve-log";
+	$eve_out_types .= "\n            payload-printable: ".($suricatacfg['eve_log_alerts_payload'] == 'on' || $suricatacfg['eve_log_alerts_payload'] == 'only-printable' ?'yes':'no ')."    # enable dumping payload in printable (lossy) format";
+	$eve_out_types .= "\n            packet: ".($suricatacfg['eve_log_alerts_packet'] == 'on'?'yes':'no ')."               # enable dumping of packet (without stream segments)";
+	$eve_out_types .= "\n            http-body: ".($suricatacfg['eve_log_alerts_payload'] == 'on'?'yes':'no ' || $suricatacfg['eve_log_alerts_payload'] == 'only-base64' ?'yes':'no ')."            # enable dumping of http body in Base64";
+	$eve_out_types .= "\n            http-body-printable: ".($suricatacfg['eve_log_alerts_payload'] == 'on' || $suricatacfg['eve_log_alerts_payload'] == 'only-printable' ?'yes':'no ')."  # enable dumping of http body in printable format";
+	$eve_out_types .= "\n            tagged-packets: yes       # enable logging of tagged packets for rules using the 'tag' keyword";
+}
+
+if ($suricatacfg['eve_log_http'] == 'on') {
+	$eve_out_types .= "\n        - http:";
+	if ($suricatacfg['eve_log_http_extended'] == 'on') {
+		$eve_out_types .= "\n            extended: yes";
+		if ($suricatacfg['eve_log_http_extended_headers'] != "")
+			$eve_out_types .= "\n            custom: [".$suricatacfg['eve_log_http_extended_headers']."]";
+         } else {
+                $eve_out_types .= "\n            extended: no";
+         }
+}
+
+if ($suricatacfg['eve_log_dns'] == 'on') {
+	$eve_out_types .= "\n        - dns:";
+	$eve_out_types .= "\n            version: 2";
+	$eve_out_types .= "\n            query: yes";
+	$eve_out_types .= "\n            answer: yes";
+}
+
+if ($suricatacfg['eve_log_tls'] == 'on') {
+	$eve_out_types .= "\n        - tls:";
+	if ($suricatacfg['eve_log_tls_extended'] == 'on')
+		$eve_out_types .= "\n            extended: yes";
+	else
+		$eve_out_types .= "\n            extended: no";
+}
+
+if ($suricatacfg['eve_log_files'] == 'on') {
+	$eve_out_types .= "\n        - files:";
+	if ($suricatacfg['eve_log_files_magic'] == 'on')
+		$eve_out_types .= "\n            force-magic: yes";
+	else
+		$eve_out_types .= "\n            force-magic: no";
+	if ($suricatacfg['eve_log_files_hash'] != 'none') {
+		$eve_out_types .= "\n            force-hash: [{$suricatacfg['eve_log_files_hash']}]";
+	}
+}
+
+if ($suricatacfg['eve_log_ssh'] == 'on') {
+	$eve_out_types .= "\n        - ssh";
+}
+
+if ($suricatacfg['eve_log_smtp'] == 'on') {
+	$eve_out_types .= "\n        - smtp:";
+	if ($suricatacfg['eve_log_smtp_extended'] == 'on')
+		$eve_out_types .= "\n            extended: yes";
+	else
+		$eve_out_types .= "\n            extended: no";
+	if($suricatacfg['eve_log_smtp_extended_fields'] != "")
+		$eve_out_types .= "\n            custom: [".$suricatacfg['eve_log_smtp_extended_fields']."]";
+
+	$eve_out_types .= "\n            md5: [subject]";
+}
+
+if ($suricatacfg['eve_log_drop'] == 'on' && $suricatacfg['ips_mode'] == "ips_mode_inline") {
+	$eve_out_types .= "\n        - drop:";
+	$eve_out_types .= "\n            alerts: yes";
+	$eve_out_types .= "\n            flows: all";
+}
+
+if ($suricatacfg['eve_log_stats'] == 'on'){
+	$eve_out_types .= "\n        - stats:";
+	$eve_out_types .= "\n            totals: ".($suricatacfg['eve_log_stats_totals'] == 'on'?'yes':'no');
+	$eve_out_types .= "\n            deltas: ".($suricatacfg['eve_log_stats_deltas'] == 'on'?'yes':'no');
+	$eve_out_types .= "\n            threads: ".($suricatacfg['eve_log_stats_threads'] == 'on'?'yes':'no');
+}
+
+if ($suricatacfg['eve_log_flow'] == 'on') {
+	$eve_out_types .= "\n        - flow                        # Bi-directional flows";
+	$eve_out_types .= "\n        - netflow                     # Uni-directional flows";
+}
+
+// Add interface-specific IP defrag settings
+if (!empty($suricatacfg['frag_memcap']))
+	$frag_memcap = $suricatacfg['frag_memcap'];
+else
+	$frag_memcap = "33554432";
+
+if (!empty($suricatacfg['ip_max_trackers']))
+	$ip_max_trackers = $suricatacfg['ip_max_trackers'];
+else
+	$ip_max_trackers = "65535";
+
+if (!empty($suricatacfg['ip_max_frags']))
+	$ip_max_frags = $suricatacfg['ip_max_frags'];
+else
+	$ip_max_frags = "65535";
+
+if (!empty($suricatacfg['frag_hash_size']))
+	$frag_hash_size = $suricatacfg['frag_hash_size'];
+else
+	$frag_hash_size = "65536";
+
+if (!empty($suricatacfg['ip_frag_timeout']))
+	$ip_frag_timeout = $suricatacfg['ip_frag_timeout'];
+else
+	$ip_frag_timeout = "60";
+
+// Add interface-specific flow manager setttings
+if (!empty($suricatacfg['flow_memcap']))
+	$flow_memcap = $suricatacfg['flow_memcap'];
+else
+	$flow_memcap = "33554432";
+
+if (!empty($suricatacfg['flow_hash_size']))
+	$flow_hash_size = $suricatacfg['flow_hash_size'];
+else
+	$flow_hash_size = "65536";
+
+if (!empty($suricatacfg['flow_prealloc']))
+	$flow_prealloc = $suricatacfg['flow_prealloc'];
+else
+	$flow_prealloc = "10000";
+
+if (!empty($suricatacfg['flow_emerg_recovery']))
+	$flow_emerg_recovery = $suricatacfg['flow_emerg_recovery'];
+else
+	$flow_emerg_recovery = "30";
+
+if (!empty($suricatacfg['flow_prune']))
+	$flow_prune = $suricatacfg['flow_prune'];
+else
+	$flow_prune = "5";
+
+// Add interface-specific flow timeout setttings
+if (!empty($suricatacfg['flow_tcp_new_timeout']))
+	$flow_tcp_new_timeout = $suricatacfg['flow_tcp_new_timeout'];
+else
+	$flow_tcp_new_timeout = "60";
+
+if (!empty($suricatacfg['flow_tcp_established_timeout']))
+	$flow_tcp_established_timeout = $suricatacfg['flow_tcp_established_timeout'];
+else
+	$flow_tcp_established_timeout = "3600";
+
+if (!empty($suricatacfg['flow_tcp_closed_timeout']))
+	$flow_tcp_closed_timeout = $suricatacfg['flow_tcp_closed_timeout'];
+else
+	$flow_tcp_closed_timeout = "120";
+
+if (!empty($suricatacfg['flow_tcp_emerg_new_timeout']))
+	$flow_tcp_emerg_new_timeout = $suricatacfg['flow_tcp_emerg_new_timeout'];
+else
+	$flow_tcp_emerg_new_timeout = "10";
+
+if (!empty($suricatacfg['flow_tcp_emerg_established_timeout']))
+	$flow_tcp_emerg_established_timeout = $suricatacfg['flow_tcp_emerg_established_timeout'];
+else
+	$flow_tcp_emerg_established_timeout = "300";
+
+if (!empty($suricatacfg['flow_tcp_emerg_closed_timeout']))
+	$flow_tcp_emerg_closed_timeout = $suricatacfg['flow_tcp_emerg_closed_timeout'];
+else
+	$flow_tcp_emerg_closed_timeout = "20";
+
+if (!empty($suricatacfg['flow_udp_new_timeout']))
+	$flow_udp_new_timeout = $suricatacfg['flow_udp_new_timeout'];
+else
+	$flow_udp_new_timeout = "30";
+
+if (!empty($suricatacfg['flow_udp_established_timeout']))
+	$flow_udp_established_timeout = $suricatacfg['flow_udp_established_timeout'];
+else
+	$flow_udp_established_timeout = "300";
+
+if (!empty($suricatacfg['flow_udp_emerg_new_timeout']))
+	$flow_udp_emerg_new_timeout = $suricatacfg['flow_udp_emerg_new_timeout'];
+else
+	$flow_udp_emerg_new_timeout = "10";
+
+if (!empty($suricatacfg['flow_udp_emerg_established_timeout']))
+	$flow_udp_emerg_established_timeout = $suricatacfg['flow_udp_emerg_established_timeout'];
+else
+	$flow_udp_emerg_established_timeout = "100";
+
+if (!empty($suricatacfg['flow_icmp_new_timeout']))
+	$flow_icmp_new_timeout = $suricatacfg['flow_icmp_new_timeout'];
+else
+	$flow_icmp_new_timeout = "30";
+
+if (!empty($suricatacfg['flow_icmp_established_timeout']))
+	$flow_icmp_established_timeout = $suricatacfg['flow_icmp_established_timeout'];
+else
+	$flow_icmp_established_timeout = "300";
+
+if (!empty($suricatacfg['flow_icmp_emerg_new_timeout']))
+	$flow_icmp_emerg_new_timeout = $suricatacfg['flow_icmp_emerg_new_timeout'];
+else
+	$flow_icmp_emerg_new_timeout = "10";
+
+if (!empty($suricatacfg['flow_icmp_emerg_established_timeout']))
+	$flow_icmp_emerg_established_timeout = $suricatacfg['flow_icmp_emerg_established_timeout'];
+else
+	$flow_icmp_emerg_established_timeout = "100";
+
+// Add interface-specific stream settings
+if (!empty($suricatacfg['stream_memcap']))
+	$stream_memcap = $suricatacfg['stream_memcap'];
+else
+	$stream_memcap = "67108864";
+
+if (!empty($suricatacfg['stream_prealloc_sessions']))
+	$stream_prealloc_sessions = $suricatacfg['stream_prealloc_sessions'];
+else
+	$stream_prealloc_sessions = "32768";
+
+if (!empty($suricatacfg['reassembly_memcap']))
+	$reassembly_memcap = $suricatacfg['reassembly_memcap'];
+else
+	$reassembly_memcap = "67108864";
+
+if (!empty($suricatacfg['reassembly_depth']) || $suricatacfg['reassembly_depth'] == '0')
+	$reassembly_depth = $suricatacfg['reassembly_depth'];
+else
+	$reassembly_depth = "1048576";
+
+if (!empty($suricatacfg['reassembly_to_server_chunk']))
+	$reassembly_to_server_chunk = $suricatacfg['reassembly_to_server_chunk'];
+else
+	$reassembly_to_server_chunk = "2560";
+
+if (!empty($suricatacfg['reassembly_to_client_chunk']))
+	$reassembly_to_client_chunk = $suricatacfg['reassembly_to_client_chunk'];
+else
+	$reassembly_to_client_chunk = "2560";
+
+if (!empty($suricatacfg['max_synack_queued']))
+	$max_synack_queued = $suricatacfg['max_synack_queued'];
+else
+	$max_synack_queued = "5";
+
+if ($suricatacfg['enable_midstream_sessions'] == 'on')
+	$stream_enable_midstream = "true";
+else
+	$stream_enable_midstream = "false";
+
+if ($suricatacfg['enable_async_sessions'] == 'on')
+	$stream_enable_async = "true";
+else
+	$stream_enable_async = "false";
+
+// Add the OS-specific host policies if configured, otherwise
+// just set default to BSD for all networks.
+$host_os_policy = "";
+if (!is_array($suricatacfg['host_os_policy']))
+	$suricatacfg['host_os_policy'] = array();
+if (!is_array($suricatacfg['host_os_policy']['item']))
+	$suricatacfg['host_os_policy']['item'] = array();
+if (count($suricatacfg['host_os_policy']['item']) < 1)
+	$host_os_policy = "bsd: [0.0.0.0/0]";
+else {
+	foreach ($suricatacfg['host_os_policy']['item'] as $k => $v) {
+		$engine = "{$v['policy']}: ";
+		if ($v['bind_to'] <> "all") {
+			$tmp = trim(filter_expand_alias($v['bind_to']));
+			if (!empty($tmp)) {
+				$engine .= "[";
+				$tmp = preg_replace('/\s+/', ',', $tmp);
+				$list = explode(',', $tmp);
+				foreach ($list as $addr) {
+					if (is_ipaddrv6($addr) || is_subnetv6($addr))
+						$engine .= "\"{$addr}\", ";
+					elseif (is_ipaddrv4($addr) || is_subnetv4($addr))
+						$engine .= "{$addr}, ";
+					else
+						log_error("[suricata] WARNING: invalid IP address value '{$addr}' in Alias {$v['bind_to']} will be ignored.");
+				}
+				$engine = trim($engine, ' ,');
+				$engine .= "]";
+			}
+			else {
+				log_error("[suricata] WARNING: unable to resolve IP List Alias '{$v['bind_to']}' for Host OS Policy '{$v['name']}' ... ignoring this entry.");
+				continue;
+			}
+		}
+		else
+			$engine .= "[0.0.0.0/0]";
+
+		$host_os_policy .= "  {$engine}\n";
+	}
+	// Remove trailing newline
+	$host_os_policy = trim($host_os_policy);
+}
+
+// Add the HTTP Server-specific policies if configured, otherwise
+// just set default to IDS for all networks.
+$http_hosts_policy = "";
+$http_hosts_default_policy = "";
+if (!is_array($suricatacfg['libhtp_policy']))
+	$suricatacfg['libhtp_policy'] = array();
+if (!is_array($suricatacfg['libhtp_policy']['item']))
+	$suricatacfg['libhtp_policy']['item'] = array();
+if (count($suricatacfg['libhtp_policy']['item']) < 1) {
+	$http_hosts_default_policy = "     personality: IDS\n     request-body-limit: 4096\n     response-body-limit: 4096\n";
+	$http_hosts_default_policy .= "     double-decode-path: no\n     double-decode-query: no\n     uri-include-all: no\n";
+}
+else {
+	foreach ($suricatacfg['libhtp_policy']['item'] as $k => $v) {
+		if ($v['bind_to'] <> "all") {
+			$engine = "server-config:\n     - {$v['name']}:\n";
+			$tmp = trim(filter_expand_alias($v['bind_to']));
+			if (!empty($tmp)) {
+				$engine .= "         address: [";
+				$tmp = preg_replace('/\s+/', ',', $tmp);
+				$list = explode(',', $tmp);
+				foreach ($list as $addr) {
+					if (is_ipaddrv6($addr) || is_subnetv6($addr))
+						$engine .= "\"{$addr}\", ";
+					elseif (is_ipaddrv4($addr) || is_subnetv4($addr))
+						$engine .= "{$addr}, ";
+					else {
+						log_error("[suricata] WARNING: invalid IP address value '{$addr}' in Alias {$v['bind_to']} will be ignored.");
+						continue;
+					}
+				}
+				$engine = trim($engine, ' ,');
+				$engine .= "]\n";
+				$engine .= "         personality: {$v['personality']}\n         request-body-limit: {$v['request-body-limit']}\n";
+				$engine .= "         response-body-limit: {$v['response-body-limit']}\n";
+				$engine .= "         double-decode-path: {$v['double-decode-path']}\n";
+				$engine .= "         double-decode-query: {$v['double-decode-query']}\n";
+				$engine .= "         uri-include-all: {$v['uri-include-all']}\n";
+				$http_hosts_policy .= "   {$engine}\n";
+			}
+			else {
+				log_error("[suricata] WARNING: unable to resolve IP List Alias '{$v['bind_to']}' for Host OS Policy '{$v['name']}' ... ignoring this entry.");
+				continue;
+			}
+		}
+		else {
+			$http_hosts_default_policy = "     personality: {$v['personality']}\n     request-body-limit: {$v['request-body-limit']}\n";
+			$http_hosts_default_policy .= "     response-body-limit: {$v['response-body-limit']}\n";
+			$http_hosts_default_policy .= "     double-decode-path: {$v['double-decode-path']}\n";
+			$http_hosts_default_policy .= "     double-decode-query: {$v['double-decode-query']}\n";
+			$http_hosts_default_policy .= "     uri-include-all: {$v['uri-include-all']}\n";
+		}
+	}
+	// Remove trailing newline
+	$http_hosts_default_policy = trim($http_hosts_default_policy);
+	$http_hosts_policy = trim($http_hosts_policy);
+}
+
+// Configure ASN1 max frames value
+if (!empty($suricatacfg['asn1_max_frames']))
+	$asn1_max_frames = $suricatacfg['asn1_max_frames'];
+else
+	$asn1_max_frames = "256";
+
+// Configure App-Layer Parsers/Detection
+if (!empty($suricatacfg['dcerpc_parser']))
+	$dcerpc_parser = $suricatacfg['dcerpc_parser'];
+else
+	$dcerpc_parser = "yes";
+if (!empty($suricatacfg['ftp_parser']))
+	$ftp_parser = $suricatacfg['ftp_parser'];
+else
+	$ftp_parser = "yes";
+if (!empty($suricatacfg['ssh_parser']))
+	$ssh_parser = $suricatacfg['ssh_parser'];
+else
+	$ssh_parser = "yes";
+if (!empty($suricatacfg['imap_parser']))
+	$imap_parser = $suricatacfg['imap_parser'];
+else
+	$imap_parser = "detection-only";
+if (!empty($suricatacfg['msn_parser']))
+	$msn_parser = $suricatacfg['msn_parser'];
+else
+	$msn_parser = "detection-only";
+if (!empty($suricatacfg['smb_parser']))
+	$smb_parser = $suricatacfg['smb_parser'];
+else
+	$smb_parser = "yes";
+
+/* DNS Parser */
+if (!empty($suricatacfg['dns_parser_tcp']))
+	$dns_parser_tcp = $suricatacfg['dns_parser_tcp'];
+else
+	$dns_parser_tcp = "yes";
+if (!empty($suricatacfg['dns_parser_udp']))
+	$dns_parser_udp = $suricatacfg['dns_parser_udp'];
+else
+	$dns_parser_udp = "yes";
+if (!empty($suricatacfg['dns_parser_udp_ports'])) {
+	if (is_alias($suricatacfg['dns_parser_udp_ports'])) {
+		$dns_parser_udp_port = trim(filter_expand_alias($suricatacfg['dns_parser_udp_ports']));
+		$dns_parser_udp_port = preg_replace('/\s+/', ', ', trim($dns_parser_udp_port));
+	}
+	else {
+		$dns_parser_udp_port = $suricatacfg['dns_parser_udp_ports'];
+	}
+}
+else {
+	$dns_parser_udp_port = "443";
+}
+if (!empty($suricatacfg['dns_parser_tcp_ports'])) {
+	if (is_alias($suricatacfg['dns_parser_tcp_ports'])) {
+		$dns_parser_tcp_port = trim(filter_expand_alias($suricatacfg['dns_parser_tcp_ports']));
+		$dns_parser_tcp_port = preg_replace('/\s+/', ', ', trim($dns_parser_tcp_port));
+	}
+	else {
+		$dns_parser_tcp_port = $suricatacfg['dns_parser_tcp_ports'];
+	}
+}
+else {
+	$dns_parser_tcp_port = "443";
+}
+if (!empty($suricatacfg['dns_global_memcap']))
+	$dns_global_memcap = $suricatacfg['dns_global_memcap'];
+else
+	$dns_global_memcap = "16777216";
+if (!empty($suricatacfg['dns_state_memcap']))
+	$dns_state_memcap = $suricatacfg['dns_state_memcap'];
+else
+	$dns_state_memcap = "524288";
+if (!empty($suricatacfg['dns_request_flood_limit']))
+	$dns_request_flood_limit = $suricatacfg['dns_request_flood_limit'];
+else
+	$dns_request_flood_limit = "500";
+
+/* HTTP Parser */
+if (!empty($suricatacfg['http_parser']))
+	$http_parser = $suricatacfg['http_parser'];
+else
+	$http_parser = "yes";
+if (!empty($suricatacfg['http_parser_memcap']))
+	$http_parser_memcap = $suricatacfg['http_parser_memcap'];
+else
+	$http_parser_memcap = "67108864";
+
+/* SMTP Parser */
+if (!empty($suricatacfg['smtp_parser'])) {
+	$smtp_parser = $suricatacfg['smtp_parser'];
+}
+else {
+	$smtp_parser = "yes";
+}
+if ($suricatacfg['smtp_parser_decode_mime'] == "on") {
+	$smtp_decode_mime = "yes";
+}
+else {
+	$smtp_decode_mime = "no";
+}
+if ($suricatacfg['smtp_parser_decode_base64'] == "on") {
+	$smtp_decode_base64 = "yes";
+}
+else {
+	$smtp_decode_base64 = "no";
+}
+if ($suricatacfg['smtp_parser_decode_quoted_printable'] == "on") {
+	$smtp_decode_quoted_printable = "yes";
+}
+else {
+	$smtp_decode_quoted_printable = "no";
+}
+if ($suricatacfg['smtp_parser_extract_urls'] == "on") {
+	$smtp_extract_urls = "yes";
+}
+else {
+	$smtp_extract_urls = "no";
+}
+if ($suricatacfg['smtp_parser_compute_body_md5'] == "on") {
+	$smtp_body_md5 = "yes";
+}
+else {
+	$smtp_body_md5 = "no";
+}
+
+/* TLS Parser */
+if (!empty($suricatacfg['tls_parser'])) {
+	$tls_parser = $suricatacfg['tls_parser'];
+}
+else {
+	$tls_parser = "yes";
+}
+if (!empty($suricatacfg['tls_detect_ports'])) {
+	if (is_alias($suricatacfg['tls_detect_ports'])) {
+		$tls_detect_port = trim(filter_expand_alias($suricatacfg['tls_detect_ports']));
+		$tls_detect_port = preg_replace('/\s+/', ', ', trim($tls_detect_port));
+	}
+	else {
+		$tls_detect_port = $suricatacfg['tls_detect_ports'];
+	}
+}
+else {
+	$tls_detect_port = "443";
+}
+if (!empty($suricatacfg['tls_ja3_fingerprint'])) {
+	$tls_ja3 = $suricatacfg['tls_ja3_fingerprint'];
+}
+else {
+	$tls_ja3 = "no";
+}
+if (!empty($suricatacfg['tls_encrypt_handling'])) {
+	$tls_encrypt_handling = $suricatacfg['tls_encrypt_handling'];
+}
+else {
+	$tls_encrypt_handling = "default";
+}
+
+/* Configure the IP REP section */
+$iprep_path = rtrim(SURICATA_IPREP_PATH, '/');
+$iprep_config = "# IP Reputation\n";
+if ($suricatacfg['enable_iprep'] == "on") {
+	$iprep_config .= "default-reputation-path: {$iprep_path}\n";
+	$iprep_config .= "reputation-categories-file: {$iprep_path}/{$suricatacfg['iprep_catlist']}\n";
+	$iprep_config .= "reputation-files:";
+
+	if (!is_array($suricatacfg['iplist_files']))
+		$suricatacfg['iplist_files'] = array();
+	if (!is_array($suricatacfg['iplist_files']['item']))
+		$suricatacfg['iplist_files']['item'] = array();
+
+	foreach ($suricatacfg['iplist_files']['item'] as $f)
+		$iprep_config .= "\n  - $f";
+}
+
+/* Configure Host Table settings */
+if (!empty($suricatacfg['host_memcap']))
+	$host_memcap = $suricatacfg['host_memcap'];
+else
+	$host_memcap = "33554432";
+if (!empty($suricatacfg['host_hash_size']))
+	$host_hash_size = $suricatacfg['host_hash_size'];
+else
+	$host_hash_size = "4096";
+if (!empty($suricatacfg['host_prealloc']))
+	$host_prealloc = $suricatacfg['host_prealloc'];
+else
+	$host_prealloc = "1000";
+
+// Create the rules files and save in the interface directory
+suricata_prepare_rule_files($suricatacfg, $suricatacfgdir);
+
+// Check and configure only non-empty rules files for the interface
+$rules_files = "";
+if (filesize("{$suricatacfgdir}/rules/".SURICATA_ENFORCING_RULES_FILENAME) > 0)
+	$rules_files .= SURICATA_ENFORCING_RULES_FILENAME;
+if (filesize("{$suricatacfgdir}/rules/".FLOWBITS_FILENAME) > 0)
+	$rules_files .= "\n - " . FLOWBITS_FILENAME;
+if (filesize("{$suricatacfgdir}/rules/custom.rules") > 0)
+	$rules_files .= "\n - custom.rules";
+$rules_files = ltrim($rules_files, '\n -');
+
+// Add the general logging settings to the configuration (non-interface specific)
+if ($config['installedpackages']['suricata']['config'][0]['log_to_systemlog'] == 'on')
+	$suricata_use_syslog = "yes";
+else
+	$suricata_use_syslog = "no";
+
+if (!empty($config['installedpackages']['suricata']['config'][0]['log_to_systemlog']))
+	$suricata_use_syslog_facility = $config['installedpackages']['suricata']['config'][0]['log_to_systemlog'];
+else
+	$suricata_use_syslog_facility = "local1";
+
+// Configure IPS operational mode
+if ($suricatacfg['ips_mode'] == 'ips_mode_inline' && $suricatacfg['blockoffenders'] == 'on') {
+	// Note -- Netmap promiscuous mode logic is backwards from pcap
+	$netmap_intf_promisc_mode = $intf_promisc_mode == 'yes' ? 'no' : 'yes';
+	$suricata_ips_mode = <<<EOD
+# Netmap
+netmap:
+ - interface: default
+   threads: auto
+   copy-mode: ips
+   disable-promisc: {$netmap_intf_promisc_mode}
+   checksum-checks: auto
+ - interface: {$if_real}
+   copy-iface: {$if_real}+
+ - interface: {$if_real}+
+   copy-iface: {$if_real}
+EOD;
+}
+else {
+	$suricata_ips_mode = <<<EOD
+# PCAP
+pcap:
+  - interface: {$if_real}
+    checksum-checks: auto
+    promisc: {$intf_promisc_mode}
+    snaplen: {$intf_snaplen}
+EOD;
+}
+
+$suricata_config_pass_thru = base64_decode($suricatacfg['configpassthru']);
+
+?>

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -1,0 +1,680 @@
+<?php
+/*
+ * suricata_migrate_config.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2019 Rubicon Communications, LLC (Netgate)
+ * Copyright (C) 2019 Bill Meeks
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once("config.inc");
+require_once("functions.inc");
+
+/****************************************************************************/
+/* The code in this module is called once during the post-install process   */
+/* via an "include" line.  It is used to perform a one-time migration of    */
+/* Suricata configuration parameters to any new format required by the      */
+/* latest package version.                                                  */
+/****************************************************************************/
+
+global $config;
+
+if (!is_array($config['installedpackages']['suricata']))
+	$config['installedpackages']['suricata'] = array();
+if (!is_array($config['installedpackages']['suricata']['rule']))
+	$config['installedpackages']['suricata']['rule'] = array();
+
+// Just exit if this is a clean install with no saved settings
+if (empty($config['installedpackages']['suricata']['rule']))
+	return;
+
+$rule = &$config['installedpackages']['suricata']['rule'];
+
+/****************************************************************************/
+/* Loop through all the <rule> elements in the Suricata configuration and   */
+/* migrate relevant parameters to the new format.                           */
+/****************************************************************************/
+
+$updated_cfg = false;
+log_error("[Suricata] Checking configuration settings version...");
+
+// Check the configuration version to see if XMLRPC Sync should be
+// auto-disabled as part of the upgrade due to config format changes.
+if ($config['installedpackages']['suricata']['config'][0]['suricata_config_ver'] < 2 && 
+    ($config['installedpackages']['suricatasync']['config'][0]['varsynconchanges'] == 'auto' ||
+     $config['installedpackages']['suricatasync']['config'][0]['varsynconchanges'] == 'manual')) {
+	$config['installedpackages']['suricatasync']['config'][0]['varsynconchanges'] = "disabled";
+	log_error("[Suricata] Turning off Suricata Sync on this host due to configuration format changes in this update.  Upgrade all Suricata Sync targets to this same Suricata package version before re-enabling Suricata Sync.");
+	$updated_cfg = true;
+}
+
+/**********************************************************/
+/* Create new Auto SID Mgmt settings if not set           */
+/**********************************************************/
+if (empty($config['installedpackages']['suricata']['config'][0]['auto_manage_sids'])) {
+	$config['installedpackages']['suricata']['config'][0]['auto_manage_sids'] = "off";
+	$config['installedpackages']['suricata']['config'][0]['sid_changes_log_limit_size'] = "250";
+	$config['installedpackages']['suricata']['config'][0]['sid_changes_log_retention'] = "336";
+	$updated_cfg = true;
+}
+
+/**********************************************************/
+/* Migrate content of any existing SID Mgmt files in the  */
+/* /var/db/suricata/sidmods directory to Base64 encoded   */
+/* strings in SID_MGMT_LIST array in config.xml.          */
+/**********************************************************/
+if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists'])) {
+	$config['installedpackages']['suricata']['sid_mgmt_lists'] = array();
+}
+if (empty($config['installedpackages']['suricata']['config'][0]['sid_list_migration']) && count($config['installedpackages']['suricata']['sid_mgmt_lists']) < 1) {
+	if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists']['item'])) {
+		$config['installedpackages']['suricata']['sid_mgmt_lists']['item'] = array();
+	}
+	$a_list = &$config['installedpackages']['suricata']['sid_mgmt_lists']['item'];
+	$sidmodfiles = return_dir_as_array("/var/db/suricata/sidmods/");
+	foreach ($sidmodfiles as $sidfile) {
+		$data = file_get_contents("/var/db/suricata/sidmods/" . $sidfile);
+		if ($data !== FALSE) {
+			$tmp = array();
+			$tmp['name'] = basename($sidfile);
+			$tmp['modtime'] = filemtime("/var/db/suricata/sidmods/" . $sidfile);
+			$tmp['content'] = base64_encode($data);
+			$a_list[] = $tmp;
+		}
+	}
+	$config['installedpackages']['suricata']['config'][0]['sid_list_migration'] = "1";
+	$updated_cfg = true;
+	unset($a_list);
+}
+
+/**********************************************************/
+/* Create new Auto GeoIP update setting if not set        */
+/**********************************************************/
+if (empty($config['installedpackages']['suricata']['config'][0]['autogeoipupdate'])) {
+	$config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] = "on";
+	$updated_cfg = true;
+}
+
+/**********************************************************/
+/* Create new ET IQRisk IP Reputation setting if not set  */
+/**********************************************************/
+if (empty($config['installedpackages']['suricata']['config'][0]['et_iqrisk_enable'])) {
+	$config['installedpackages']['suricata']['config'][0]['et_iqrisk_enable'] = "off";
+	$updated_cfg = true;
+}
+
+/**********************************************************/
+/* Create new HIDE_DEPRECATED_RULES setting if not set    */
+/**********************************************************/
+if (empty($config['installedpackages']['suricata']['config'][0]['hide_deprecated_rules'])) {
+	$config['installedpackages']['suricata']['config'][0]['hide_deprecated_rules'] = "off";
+	$updated_cfg = true;
+}
+
+/**********************************************************/
+/* Set default log size and retention limits if not set   */
+/**********************************************************/
+if (!isset($config['installedpackages']['suricata']['config'][0]['alert_log_retention']) && $config['installedpackages']['suricata']['config'][0]['alert_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['alert_log_retention'] = "336";
+	$updated_cfg = true;
+}
+if (!isset($config['installedpackages']['suricata']['config'][0]['alert_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['alert_log_limit_size'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['alert_log_limit_size'] = "500";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['block_log_retention']) && $config['installedpackages']['suricata']['config'][0]['block_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['block_log_retention'] = "336";
+	$updated_cfg = true;
+}
+if (!isset($config['installedpackages']['suricata']['config'][0]['block_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['block_log_limit_size'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['block_log_limit_size'] = "500";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['dns_log_retention']) && $config['installedpackages']['suricata']['config'][0]['dns_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['dns_log_retention'] = "168";
+	$updated_cfg = true;
+}
+if (!isset($config['installedpackages']['suricata']['config'][0]['dns_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['dns_log_limit_size'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['dns_log_limit_size'] = "750";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['eve_log_retention']) && $config['installedpackages']['suricata']['config'][0]['eve_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['eve_log_retention'] = "168";
+	$updated_cfg = true;
+}
+if (!isset($config['installedpackages']['suricata']['config'][0]['eve_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['eve_log_limit_size'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['eve_log_limit_size'] = "5000";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['files_json_log_retention']) && $config['installedpackages']['suricata']['config'][0]['files_json_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['files_json_log_retention'] = "168";
+	$updated_cfg = true;
+}
+if (!isset($config['installedpackages']['suricata']['config'][0]['files_json_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['files_json_log_limit_size'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['files_json_log_limit_size'] = "1000";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['http_log_retention']) && $config['installedpackages']['suricata']['config'][0]['http_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['http_log_retention'] = "168";
+	$updated_cfg = true;
+}
+if (!isset($config['installedpackages']['suricata']['config'][0]['http_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['http_log_limit_size'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['http_log_limit_size'] = "1000";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['stats_log_retention']) && $config['installedpackages']['suricata']['config'][0]['stats_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['stats_log_retention'] = "168";
+	$updated_cfg = true;
+}
+if (!isset($config['installedpackages']['suricata']['config'][0]['stats_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['stats_log_limit_size'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['stats_log_limit_size'] = "500";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['tls_log_retention']) && $config['installedpackages']['suricata']['config'][0]['tls_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['tls_log_retention'] = "336";
+	$updated_cfg = true;
+}
+if (!isset($config['installedpackages']['suricata']['config'][0]['tls_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['tls_log_limit_size'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['tls_log_limit_size'] = "500";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['file_store_retention']) && $config['installedpackages']['suricata']['config'][0]['file_store_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['file_store_retention'] = "168";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention']) && $config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'] = "168";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['u2_archive_log_retention']) && $config['installedpackages']['suricata']['config'][0]['u2_archive_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['u2_archive_log_retention'] = "168";
+	$updated_cfg = true;
+}
+
+// Now process the interface-specific settings
+foreach ($rule as &$r) {
+
+	// Initialize arrays for supported preprocessors if necessary
+	if (!is_array($r['libhtp_policy']))
+		$r['libhtp_policy'] = array();
+	if (!is_array($r['libhtp_policy']['item']))
+		$r['libhtp_policy']['item'] = array();
+
+	$pconfig = array();
+	$pconfig = $r;
+
+	/***********************************************************/
+	/* This setting is deprecated in Suricata 2.0 and higher,  */
+	/* so remove it from the configuration.                    */
+	/***********************************************************/
+	if (isset($pconfig['stream_max_sessions'])) {
+		unset($pconfig['stream_max_sessions']);
+		$updated_cfg = true;
+	}
+
+	/***********************************************************/
+	/* HTTP server personalities for "Apache" and "Apache_2_2" */
+	/* are deprecated and replaced with "Apache_2" in Suricata */
+	/* versions greater than 2.0.                              */
+	/***********************************************************/
+	$http_serv = &$pconfig['libhtp_policy']['item'];
+	foreach ($http_serv as &$policy) {
+		if ($policy['personality'] == "Apache" || $policy['personality'] == "Apache_2_2") {
+			$policy['personality'] = "Apache_2";
+			$updated_cfg = true;
+		}
+		// Set new URI inspect option for Suricata 2.0 and higher
+		if (!isset($policy['uri-include-all'])) {
+			$policy['uri-include-all'] = "no";
+			$updated_cfg = true;
+		}
+	}
+
+	/***********************************************************/
+	/* Add the new 'dns-events.rules' file to the rulesets.    */
+	/***********************************************************/
+	if (strpos($pconfig['rulesets'], "dns-events.rules") === FALSE) {
+		$pconfig['rulesets'] = rtrim($pconfig['rulesets'], "||") . "||dns-events.rules";	
+		$updated_cfg = true;
+	}
+
+	/***********************************************************/
+	/* Add new run mode value and default it to 'autofp'.      */
+	/***********************************************************/
+	if (empty($pconfig['runmode'])) {
+		$pconfig['runmode'] = "autofp";
+		$updated_cfg = true;
+	}
+
+	/***********************************************************/
+	/* Add new interface promisc mode value and default 'on'.  */
+	/***********************************************************/
+	if (empty($pconfig['intf_promisc_mode'])) {
+		$pconfig['intf_promisc_mode'] = "on";
+		$updated_cfg = true;
+	}
+
+	/***********************************************************/
+	/* Add new HTTP Log Extended Info setting if not present   */
+	/***********************************************************/
+	if (!isset($pconfig['http_log_extended'])) {
+		$pconfig['http_log_extended'] = "on";
+		$updated_cfg = true;
+	}
+
+	/***********************************************************/
+	/* Add new EVE logging settings if not present             */
+	/***********************************************************/
+	if (!isset($pconfig['eve_output_type'])) {
+		$pconfig['eve_output_type'] = "regular";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_alerts_xff'])) {
+		$pconfig['eve_log_alerts_xff'] = "off";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_alerts_xff_mode'])) {
+		$pconfig['eve_log_alerts_xff_mode'] = "extra-data";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_alerts_xff_deployment'])) {
+		$pconfig['eve_log_alerts_xff_deployment'] = "reverse";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_alerts_xff_header'])) {
+		$pconfig['eve_log_alerts_xff_header'] = "X-Forwarded-For";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['eve_systemlog_facility'])) {
+		$pconfig['eve_systemlog_facility'] = "local1";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['eve_systemlog_priority'])) {
+		$pconfig['eve_systemlog_priority'] = "info";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_alerts'])) {
+		$pconfig['eve_log_alerts'] = "on";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_http'])) {
+		$pconfig['eve_log_http'] = "on";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_dns'])) {
+		$pconfig['eve_log_dns'] = "on";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_tls'])) {
+		$pconfig['eve_log_tls'] = "on";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_files'])) {
+		$pconfig['eve_log_files'] = "on";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_ssh'])) {
+		$pconfig['eve_log_ssh'] = "on";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_smtp'])) {
+		$pconfig['eve_log_smtp'] = "on";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_flow'])) {
+		$pconfig['eve_log_flow'] = "off";
+		$updated_cfg = true;
+	}    
+	if (!isset($pconfig['eve_log_drop'])) {
+		$pconfig['eve_log_drop'] = "on";
+		$updated_cfg = true;
+	}
+
+	/******************************************************************/
+	/* SHA1 and SHA256 were added as additional hashing options in    */
+	/* Suricata 3.x, so the old binary on/off MD5 hashing parameter   */
+	/* is now one of three string values: NONE, MD5, SHA1 or SHA256.  */
+	/* It has been moved to a new parameter name and the old one is   */
+	/* now deprecated and removed from the config.                    */
+	/******************************************************************/
+	if (!isset($pconfig['tracked_files_hash'])) {
+		if ($pconfig['enabled_tracked_files_md5'] == "on") {
+			$pconfig['tracked_files_hash'] = "md5";
+		}
+		else {
+			$pconfig['tracked_files_hash'] = "none";
+		}
+		unset($pconfig['enabled_tracked_files_md5']);
+		$updated_cfg = true;
+	}
+
+	/******************************************************************/
+	/* Remove per interface default log size and retention limits     */ 
+	/* if they were set by early bug.                                 */
+	/******************************************************************/
+	if (isset($pconfig['alert_log_retention'])) {
+		unset($pconfig['alert_log_retention']);
+		$updated_cfg = true;
+	}
+	if (isset($pconfig['alert_log_limit_size'])) {
+		unset($pconfig['alert_log_limit_size']);
+		$updated_cfg = true;
+	}
+
+	if (isset($pconfig['block_log_retention'])) {
+		unset($pconfig['block_log_retention']);
+		$updated_cfg = true;
+	}
+	if (isset($pconfig['block_log_limit_size'])) {
+		unset($pconfig['block_log_limit_size']);
+		$updated_cfg = true;
+	}
+
+	if (isset($pconfig['dns_log_retention'])) {
+		unset($pconfig['dns_log_retention']);
+		$updated_cfg = true;
+	}
+	if (isset($pconfig['dns_log_limit_size'])) {
+		unset($pconfig['dns_log_limit_size']);
+		$updated_cfg = true;
+	}
+
+	if (isset($pconfig['eve_log_retention'])) {
+		unset($pconfig['eve_log_retention']);
+		$updated_cfg = true;
+	}
+	if (isset($pconfig['eve_log_limit_size'])) {
+		unset($pconfig['eve_log_limit_size']);
+		$updated_cfg = true;
+	}
+
+	if (isset($pconfig['files_json_log_retention'])) {
+		unset($pconfig['files_json_log_retention']);
+		$updated_cfg = true;
+	}
+	if (isset($pconfig['files_json_log_limit_size'])) {
+		unset($pconfig['files_json_log_limit_size']);
+		$updated_cfg = true;
+	}
+
+	if (isset($pconfig['http_log_retention'])) {
+		unset($pconfig['http_log_retention']);
+		$updated_cfg = true;
+	}
+	if (isset($pconfig['http_log_limit_size'])) {
+		unset($pconfig['http_log_limit_size']);
+		$updated_cfg = true;
+	}
+
+	if (isset($pconfig['stats_log_retention'])) {
+		unset($pconfig['stats_log_retention']);
+		$updated_cfg = true;
+	}
+	if (isset($pconfig['stats_log_limit_size'])) {
+		unset($pconfig['stats_log_limit_size']);
+		$updated_cfg = true;
+	}
+
+	if (isset($pconfig['tls_log_retention'])) {
+		unset($pconfig['tls_log_retention']);
+		$updated_cfg = true;
+	}
+	if (isset($pconfig['tls_log_limit_size'])) {
+		unset($pconfig['tls_log_limit_size']);
+		$updated_cfg = true;
+	}
+
+	if (isset($pconfig['file_store_retention'])) {
+		unset($pconfig['file_store_retention']);
+		$updated_cfg = true;
+	}
+
+	if (isset($pconfig['u2_archive_log_retention'])) {
+		unset($pconfig['u2_archive_log_retention']);
+		$updated_cfg = true;
+	}
+
+	/************************************************************/
+	/* Create new DNS App-Layer parser settings if not set      */
+	/************************************************************/
+	if (empty($pconfig['dns_global_memcap'])) {
+		$pconfig['dns_global_memcap'] = "16777216";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['dns_state_memcap'])) {
+		$pconfig['dns_state_memcap'] = "524288";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['dns_request_flood_limit'])) {
+		$pconfig['dns_request_flood_limit'] = "500";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['dns_parser_udp'])) {
+		$pconfig['dns_parser_udp'] = "yes";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['dns_parser_tcp'])) {
+		$pconfig['dns_parser_tcp'] = "yes";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['dns_parser_udp_ports'])) {
+		$pconfig['dns_parser_udp_ports'] = "53";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['dns_parser_tcp_ports'])) {
+		$pconfig['dns_parser_tcp_ports'] = "53";
+		$updated_cfg = true;
+	}
+
+	/***********************************************************/
+	/* Create new HTTP App-Layer parser settings if not set    */
+	/***********************************************************/
+	if (empty($pconfig['http_parser'])) {
+		$pconfig['http_parser'] = "yes";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['http_parser_memcap'])) {
+		$pconfig['http_parser_memcap'] = "67108864";
+		$updated_cfg = true;
+	}
+
+	/***********************************************************/
+	/* Create new SMTP App-Layer parser settings if not set    */
+	/***********************************************************/
+	if (empty($pconfig['smtp_parser_decode_mime'])) {
+		$pconfig['smtp_parser_decode_mime'] = "off";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['smtp_parser_decode_base64'])) {
+		$pconfig['smtp_parser_decode_base64'] = "on";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['smtp_parser_decode_quoted_printable'])) {
+		$pconfig['smtp_parser_decode_quoted_printable'] = "on";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['smtp_parser_extract_urls'])) {
+		$pconfig['smtp_parser_extract_urls'] = "on";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['smtp_parser_compute_body_md5'])) {
+		$pconfig['smtp_parser_compute_body_md5'] = "on";
+		$updated_cfg = true;
+	}
+
+	/***********************************************************/
+	/* Create new TLS App-Layer parser settings if not set    */
+	/***********************************************************/
+	if (empty($pconfig['tls_detect_ports'])) {
+		$pconfig['tls_detect_ports'] = "443";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['tls_encrypt_handling'])) {
+		$pconfig['tls_encrypt_handling'] = "default";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['tls_ja3_fingerprint'])) {
+		$pconfig['tls_ja3_fingerprint'] = "off";
+		$updated_cfg = true;
+	}
+
+	/**********************************************************/
+	/* Create other App-Layer parser settings if not set      */
+	/**********************************************************/
+	if (empty($pconfig['tls_parser'])) {
+		$pconfig['tls_parser'] = "yes";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['smtp_parser'])) {
+		$pconfig['smtp_parser'] = "yes";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['imap_parser'])) {
+		$pconfig['imap_parser'] = "detection-only";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['ssh_parser'])) {
+		$pconfig['ssh_parser'] = "yes";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['ftp_parser'])) {
+		$pconfig['ftp_parser'] = "yes";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['dcerpc_parser'])) {
+		$pconfig['dcerpc_parser'] = "yes";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['smb_parser'])) {
+		$pconfig['smb_parser'] = "yes";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['msn_parser'])) {
+		$pconfig['msn_parser'] = "detection-only";
+		$updated_cfg = true;
+	}
+
+	/**********************************************************/
+	/* Create interface IP Reputation settings if not set     */
+	/**********************************************************/
+	if (empty($pconfig['enable_iprep'])) {
+		$pconfig['enable_iprep'] = "off";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['host_memcap'])) {
+		$pconfig['host_memcap'] = "16777216";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['host_hash_size'])) {
+		$pconfig['host_hash_size'] = "4096";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['host_prealloc'])) {
+		$pconfig['host_prealloc'] = "1000";
+		$updated_cfg = true;
+	}
+
+	/**********************************************************/
+	/* Create interface Unified2 XFF log settings if not set  */
+	/**********************************************************/
+	if (!isset($pconfig['barnyard_xff_logging'])) {
+		$pconfig['barnyard_xff_logging'] = "off";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['barnyard_xff_mode'])) {
+		$pconfig['barnyard_xff_mode'] = "extra-data";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['barnyard_xff_deployment'])) {
+		$pconfig['barnyard_xff_deployment'] = "reverse";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['barnyard_xff_header'])) {
+		$pconfig['barnyard_xff_header'] = "X-Forwarded-For";
+		$updated_cfg = true;
+	}
+
+	/**********************************************************/
+	/* Create new interface stream setting if not set         */
+	/**********************************************************/
+	if (empty($pconfig['max_synack_queued'])) {
+		$pconfig['max_synack_queued'] = "5";
+		$updated_cfg = true;
+	}
+
+	/**********************************************************/
+	/* Create new interface IPS mode setting if not set       */
+	/**********************************************************/
+	if (empty($pconfig['ips_mode'])) {
+		$pconfig['ips_mode'] = "ips_mode_legacy";
+		$updated_cfg = true;
+	}
+
+	/**********************************************************/
+	/* Create new interface block DROPs only mode setting if  */
+	/* not already configured.  Default to "off".             */
+	/**********************************************************/
+	if (empty($pconfig['block_drops_only'])) {
+		$pconfig['block_drops_only'] = "no";
+		$updated_cfg = true;
+	}
+
+	/**********************************************************/
+	/* Suricata 3.2.1 introduced support for hyperscan as an  */
+	/* option for the multi pattern matcher (MPM) algorithm.  */
+	/* Several older MPM algorithms were also deprecated.     */
+	/**********************************************************/
+	$old_mpm_algos = array('ac-gfbs', 'b2g', 'b2gc', 'b2gm', 'b3g', 'wumanber');
+	if (in_array($pconfig['mpm_algo'], $old_mpm_algos)) {
+		$pconfig['mpm_algo'] = "auto";
+		$updated_cfg = true;
+	}
+
+	/**********************************************************/
+	/* Set default value for new interface snaplen parameter  */
+	/* if one has not been previously configured.             */
+	/**********************************************************/
+	if (empty($pconfig['intf_snaplen'])) {
+		$pconfig['intf_snaplen'] = "1518";
+		$updated_cfg = true;
+	}
+
+	// Save the new configuration data into the $config array pointer
+	$r = $pconfig;
+}
+// Release reference to final array element
+unset($r);
+
+// Log a message indicating what we did
+if ($updated_cfg) {
+	write_config("Updated Suricata package settings to new configuration format.");
+	log_error("[Suricata] Settings successfully migrated to new configuration format.");
+}
+else {
+	log_error("[Suricata] Configuration version is current.");
+}
+
+?>

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_post_install.php
@@ -1,0 +1,286 @@
+<?php
+/*
+ * suricata_post_install.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2019 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (c) 2009 Robert Zelaya Sr. Developer
+ * Copyright (c) 2019 Bill Meeks
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/****************************************************************************/
+/* This module is called once during the Suricata package installation to   */
+/* perform required post-installation setup.  It should only be executed    */
+/* from the Package Manager process via the custom-post-install hook in     */
+/* the suricata.xml package configuration file.                                */
+/****************************************************************************/
+
+require_once("config.inc");
+require_once("functions.inc");
+require_once("/usr/local/pkg/suricata/suricata.inc");
+require("/usr/local/pkg/suricata/suricata_defs.inc");
+
+global $config, $g, $rebuild_rules, $pkg_interface, $suricata_gui_include;
+
+// Initialize some common values from defined constants
+$suricatadir = SURICATADIR;
+$suricatalogdir = SURICATALOGDIR;
+$flowbit_rules_file = FLOWBITS_FILENAME;
+$suricata_enforcing_rules_file = SURICATA_ENFORCING_RULES_FILENAME;
+$rcdir = RCFILEPREFIX;
+
+// Hard kill any running Suricata process that may have been started by any
+// of the pfSense scripts such as check_reload_status() or rc.start_packages
+if(is_process_running("suricata")) {
+	killbyname("suricata");
+	sleep(2);
+	// Delete any leftover suricata PID files in /var/run
+	unlink_if_exists("{$g['varrun_path']}/suricata_*.pid");
+}
+// Hard kill any running Barnyard2 processes
+if(is_process_running("barnyard")) {
+	killbyname("barnyard2");
+	sleep(2);
+	// Delete any leftover barnyard2 PID files in /var/run
+	unlink_if_exists("{$g['varrun_path']}/barnyard2_*.pid");
+}
+
+// Set flag for post-install in progress
+$g['suricata_postinstall'] = true;
+
+// Remove any LCK files for Suricata that might have been left behind
+unlink_if_exists("{$g['varrun_path']}/suricata_pkg_starting.lck");
+
+// Mount file system read/write so we can modify some files
+conf_mount_rw();
+
+// Remove any previously installed script since we rebuild it
+unlink_if_exists("{$rcdir}suricata.sh");
+
+// Create the top-tier log directory
+safe_mkdir(SURICATALOGDIR);
+
+// Create the IP Rep and SID Mods lists directory
+safe_mkdir(SURICATA_SID_MODS_PATH);
+safe_mkdir(SURICATA_IPREP_PATH);
+
+// Download the latest GeoIP DB updates and create cron task if the feature is not disabled
+if ($config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] != 'off') {
+	log_error(gettext("[Suricata] Installing free GeoLite2 country IP database file in /usr/local/share/suricata/GeoLite2/..."));
+	include("/usr/local/pkg/suricata/suricata_geoipupdate.php");
+	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_geoipupdate.php", TRUE, 0, 6, "*", "*", "*", "root");
+}
+
+// Download the latest ET IQRisk updates and create cron task if the feature is not disabled
+if ($config['installedpackages']['suricata']['config'][0]['et_iqrisk_enable'] == 'on') {
+	log_error(gettext("[Suricata] Installing Emerging Threats IQRisk IP List..."));
+	include("/usr/local/pkg/suricata/suricata_etiqrisk_update.php");
+	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_etiqrisk_update.php", TRUE, 0, "*/6", "*", "*", "*", "root");
+}
+
+/*********************************************************/
+/* START OF BUG FIX CODE                                 */
+/*                                                       */
+/* Remove any Suricata cron tasks that may have been     */
+/* left from a previous uninstall due to a bug that      */
+/* saved edited cron tasks as new ones while still       */
+/* leaving the original task.  Correct cron task         */
+/* entries will be recreated below if saved settings     */
+/* are detected.                                         */
+/*********************************************************/
+$cron_count = 0;
+$suri_pf_table = SURICATA_PF_TABLE;
+
+while (suricata_cron_job_exists($suri_pf_table, FALSE)) {
+	install_cron_job($suri_pf_table, false);
+	$cron_count++;
+}
+
+if ($cron_count > 0) {
+	log_error(gettext("[Suricata] Removed {$cron_count} duplicate 'remove_blocked_hosts' cron task(s)."));
+}
+
+/*********************************************************/
+/* END OF BUG FIX CODE                                   */
+/*********************************************************/
+
+// Make sure config variable is an array (PHP7 likes every level to be created individually )
+if (!is_array($config['installedpackages']['suricata'])) {
+	$config['installedpackages']['suricata'] = array();
+}
+
+if (!is_array($config['installedpackages']['suricata']['rule'])) {
+	$config['installedpackages']['suricata']['rule'] = array();
+}
+
+if (!is_array($config['installedpackages']['suricata']['config'])) {
+	$config['installedpackages']['suricata']['config'] = array();
+}
+
+if (!is_array($config['installedpackages']['suricata']['config'][0])) {
+	$config['installedpackages']['suricata']['config'][0] = array();
+}
+
+// remake saved settings if previously flagged
+if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] == 'on') {
+	log_error(gettext("[Suricata] Saved settings detected... rebuilding installation with saved settings."));
+	update_status(gettext("Saved settings detected...") . "\n");
+
+	/****************************************************************/
+	/* Add all the new built-in events rules to each configured     */
+	/* interface.                                                   */
+	/****************************************************************/
+	if (count($config['installedpackages']['suricata']['rule']) > 0) {
+
+		// Array of default events rules for Suricata.  Note this
+		// is a modified list used when Rust support is disabled.
+		$builtin_rules = array( "app-layer-events.rules", "decoder-events.rules", "dnp3-events.rules", "dns-events.rules", "files.rules", "http-events.rules",  
+					"modbus-events.rules", "smtp-events.rules", "stream-events.rules", "tls-events.rules" );
+		$rust_required_rules = array( "ipsec-events.rules", "kerberos-events.rules", "nfs-events.rules", "ntp-events.rules", "smb-events.rules" );
+		$suriconf = &$config['installedpackages']['suricata']['rule'];
+		foreach ($suriconf as &$suricatacfg) {
+			$rulesets = explode("||", $suricatacfg['rulesets']);
+			foreach ($builtin_rules as $name) {
+				if (in_array($name, $rulesets)) {
+					continue;
+				}
+				else {
+					$rulesets[] = $name;
+				}
+			}
+
+			// Make sure any rules files requiring Rust support are 
+			// removed from list of enabled rulesets for interface.
+			foreach ($rulesets as $key => $rfile) {
+				if (in_array($rfile, $rust_required_rules)) {
+					unset($rulesets[$key]);
+				}
+			}
+
+			// Remove any duplicate ruleset names from earlier bug
+			// and write result back to interface config location.
+			$suricatacfg['rulesets'] = implode("||", array_keys(array_flip($rulesets)));
+		}
+		unset($builtin_rules, $rulesets, $rust_required_rules);
+	}
+	/****************************************************************/
+	/* End of built-in events rules fix.                            */
+	/****************************************************************/
+
+	/* Do one-time settings migration for new version configuration */
+	update_status(gettext("Migrating settings to new configuration..."));
+	include('/usr/local/pkg/suricata/suricata_migrate_config.php');
+	update_status(gettext(" done.") . "\n");
+	log_error(gettext("[Suricata] Downloading and updating configured rule types."));
+	include('/usr/local/pkg/suricata/suricata_check_for_rule_updates.php');
+	update_status(gettext("Generating suricata.yaml configuration file from saved settings.") . "\n");
+	$rebuild_rules = true;
+	conf_mount_rw();
+
+	// Make sure config variable is an array (PHP7 likes every level to be created individually )
+	if (!is_array($config['installedpackages']['suricata'])) {
+		$config['installedpackages']['suricata'] = array();
+	}
+
+	if (!is_array($config['installedpackages']['suricata']['rule'])) {
+		$config['installedpackages']['suricata']['rule'] = array();
+	}
+
+	if (!is_array($config['installedpackages']['suricata']['config'])) {
+		$config['installedpackages']['suricata']['config'] = array();
+	}
+
+	if (!is_array($config['installedpackages']['suricata']['config'][0])) {
+		$config['installedpackages']['suricata']['config'][0] = array();
+	}
+
+	// Create the suricata.yaml files for each enabled interface
+	$suriconf = $config['installedpackages']['suricata']['rule'];
+
+	foreach ($suriconf as $suricatacfg) {
+		$if_real = get_real_interface($suricatacfg['interface']);
+		$suricata_uuid = $suricatacfg['uuid'];
+		$suricatacfgdir = "{$suricatadir}suricata_{$suricata_uuid}_{$if_real}";
+		update_status(gettext("Generating YAML configuration file for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . "..."));
+
+		// Pull in the PHP code that generates the suricata.yaml file
+		// variables that will be substituted further down below.
+		include("/usr/local/pkg/suricata/suricata_generate_yaml.php");
+
+		// Pull in the boilerplate template for the suricata.yaml
+		// configuration file.  The contents of the template along
+		// with substituted variables are stored in $suricata_conf_text
+		// (which is defined in the included file).
+		include("/usr/local/pkg/suricata/suricata_yaml_template.inc");
+
+		// Now write out the conf file using $suricata_conf_text contents
+		@file_put_contents("{$suricatacfgdir}/suricata.yaml", $suricata_conf_text);
+		unset($suricata_conf_text);
+
+		// create barnyard2.conf file for interface
+		if ($suricatacfg['barnyard_enable'] == 'on')
+			suricata_generate_barnyard2_conf($suricatacfg, $if_real);
+
+		update_status(gettext(" done.") . "\n");
+	}
+
+	// create Suricata bootup file suricata.sh
+	suricata_create_rc();
+
+	// Set Log Limit, Block Hosts Time and Rules Update Time
+	suricata_loglimit_install_cron(true);
+	suricata_rm_blocked_install_cron($config['installedpackages']['suricata']['config'][0]['rm_blocked'] != "never_b" ? true : false);
+	suricata_rules_up_install_cron($config['installedpackages']['suricata']['config'][0]['autoruleupdate'] != "never_up" ? true : false);
+
+	// Restore the Dashboard Widget if it was previously enabled and saved
+	if (!empty($config['installedpackages']['suricata']['config'][0]['dashboard_widget']) && !empty($config['widgets']['sequence'])) {
+		if (strpos($config['widgets']['sequence'], "suricata_alerts") === FALSE)
+			$config['widgets']['sequence'] .= "," . $config['installedpackages']['suricata']['config'][0]['dashboard_widget'];
+	}
+	if (!empty($config['installedpackages']['suricata']['config'][0]['dashboard_widget_rows']) && !empty($config['widgets'])) {
+		if (empty($config['widgets']['widget_suricata_display_lines']))
+			$config['widgets']['widget_suricata_display_lines'] = $config['installedpackages']['suricata']['config'][0]['dashboard_widget_rows'];
+	}
+
+	$rebuild_rules = false;
+	update_status(gettext("Finished rebuilding Suricata configuration from saved settings.") . "\n");
+	log_error(gettext("[Suricata] Finished rebuilding installation from saved settings."));
+}
+
+// If this is first install and "forcekeepsettings" is empty,
+// then default it to 'on'.
+if (empty($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'])) {
+	update_status("   " . gettext("\n  Setting up initial configuration.") . "\n");
+	$config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] = 'on';
+}
+
+// Finished with file system mods, so remount it read-only
+conf_mount_ro();
+
+// Update Suricata package version in configuration
+update_status(gettext("  " . "Setting package version in configuration file.") . "\n");
+$config['installedpackages']['suricata']['config'][0]['suricata_config_ver'] = $config['installedpackages']['package'][get_package_id("suricata")]['version'];
+
+write_config("Suricata pkg v{$config['installedpackages']['package'][get_package_id("suricata")]['version']}: post-install configuration saved.");
+
+// Done with post-install, so clear flag
+unset($g['suricata_postinstall']);
+log_error(gettext("[Suricata] Package post-installation tasks completed."));
+return true;
+
+?>

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -1,0 +1,394 @@
+<?php
+
+// This is the template used to generate the suricata.yaml
+// configuration file for the interface.  The contents of
+// this file are written to the suricata.yaml file for
+// the interface.  Key parameters are provided by the
+// included string variables.
+
+	$suricata_conf_text = <<<EOD
+%YAML 1.1
+---
+
+max-pending-packets: {$max_pend_pkts}
+
+# Runmode the engine should use.
+runmode: {$runmode}
+
+# If set to auto, the variable is internally switched to 'router' in IPS 
+# mode and 'sniffer-only' in IDS mode.
+host-mode: auto
+
+# Specifies the kind of flow load balancer used by the flow pinned autofp mode.
+autofp-scheduler: active-packets
+
+# Daemon working directory
+daemon-directory: {$suricatacfgdir}
+
+default-packet-size: 1514
+
+# The default logging directory.
+default-log-dir: {$suricatalogdir}suricata_{$if_real}{$suricata_uuid}
+
+# Configure the type of alert (and other) logging.
+outputs:
+
+  # alert-pf blocking plugin
+  - alert-pf:
+      enabled: {$suri_blockoffenders}
+      kill-state: {$suri_killstates}
+      block-drops-only: {$suri_blockdrops}
+      pass-list: {$suri_passlist}
+      block-ip: {$suri_blockip}
+      pf-table: {$suri_pf_table}
+
+  # a line based alerts log similar to Snort's fast.log
+  - fast:
+      enabled: yes
+      filename: alerts.log
+      append: yes
+      filetype: regular
+
+  # alert output for use with Barnyard2
+  - unified2-alert:
+      enabled: {$barnyard2_enabled}
+      filename: unified2.alert
+      limit: {$unified2_log_limit}
+      sensor-id: {$unified2_sensor_id}
+      {$unified2_xff_output}
+
+  - http-log:
+      enabled: {$http_log_enabled}
+      filename: http.log
+      append: {$http_log_append}
+      extended: {$http_log_extended}
+      filetype: regular
+
+  - pcap-log:
+      enabled: {$pcap_log_enabled}
+      filename: log.pcap
+      limit: {$pcap_log_limit_size}mb
+      max-files: {$pcap_log_max_files}
+      mode: normal
+
+  - tls-log:
+      enabled: {$tls_log_enabled}
+      filename: tls.log
+      extended: {$tls_log_extended}
+
+  - tls-store:
+      enabled: {$tls_store_enabled}
+      certs-log-dir: certs
+
+  - stats:
+      enabled: {$stats_log_enabled}
+      filename: stats.log
+      interval: {$stats_upd_interval}
+      append: {$stats_log_append}
+
+  - syslog:
+      enabled: {$alert_syslog}
+      identity: suricata
+      facility: {$alert_syslog_facility}
+      level: {$alert_syslog_priority}
+
+  - drop:
+      enabled: no
+      filename: drop.log
+      append: yes
+      filetype: regular
+
+  - file-store:
+      version: 2
+      enabled: {$file_store_enabled}
+      log-dir: files
+      force-magic: {$json_log_magic}
+      {$json_log_hash}
+      {$file_store_waldo}
+
+  - file-log:
+      enabled: {$json_log_enabled}
+      filename: files-json.log
+      append: {$json_log_append}
+      filetype: regular
+      force-magic: {$json_log_magic}
+      {$json_log_hash}
+
+  - dns-log:
+      enabled: {$dns_log_enabled}
+      filename: dns.log
+      append: {$dns_log_append}
+      filetype: regular
+
+  - eve-log:
+      enabled: {$enable_eve_log}
+      filetype: {$eve_output_type}
+      filename: eve.json
+      redis: {$eve_redis_output}
+      identity: "suricata"
+      facility: {$eve_systemlog_facility}
+      level: {$eve_systemlog_priority}
+      xff:
+        enabled: {$eve_xff_enabled}
+        mode: {$eve_xff_mode}
+        deployment: {$eve_xff_deployment}
+        header: {$eve_xff_header}
+      types: {$eve_out_types}
+
+# Magic file. The extension .mgc is added to the value here.
+magic-file: /usr/share/misc/magic
+
+# GeoLite2 IP geo-location database file path and filename.
+geoip-database: /usr/local/share/suricata/GeoLite2/GeoLite2-Country.mmdb
+
+# Specify a threshold config file
+threshold-file: {$suricatacfgdir}/threshold.config
+
+detect-engine:
+  - profile: {$detect_eng_profile}
+  - sgh-mpm-context: {$sgh_mpm_ctx}
+  - inspection-recursion-limit: {$inspection_recursion_limit}
+  - delayed-detect: {$delayed_detect}
+
+# Suricata is multi-threaded. Here the threading can be influenced.
+threading:
+  set-cpu-affinity: no
+  detect-thread-ratio: 1.0
+
+# Luajit has a strange memory requirement, it's 'states' need to be in the
+# first 2G of the process' memory.
+#
+# 'luajit.states' is used to control how many states are preallocated.
+# State use: per detect script: 1 per detect thread. Per output script: 1 per
+# script.
+luajit:
+  states: 128
+
+# Multi pattern algorithm
+# The default mpm-algo value of "auto" will use "hs" if Hyperscan is
+# available, "ac" otherwise.
+mpm-algo: {$mpm_algo}
+
+# Single pattern algorithm
+# The default of "auto" will use "hs" if available, otherwise "bm".
+spm-algo: auto
+
+# Defrag settings:
+defrag:
+  memcap: {$frag_memcap}
+  hash-size: {$frag_hash_size}
+  trackers: {$ip_max_trackers}
+  max-frags: {$ip_max_frags}
+  prealloc: yes
+  timeout: {$ip_frag_timeout}
+
+# Flow settings:
+flow:
+  memcap: {$flow_memcap}
+  hash-size: {$flow_hash_size}
+  prealloc: {$flow_prealloc}
+  emergency-recovery: {$flow_emerg_recovery}
+  prune-flows: {$flow_prune}
+
+# This option controls the use of vlan ids in the flow (and defrag)
+# hashing.
+vlan:
+  use-for-tracking: true
+
+# Specific timeouts for flows.
+flow-timeouts:
+  default:
+    new: 30
+    established: 300
+    closed: 0
+    emergency-new: 10
+    emergency-established: 100
+    emergency-closed: 0
+  tcp:
+    new: {$flow_tcp_new_timeout}
+    established: {$flow_tcp_established_timeout}
+    closed: {$flow_tcp_closed_timeout}
+    emergency-new: {$flow_tcp_emerg_new_timeout}
+    emergency-established: {$flow_tcp_emerg_established_timeout}
+    emergency-closed: {$flow_tcp_emerg_closed_timeout}
+  udp:
+    new: {$flow_udp_new_timeout}
+    established: {$flow_udp_established_timeout}
+    emergency-new: {$flow_udp_emerg_new_timeout}
+    emergency-established: {$flow_udp_emerg_established_timeout}
+  icmp:
+    new: {$flow_icmp_new_timeout}
+    established: {$flow_icmp_established_timeout}
+    emergency-new: {$flow_icmp_emerg_new_timeout}
+    emergency-established: {$flow_icmp_emerg_established_timeout}
+
+stream:
+  memcap: {$stream_memcap}
+  checksum-validation: no
+  inline: auto
+  prealloc-sessions: {$stream_prealloc_sessions}
+  midstream: {$stream_enable_midstream}
+  async-oneside: {$stream_enable_async}
+  max-synack-queued: {$max_synack_queued}
+  reassembly:
+    memcap: {$reassembly_memcap}
+    depth: {$reassembly_depth}
+    toserver-chunk-size: {$reassembly_to_server_chunk}
+    toclient-chunk-size: {$reassembly_to_client_chunk}
+
+# Host table is used by tagging and per host thresholding subsystems.
+host:
+  hash-size: {$host_hash_size}
+  prealloc: {$host_prealloc}
+  memcap: {$host_memcap}
+
+# Host specific policies for defragmentation and TCP stream reassembly.
+host-os-policy:
+  {$host_os_policy}
+
+# Logging configuration.  This is not about logging IDS alerts, but
+# IDS output about what its doing, errors, etc.
+logging:
+
+  # This value is overriden by the SC_LOG_LEVEL env var.
+  default-log-level: info
+  default-log-format: "%t - <%d> -- "
+
+  # Define your logging outputs.
+  outputs:
+  - console:
+      enabled: yes
+  - file:
+      enabled: yes
+      filename: {$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/suricata.log
+  - syslog:
+      enabled: {$suricata_use_syslog}
+      facility: {$suricata_use_syslog_facility}
+      format: "[%i] <%d> -- "
+
+# IPS Mode Configuration
+{$suricata_ips_mode}
+
+legacy:
+  uricontent: enabled
+
+default-rule-path: {$suricatacfgdir}/rules
+rule-files:
+ - {$rules_files}
+
+classification-file: {$suricatacfgdir}/classification.config
+reference-config-file: {$suricatacfgdir}/reference.config
+
+# Holds variables that would be used by the engine.
+vars:
+
+  # Holds the address group vars that would be passed in a Signature.
+  address-groups:
+    HOME_NET: "[{$home_net}]"
+    EXTERNAL_NET: "{$external_net}"
+    {$addr_vars}
+
+  # Holds the port group vars that would be passed in a Signature.
+  port-groups:
+    {$port_vars}
+
+# Set the order of alerts based on actions
+action-order:
+  - pass
+  - drop
+  - reject
+  - alert
+
+{$iprep_config}
+
+# Limit for the maximum number of asn1 frames to decode (default 256)
+asn1-max-frames: {$asn1_max_frames}
+
+engine-analysis:
+  rules-fast-pattern: yes
+  rules: yes
+
+#recursion and match limits for PCRE where supported
+pcre:
+  match-limit: 3500
+  match-limit-recursion: 1500
+
+# Holds details on the app-layer. The protocols section details each protocol.
+app-layer:
+  protocols:
+    dcerpc:
+      enabled: {$dcerpc_parser}
+    dnp3:
+      enabled: yes
+      detection-ports:
+        dp: 20000
+    dns:
+      global-memcap: {$dns_global_memcap}
+      state-memcap: {$dns_state_memcap}
+      request-flood: {$dns_request_flood_limit}
+      tcp:
+        enabled: {$dns_parser_tcp}
+        detection-ports:
+          dp: {$dns_parser_tcp_port}
+      udp:
+        enabled: {$dns_parser_udp}
+        detection-ports:
+          dp: {$dns_parser_udp_port}
+    ftp:
+      enabled: {$ftp_parser}
+    http:
+      enabled: {$http_parser}
+      memcap: {$http_parser_memcap}
+    imap:
+      enabled: {$imap_parser}
+    modbus:
+      enabled: yes
+      request-flood: 500
+      detection-ports:
+        dp: 502
+      stream-depth: 0
+    msn:
+      enabled: {$msn_parser}
+    tls:
+      enabled: {$tls_parser}
+      detection-ports:
+        dp: {$tls_detect_port}
+      ja3-fingerprints: {$tls_ja3}
+      encrypt-handling: {$tls_encrypt_handling}
+    smb:
+      enabled: {$smb_parser}
+      detection-ports:
+        dp: 139, 445
+    smtp:
+      enabled: {$smtp_parser}
+      mime:
+        decode-mime: {$smtp_decode_mime}
+        decode-base64: {$smtp_decode_base64}
+        decode-quoted-printable: {$smtp_decode_quoted_printable}
+        header-value-depth: 2000
+        extract-urls: {$smtp_extract_urls}
+        body-md5: {$smtp_body_md5}
+      inspected-tracker:
+        content-limit: 100000
+        content-inspect-min-size: 32768
+        content-inspect-window: 4096
+    ssh:
+      enabled: {$ssh_parser}
+
+###########################################################################
+# Configure libhtp.
+libhtp:
+   default-config:
+     {$http_hosts_default_policy}
+
+   {$http_hosts_policy}
+
+coredump:
+  max-dump: unlimited
+
+# Suricata user pass through configuration
+{$suricata_config_pass_thru}
+
+EOD;
+
+?>

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_app_parsers.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_app_parsers.php
@@ -1,0 +1,883 @@
+<?php
+/*
+ * suricata_app_parsers.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2003-2004 Manuel Kasper
+ * Copyright (c) 2005 Bill Marquette
+ * Copyright (c) 2009 Robert Zelaya Sr. Developer
+ * Copyright (c) 2019 Bill Meeks
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once("guiconfig.inc");
+require_once("/usr/local/pkg/suricata/suricata.inc");
+
+global $g, $rebuild_rules;
+
+if (isset($_POST['id']) && is_numericint($_POST['id']))
+	$id = $_POST['id'];
+elseif (isset($_GET['id']) && is_numericint($_GET['id']))
+	$id = htmlspecialchars($_GET['id']);
+
+if (is_null($id))
+	$id = 0;
+
+// Initialize Suricata interface and HTTP libhtp engine arrays if necessary
+init_config_arr( array( 'installedpackages' , 'suricata' , 'rule') );
+init_config_arr( array('installedpackages', 'suricata', 'rule', $id, 'libhtp_policy', 'item') );
+
+// Initialize required array variables as necessary
+init_config_arr( array('aliases', 'alias') );
+$a_aliases = $config['aliases']['alias'];
+
+$a_nat = &$config['installedpackages']['suricata']['rule'];
+
+$libhtp_engine_next_id = count($a_nat[$id]['libhtp_policy']['item']);
+
+// Build a lookup array of currently used engine 'bind_to' Aliases
+// so we can screen matching Alias names from the list.
+$used = array();
+foreach ($a_nat[$id]['libhtp_policy']['item'] as $v)
+	$used[$v['bind_to']] = true;
+
+$pconfig = array();
+if (isset($id) && $a_nat[$id]) {
+	/* Get current values from config for page form fields */
+	$pconfig = $a_nat[$id];
+
+	// See if Host-OS policy engine array is configured and use
+	// it; otherwise create a default engine configuration.
+	if (empty($pconfig['libhtp_policy']['item'])) {
+		$default = array( "name" => "default", "bind_to" => "all", "personality" => "IDS",
+				  "request-body-limit" => 4096, "response-body-limit" => 4096,
+				  "double-decode-path" => "no", "double-decode-query" => "no",
+				  "uri-include-all" => "no" );
+		$pconfig['libhtp_policy']['item'] = array();
+		$pconfig['libhtp_policy']['item'][] = $default;
+		if (!is_array($a_nat[$id]['libhtp_policy']['item']))
+			$a_nat[$id]['libhtp_policy']['item'] = array();
+		$a_nat[$id]['libhtp_policy']['item'][] = $default;
+		write_config("Suricata pkg: created a new default HTTP server configuration for " . convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']));
+		$libhtp_engine_next_id++;
+	}
+	else
+		$pconfig['libhtp_policy'] = $a_nat[$id]['libhtp_policy'];
+}
+
+// Check for "import or select alias mode" and set flags if TRUE.
+// "selectalias", when true, displays radio buttons to limit
+// multiple selections.
+if ($_POST['import_alias']) {
+	$eng_id = $libhtp_engine_next_id;
+	$importalias = true;
+	$selectalias = false;
+	$title = "HTTP Server Policy";
+}
+elseif ($_POST['select_alias']) {
+	$importalias = true;
+	$selectalias = true;
+	$title = "HTTP Server Policy";
+
+	// Preserve current Libhtp Policy Engine settings
+	$eng_id = $_POST['eng_id'];
+	$eng_name = $_POST['policy_name'];
+	$eng_bind = $_POST['policy_bind_to'];
+	$eng_personality = $_POST['personality'];
+	$eng_req_body_limit = $_POST['req_body_limit'];
+	$eng_resp_body_limit = $_POST['resp_body_limit'];
+	$eng_enable_double_decode_path = $_POST['enable_double_decode_path'];
+	$eng_enable_double_decode_query = $_POST['enable_double_decode_query'];
+	$eng_enable_uri_include_all = $_POST['enable_uri_include_all'];
+	$mode = "add_edit_libhtp_policy";
+}
+
+if ($_POST['save_libhtp_policy']) {
+	if ($_POST['eng_id'] != "") {
+		$eng_id = $_POST['eng_id'];
+
+		// Grab all the POST values and save in new temp array
+		$engine = array();
+		$policy_name = trim($_POST['policy_name']);
+		if ($policy_name) {
+			$engine['name'] = $policy_name;
+		}
+		else
+			$input_errors[] = gettext("The 'Policy Name' value cannot be blank.");
+
+		if ($_POST['policy_bind_to']) {
+			if (is_alias($_POST['policy_bind_to']))
+				$engine['bind_to'] = $_POST['policy_bind_to'];
+			elseif (strtolower(trim($_POST['policy_bind_to'])) == "all")
+				$engine['bind_to'] = "all";
+			else
+				$input_errors[] = gettext("You must provide a valid Alias or the reserved keyword 'all' for the 'Bind-To IP Address' value.");
+		}
+		else
+			$input_errors[] = gettext("The 'Bind-To IP Address' value cannot be blank.  Provide a valid Alias or the reserved keyword 'all'.");
+
+		if ($_POST['personality']) { $engine['personality'] = $_POST['personality']; } else { $engine['personality'] = "bsd"; }
+
+		if (is_numeric($_POST['req_body_limit']) && $_POST['req_body_limit'] >= 0)
+			$engine['request-body-limit'] = $_POST['req_body_limit'];
+		else
+			$input_errors[] = gettext("The value for 'Request Body Limit' must be all numbers and greater than or equal to zero.");
+
+		if (is_numeric($_POST['resp_body_limit']) && $_POST['resp_body_limit'] >= 0)
+			$engine['response-body-limit'] = $_POST['resp_body_limit'];
+		else
+			$input_errors[] = gettext("The value for 'Response Body Limit' must be all numbers and greater than or equal to zero.");
+
+		if ($_POST['enable_double_decode_path']) { $engine['double-decode-path'] = 'yes'; }else{ $engine['double-decode-path'] = 'no'; }
+		if ($_POST['enable_double_decode_query']) { $engine['double-decode-query'] = 'yes'; }else{ $engine['double-decode-query'] = 'no'; }
+		if ($_POST['enable_uri_include_all']) { $engine['uri-include-all'] = 'yes'; }else{ $engine['uri-include-all'] = 'no'; }
+
+		// Can only have one "all" Bind_To address
+		if ($engine['bind_to'] == "all" && $engine['name'] != "default")
+			$input_errors[] = gettext("Only one default OS-Policy Engine can be bound to all addresses.");
+
+		// if no errors, write new entry to conf
+		if (!$input_errors) {
+			if (isset($eng_id) && isset($a_nat[$id]['libhtp_policy']['item'][$eng_id])) {
+				$a_nat[$id]['libhtp_policy']['item'][$eng_id] = $engine;
+			}
+			else
+				$a_nat[$id]['libhtp_policy']['item'][] = $engine;
+
+			/* Reorder the engine array to ensure the */
+			/* 'bind_to=all' entry is at the bottom   */
+			/* if it contains more than one entry.	  */
+			if (count($a_nat[$id]['libhtp_policy']['item']) > 1) {
+				$i = -1;
+				foreach ($a_nat[$id]['libhtp_policy']['item'] as $f => $v) {
+					if ($v['bind_to'] == "all") {
+						$i = $f;
+						break;
+					}
+				}
+				/* Only relocate the entry if we  */
+				/* found it, and it's not already */
+				/* at the end.					  */
+				if ($i > -1 && ($i < (count($a_nat[$id]['libhtp_policy']['item']) - 1))) {
+					$tmp = $a_nat[$id]['libhtp_policy']['item'][$i];
+					unset($a_nat[$id]['libhtp_policy']['item'][$i]);
+					$a_nat[$id]['libhtp_policy']['item'][] = $tmp;
+				}
+			}
+
+			// Now write the new engine array to conf
+			write_config("Suricata pkg: saved updated HTTP server configuration for " . convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']));
+			$add_edit_libhtp_policy = false;
+			header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
+			header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
+			header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+			header( 'Cache-Control: post-check=0, pre-check=0', false );
+			header( 'Pragma: no-cache' );
+			header("Location: suricata_app_parsers.php?id=$id");
+			exit;
+		}
+		else {
+			$add_edit_libhtp_policy = true;
+			$pengcfg = $engine;
+		}
+	}
+}
+elseif ($_POST['add_libhtp_policy']) {
+	$add_edit_libhtp_policy = true;
+	$pengcfg = array( "name" => "engine_{$libhtp_engine_next_id}", "bind_to" => "", "personality" => "IDS",
+			  "request-body-limit" => "4096", "response-body-limit" => "4096",
+			  "double-decode-path" => "no", "double-decode-query" => "no", "uri-include-all" => "no" );
+	$eng_id = $libhtp_engine_next_id;
+}
+elseif ($_POST['edit_libhtp_policy']) {
+	if ($_POST['eng_id'] != "") {
+		$add_edit_libhtp_policy = true;
+		$eng_id = $_POST['eng_id'];
+		$pengcfg = $a_nat[$id]['libhtp_policy']['item'][$eng_id];
+	}
+}
+elseif ($_POST['del_libhtp_policy']) {
+	$natent = array();
+	$natent = $pconfig;
+
+	if ($_POST['eng_id'] != "") {
+		unset($natent['libhtp_policy']['item'][$_POST['eng_id']]);
+		$pconfig = $natent;
+	}
+	if (isset($id) && isset($a_nat[$id])) {
+		$a_nat[$id] = $natent;
+		write_config("Suricata pkg: deleted a HTTP server configuration for " . convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']));
+	}
+	$add_edit_libhtp_policy = false;
+	header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
+	header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
+	header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+	header( 'Cache-Control: post-check=0, pre-check=0', false );
+	header( 'Pragma: no-cache' );
+	header("Location: suricata_app_parsers.php?id=$id");
+	exit;
+}
+elseif ($_POST['cancel_libhtp_policy']) {
+	$add_edit_libhtp_policy = false;
+}
+elseif ($_POST['ResetAll']) {
+
+	/* Reset all the settings to defaults */
+	$pconfig['asn1_max_frames'] = "256";
+	$pconfig['dns_global_memcap'] = "16777216";
+	$pconfig['dns_state_memcap'] = "524288";
+	$pconfig['dns_request_flood_limit'] = "500";
+	$pconfig['http_parser_memcap'] = "67108864";
+	$pconfig['dns_parser_udp'] = "yes";
+	$pconfig['dns_parser_udp_ports'] = "53";
+	$pconfig['dns_parser_tcp'] = "yes";
+	$pconfig['dns_parser_tcp_ports'] = "53";
+	$pconfig['http_parser'] = "yes";
+	$pconfig['tls_parser'] = "yes";
+	$pconfig['tls_detect_ports'] = "443";
+	$pconfig['tls_encrypt_handling'] = "default";
+	$pconfig['tls_ja3_fingerprint'] = "off";
+	$pconfig['smtp_parser'] = "yes";
+	$pconfig['smtp_parser_decode_mime'] = "off";
+	$pconfig['smtp_parser_decode_base64'] = "on";
+	$pconfig['smtp_parser_decode_quoted_printable'] = "on";
+	$pconfig['smtp_parser_extract_urls'] = "on";
+	$pconfig['smtp_parser_compute_body_md5'] = "off";
+	$pconfig['imap_parser'] = "detection-only";
+	$pconfig['ssh_parser'] = "yes";
+	$pconfig['ftp_parser'] = "yes";
+	$pconfig['dcerpc_parser'] = "yes";
+	$pconfig['smb_parser'] = "yes";
+	$pconfig['msn_parser'] = "detection-only";
+
+	/* Log a message at the top of the page to inform the user */
+	$savemsg = gettext("All flow and stream settings on this page have been reset to their defaults.  Click APPLY if you wish to keep these new settings.");
+}
+elseif ($_POST['save_import_alias']) {
+	// If saving out of "select alias" mode,
+	// then return to Libhtp Policy Engine edit
+	// page.
+	if ($_POST['mode'] == 'add_edit_libhtp_policy') {
+		$pengcfg = array();
+		$eng_id = $_POST['eng_id'];
+		$pengcfg['name'] = $_POST['eng_name'];
+		$pengcfg['bind_to'] = $_POST['eng_bind'];
+		$pengcfg['personality'] = $_POST['eng_personality'];
+		$pengcfg['request-body-limit'] = $_POST['eng_req_body_limit'];
+		$pengcfg['response-body-limit'] = $_POST['eng_resp_body_limit'];
+		$pengcfg['double-decode-path'] = $_POST['eng_enable_double_decode_path'];
+		$pengcfg['double-decode-query'] = $_POST['eng_enable_double_decode_query'];
+		$pengcfg['uri-include-all'] = $_POST['eng_enable_uri_include_all'];
+		$add_edit_libhtp_policy = true;
+		$mode = "add_edit_libhtp_policy";
+
+		if (is_array($_POST['aliastoimport']) && count($_POST['aliastoimport']) == 1) {
+			$pengcfg['bind_to'] = $_POST['aliastoimport'][0];
+			$importalias = false;
+			$selectalias = false;
+		}
+		else {
+			$input_errors[] = gettext("No Alias is selected for import.  Nothing to SAVE.");
+			$importalias = true;
+			$selectalias = true;
+			$eng_id = $_POST['eng_id'];
+			$eng_name = $_POST['eng_name'];
+			$eng_bind = $_POST['eng_bind'];
+			$eng_personality = $_POST['eng_personality'];
+			$eng_req_body_limit = $_POST['eng_req_body_limit'];
+			$eng_resp_body_limit = $_POST['eng_resp_body_limit'];
+			$eng_enable_double_decode_path = $_POST['eng_enable_double_decode_path'];
+			$eng_enable_double_decode_query = $_POST['eng_enable_double_decode_query'];
+			$eng_enable_uri_include_all = $_POST['eng_enable_uri_include_all'];
+		}
+	}
+	else {
+		$engine = array( "name" => "", "bind_to" => "", "personality" => "IDS",
+				 "request-body-limit" => "4096", "response-body-limit" => "4096",
+				 "double-decode-path" => "no", "double-decode-query" => "no", "uri-include-all" => "no" );
+
+		// See if anything was checked to import
+		if (is_array($_POST['aliastoimport']) && count($_POST['aliastoimport']) > 0) {
+			foreach ($_POST['aliastoimport'] as $item) {
+				$engine['name'] = strtolower($item);
+				$engine['bind_to'] = $item;
+				$a_nat[$id]['libhtp_policy']['item'][] = $engine;
+			}
+		}
+		else {
+			$input_errors[] = gettext("No entries were selected for import. Please select one or more Aliases for import and click SAVE.");
+			$importalias = true;
+		}
+
+		// if no errors, write new entry to conf
+		if (!$input_errors) {
+			// Reorder the engine array to ensure the
+			// 'bind_to=all' entry is at the bottom if
+			// the array contains more than one entry.
+			if (count($a_nat[$id]['libhtp_policy']['item']) > 1) {
+				$i = -1;
+				foreach ($a_nat[$id]['libhtp_policy']['item'] as $f => $v) {
+					if ($v['bind_to'] == "all") {
+						$i = $f;
+						break;
+					}
+				}
+				// Only relocate the entry if we
+				// found it, and it's not already
+				// at the end.
+				if ($i > -1 && ($i < (count($a_nat[$id]['libhtp_policy']['item']) - 1))) {
+					$tmp = $a_nat[$id]['libhtp_policy']['item'][$i];
+					unset($a_nat[$id]['libhtp_policy']['item'][$i]);
+					$a_nat[$id]['libhtp_policy']['item'][] = $tmp;
+				}
+				$pconfig['libhtp_policy']['item'] = $a_nat[$id]['libhtp_policy']['item'];
+			}
+
+			// Write the new engine array to config file
+			write_config("Suricata pkg: saved an updated HTTP server configuration for " . convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']));
+			$importalias = false;
+			header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
+			header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
+			header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+			header( 'Cache-Control: post-check=0, pre-check=0', false );
+			header( 'Pragma: no-cache' );
+			header("Location: suricata_app_parsers.php?id=$id");
+			exit;
+		}
+	}
+}
+elseif ($_POST['cancel_import_alias']) {
+	$importalias = false;
+	$selectalias = false;
+	$eng_id = $_POST['eng_id'];
+
+	// If cancelling out of "select alias" mode,
+	// then return to Libhtp Policy Engine edit
+	// page.
+	if ($_POST['mode'] == 'add_edit_libhtp_policy') {
+		$pengcfg = array();
+		$pengcfg['name'] = $_POST['eng_name'];
+		$pengcfg['bind_to'] = $_POST['eng_bind'];
+		$pengcfg['personality'] = $_POST['eng_personality'];
+		$pengcfg['request-body-limit'] = $_POST['eng_req_body_limit'];
+		$pengcfg['response-body-limit'] = $_POST['eng_resp_body_limit'];
+		$pengcfg['double-decode-path'] = $_POST['eng_enable_double_decode_path'];
+		$pengcfg['double-decode-query'] = $_POST['eng_enable_double_decode_query'];
+		$pengcfg['uri-include-all'] = $_POST['eng_enable_uri_include_all'];
+		$add_edit_libhtp_policy = true;
+	}
+}
+elseif ($_POST['save'] || $_POST['apply']) {
+	$natent = array();
+	$natent = $pconfig;
+
+	// TODO: validate input values
+	if (!is_numeric($_POST['asn1_max_frames'] ) || $_POST['asn1_max_frames'] < 1)
+		$input_errors[] = gettext("The value for 'ASN1 Max Frames' must be all numbers and greater than 0.");
+
+	if (!is_numeric($_POST['dns_global_memcap'] ) || $_POST['dns_global_memcap'] < 1)
+		$input_errors[] = gettext("The value for 'DNS Global Memcap' must be all numbers and greater than 0.");
+
+	if (!is_numeric($_POST['dns_state_memcap'] ) || $_POST['dns_state_memcap'] < 1)
+		$input_errors[] = gettext("The value for 'DNS Flow/State Memcap' must be all numbers and greater than 0.");
+
+	if (!is_numeric($_POST['dns_request_flood_limit'] ) || $_POST['dns_request_flood_limit'] < 1)
+		$input_errors[] = gettext("The value for 'DNS Request Flood Limit' must be all numbers and greater than 0.");
+
+	if (!is_numeric($_POST['http_parser_memcap'] ) || $_POST['http_parser_memcap'] < 1)
+		$input_errors[] = gettext("The value for 'HTTP Memcap' must be all numbers and greater than 0.");
+
+	if (is_alias($_POST['tls_detect_ports']) && trim(filter_expand_alias($_POST['tls_detect_ports'])) == "") {
+		$input_errors[] = gettext("An invalid Port alias was specified for TLS Detect Ports.");
+	}
+
+	if (is_alias($_POST['dns_parser_udp_ports']) && trim(filter_expand_alias($_POST['dns_parser_udp_ports'])) == "") {
+		$input_errors[] = gettext("An invalid Port alias was specified for DNS Parser UDP Detect Ports.");
+	}
+
+	if (is_alias($_POST['dns_parser_tcp_ports']) && trim(filter_expand_alias($_POST['dns_parser_tcp_ports'])) == "") {
+		$input_errors[] = gettext("An invalid Port alias was specified for DNS Parser TCP Detect Ports.");
+	}
+
+	/* if no errors write to conf */
+	if (!$input_errors) {
+		if ($_POST['asn1_max_frames'] != "") { $natent['asn1_max_frames'] = $_POST['asn1_max_frames']; }else{ $natent['asn1_max_frames'] = "256"; }
+		if ($_POST['dns_global_memcap'] != ""){ $natent['dns_global_memcap'] = $_POST['dns_global_memcap']; }else{ $natent['dns_global_memcap'] = "16777216"; }
+		if ($_POST['dns_state_memcap'] != ""){ $natent['dns_state_memcap'] = $_POST['dns_state_memcap']; }else{ $natent['dns_state_memcap'] = "524288"; }
+		if ($_POST['dns_request_flood_limit'] != ""){ $natent['dns_request_flood_limit'] = $_POST['dns_request_flood_limit']; }else{ $natent['dns_request_flood_limit'] = "500"; }
+		if ($_POST['http_parser_memcap'] != ""){ $natent['http_parser_memcap'] = $_POST['http_parser_memcap']; }else{ $natent['http_parser_memcap'] = "67108864"; }
+
+		$natent['dns_parser_udp'] = $_POST['dns_parser_udp'];
+		$natent['dns_parser_tcp'] = $_POST['dns_parser_tcp'];
+		$natent['dns_parser_udp_ports'] = $_POST['dns_parser_udp_ports'];
+		$natent['dns_parser_tcp_ports'] = $_POST['dns_parser_tcp_ports'];
+		$natent['http_parser'] = $_POST['http_parser'];
+		$natent['tls_parser'] = $_POST['tls_parser'];
+		$natent['tls_detect_ports'] = $_POST['tls_detect_ports'];
+		$natent['tls_encrypt_handling'] = $_POST['tls_encrypt_handling'];
+		$natent['tls_ja3_fingerprint'] = $_POST['tls_ja3_fingerprint'];
+		$natent['smtp_parser'] = $_POST['smtp_parser'];
+		$natent['smtp_parser_decode_mime'] = $_POST['smtp_parser_decode_mime'];
+		$natent['smtp_parser_decode_base64'] = $_POST['smtp_parser_decode_base64'];
+		$natent['smtp_parser_decode_quoted_printable'] = $_POST['smtp_parser_decode_quoted_printable'];
+		$natent['smtp_parser_extract_urls'] = $_POST['smtp_parser_extract_urls'];
+		$natent['smtp_parser_compute_body_md5'] = $_POST['smtp_parser_compute_body_md5'];
+		$natent['imap_parser'] = $_POST['imap_parser'];
+		$natent['ssh_parser'] = $_POST['ssh_parser'];
+		$natent['ftp_parser'] = $_POST['ftp_parser'];
+		$natent['dcerpc_parser'] = $_POST['dcerpc_parser'];
+		$natent['smb_parser'] = $_POST['smb_parser'];
+		$natent['msn_parser'] = $_POST['msn_parser'];
+
+		/**************************************************/
+		/* If we have a valid rule ID, save configuration */
+		/* then update the suricata.conf file for this	  */
+		/* interface.									  */
+		/**************************************************/
+		if (isset($id) && $a_nat[$id]) {
+			$a_nat[$id] = $natent;
+			write_config("Suricata pkg: saved updated app-layer parser configuration for " . convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']));
+			$rebuild_rules = false;
+			conf_mount_rw();
+			suricata_generate_yaml($natent);
+			conf_mount_ro();
+
+			// Sync to configured CARP slaves if any are enabled
+			suricata_sync_on_changes();
+		}
+
+		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
+		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
+		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+		header( 'Cache-Control: post-check=0, pre-check=0', false );
+		header( 'Pragma: no-cache' );
+		header("Location: suricata_app_parsers.php?id=$id");
+		exit;
+	}
+}
+
+$if_friendly = convert_friendly_interface_to_friendly_descr($pconfig['interface']);
+$pgtitle = array(gettext("Services"), gettext("Suricata"), gettext("Application Layer Parsers - {$if_friendly}"));
+include_once("head.inc");
+
+/* Display error message */
+if ($input_errors) {
+	print_input_errors($input_errors);
+}
+
+if ($savemsg) {
+	/* Display save message */
+	print_info_box($savemsg);
+}
+
+$tab_array = array();
+$tab_array[] = array(gettext("Interfaces"), true, "/suricata/suricata_interfaces.php");
+$tab_array[] = array(gettext("Global Settings"), false, "/suricata/suricata_global.php");
+$tab_array[] = array(gettext("Updates"), false, "/suricata/suricata_download_updates.php");
+$tab_array[] = array(gettext("Alerts"), false, "/suricata/suricata_alerts.php?instance={$id}");
+$tab_array[] = array(gettext("Blocks"), false, "/suricata/suricata_blocked.php");
+$tab_array[] = array(gettext("Pass Lists"), false, "/suricata/suricata_passlist.php");
+$tab_array[] = array(gettext("Suppress"), false, "/suricata/suricata_suppress.php");
+$tab_array[] = array(gettext("Logs View"), false, "/suricata/suricata_logs_browser.php?instance={$id}");
+$tab_array[] = array(gettext("Logs Mgmt"), false, "/suricata/suricata_logs_mgmt.php");
+$tab_array[] = array(gettext("SID Mgmt"), false, "/suricata/suricata_sid_mgmt.php");
+$tab_array[] = array(gettext("Sync"), false, "/pkg_edit.php?xml=suricata/suricata_sync.xml");
+$tab_array[] = array(gettext("IP Lists"), false, "/suricata/suricata_ip_list_mgmt.php");
+display_top_tabs($tab_array, true);
+
+$menu_iface=($if_friendly?substr($if_friendly,0,5)." ":"Iface ");
+$tab_array = array();
+$tab_array[] = array($menu_iface . gettext("Settings"), false, "/suricata/suricata_interfaces_edit.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("Categories"), false, "/suricata/suricata_rulesets.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("Rules"), false, "/suricata/suricata_rules.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("Flow/Stream"), false, "/suricata/suricata_flow_stream.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("App Parsers"), true, "/suricata/suricata_app_parsers.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("Variables"), false, "/suricata/suricata_define_vars.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("Barnyard2"), false, "/suricata/suricata_barnyard.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("IP Rep"), false, "/suricata/suricata_ip_reputation.php?id={$id}");
+display_top_tabs($tab_array, true);
+?>
+
+<?php
+
+if ($importalias) {
+
+	print('<form action="suricata_app_parsers.php" method="post" name="iform" id="iform" class="form-horizontal">');
+	print('<input name="id" type="hidden" value="' . $id . '"/>');
+	print('<input type="hidden" name="eng_id" id="eng_id" value="' . $eng_id . '"/>');
+
+	if ($selectalias) {
+		print('<input type="hidden" name="eng_name" value="' . $eng_name . '"/>');
+		print('<input type="hidden" name="eng_bind" value="' . $eng_bind . '"/>');
+		print('<input type="hidden" name="eng_personality" value="' . $eng_personality . '"/>');
+		print('<input type="hidden" name="eng_req_body_limit" value="' . $eng_req_body_limit . '"/>');
+		print('<input type="hidden" name="eng_resp_body_limit" value="' . $eng_resp_body_limit . '"/>');
+		print('<input type="hidden" name="eng_enable_double_decode_path" value="' . $eng_enable_double_decode_path . '"/>');
+		print('<input type="hidden" name="eng_enable_double_decode_query" value="' . $eng_enable_double_decode_query . '"/>');
+		print('<input type="hidden" name="eng_enable_uri_include_all" value="' . $eng_enable_uri_include_all . '"/>');
+	}
+
+	include("/usr/local/www/suricata/suricata_import_aliases.php");
+	print('</form>');
+
+} elseif ($add_edit_libhtp_policy) {
+
+	include("/usr/local/www/suricata/suricata_libhtp_policy_engine.php");
+
+} else {
+
+	print('<form action="suricata_app_parsers.php" method="post" name="iform" id="iform" class="form-horizontal">');
+	print('<input name="id" type="hidden" value="' . $id . '"/>');
+	print('<input type="hidden" name="eng_id" id="eng_id" value=""/>');
+
+	$section = new Form_Section('Abstract Syntax One Settings');
+	$section->addInput(new Form_Input(
+		'asn1_max_frames',
+		'Asn1 Max Frames',
+		'text',
+		$pconfig['asn1_max_frames']
+	))->setHelp('Limit for max number of asn1 frames to decode. Default is 256 frames. To protect itself, Suricata will inspect only the maximum asn1 frames specified. Application layer protocols such as X.400 electronic mail, X.500 and LDAP directory services, H.323 (VoIP), and SNMP, use ASN.1 to describe the protocol data units (PDUs) they exchange.');
+	print($section);
+
+	$section = new Form_Section('DNS App-Layer Parser Settings');
+	$section->addInput(new Form_Select(
+		'dns_parser_udp',
+		'UDP Parser',
+		$pconfig['dns_parser_udp'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
+		'dns_parser_tcp',
+		'TCP Parser',
+		$pconfig['dns_parser_tcp'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Input(
+		'dns_parser_udp_ports',
+		'UDP Detection Port',
+		'text',
+		$pconfig['dns_parser_udp_ports']
+	))->setHelp('Enter comma-separated list (or a Port alias) of ports for the DNS UDP parser. Default is 53.');
+	$section->addInput(new Form_Input(
+		'dns_parser_tcp_ports',
+		'TCP Detection Port',
+		'text',
+		$pconfig['dns_parser_tcp_ports']
+	))->setHelp('Enter comma-separated list (or a Port alias) of ports for the DNS TCP parser. Default is 53.');
+	$section->addInput(new Form_Input(
+		'dns_global_memcap',
+		'Global Memcap',
+		'text',
+		$pconfig['dns_global_memcap']
+	))->setHelp('Sets the global memcap limit for the DNS parser. Default is 16777216 bytes (16MB).');
+	$section->addInput(new Form_Input(
+		'dns_state_memcap',
+		'Flow/State Memcap',
+		'text',
+		$pconfig['dns_state_memcap']
+	))->setHelp('Sets per flow/state memcap limit for the DNS parser. Default is 524288 bytes (512KB).');
+	$section->addInput(new Form_Input(
+		'dns_request_flood_limit',
+		'Request Flood Limit',
+		'text',
+		$pconfig['dns_request_flood_limit']
+	))->setHelp('How many unreplied DNS requests are considered a flood. Default is 500 requests. If this limit is reached, \'app-layer-event:dns.flooded\' will match and alert.');
+	print($section);
+
+	$section = new Form_Section('SMTP App-Layer Parser Settings');
+	$section->addInput(new Form_Select(
+		'smtp_parser',
+		'SMTP Parser',
+		$pconfig['smtp_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for SMTP. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Checkbox(
+		'smtp_parser_decode_mime',
+		'Enable MIME Decoding',
+		'Suricata will decode MIME messages from SMTP transactions.  Note this may be resource intensive! Default is Not Checked.',
+		$pconfig['smtp_parser_decode_mime'] == 'on' ? true:false,
+		'on'
+	));
+	$section->addInput(new Form_Checkbox(
+		'smtp_parser_decode_base64',
+		'Base64 MIME Decoding',
+		'Suricata will decode Base64 MIME entity bodies. Default is Checked.',
+		$pconfig['smtp_parser_decode_base64'] == 'on' ? true:false,
+		'on'
+	));
+	$section->addInput(new Form_Checkbox(
+		'smtp_parser_decode_quoted_printable',
+		'Quoted-Printable MIME Decoding',
+		'Suricata will decode quoted-printable MIME entity bodies. Default is Checked.',
+		$pconfig['smtp_parser_decode_quoted_printable'] == 'on' ? true:false,
+		'on'
+	));
+	$section->addInput(new Form_Checkbox(
+		'smtp_parser_extract_urls',
+		'MIME URL Extraction',
+		'Suricata will Extract URLs and save in state data structure. Default is Checked.',
+		$pconfig['smtp_parser_extract_urls'] == 'on' ? true:false,
+		'on'
+	));
+	$section->addInput(new Form_Checkbox(
+		'smtp_parser_compute_body_md5',
+		'MIME Body MD5 Calculation',
+		'Suricata will compute the md5 of the mail body so it can be journalized. Default is Not Checked.',
+		$pconfig['smtp_parser_compute_body_md5'] == 'on' ? true:false,
+		'on'
+	));
+	print($section);
+
+	$section = new Form_Section('TLS App-Layer Parser Settings');
+	$section->addInput(new Form_Select(
+		'tls_parser',
+		'TLS Parser',
+		$pconfig['tls_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for TLS. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Input(
+		'tls_detect_ports',
+		'Detection Ports',
+		'text',
+		$pconfig['tls_detect_ports']
+	))->setHelp('Enter a comma-separated list of ports (or port alias) to examine for TLS traffic (e.g., 443, 8443). Default is 443.');
+	$section->addInput(new Form_Select(
+		'tls_encrypt_handling',
+		'Encryption Handling',
+		$pconfig['tls_encrypt_handling'],
+		array(  "default" => "Default", "bypass" => "Bypass", "full" => "Full" )
+	))->setHelp('What to do when the encrypted communications start. "Default" keeps tracking the TLS session to check for protocol anomalies and inspect tls_* keywords; "Bypass" stops ' . 
+		    'processing this flow as much as possible; and "Full" keeps tracking and inspection as normal including unmodified content keyword signatures.  For best performance, select "Bypass".');
+	$section->addInput(new Form_Checkbox(
+		'tls_ja3_fingerprint',
+		'JA3 Fingerprint',
+		'Suricata will generate JA3 fingerprint from client hello. Default is Not Checked.',
+		$pconfig['tls_ja3_fingerprint'] == 'on' ? true:false,
+		'on'
+	));
+	print($section);
+
+	$section = new Form_Section('Other App-Layer Parser Settings');
+	$section->addInput(new Form_Select(
+		'dcerpc_parser',
+		'DCERPC Parser',
+		$pconfig['dcerpc_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for DCERPC. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
+		'ftp_parser',
+		'FTP Parser',
+		$pconfig['ftp_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for FTP. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
+		'imap_parser',
+		'IMAP Parser',
+		$pconfig['imap_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for IMAP. Default is detection-only. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
+		'msn_parser',
+		'MSN Parser',
+		$pconfig['msn_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for MSN. Default is detection-only. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
+		'smb_parser',
+		'SMB Parser',
+		$pconfig['smb_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for SMB (note: this inspects SMBv1 traffic only!). Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
+		'ssh_parser',
+		'SSH Parser',
+		$pconfig['ssh_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for SSH. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	print($section);
+
+?>
+
+	<div class="panel panel-default">
+		<div class="panel-heading"><h2 class="panel-title"><?=gettext('HTTP App-Layer Parser Settings');?></h2></div>
+		<div class="panel-body">
+			<div class="form-group">
+				<label class="col-sm-2 control-label">
+					<?=gettext("Memcap"); ?>
+				</label>
+				<div class="col-sm-10">
+					<input name="http_parser_memcap" type="text" class="form-control" id="http_parser_memcap" size="9" value="<?=htmlspecialchars($pconfig['http_parser_memcap'])?>">
+					<span class="help-block">Sets the memcap limit for the HTTP parser. Default is 67108864 bytes (64MB).</span>
+				</div>
+			</div>
+			<div class="form-group">
+				<label class="col-sm-2 control-label">
+					<?=gettext("HTTP Parser"); ?>
+				</label>
+				<div class="col-sm-10">
+					<select name="http_parser" id="http_parser" class="form-control">
+						<?php
+							$opt = array(  "yes", "no", "detection-only" );
+							foreach ($opt as $val) {
+								$selected = "";
+								if ($val == $pconfig['http_parser'])
+									$selected = " selected";
+								echo "<option value='{$val}'{$selected}>" . $val . "</option>\n";
+							}
+						?>
+					</select>
+					<span class="help-block">Choose the parser/detection setting for HTTP. Default is yes. electing "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.</span>
+				</div>
+			</div>
+			<div class="form-group">
+				<label class="col-sm-2 control-label">
+					<?=gettext("Server Configurations"); ?>
+				</label>
+				<div class="col-sm-10">
+					<div class="table-responsive">
+						<table class="table table-striped table-hover table-condensed">
+							<thead>
+								<tr>
+									<th><?=gettext("Name")?></th>
+									<th><?=gettext("Bind-To Address Alias")?></th>
+									<th>
+										<button type="submit" name="import_alias" class="btn btn-sm btn-primary" title="<?=gettext("Import server configuration from existing Aliases")?>" value="Import">
+											<i class="fa fa-upload icon-embed-btn"></i>
+											<?=gettext("Import"); ?>
+										</button>
+										<button type="submit" name="add_libhtp_policy" class="btn btn-sm btn-success" title="<?=gettext("Add a new server configuration")?>" value="Add">
+											<i class="fa fa-plus icon-embed-btn"></i>
+											<?=gettext("Add"); ?>
+										</button>
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+							<?php foreach ($pconfig['libhtp_policy']['item'] as $f => $v): ?>
+								<tr>
+									<td><?=gettext($v['name'])?></td>
+									<td class="text-center"><?=gettext($v['bind_to'])?></td>
+									<td class="text-right">
+										<button type="submit" name="edit_libhtp_policy" value="Edit" class="btn btn-sm btn-primary" onclick="$('#eng_id').val('<?=$f?>')" title="<?=gettext("Edit this server configuration")?>">
+											<i class="fa fa-pencil icon-embed-btn"></i>
+											<?=gettext("Edit"); ?>
+										</button>
+									<?php if ($v['bind_to'] != "all") : ?>
+										<button type="submit" name="del_libhtp_policy" value="Delete" class="btn btn-sm btn-danger" onclick="$('#eng_id').val('<?=$f?>');" title="<?=gettext("Delete this server configuration")?>">
+											<i class="fa fa-trash icon-embed-btn"></i>
+											<?=gettext("Delete"); ?>
+										</button>
+									<?php else : ?>
+										<button type="submit" name="del_libhtp_policy" value="Delete" class="btn btn-sm btn-danger" title="<?=gettext("Delete this server configuration")?>" disabled>
+											<i class="fa fa-trash icon-embed-btn"></i>
+											<?=gettext("Delete"); ?>
+										</button>
+									<?php endif ?>
+									</td>
+								</tr>
+							<?php endforeach; ?>
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="col-sm-10 col-sm-offset-2">
+		<button type="submit" id="save" name="save" value="Save" class="btn btn-primary" title="<?=gettext('Save App Parsers settings');?>">
+			<i class="fa fa-save icon-embed-btn"></i>
+			<?=gettext('Save');?>
+		</button>
+	</div>
+
+</form>
+
+<?php } ?>
+
+<script type="text/javascript">
+//<![CDATA[
+events.push(function(){
+
+	function toggle_smtp_mime_decoding() {
+		if ($('#smtp_parser').val() == 'yes') {
+			hideCheckbox('smtp_parser_decode_mime', false);
+			var hide = ! ($('#smtp_parser_decode_mime').prop('checked'));
+			hideCheckbox('smtp_parser_decode_base64',hide);
+			hideCheckbox('smtp_parser_decode_quoted_printable',hide);
+			hideCheckbox('smtp_parser_extract_urls',hide);
+			hideCheckbox('smtp_parser_compute_body_md5',hide);
+		}
+		else {
+			hideCheckbox('smtp_parser_decode_mime', true);
+			hideCheckbox('smtp_parser_decode_base64',true);
+			hideCheckbox('smtp_parser_decode_quoted_printable',true);
+			hideCheckbox('smtp_parser_extract_urls',true);
+			hideCheckbox('smtp_parser_compute_body_md5',true);
+		}
+	}
+
+	function toggle_tls_parser() {
+		if ($('#tls_parser').val() == 'yes') {
+			hideInput('tls_detect_ports', false);
+			hideSelect('tls_encrypt_handling', false);
+			hideCheckbox('tls_ja3_fingerprint', false);
+		}
+		else {
+			hideInput('tls_detect_ports', true);
+			hideSelect('tls_encrypt_handling', true);
+			hideCheckbox('tls_ja3_fingerprint', true);
+		}
+	}
+
+	// ---------- Click checkbox handlers ---------------------------------------------------------
+	// When form control id is clicked, disable/enable it's associated form controls
+
+	$('#smtp_parser_decode_mime').click(function() {
+		toggle_smtp_mime_decoding();
+	});
+
+	// ---------- Selection control handlers ---------------------------------------------------------
+	// When form control selection changes, disable/enable it's associated form controls
+	$('#smtp_parser').on('change', function() {
+		toggle_smtp_mime_decoding();
+	});
+
+	$('#tls_parser').on('change', function() {
+		toggle_tls_parser();
+	});
+
+	// ---------- On initial page load ------------------------------------------------------------
+	var portsarray = <?= json_encode(get_alias_list(array("port"))) ?>;
+
+	$('#tls_detect_ports').autocomplete({
+		source: portsarray
+	});
+	$('#dns_parser_udp_ports').autocomplete({
+		source: portsarray
+	});
+	$('#dns_parser_tcp_ports').autocomplete({
+		source: portsarray
+	});
+
+	toggle_smtp_mime_decoding();
+	toggle_tls_parser();
+
+});
+//]]>
+</script>
+
+<?php include("foot.inc"); ?>

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1,0 +1,1879 @@
+<?php
+/*
+ * suricata_interfaces_edit.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2003-2004 Manuel Kasper
+ * Copyright (c) 2005 Bill Marquette
+ * Copyright (c) 2009 Robert Zelaya Sr. Developer
+ * Copyright (c) 2019 Bill Meeks
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once("guiconfig.inc");
+require_once("/usr/local/pkg/suricata/suricata.inc");
+
+global $g, $rebuild_rules;
+
+$suricatadir = SURICATADIR;
+$suricatalogdir = SURICATALOGDIR;
+
+init_config_arr(array('installedpackages', 'suricata', 'rule'));
+$suricataglob = $config['installedpackages']['suricata'];
+$a_rule = &$config['installedpackages']['suricata']['rule'];
+
+if (isset($_POST['id']) && is_numericint($_POST['id']))
+	$id = $_POST['id'];
+elseif (isset($_GET['id']) && is_numericint($_GET['id']));
+	$id = htmlspecialchars($_GET['id'], ENT_QUOTES | ENT_HTML401);
+
+if (is_null($id)) {
+		header("Location: /suricata/suricata_interfaces.php");
+		exit;
+}
+
+if (isset($_POST['action']))
+	$action = htmlspecialchars($_POST['action'], ENT_QUOTES | ENT_HTML401);
+elseif (isset($_GET['action']))
+	$action = htmlspecialchars($_GET['action'], ENT_QUOTES | ENT_HTML401);
+else
+	$action = "";
+
+$pconfig = array();
+if (empty($suricataglob['rule'][$id]['uuid'])) {
+	/* Adding new interface, so generate a new UUID and flag rules to build. */
+	$pconfig['uuid'] = suricata_generate_id();
+	$rebuild_rules = true;
+}
+else {
+	$pconfig['uuid'] = $a_rule[$id]['uuid'];
+	$pconfig['descr'] = $a_rule[$id]['descr'];
+	$rebuild_rules = false;
+}
+$suricata_uuid = $pconfig['uuid'];
+
+// Get the physical configured interfaces on the firewall
+$interfaces = get_configured_interface_with_descr();
+
+// See if interface is already configured, and use its values
+if (isset($id) && isset($a_rule[$id])) {
+	/* old options */
+	$pconfig = $a_rule[$id];
+	if (!empty($pconfig['configpassthru']))
+		$pconfig['configpassthru'] = base64_decode($pconfig['configpassthru']);
+	if (empty($pconfig['uuid']))
+		$pconfig['uuid'] = $suricata_uuid;
+}
+
+// Must be a new interface, so try to pick next available physical interface to use
+elseif (isset($id) && !isset($a_rule[$id])) {
+	$ifaces = get_configured_interface_list();
+	$ifrules = array();
+	foreach($a_rule as $r)
+		$ifrules[] = $r['interface'];
+	foreach ($ifaces as $i) {
+		if (!in_array($i, $ifrules)) {
+			$pconfig['interface'] = $i;
+			$pconfig['enable'] = 'on';
+			$pconfig['descr'] = strtoupper($i);
+			$pconfig['inspect_recursion_limit'] = '3000';
+			break;
+		}
+	}
+	if (count($ifrules) == count($ifaces)) {
+		$input_errors[] = gettext("No more available interfaces to configure for Suricata!");
+		$interfaces = array();
+		$pconfig = array();
+	}
+}
+
+// Set defaults for any empty key parameters
+if (empty($pconfig['blockoffendersip']))
+	$pconfig['blockoffendersip'] = "both";
+if (empty($pconfig['blockoffenderskill']))
+	$pconfig['blockoffenderskill'] = "on";
+if (empty($pconfig['ips_mode']))
+	$pconfig['ips_mode'] = 'ips_mode_legacy';
+if (empty($pconfig['block_drops_only']))
+	$pconfig['block_drops_only'] = "off";
+if (empty($pconfig['runmode']))
+	$pconfig['runmode'] = "autofp";
+if (empty($pconfig['max_pending_packets']))
+	$pconfig['max_pending_packets'] = "1024";
+if (empty($pconfig['detect_eng_profile']))
+	$pconfig['detect_eng_profile'] = "medium";
+if (empty($pconfig['mpm_algo']))
+	$pconfig['mpm_algo'] = "auto";
+if (empty($pconfig['sgh_mpm_context']))
+	$pconfig['sgh_mpm_context'] = "auto";
+if (empty($pconfig['enable_http_log']))
+	$pconfig['enable_http_log'] = "on";
+if (empty($pconfig['append_http_log']))
+	$pconfig['append_http_log'] = "on";
+if (empty($pconfig['http_log_extended']))
+	$pconfig['http_log_extended'] = "on";
+if (empty($pconfig['tls_log_extended']))
+	$pconfig['tls_log_extended'] = "on";
+if (empty($pconfig['append_dns_log']))
+	$pconfig['append_dns_log'] = "on";
+if (empty($pconfig['stats_upd_interval']))
+	$pconfig['stats_upd_interval'] = "10";
+if (empty($pconfig['append_json_file_log']))
+	$pconfig['append_json_file_log'] = "on";
+if (empty($pconfig['max_pcap_log_size']))
+	$pconfig['max_pcap_log_size'] = "32";
+if (empty($pconfig['max_pcap_log_files']))
+	$pconfig['max_pcap_log_files'] = "1000";
+if (empty($pconfig['alertsystemlog_facility']))
+	$pconfig['alertsystemlog_facility'] = "local1";
+if (empty($pconfig['alertsystemlog_priority']))
+	$pconfig['alertsystemlog_priority'] = "notice";
+if (empty($pconfig['eve_output_type']))
+	$pconfig['eve_output_type'] = "regular";
+if (empty($pconfig['eve_systemlog_facility']))
+	$pconfig['eve_systemlog_facility'] = "local1";
+if (empty($pconfig['eve_systemlog_priority']))
+	$pconfig['eve_systemlog_priority'] = "notice";
+if (empty($pconfig['eve_log_alerts']))
+	$pconfig['eve_log_alerts'] = "on";
+if (empty($pconfig['eve_log_alerts_payload']))
+	$pconfig['eve_log_alerts_payload'] = "on";
+if (empty($pconfig['eve_log_alerts_packet']))
+	$pconfig['eve_log_alerts_packet'] = "on";
+if (empty($pconfig['eve_log_alerts_http']))
+	$pconfig['eve_log_alerts_http'] = "on";
+if (empty($pconfig['eve_log_alerts_xff']))
+	$pconfig['eve_log_alerts_xff'] = "off";
+if (empty($pconfig['eve_log_alerts_xff_mode']))
+	$pconfig['eve_log_alerts_xff_mode'] = "extra-data";
+if (empty($pconfig['eve_log_alerts_xff_deployment']))
+	$pconfig['eve_log_alerts_xff_deployment'] = "reverse";
+if (empty($pconfig['eve_log_alerts_xff_header']))
+	$pconfig['eve_log_alerts_xff_header'] = "X-Forwarded-For";
+if (empty($pconfig['eve_log_http']))
+	$pconfig['eve_log_http'] = "on";
+if (empty($pconfig['eve_log_dns']))
+	$pconfig['eve_log_dns'] = "on";
+if (empty($pconfig['eve_log_tls']))
+	$pconfig['eve_log_tls'] = "on";
+if (empty($pconfig['eve_log_files']))
+	$pconfig['eve_log_files'] = "on";
+if (empty($pconfig['eve_log_ssh']))
+	$pconfig['eve_log_ssh'] = "on";
+if (empty($pconfig['eve_log_smtp']))
+	$pconfig['eve_log_smtp'] = "on";
+if (empty($pconfig['eve_log_flow']))
+	$pconfig['eve_log_flow'] = "off";
+if (empty($pconfig['eve_log_stats']))
+	$pconfig['eve_log_stats'] = "off";
+if (empty($pconfig['eve_log_stats_totals']))
+	$pconfig['eve_log_stats_totals'] = "on";
+if (empty($pconfig['eve_log_stats_deltas']))
+	$pconfig['eve_log_stats_deltas'] = "off";
+if (empty($pconfig['eve_log_stats_threads']))
+	$pconfig['eve_log_stats_threads'] = "off";
+if (empty($pconfig['eve_log_drop'])) {
+	$pconfig['eve_log_drop'] = "on";
+}
+
+if (empty($pconfig['eve_log_http_extended']))
+	$pconfig['eve_log_http_extended'] = $pconfig['http_log_extended'];
+if (empty($pconfig['eve_log_tls_extended']))
+	$pconfig['eve_log_tls_extended'] = $pconfig['tls_log_extended'];
+if (empty($pconfig['eve_log_smtp_extended']))
+	$pconfig['eve_log_smtp_extended'] = $pconfig['smtp_log_extended'];
+
+if (empty($pconfig['eve_log_http_extended_headers']))
+	$pconfig['eve_log_http_extended_headers'] = "accept, accept-charset, accept-datetime, accept-encoding, accept-language, accept-range, age, allow, authorization, cache-control, connection, content-encoding, content-language, content-length, content-location, content-md5, content-range, content-type, cookie, date, dnt, etags, from, last-modified, link, location, max-forwards, origin, pragma, proxy-authenticate, proxy-authorization, range, referrer, refresh, retry-after, server, set-cookie, te, trailer, transfer-encoding, upgrade, vary, via, warning, www-authenticate, x-authenticated-user, x-flash-version, x-forwarded-proto, x-requested-with";
+
+if (empty($pconfig['eve_log_smtp_extended_fields']))
+	$pconfig['eve_log_smtp_extended_fields'] = "received, x-mailer, x-originating-ip, relays, reply-to, bcc";
+
+if (empty($pconfig['eve_log_files_magic']))
+	$pconfig['eve_log_files_magic'] = "off";
+if (empty($pconfig['eve_log_files_hash']))
+	$pconfig['eve_log_files_hash'] = "none";
+
+if (empty($pconfig['eve_redis_server']))
+	$pconfig['eve_redis_server'] = "127.0.0.1";
+if (empty($pconfig['eve_redis_port']))
+	$pconfig['eve_redis_port'] = "6379";
+if (empty($pconfig['eve_redis_mode']))
+	$pconfig['eve_redis_mode'] = "list";
+if (empty($pconfig['eve_redis_key']))
+	$pconfig['eve_redis_key'] = "suricata";
+
+if (empty($pconfig['intf_promisc_mode']))
+	$pconfig['intf_promisc_mode'] = "on";
+if (empty($pconfig['intf_snaplen']))
+	$pconfig['intf_snaplen'] = "1518";
+
+// See if creating a new interface by duplicating an existing one
+if (strcasecmp($action, 'dup') == 0) {
+
+	// Try to pick the next available physical interface to use
+	$ifaces = get_configured_interface_list();
+	$ifrules = array();
+	foreach($a_rule as $r)
+		$ifrules[] = $r['interface'];
+	foreach ($ifaces as $i) {
+		if (!in_array($i, $ifrules)) {
+			$pconfig['interface'] = $i;
+			$pconfig['enable'] = 'on';
+			$pconfig['descr'] = strtoupper($i);
+			$pconfig['inspect_recursion_limit'] = '3000';
+			break;
+		}
+	}
+
+	if (count($ifrules) == count($ifaces)) {
+		$input_errors[] = gettext("No more available interfaces to configure for Suricata!");
+		$interfaces = array();
+		$pconfig = array();
+	}
+
+	// Set Home Net, External Net, Suppress List and Pass List to defaults
+	unset($pconfig['suppresslistname']);
+	unset($pconfig['passlistname']);
+	unset($pconfig['homelistname']);
+	unset($pconfig['externallistname']);
+}
+
+if ($_REQUEST['ajax'] == 'ajax') {
+	print("At least we got that straight!");
+	exit;
+}
+
+if (isset($_POST["save"]) && !$input_errors) {
+	if (!isset($_POST['interface']))
+		$input_errors[] = gettext("Choosing an Interface is mandatory!");
+
+	/* See if assigned interface is already in use */
+	if (isset($_POST['interface'])) {
+		foreach ($a_rule as $k => $v) {
+			if (($v['interface'] == $_POST['interface']) && ($id != $k)) {
+				$input_errors[] = gettext("The '{$_POST['interface']}' interface is already assigned to another Suricata instance.");
+				break;
+			}
+		}
+	}
+
+	// If Suricata is disabled on this interface, stop any running instance,
+	// save the change and exit.
+	if ($_POST['enable'] != 'on') {
+		$a_rule[$id]['enable'] = $_POST['enable'] ? 'on' : 'off';
+		suricata_stop($a_rule[$id], get_real_interface($a_rule[$id]['interface']));
+		write_config("Suricata pkg: disabled Suricata on " . convert_friendly_interface_to_friendly_descr($a_rule[$id]['interface']));
+		$rebuild_rules = false;
+		conf_mount_rw();
+		sync_suricata_package_config();
+		conf_mount_ro();
+		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
+		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
+		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+		header( 'Cache-Control: post-check=0, pre-check=0', false );
+		header( 'Pragma: no-cache' );
+		header("Location: /suricata/suricata_interfaces.php");
+		exit;
+	}
+
+	// Validate inputs
+	if (isset($_POST['stats_upd_interval']) && !is_numericint($_POST['stats_upd_interval']))
+		$input_errors[] = gettext("The value for Stats Update Interval must contain only digits and evaluate to an integer.");
+
+	if ($_POST['max_pending_packets'] < 1 || $_POST['max_pending_packets'] > 65000)
+		$input_errors[] = gettext("The value for Maximum-Pending-Packets must be between 1 and 65,000!");
+
+	if (isset($_POST['max_pcap_log_size']) && !is_numeric($_POST['max_pcap_log_size']))
+		$input_errors[] = gettext("The value for 'Max Packet Log Size' must be numbers only.  Do not include any alphabetic characters.");
+
+	if (isset($_POST['max_pcap_log_files']) && !is_numeric($_POST['max_pcap_log_files']))
+		$input_errors[] = gettext("The value for 'Max Packet Log Files' must be numbers only.");
+
+	if (!empty($_POST['inspect_recursion_limit']) && !is_numeric($_POST['inspect_recursion_limit']))
+		$input_errors[] = gettext("The value for Inspect Recursion Limit can either be blank or contain only digits evaluating to an integer greater than or equal to 0.");
+
+	if ($_POST['intf_snaplen'] < 1 || !is_numeric($_POST['intf_snaplen']))
+		$input_errors[] = gettext("The value for Interface Snaplen must contain only digits evaluating to an integer value greater than or equal to 1.");
+
+	if (!empty($_POST['eve_redis_server']) && !is_ipaddr($_POST['eve_redis_server']))
+		$input_errors[] = gettext("The value for 'EVE REDIS Server' must be an IP address.");
+
+	if (!empty($_POST['eve_redis_port']) && !is_port($_POST['eve_redis_port']))
+		$input_errors[] = gettext("The value for 'EVE REDIS Server' must have a valid TCP port.");
+
+	if (!empty($_POST['eve_redis_key']) && !preg_match('/^[A-Za-z0-9]+$/',$_POST['eve_redis_key']))
+		$input_errors[] = gettext("The value for 'EVE REDIS Key' must be alphanumeric.");
+
+	// if no errors write to suricata.yaml
+	if (!$input_errors) {
+		$natent = $a_rule[$id];
+		$natent['interface'] = $_POST['interface'];
+		$natent['enable'] = $_POST['enable'] ? 'on' : 'off';
+		$natent['uuid'] = $pconfig['uuid'];
+
+		if ($_POST['descr']) $natent['descr'] =  htmlspecialchars($_POST['descr']); else $natent['descr'] = strtoupper($natent['interface']);
+		if ($_POST['max_pcap_log_size']) $natent['max_pcap_log_size'] = $_POST['max_pcap_log_size']; else unset($natent['max_pcap_log_size']);
+		if ($_POST['max_pcap_log_files']) $natent['max_pcap_log_files'] = $_POST['max_pcap_log_files']; else unset($natent['max_pcap_log_files']);
+		if ($_POST['enable_stats_log'] == "on") { $natent['enable_stats_log'] = 'on'; }else{ $natent['enable_stats_log'] = 'off'; }
+		if ($_POST['append_stats_log'] == "on") { $natent['append_stats_log'] = 'on'; }else{ $natent['append_stats_log'] = 'off'; }
+		if ($_POST['stats_upd_interval'] >= 1) $natent['stats_upd_interval'] = $_POST['stats_upd_interval']; else $natent['stats_upd_interval'] = "10";
+		if ($_POST['enable_http_log'] == "on") { $natent['enable_http_log'] = 'on'; }else{ $natent['enable_http_log'] = 'off'; }
+		if ($_POST['append_http_log'] == "on") { $natent['append_http_log'] = 'on'; }else{ $natent['append_http_log'] = 'off'; }
+		if ($_POST['enable_tls_log'] == "on") { $natent['enable_tls_log'] = 'on'; }else{ $natent['enable_tls_log'] = 'off'; }
+		if ($_POST['enable_tls_store'] == "on") { $natent['enable_tls_store'] = 'on'; }else{ $natent['enable_tls_store'] = 'off'; }
+		if ($_POST['http_log_extended'] == "on") { $natent['http_log_extended'] = 'on'; }else{ $natent['http_log_extended'] = 'off'; }
+		if ($_POST['tls_log_extended'] == "on") { $natent['tls_log_extended'] = 'on'; }else{ $natent['tls_log_extended'] = 'off'; }
+		if ($_POST['enable_pcap_log'] == "on") { $natent['enable_pcap_log'] = 'on'; }else{ $natent['enable_pcap_log'] = 'off'; }
+		if ($_POST['enable_json_file_log'] == "on") { $natent['enable_json_file_log'] = 'on'; }else{ $natent['enable_json_file_log'] = 'off'; }
+		if ($_POST['append_json_file_log'] == "on") { $natent['append_json_file_log'] = 'on'; }else{ $natent['append_json_file_log'] = 'off'; }
+		if ($_POST['enable_tracked_files_magic'] == "on") { $natent['enable_tracked_files_magic'] = 'on'; }else{ $natent['enable_tracked_files_magic'] = 'off'; }
+		if ($_POST['tracked_files_hash']) $natent['tracked_files_hash'] = $_POST['tracked_files_hash'];
+		if ($_POST['enable_file_store'] == "on") { $natent['enable_file_store'] = 'on'; }else{ $natent['enable_file_store'] = 'off'; }
+		if ($_POST['enable_eve_log'] == "on") { $natent['enable_eve_log'] = 'on'; }else{ $natent['enable_eve_log'] = 'off'; }
+		if ($_POST['runmode']) $natent['runmode'] = $_POST['runmode']; else unset($natent['runmode']);
+		if ($_POST['max_pending_packets']) $natent['max_pending_packets'] = $_POST['max_pending_packets']; else unset($natent['max_pending_packets']);
+		if ($_POST['inspect_recursion_limit'] >= '0') $natent['inspect_recursion_limit'] = $_POST['inspect_recursion_limit']; else unset($natent['inspect_recursion_limit']);
+		if ($_POST['intf_snaplen'] > '0') $natent['intf_snaplen'] = $_POST['intf_snaplen']; else $natent['inspect_recursion_limit'] = "1518";
+		if ($_POST['detect_eng_profile']) $natent['detect_eng_profile'] = $_POST['detect_eng_profile']; else unset($natent['detect_eng_profile']);
+		if ($_POST['mpm_algo']) $natent['mpm_algo'] = $_POST['mpm_algo']; else unset($natent['mpm_algo']);
+		if ($_POST['sgh_mpm_context']) $natent['sgh_mpm_context'] = $_POST['sgh_mpm_context']; else unset($natent['sgh_mpm_context']);
+		if ($_POST['blockoffenders'] == "on") $natent['blockoffenders'] = 'on'; else $natent['blockoffenders'] = 'off';
+		if ($_POST['ips_mode']) $natent['ips_mode'] = $_POST['ips_mode']; else unset($natent['ips_mode']);
+		if ($_POST['blockoffenderskill'] == "on") $natent['blockoffenderskill'] = 'on'; else $natent['blockoffenderskill'] = 'off';
+		if ($_POST['block_drops_only'] == "on") $natent['block_drops_only'] = 'on'; else $natent['block_drops_only'] = 'off';
+		if ($_POST['blockoffendersip']) $natent['blockoffendersip'] = $_POST['blockoffendersip']; else unset($natent['blockoffendersip']);
+		if ($_POST['passlistname']) $natent['passlistname'] =  $_POST['passlistname']; else unset($natent['passlistname']);
+		if ($_POST['homelistname']) $natent['homelistname'] =  $_POST['homelistname']; else unset($natent['homelistname']);
+		if ($_POST['externallistname']) $natent['externallistname'] =  $_POST['externallistname']; else unset($natent['externallistname']);
+		if ($_POST['suppresslistname']) $natent['suppresslistname'] =  $_POST['suppresslistname']; else unset($natent['suppresslistname']);
+		if ($_POST['alertsystemlog'] == "on") { $natent['alertsystemlog'] = 'on'; }else{ $natent['alertsystemlog'] = 'off'; }
+		if ($_POST['alertsystemlog_facility']) $natent['alertsystemlog_facility'] = $_POST['alertsystemlog_facility'];
+		if ($_POST['alertsystemlog_priority']) $natent['alertsystemlog_priority'] = $_POST['alertsystemlog_priority'];
+		if ($_POST['enable_dns_log'] == "on") { $natent['enable_dns_log'] = 'on'; }else{ $natent['enable_dns_log'] = 'off'; }
+		if ($_POST['append_dns_log'] == "on") { $natent['append_dns_log'] = 'on'; }else{ $natent['append_dns_log'] = 'off'; }
+		if ($_POST['enable_eve_log'] == "on") { $natent['enable_eve_log'] = 'on'; }else{ $natent['enable_eve_log'] = 'off'; }
+		if ($_POST['eve_output_type']) $natent['eve_output_type'] = $_POST['eve_output_type'];
+		if ($_POST['eve_systemlog_facility']) $natent['eve_systemlog_facility'] = $_POST['eve_systemlog_facility'];
+		if ($_POST['eve_systemlog_priority']) $natent['eve_systemlog_priority'] = $_POST['eve_systemlog_priority'];
+		if ($_POST['eve_log_alerts'] == "on") { $natent['eve_log_alerts'] = 'on'; }else{ $natent['eve_log_alerts'] = 'off'; }
+		if ($_POST['eve_log_alerts_payload']) { $natent['eve_log_alerts_payload'] = $_POST['eve_log_alerts_payload']; }else{ $natent['eve_log_alerts_payload'] = 'off'; }
+		if ($_POST['eve_log_alerts_packet'] == "on") { $natent['eve_log_alerts_packet'] = 'on'; }else{ $natent['eve_log_alerts_packet'] = 'off'; }
+		if ($_POST['eve_log_alerts_http'] == "on") { $natent['eve_log_alerts_http'] = 'on'; }else{ $natent['eve_log_alerts_http'] = 'off'; }
+		if ($_POST['eve_log_alerts_xff'] == "on") { $natent['eve_log_alerts_xff'] = 'on'; }else{ $natent['eve_log_alerts_xff'] = 'off'; }
+		if ($_POST['eve_log_alerts_xff_mode']) { $natent['eve_log_alerts_xff_mode'] = $_POST['eve_log_alerts_xff_mode']; }else{ $natent['eve_log_alert_xff_mode'] = 'extra-data'; }
+		if ($_POST['eve_log_alerts_xff_deployment']) { $natent['eve_log_alerts_xff_deployment'] = $_POST['eve_log_alerts_xff_deployment']; }else{ $natent['eve_log_alert_xff_deployment'] = 'reverse'; }
+		if ($_POST['eve_log_alerts_xff_header']) { $natent['eve_log_alerts_xff_header'] = $_POST['eve_log_alerts_xff_header']; }else{ $natent['eve_log_alert_xff_mode'] = 'X-Forwarded-For'; }
+		if ($_POST['eve_log_http'] == "on") { $natent['eve_log_http'] = 'on'; }else{ $natent['eve_log_http'] = 'off'; }
+		if ($_POST['eve_log_dns'] == "on") { $natent['eve_log_dns'] = 'on'; }else{ $natent['eve_log_dns'] = 'off'; }
+		if ($_POST['eve_log_tls'] == "on") { $natent['eve_log_tls'] = 'on'; }else{ $natent['eve_log_tls'] = 'off'; }
+		if ($_POST['eve_log_files'] == "on") { $natent['eve_log_files'] = 'on'; }else{ $natent['eve_log_files'] = 'off'; }
+		if ($_POST['eve_log_ssh'] == "on") { $natent['eve_log_ssh'] = 'on'; }else{ $natent['eve_log_ssh'] = 'off'; }
+		if ($_POST['eve_log_smtp'] == "on") { $natent['eve_log_smtp'] = 'on'; }else{ $natent['eve_log_smtp'] = 'off'; }
+		if ($_POST['eve_log_stats'] == "on") { $natent['eve_log_stats'] = 'on'; }else{ $natent['eve_log_stats'] = 'off'; }
+		if ($_POST['eve_log_flow'] == "on") { $natent['eve_log_flow'] = 'on'; }else{ $natent['eve_log_flow'] = 'off'; }
+		if ($_POST['eve_log_stats_totals'] == "on") { $natent['eve_log_stats_totals'] = 'on'; }else{ $natent['eve_log_stats_totals'] = 'off'; }
+		if ($_POST['eve_log_stats_deltas'] == "on") { $natent['eve_log_stats_deltas'] = 'on'; }else{ $natent['eve_log_stats_deltas'] = 'off'; }
+		if ($_POST['eve_log_stats_threads'] == "on") { $natent['eve_log_stats_threads'] = 'on'; }else{ $natent['eve_log_stats_threads'] = 'off'; }
+		if ($_POST['eve_log_http_extended'] == "on") { $natent['eve_log_http_extended'] = 'on'; }else{ $natent['eve_log_http_extended'] = 'off'; }
+		if ($_POST['eve_log_tls_extended'] == "on") { $natent['eve_log_tls_extended'] = 'on'; }else{ $natent['eve_log_tls_extended'] = 'off'; }
+		if ($_POST['eve_log_smtp_extended'] == "on") { $natent['eve_log_smtp_extended'] = 'on'; }else{ $natent['eve_log_smtp_extended'] = 'off'; }
+		if ($_POST['eve_log_http_extended_headers']) { $natent['eve_log_http_extended_headers'] = implode(", ",$_POST['eve_log_http_extended_headers']); }else{ $natent['eve_log_http_extended_headers'] = ""; }
+		if ($_POST['eve_log_smtp_extended_fields']) { $natent['eve_log_smtp_extended_fields'] = implode(", ",$_POST['eve_log_smtp_extended_fields']); }else{ $natent['eve_log_smtp_extended_fields'] = ""; }
+
+		if ($_POST['eve_log_files_magic'] == "on") { $natent['eve_log_files_magic'] = 'on'; }else{ $natent['eve_log_files_magic'] = 'off'; }
+		if ($_POST['eve_log_files_hash']) { $natent['eve_log_files_hash'] = $_POST['eve_log_files_hash']; }else{ $natent['eve_log_files_hash'] = 'none'; }
+		if ($_POST['eve_log_drop'] == "on") { $natent['eve_log_drop'] = 'on'; }else{ $natent['eve_log_drop'] = 'off'; }
+		if ($_POST['delayed_detect'] == "on") { $natent['delayed_detect'] = 'on'; }else{ $natent['delayed_detect'] = 'off'; }
+		if ($_POST['intf_promisc_mode'] == "on") { $natent['intf_promisc_mode'] = 'on'; }else{ $natent['intf_promisc_mode'] = 'off'; }
+		if ($_POST['configpassthru']) $natent['configpassthru'] = base64_encode(str_replace("\r\n", "\n", $_POST['configpassthru'])); else unset($natent['configpassthru']);
+
+		if ($_POST['eve_redis_server']) $natent['eve_redis_server'] = $_POST['eve_redis_server'];
+		if ($_POST['eve_redis_port']) $natent['eve_redis_port'] = $_POST['eve_redis_port'];
+		if ($_POST['eve_redis_mode']) $natent['eve_redis_mode'] = $_POST['eve_redis_mode'];
+		if ($_POST['eve_redis_key']) $natent['eve_redis_key'] = $_POST['eve_redis_key'];
+
+		// Check if EVE OUTPUT TYPE is 'syslog' and auto-enable Suricata syslog output if true.
+		if ($natent['eve_output_type'] == "syslog" && $natent['alertsystemlog'] == "off") {
+			$natent['alertsystemlog'] = "on";
+			$savemsg1 = gettext("EVE Output to syslog requires Suricata alerts to be copied to the system log, so 'Send Alerts to System Log' has been auto-enabled.");
+		}
+
+		// Check if Inline IPS mode is enabled and display a message about potential
+		// incompatibilities with Netmap and some NIC hardware drivers.
+		if ($natent['ips_mode'] == "ips_mode_inline") {
+			$savemsg2 = gettext("Inline IPS Mode is selected.  Not all hardware NIC drivers support Netmap operation which is required for Inline IPS Mode.  If problems are experienced, switch to Legacy Mode instead.");
+		}
+
+		$if_real = get_real_interface($natent['interface']);
+		if (isset($id) && $a_rule[$id] && $action == '') {
+			// See if moving an existing Suricata instance to another physical interface
+			if ($natent['interface'] != $a_rule[$id]['interface']) {
+				$oif_real = get_real_interface($a_rule[$id]['interface']);
+				if (suricata_is_running($a_rule[$id]['uuid'], $oif_real)) {
+					suricata_stop($a_rule[$id], $oif_real);
+					$suricata_start = true;
+				}
+				else
+					$suricata_start = false;
+				@rename("{$suricatalogdir}suricata_{$oif_real}{$a_rule[$id]['uuid']}", "{$suricatalogdir}suricata_{$if_real}{$a_rule[$id]['uuid']}");
+				conf_mount_rw();
+				@rename("{$suricatadir}suricata_{$a_rule[$id]['uuid']}_{$oif_real}", "{$suricatadir}suricata_{$a_rule[$id]['uuid']}_{$if_real}");
+				conf_mount_ro();
+			}
+			$a_rule[$id] = $natent;
+		}
+		elseif (strcasecmp($action, 'dup') == 0) {
+			// Duplicating an existing interface to a new interface, so set flag to build new rules
+			$rebuild_rules = true;
+
+			// Duplicating an interface, so need to generate a new UUID for the cloned interface
+			$natent['uuid'] = suricata_generate_id();
+
+			// Add the new duplicated interface configuration to the [rule] array in config
+			$a_rule[] = $natent;
+		}
+		else {
+			// Adding new interface, so set interface configuration parameter defaults
+			$natent['ip_max_frags'] = "65535";
+			$natent['ip_frag_timeout'] = "60";
+			$natent['frag_memcap'] = '33554432';
+			$natent['ip_max_trackers'] = '65535';
+			$natent['frag_hash_size'] = '65536';
+
+			$natent['flow_memcap'] = '33554432';
+			$natent['flow_prealloc'] = '10000';
+			$natent['flow_hash_size'] = '65536';
+			$natent['flow_emerg_recovery'] = '30';
+			$natent['flow_prune'] = '5';
+
+			$natent['flow_tcp_new_timeout'] = '60';
+			$natent['flow_tcp_established_timeout'] = '3600';
+			$natent['flow_tcp_closed_timeout'] = '120';
+			$natent['flow_tcp_emerg_new_timeout'] = '10';
+			$natent['flow_tcp_emerg_established_timeout'] = '300';
+			$natent['flow_tcp_emerg_closed_timeout'] = '20';
+
+			$natent['flow_udp_new_timeout'] = '30';
+			$natent['flow_udp_established_timeout'] = '300';
+			$natent['flow_udp_emerg_new_timeout'] = '10';
+			$natent['flow_udp_emerg_established_timeout'] = '100';
+
+			$natent['flow_icmp_new_timeout'] = '30';
+			$natent['flow_icmp_established_timeout'] = '300';
+			$natent['flow_icmp_emerg_new_timeout'] = '10';
+			$natent['flow_icmp_emerg_established_timeout'] = '100';
+
+			$natent['stream_memcap'] = '67108864';
+			$natent['stream_prealloc_sessions'] = '32768';
+			$natent['reassembly_memcap'] = '67108864';
+			$natent['reassembly_depth'] = '1048576';
+			$natent['reassembly_to_server_chunk'] = '2560';
+			$natent['reassembly_to_client_chunk'] = '2560';
+			$natent['max_synack_queued'] = '5';
+			$natent['enable_midstream_sessions'] = 'off';
+			$natent['enable_async_sessions'] = 'off';
+			$natent['delayed_detect'] = 'off';
+			$natent['intf_promisc_mode'] = 'on';
+			$natent['intf_snaplen'] = '1518';
+
+			$natent['asn1_max_frames'] = '256';
+			$natent['dns_global_memcap'] = "16777216";
+			$natent['dns_state_memcap'] = "524288";
+			$natent['dns_request_flood_limit'] = "500";
+			$natent['http_parser_memcap'] = "67108864";
+			$natent['dns_parser_udp'] = "yes";
+			$natent['dns_parser_tcp'] = "yes";
+			$natent['dns_parser_udp_ports'] = "53";
+			$natent['dns_parser_tcp_ports'] = "53";
+			$natent['http_parser'] = "yes";
+			$natent['tls_parser'] = "yes";
+			$natent['tls_detect_ports'] = "443";
+			$natent['tls_encrypt_handling'] = "default";
+			$natent['tls_ja3_fingerprint'] = "off";
+			$natent['smtp_parser'] = "yes";
+			$natent['smtp_parser_decode_mime'] = "off";
+			$natent['smtp_parser_decode_base64'] = "on";
+			$natent['smtp_parser_decode_quoted_printable'] = "on";
+			$natent['smtp_parser_extract_urls'] = "on";
+			$natent['smtp_parser_compute_body_md5'] = "off";
+			$natent['imap_parser'] = "detection-only";
+			$natent['ssh_parser'] = "yes";
+			$natent['ftp_parser'] = "yes";
+			$natent['dcerpc_parser'] = "yes";
+			$natent['smb_parser'] = "yes";
+			$natent['msn_parser'] = "detection-only";
+
+			$natent['enable_iprep'] = "off";
+			$natent['host_memcap'] = "33554432";
+			$natent['host_hash_size'] = "4096";
+			$natent['host_prealloc'] = "1000";
+
+			$default = array( "name" => "default", "bind_to" => "all", "policy" => "bsd" );
+			if (!is_array($natent['host_os_policy']))
+				$natent['host_os_policy'] = array();
+			if (!is_array($natent['host_os_policy']['item']))
+				$natent['host_os_policy']['item'] = array();
+			$natent['host_os_policy']['item'][] = $default;
+
+			$default = array( "name" => "default", "bind_to" => "all", "personality" => "IDS",
+					  "request-body-limit" => 4096, "response-body-limit" => 4096,
+					  "double-decode-path" => "no", "double-decode-query" => "no",
+					  "uri-include-all" => "no" );
+			if (!is_array($natent['libhtp_policy']))
+				$natent['libhtp_policy'] = array();
+			if (!is_array($natent['libhtp_policy']['item']))
+				$natent['libhtp_policy']['item'] = array();
+			$natent['libhtp_policy']['item'][] = $default;
+
+			// Enable the basic default rules for the interface
+			$natent['rulesets'] = "app-layer-events.rules||decoder-events.rules||dnp3-events.rules||dns-events.rules||files.rules||http-events.rules||ipsec-events.rules||kerberos-events.rules||" . 
+					      "modbus-events.rules||nfs-events.rules||ntp-events.rules||smb-events.rules||smtp-events.rules||stream-events.rules||tls-events.rules";
+
+			// Adding a new interface, so set flag to build new rules
+			$rebuild_rules = true;
+
+			// Add the new interface configuration to the [rule] array in config
+			$a_rule[] = $natent;
+		}
+
+		// If Suricata is disabled on this interface, stop any running instance
+		if ($natent['enable'] != 'on')
+			suricata_stop($natent, $if_real);
+
+		// Save configuration changes
+		write_config("Suricata pkg: modified interface configuration for " . convert_friendly_interface_to_friendly_descr($natent['interface']));
+
+		// Update suricata.conf and suricata.sh files for this interface
+		conf_mount_rw();
+		sync_suricata_package_config();
+		conf_mount_ro();
+
+		// Refresh page fields with just-saved values
+		$pconfig = $natent;
+	} else
+		$pconfig = $_POST;
+}
+
+function suricata_get_config_lists($lists) {
+	global $suricataglob;
+
+	$list = array();
+
+	if (is_array($suricataglob[$lists]['item'])) {
+		$slist_select = $suricataglob[$lists]['item'];
+		foreach ($slist_select as $value) {
+			$ilistname = $value['name'];
+			$list[$ilistname] = htmlspecialchars($ilistname);
+		}
+	}
+
+	return(['default' => 'default'] + $list);
+}
+
+$if_friendly = convert_friendly_interface_to_friendly_descr($pconfig['interface']);
+
+$pgtitle = array(gettext("Services"), gettext("Suricata"), gettext("Edit Interface Settings - {$if_friendly}"));
+include_once("head.inc");
+
+/* Display Alert message */
+if ($input_errors) {
+	print_input_errors($input_errors);
+}
+if ($savemsg1) {
+	print_info_box($savemsg1);
+}
+if ($savemsg2) {
+	print_info_box($savemsg2);
+}
+
+if ($pconfig['enable'] == 'on' && $pconfig['ips_mode'] == 'ips_mode_inline' && (!isset($config['system']['disablechecksumoffloading']) || !isset($config['system']['disablesegmentationoffloading']) || !isset($config['system']['disablelargereceiveoffloading']))) {
+	print_info_box(gettext('IPS inline mode requires that Hardware Checksum, Hardware TCP Segmentation and Hardware Large Receive Offloading ' .
+				'all be disabled on the ') . '<b>' . gettext('System > Advanced > Networking ') . '</b>' . gettext('tab.'));
+}
+
+$tab_array = array();
+$tab_array[] = array(gettext("Interfaces"), true, "/suricata/suricata_interfaces.php");
+$tab_array[] = array(gettext("Global Settings"), false, "/suricata/suricata_global.php");
+$tab_array[] = array(gettext("Updates"), false, "/suricata/suricata_download_updates.php");
+$tab_array[] = array(gettext("Alerts"), false, "/suricata/suricata_alerts.php?instance={$id}");
+$tab_array[] = array(gettext("Blocks"), false, "/suricata/suricata_blocked.php");
+$tab_array[] = array(gettext("Pass Lists"), false, "/suricata/suricata_passlist.php");
+$tab_array[] = array(gettext("Suppress"), false, "/suricata/suricata_suppress.php");
+$tab_array[] = array(gettext("Logs View"), false, "/suricata/suricata_logs_browser.php?instance={$id}");
+$tab_array[] = array(gettext("Logs Mgmt"), false, "/suricata/suricata_logs_mgmt.php");
+$tab_array[] = array(gettext("SID Mgmt"), false, "/suricata/suricata_sid_mgmt.php");
+$tab_array[] = array(gettext("Sync"), false, "/pkg_edit.php?xml=suricata/suricata_sync.xml");
+$tab_array[] = array(gettext("IP Lists"), false, "/suricata/suricata_ip_list_mgmt.php");
+display_top_tabs($tab_array, true);
+
+$tab_array = array();
+$menu_iface=($if_friendly?substr($if_friendly,0,5)." ":"Iface ");
+$tab_array[] = array($menu_iface . gettext("Settings"), true, "/suricata/suricata_interfaces_edit.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("Categories"), false, "/suricata/suricata_rulesets.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("Rules"), false, "/suricata/suricata_rules.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("Flow/Stream"), false, "/suricata/suricata_flow_stream.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("App Parsers"), false, "/suricata/suricata_app_parsers.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("Variables"), false, "/suricata/suricata_define_vars.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("Barnyard2"), false, "/suricata/suricata_barnyard.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("IP Rep"), false, "/suricata/suricata_ip_reputation.php?id={$id}");
+display_top_tabs($tab_array, true);
+
+$form = new Form;
+
+$section = new Form_Section('General Settings');
+$section->addInput(new Form_Checkbox(
+	'enable',
+	'Enable',
+	'Checking this box enables Suricata inspection on the interface.',
+	$pconfig['enable'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Select(
+	'interface',
+	'Interface',
+	$pconfig['interface'],
+	$interfaces
+))->setHelp('Choose which interface this Suricata instance applies to. In most cases, you will want to use WAN here if this is the first Suricata-configured interface.');
+
+$section->addInput(new Form_Input(
+	'descr',
+	'Description',
+	'text',
+	$pconfig['descr']
+))->setHelp('Enter a meaningful description here for your reference. The default is the interface name.');
+
+$form->add($section);
+
+$section = new Form_Section('Logging Settings');
+
+$section->addInput(new Form_Checkbox(
+	'alertsystemlog',
+	'Send Alerts to System Log',
+	'Suricata will send Alerts from this interface to the firewall\'s system log.',
+	$pconfig['alertsystemlog'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Select(
+	'alertsystemlog_facility',
+	'Log Facility',
+	$pconfig['alertsystemlog_facility'],
+	array(  "auth" => "AUTH", "authpriv" => "AUTHPRIV", "daemon" => "DAEMON", "kern" => "KERN", "security" => "SECURITY", 
+		"syslog" => "SYSLOG", "user" => "USER", "local0" => "LOCAL0", "local1" => "LOCAL1", "local2" => "LOCAL2", 
+		"local3" => "LOCAL3", "local4" => "LOCAL4", "local5" => "LOCAL5", "local6" => "LOCAL6", "local7" => "LOCAL7" )
+))->setHelp('Select system log Facility to use for reporting. Default is LOCAL1.');
+
+$section->addInput(new Form_Select(
+	'alertsystemlog_priority',
+	'Log Priority',
+	$pconfig['alertsystemlog_priority'],
+	array( "emerg" => "EMERG", "crit" => "CRIT", "alert" => "ALERT", "err" => "ERR", "warning" => "WARNING", "notice" => "NOTICE", "info" => "INFO" )
+))->setHelp('Select system log Priority (Level) to use for reporting. Default is NOTICE.');
+
+$section->addInput(new Form_Checkbox(
+	'enable_dns_log',
+	'Enable DNS Log',
+	'Suricata will log DNS requests and replies for the interface. Default is Not Checked.',
+	$pconfig['enable_dns_log'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Checkbox(
+	'append_dns_log',
+	'Append DNS Log',
+	'Suricata will append-to instead of clearing DNS log file when restarting. Default is Checked.',
+	$pconfig['append_dns_log'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Checkbox(
+	'enable_stats_log',
+	'Enable Stats Log',
+	'Suricata will periodically log statistics for the interface. Default is Not Checked.',
+	$pconfig['enable_stats_log'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Input(
+	'stats_upd_interval',
+	'Stats Update Interval',
+	'text',
+	$pconfig['stats_upd_interval']
+))->setHelp('Enter the update interval in seconds for collection and logging of statistics. Default is 10.');
+
+$section->addInput(new Form_Checkbox(
+	'append_stats_log',
+	'Append Stats Log',
+	'Suricata will append-to instead of clearing statistics log file when restarting. Default is Not Checked.',
+	$pconfig['append_stats_log'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Checkbox(
+	'enable_http_log',
+	'Enable HTTP Log',
+	'Suricata will log decoded HTTP traffic for the interface. Default is Checked.',
+	$pconfig['enable_http_log'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Checkbox(
+	'append_http_log',
+	'Append HTTP Log',
+	'Suricata will append-to instead of clearing HTTP log file when restarting. Default is Checked.',
+	$pconfig['append_http_log'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Checkbox(
+	'http_log_extended',
+	'Log Extended HTTP Info',
+	'Suricata will log extended HTTP information. Default is Checked.',
+	$pconfig['http_log_extended'] == 'on' ? true:false,
+	'on'
+));
+$section->addInput(new Form_Checkbox(
+	'enable_tls_log',
+	'Enable TLS Log',
+	'Suricata will log TLS handshake traffic for the interface. Default is Not Checked.',
+	$pconfig['enable_tls_log'] == 'on' ? true:false,
+	'on'
+));
+$section->addInput(new Form_Checkbox(
+	'enable_tls_store',
+	'Enable TLS Store',
+	'Suricata will log and store TLS certificates for the interface. Default is Not Checked.',
+	$pconfig['enable_tls_store'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Checkbox(
+	'tls_log_extended',
+	'Log Extended TLS Info',
+	'Suricata will log extended TLS info such as fingerprint. Default is Checked.',
+	$pconfig['tls_log_extended'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Checkbox(
+	'enable_json_file_log',
+	'Enable Tracked-Files Log',
+	'Suricata will log tracked files in JavaScript Object Notation (JSON) format. Default is Not Checked.',
+	$pconfig['enable_json_file_log'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Checkbox(
+	'append_json_file_log',
+	'Append Tracked-Files Log',
+	'Suricata will append-to instead of clearing Tracked Files log file when restarting. Default is Checked.',
+	$pconfig['append_json_file_log'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Checkbox(
+	'enable_tracked_files_magic',
+	'Enable Logging Magic for Tracked-Files',
+	'Suricata will force logging magic on all logged Tracked Files. Default is Not Checked.',
+	$pconfig['enable_tracked_files_magic'] == 'on' ? true:false,
+	'on'
+));
+$section->addInput(new Form_Select(
+	'tracked_files_hash',
+	'Tracked-Files Checksum',
+	$pconfig['tracked_files_hash'],
+	array("none" => "None", "md5" => "MD5", "sha1" => "SHA1", "sha256" => "SHA256")
+))->setHelp('Suricata will generate checksums for all logged Tracked Files using the chosen algorithm. Default is None.');
+$section->addInput(new Form_Checkbox(
+	'enable_file_store',
+	'Enable File-Store',
+	'Suricata will extract and store files from application layer streams. Default is Not Checked. Warning: This will consume a significant amount of disk space on a busy network when enabled.',
+	$pconfig['enable_file_store'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Checkbox(
+	'enable_pcap_log',
+	'Enable Packet Log',
+	'Suricata will log decoded packets for the interface in pcap-format. Default is Not Checked. This can consume a significant amount of disk space when enabled.',
+	$pconfig['enable_pcap_log'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Input(
+	'max_pcap_log_size',
+	'Max Packet Log File Size',
+	'text',
+	$pconfig['max_pcap_log_size']
+))->setHelp('Enter maximum size in MB for a packet log file. Default is 32. When the packet log file size reaches the set limit, it will be rotated and a new one created.');
+
+$section->addInput(new Form_Input(
+	'max_pcap_log_files',
+	'Max Packet Log Files',
+	'text',
+	$pconfig['max_pcap_log_files']
+))->setHelp('Enter maximum number of packet log files to maintain. Default is 1000. When the number of packet log files reaches the set limit, the oldest file will be overwritten.');
+
+$form->add($section);
+
+$section = new Form_Section('EVE Output Settings');
+
+$section->addInput(new Form_Checkbox(
+	'enable_eve_log',
+	'EVE JSON Log',
+	'Suricata will output selected info in JSON format to a single file or to syslog. Default is Not Checked.',
+	$pconfig['enable_eve_log'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Select(
+	'eve_output_type',
+	'EVE Output Type',
+	$pconfig['eve_output_type'],
+	array("regular" => "FILE", "syslog" => "SYSLOG", "redis"=>"REDIS")
+))->setHelp('Select EVE log output destination. Choosing FILE is suggested, and is the default value.');
+
+$section->addInput(new Form_Select(
+	'eve_systemlog_facility',
+	'EVE Syslog Output Facility',
+	$pconfig['eve_systemlog_facility'],
+	array(  "auth" => "AUTH", "authpriv" => "AUTHPRIV", "daemon" => "DAEMON", "kern" => "KERN", "security" => "SECURITY", 
+		"syslog" => "SYSLOG", "user" => "USER", "local0" => "LOCAL0", "local1" => "LOCAL1", "local2" => "LOCAL2", 
+		"local3" => "LOCAL3", "local4" => "LOCAL4", "local5" => "LOCAL5", "local6" => "LOCAL6", "local7" => "LOCAL7" )
+))->setHelp('Select EVE syslog output facility.');
+
+$section->addInput(new Form_Select(
+	'eve_systemlog_priority',
+	'EVE Syslog Output Priority',
+	$pconfig['eve_systemlog_priority'],
+	array( "emerg" => "EMERG", "crit" => "CRIT", "alert" => "ALERT", "err" => "ERR", "warning" => "WARNING", "notice" => "NOTICE", "info" => "INFO" )
+))->setHelp('Select EVE syslog output priority.');
+
+$group = new Form_Group('EVE REDIS Server');
+
+$group->add(new Form_Input(
+	'eve_redis_server',
+	'Redis Server',
+	'text',
+	$pconfig['eve_redis_server']
+))->setHelp('Enter the Redis server IP');
+
+$group->add(new Form_Input(
+	'eve_redis_port',
+	'Port',
+	'text',
+	$pconfig['eve_redis_port']
+))->setHelp('Enter the Redis server port');
+
+$section->add($group)->addClass('eve_redis_connection');
+
+$section->addInput(new Form_Select(
+	'eve_redis_mode',
+	'EVE REDIS Mode',
+	$pconfig['eve_redis_mode'],
+	array("list"=>"List (LPUSH)","rpush"=>"List (RPUSH)","channel"=>"Channel(PUBLISH)")
+))->setHelp('Select the REDIS output mode');
+
+$section->addInput(new Form_Input(
+	'eve_redis_key',
+	'EVE REDIS Key',
+	'text',
+	$pconfig['eve_redis_key']
+))->setHelp('Enter the REDIS Key');
+
+$section->addInput(new Form_Checkbox(
+	'eve_log_alerts_xff',
+	'EVE HTTP XFF Support',
+	'Log X-Forwarded-For IP addresses.  Default is Not Checked.',
+	$pconfig['eve_log_alerts_xff'] == 'on' ? true:false,
+	'on'
+));
+$section->addInput(new Form_Select(
+	'eve_log_alerts_xff_mode',
+	'EVE X-Forwarded-For Operational Mode',
+	$pconfig['eve_log_alerts_xff_mode'],
+	array( "extra-data" => "extra-data", "overwrite" => "overwrite" )
+))->setHelp('Select HTTP X-Forwarded-For Operation Mode. Extra-Data adds an extra field while Overwrite overwrites the existing source or destination IP. Default is extra-data.');
+
+$section->addInput(new Form_Select(
+	'eve_log_alerts_xff_deployment',
+	'EVE X-Forwarded-For Deployment',
+	$pconfig['eve_log_alerts_xff_deployment'],
+	array( "reverse" => "reverse", "forward" => "forward" )
+))->setHelp('Select HTTP X-Forwarded-For Deployment.  Reverse deployment uses the last IP address while Forward uses the first one. Default is reverse.');
+
+$section->addInput(new Form_Input(
+	'eve_log_alerts_xff_header',
+	'EVE Log Alert X-Forwarded-For Header',
+	'text',
+	$pconfig['eve_log_alerts_xff_header']
+))->setHelp('Enter header where actual IP address is reported. Default is X-Forwarded-For. If more than one IP address is present, the last one will be used.');
+
+$section->addInput(new Form_Checkbox(
+	'eve_log_alerts',
+	'EVE Log Alerts',
+	'Suricata will output Alerts via EVE',
+	$pconfig['eve_log_alerts'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Select(
+	'eve_log_alerts_payload',
+	'EVE Log Alert Payload Data Formats',
+	$pconfig['eve_log_alerts_payload'],
+	array("off"=>"NO","only-base64"=>"BASE64","only-printable"=>"PRINTABLE","on"=>"BOTH")
+))->setHelp('Log the payload data with alerts.  Options are No (disable payload logging), Only Printable (lossy) format, Only Base64 encoded or Both. See Suricata documentation.');
+
+$group = new Form_Group('EVE Log Alert details');
+
+$group->add(new Form_Checkbox(
+	'eve_log_alerts_packet',
+	'Alert Payloads',
+	'Log a packet dump with alerts.',
+	$pconfig['eve_log_alerts_packet'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_alerts_http',
+	'Alert Payloads',
+	'Log additional HTTP data.',
+	$pconfig['eve_log_alerts_http'] == 'on' ? true:false,
+	'on'
+));
+
+$group->setHelp('Select which details Suricata will use to enrich alerts.');
+
+$section->add($group)->addClass('eve_log_alerts_details');
+
+$group = new Form_Group('EVE Logged Traffic');
+
+$group->add(new Form_Checkbox(
+	'eve_log_http',
+	'HTTP Traffic',
+	'HTTP Traffic',
+	$pconfig['eve_log_http'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_dns',
+	'DNS Traffic',
+	'DNS Traffic',
+	$pconfig['eve_log_dns'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_smtp',
+	'SMTP Traffic',
+	'SMTP Traffic',
+	$pconfig['eve_log_smtp'] == 'on' ? true:false,
+	'on'
+));
+
+$group->setHelp('Choose the traffic types to log via EVE JSON output.');
+$section->add($group)->addClass('eve_log_info');
+
+$group = new Form_Group('EVE Logged Info');
+$group->add(new Form_Checkbox(
+	'eve_log_tls',
+	'TLS Handshakes',
+	'TLS Handshakes',
+	$pconfig['eve_log_tls'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_ssh',
+	'SSH Handshakes',
+	'SSH Handshakes',
+	$pconfig['eve_log_ssh'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_files',
+	'Tracked Files',
+	'Tracked Files',
+	$pconfig['eve_log_files'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_stats',
+	'Suricata Stats',
+	'Suricata Stats',
+	$pconfig['eve_log_stats'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_flow',
+	'Traffic Flows',
+	'Traffic Flows',
+	$pconfig['eve_log_flow'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_drop',
+	'Dropped Traffic',
+	'Dropped Traffic',
+	$pconfig['eve_log_drop'] == 'on' ? true:false,
+	'on'
+));
+
+$group->setHelp('Choose the information to log via EVE JSON output.');
+$section->add($group)->addClass('eve_log_info');
+
+$group = new Form_Group('EVE Logged Extended');
+
+$group->add(new Form_Checkbox(
+	'eve_log_http_extended',
+	'Extended HTTP Info',
+	'Extended HTTP Info',
+	$pconfig['eve_log_http_extended'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_tls_extended',
+	'Extended TLS Info',
+	'Extended TLS Info',
+	$pconfig['eve_log_tls_extended'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_smtp_extended',
+	'Extended SMTP Info',
+	'Extended SMTP Info',
+	$pconfig['eve_log_tls_extended'] == 'on' ? true:false,
+	'on'
+));
+
+$group->setHelp('Select which EVE logs are supplemented with extended information.');
+$section->add($group)->addClass('eve_log_info');
+
+$section->addInput(new Form_Select(
+	'eve_log_http_extended_headers',
+	'Extended HTTP Headers',
+	explode(", ",$pconfig['eve_log_http_extended_headers']),
+	array("accept"=>"accept","accept-charset"=>"accept-charset","accept-datetime"=>"accept-datetime","accept-encoding"=>"accept-encoding","accept-language"=>"accept-language","accept-range"=>"accept-range","age"=>"age","allow"=>"allow","authorization"=>"authorization","cache-control"=>"cache-control","connection"=>"connection","content-encoding"=>"content-encoding","content-language"=>"content-language","content-length"=>"content-length","content-location"=>"content-location","content-md5"=>"content-md5","content-range"=>"content-range","content-type"=>"content-type","cookie"=>"cookie","date"=>"date","dnt"=>"dnt","etags"=>"etags","from"=>"from","last-modified"=>"last-modified","link"=>"link","location"=>"location","max-forwards"=>"max-forwards","origin"=>"origin","pragma"=>"pragma","proxy-authenticate"=>"proxy-authenticate","proxy-authorization"=>"proxy-authorization","range"=>"range","referrer"=>"referrer","refresh"=>"refresh","retry-after"=>"retry-after","server"=>"server","set-cookie"=>"set-cookie","te"=>"te","trailer"=>"trailer","transfer-encoding"=>"transfer-encoding","upgrade"=>"upgrade","vary"=>"vary","via"=>"via","warning"=>"warning","www-authenticate"=>"www-authenticate","x-authenticated-user"=>"x-authenticated-user","x-flash-version"=>"x-flash-version","x-forwarded-proto"=>"x-forwarded-proto","x-requested-with"=>"x-requested-with"),
+	true
+))->setHelp('Select HTTP headers for logging.  Use CTRL + click for multiple selections.');
+
+
+$section->addInput(new Form_Select(
+	'eve_log_smtp_extended_fields',
+	'Extended SMTP Fields',
+	explode(", ",$pconfig['eve_log_smtp_extended_fields']),
+	array("bcc"=>"bcc","content-md5"=>"content-md5","date"=>"date","importance"=>"importance","in-reply-to"=>"in-reply-to","message-id"=>"message-id","organization"=>"organization","priority"=>"priority","received"=>"received","references"=>"references","reply-to"=>"reply-to","sensitivity"=>"sensitivity","subject"=>"subject","user-agent"=>"user-agent","x-mailer"=>"x-mailer","x-originating-ip"=>"x-originating-ip"),
+	true
+))->setHelp('Select SMTP fields for logging.  Use CTRL + click for multiple selections.');
+
+$section->addInput(new Form_Checkbox(
+	'eve_log_files_magic',
+	'Enable Logging Magic for Tracked-Files',
+	'Suricata will force logging magic on all logged Tracked Files. Default is Not Checked.',
+	$pconfig['eve_log_files_magic'] == 'on' ? true:false,
+	'on'
+));
+$section->addInput(new Form_Select(
+	'eve_log_files_hash',
+	'Tracked-Files Checksum',
+	$pconfig['eve_log_files_hash'],
+	array("none" => "None", "md5" => "MD5", "sha1" => "SHA1", "sha256" => "SHA256")
+))->setHelp('Suricata will generate checksums for all logged Tracked Files using the chosen algorithm. Default is None.');
+
+$group = new Form_Group('EVE Logged Stats');
+
+$group->add(new Form_Checkbox(
+	'eve_log_stats_totals',
+	'Stats total',
+	'Log Totals',
+	$pconfig['eve_log_stats_totals'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_stats_deltas',
+	'Stats deltas',
+	'Log deltas',
+	$pconfig['eve_log_stats_deltas'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_stats_threads',
+	'Stats per thread',
+	'Log per thread',
+	$pconfig['eve_log_stats_threads'] == 'on' ? true:false,
+	'on'
+));
+
+$section->add($group)->addClass('eve_log_stats_details');
+
+
+$form->add($section);
+
+$section = new Form_Section('Alert and Block Settings');
+
+$section->addInput(new Form_Checkbox(
+	'blockoffenders',
+	'Block Offenders',
+	'Checking this option will automatically block hosts that generate a Suricata alert.',
+	$pconfig['blockoffenders'] == 'on' ? true:false,
+	'on'
+));
+
+$group = new Form_Group('IPS Mode');
+$group->add(new Form_Select(
+	'ips_mode',
+	'IPS Mode',
+	$pconfig['ips_mode'],
+	array( "ips_mode_legacy" => "Legacy Mode", "ips_mode_inline" => "Inline Mode" )
+))->setHelp('Select blocking mode operation.  Legacy Mode inspects copies of packets while Inline Mode inserts the Suricata inspection engine ' . 
+		'into the network stack between the NIC and the OS. Default is Legacy Mode.');
+$group->setHelp('Legacy Mode uses the PCAP engine to generate copies of packets for inspection as they traverse the interface.  Some "leakage" of packets will occur before ' . 
+		'Suricata can determine if the traffic matches a rule and should be blocked.  Inline mode instead intercepts and inspects packets before they are handed ' . 
+		'off to the host network stack for further processing.  Packets matching DROP rules are simply discarded (dropped) and not passed to the host ' . 
+		'network stack.  No leakage of packets occurs with Inline Mode.  WARNING:  Inline Mode only works with NIC drivers which properly support Netmap!  If the ' . 
+		'hardware NIC driver does not support Netmap, using Inline Mode can result in a firewall system crash!  If problems are experienced with Inline Mode, switch to Legacy Mode instead.');
+$section->add($group);
+
+$section->addInput(new Form_Checkbox(
+	'blockoffenderskill',
+	'Kill States',
+	'Checking this option will kill firewall states for the blocked IP.  Default is Checked.',
+	$pconfig['blockoffenderskill'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Select(
+	'blockoffendersip',
+	'Which IP to Block',
+	$pconfig['blockoffendersip'],
+	array( 'src' => 'SRC', 'dst' => 'DST', 'both' => 'BOTH' )
+))->setHelp('Select which IP extracted from the packet you wish to block. Choosing BOTH is suggested, and it is the default value.');
+
+$section->addInput(new Form_Checkbox(
+	'block_drops_only',
+	'Block On DROP Only',
+	'Checking this option will insert blocks only when rule signatures having the DROP action are triggered.  When not checked, any rule action (ALERT or DROP) will generate a block of the offending host.  Default is Not Checked.',
+	$pconfig['block_drops_only'] == 'on' ? true:false,
+	'on'
+));
+
+$form->add($section);
+
+// Add Inline IPS rule edit warning modal pop-up
+$modal = new Modal('Important Information About IPS Inline Mode Blocking', 'ips_warn_dlg', 'large', 'Close');
+
+$modal->addInput(new Form_StaticText (
+	null,
+	'<span class="help-block">' . 
+	gettext('When using Inline IPS Mode blocking, you must manually change the rule action ') . 
+	gettext('from ALERT to DROP for every rule which you wish to block traffic when triggered.') . 
+	'<br/><br/>' . 
+	gettext('The default action for rules is ALERT.  This will produce alerts but will not ') . 
+	gettext('block traffic when using Inline IPS Mode for blocking. ') . 
+	'<br/><br/>' . 
+	gettext('Use the "dropsid.conf" feature on the SID MGMT tab to select rules whose action ') . 
+	gettext('should be changed from ALERT to DROP.  If you run the Snort rules and have ') . 
+	gettext('an IPS policy selected on the CATEGORIES tab, then rules defined as DROP by the ') . 
+	gettext('selected IPS policy will have their action automatically changed to DROP when the ') . 
+	gettext('"IPS Policy Mode" selector is configured for "Policy".') . 
+	'</span>'
+));
+
+$form->add($modal);
+
+$section = new Form_Section('Performance and Detection Engine Settings');
+$section->addInput(new Form_Select(
+	'runmode',
+	'Run Mode',
+	$pconfig['runmode'],
+	array('autofp' => 'AutoFP', 'workers' => 'Workers', 'single' => 'Single')
+))->setHelp('Choose a Suricata run mode setting. Default is "AutoFP" and is the recommended setting for most cases.  "Workers" uses multiple worker threads, each of which single-handedly processes the packets it acquires (i.e., each thread runs all thread modules). ' . 
+	    '"Single" uses only a single thread for all operations on a packet and is intended for use only in testing or development instances.');
+$section->addInput(new Form_Input(
+	'max_pending_packets',
+	'Max Pending Packets',
+	'text',
+	$pconfig['max_pending_packets']
+))->setHelp('Enter number of simultaneous packets to process. Default is 1024.<br/>This controls the number simultaneous packets the engine can handle. ' .
+			'Setting this higher generally keeps the threads more busy. The minimum value is 1 and the maximum value is 65,000.<br />' .
+			'Warning: Setting this too high can lead to degradation and a possible system crash by exhausting available memory.');
+
+$section->addInput(new Form_Select(
+	'detect_eng_profile',
+	'Detect-Engine Profile',
+	$pconfig['detect_eng_profile'],
+	array('low' => 'Low', 'medium' => 'Medium', 'high' => 'High')
+))->setHelp('Choose a detection engine profile. Default is Medium.<br />MEDIUM is recommended for most systems because it offers a good balance between memory consumption and performance. ' .
+			'LOW uses less memory, but it offers lower performance. HIGH consumes a large amount of memory, but it offers the highest performance.');
+
+$section->addInput(new Form_Select(
+	'mpm_algo',
+	'Pattern Matcher Algorithm',
+	$pconfig['mpm_algo'],
+	array('auto' => 'Auto', 'ac' => 'AC', 'ac-bs' => 'AC-BS', 'ac-ks' => 'AC-KS', 'hs' => 'Hyperscan')
+))->setHelp('Choose a multi-pattern matcher (MPM) algorithm. Auto is the default, and is the best choice for almost all systems.  Auto will use hyperscan if available.');
+
+$section->addInput(new Form_Select(
+	'sgh_mpm_context',
+	'Signature Group Header MPM Context',
+	$pconfig['sgh_mpm_context'],
+	array('auto' => 'Auto', 'full' => 'Full', 'single' => 'Single')
+))->setHelp('Choose a Signature Group Header multi-pattern matcher context. Default is Auto.<br />AUTO means Suricata selects between Full and Single based on the MPM algorithm chosen. ' .
+			'FULL means every Signature Group has its own MPM context. SINGLE means all Signature Groups share a single MPM context. Using FULL can improve performance at the expense of significant memory consumption.');
+
+$section->addInput(new Form_Input(
+	'inspect_recursion_limit',
+	'Inspection Recursion Limit',
+	'text',
+	$pconfig['inspect_recursion_limit']
+))->setHelp('Enter limit for recursive calls in content inspection code. Default is 3000.<br />When set to 0 an internal default is used. When left blank there is no recursion limit.');
+
+$section->addInput(new Form_Checkbox(
+	'delayed_detect',
+	'Delayed Detect',
+	'Suricata will build list of signatures after packet capture threads have started. Default is Not Checked.',
+	$pconfig['delayed_detect'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Checkbox(
+	'intf_promisc_mode',
+	'Promiscuous Mode',
+	'Suricata will place the monitored interface in promiscuous mode when checked. Default is Checked.',
+	$pconfig['intf_promisc_mode'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Input(
+	'intf_snaplen',
+	'Interface PCAP Snaplen',
+	'text',
+	$pconfig['intf_snaplen']
+))->setHelp('Enter value in bytes for the interface PCAP snaplen. Default is 1518.  This parameter is only valid when IDS or Legacy Mode IPS is enabled.<br />This value may need to be increased if the physical interface is passing VLAN traffic and expected alerts are not being received.');
+
+$form->add($section);
+
+$section = new Form_Section('Networks Suricata Should Inspect and Protect');
+
+$group = new Form_Group('Home Net');
+
+$group->add(new Form_Select(
+	'homelistname',
+	'Home Net',
+	$pconfig['homelistname'],
+	suricata_get_config_lists('passlist')
+))->setHelp('Choose the Home Net you want this interface to use.');
+
+$group->add(new Form_Button(
+	'btnHomeNet',
+	' ' . 'View List',
+	'#',
+	'fa-file-text-o'
+))->removeClass('btn-primary')->addClass('btn-info')->addClass('btn-sm')->setAttribute('data-toggle', 'modal')->setAttribute('data-target', '#homenet');
+
+$group->setHelp('Default Home Net adds only local networks, WAN IPs, Gateways, VPNs and VIPs.' . '<br />' .
+		'Create an Alias to hold a list of friendly IPs that the firewall cannot see or to customize the default Home Net.');
+
+$section->add($group);
+
+$group = new Form_Group('External Net');
+
+$group->add(new Form_Select(
+	'externallistname',
+	'External Net',
+	$pconfig['externallistname'],
+	suricata_get_config_lists('passlist')
+))->setHelp('Choose the External Net you want this interface to use.');
+
+$group->add(new Form_Button(
+	'btnExternalNet',
+	' ' . 'View List',
+	'#',
+	'fa-file-text-o'
+))->removeClass('btn-primary')->addClass('btn-info')->addClass('btn-sm')->setAttribute('data-target', '#externalnet')->setAttribute('data-toggle', 'modal');
+
+$group->setHelp('External Net is networks that are not Home Net.  Most users should leave this setting at default.' . '<br />' .
+		'Create a Pass List and add an Alias to it, and then assign the Pass List here for custom External Net settings.');
+
+$section->add($group);
+
+$group = new Form_Group('Pass List');
+
+$group->addClass('passlist');
+$list = suricata_get_config_lists('passlist');
+$list['none'] = 'none';
+$group->add(new Form_Select(
+	'passlistname',
+	'Pass List',
+	$pconfig['passlistname'],
+	$list
+))->setHelp('Choose the Pass List you want this interface to use. Addresses in a Pass List are never blocked. Select "none" to prevent use of a Pass List.');
+
+$group->add(new Form_Button(
+	'btnPasslist',
+	' ' . 'View List',
+	'#',
+	'fa-file-text-o'
+))->removeClass('btn-primary')->addClass('btn-info')->addClass('btn-sm')->setAttribute('data-target', '#passlist')->setAttribute('data-toggle', 'modal');
+
+$group->setHelp('The default Pass List adds Gateways, DNS servers, locally-attached networks, the WAN IP, VPNs and VIPs.  Create a Pass List with an alias to customize whitelisted IP addresses.  ' . 
+		'This option will only be used when block offenders is on.  Choosing "none" will disable Pass List generation.');
+
+$section->add($group);
+
+$form->add($section);
+
+// Add view HOME_NET modal pop-up
+$modal = new Modal('View HOME_NET', 'homenet', 'large', 'Close');
+
+$modal->addInput(new Form_Textarea (
+	'homenet_text',
+	'',
+	'...Loading...'
+))->removeClass('form-control')->addClass('row-fluid col-sm-10')->setAttribute('rows', '10')->setAttribute('wrap', 'off');
+$form->add($modal);
+
+// Add view EXTERNAL_NET modal pop-up
+$modal = new Modal('View EXTERNAL_NET', 'externalnet', 'large', 'Close');
+
+$modal->addInput(new Form_Textarea (
+	'externalnet_text',
+	'',
+	'...Loading...'
+))->removeClass('form-control')
+  ->addClass('row-fluid col-sm-10')
+  ->setAttribute('rows', '10')
+  ->setAttribute('wrap', 'off');
+
+$form->add($modal);
+
+// Add view PASS_LIST modal pop-up
+$modal = new Modal('View PASS LIST', 'passlist', 'large', 'Close');
+
+$modal->addInput(new Form_Textarea (
+	'passlist_text',
+	'',
+	'...Loading...'
+))->removeClass('form-control')
+  ->addClass('row-fluid col-sm-10')
+  ->setAttribute('rows', '10')
+  ->setAttribute('wrap', 'off');
+
+$form->add($modal);
+
+$section = new Form_Section('Alert Suppression and Filtering');
+$group = new Form_Group('Alert Suppression and Filtering');
+$group->add(new Form_Select(
+	'suppresslistname',
+	'Alert Suppression and Filtering',
+	$pconfig['suppresslistname'],
+	suricata_get_config_lists('suppress')
+))->setHelp('Choose the suppression or filtering file you want this interface to use. Default option disables suppression and filtering.');
+
+$group->add(new Form_Button(
+	'btnSuppressList',
+	' ' . 'View List',
+	'#',
+	'fa-file-text-o'
+))->removeClass('btn-primary')
+  ->addClass('btn-info btn-sm')
+  ->setAttribute('data-target', '#suppresslist')
+  ->setAttribute('data-toggle', 'modal');
+
+$section->add($group);
+
+$form->add($section);
+
+// Add view SUPPRESS_LIST modal pop-up
+$modal = new Modal('View Suppress List', 'suppresslist', 'large', 'Close');
+
+$modal->addInput(new Form_Textarea (
+	'suppresslist_text',
+	'',
+	'...Loading...'
+))->removeClass('form-control')->addClass('row-fluid col-sm-10')->setAttribute('rows', '10')->setAttribute('wrap', 'off');
+
+$form->add($modal);
+
+$section = new Form_Section('Arguments here will be automatically inserted into the Suricata configuration');
+$section->addInput(new Form_Textarea (
+	'configpassthru',
+	'Advanced Configuration Pass-Through',
+	($_POST['configpassthru']?$_POST['configpassthru']:$pconfig['configpassthru'])
+))->setHelp('Enter any additional configuration parameters to add to the Suricata configuration here, separated by a newline');
+
+$form->add($section);
+
+if (isset($id)) {
+	$form->addGlobal(new Form_Input(
+		'id',
+		'id',
+		'hidden',
+		$id
+	));
+}
+if (isset($action)) {
+	$form->addGlobal(new Form_Input(
+		'action',
+		'action',
+		'hidden',
+		$action
+	));
+}
+print($form);
+?>
+
+<div class="infoblock">
+	<?=print_info_box('<strong>Note:</strong> Please save your settings before you attempt to start Suricata.', 'info')?>
+</div>
+
+<script type="text/javascript">
+//<![CDATA[
+events.push(function(){
+
+	function enable_blockoffenders() {
+		var hide = ! $('#blockoffenders').prop('checked');
+		hideCheckbox('blockoffenderskill', hide);
+		hideCheckbox('block_drops_only', hide);
+		hideSelect('blockoffendersip', hide);
+		hideSelect('ips_mode', hide);
+		hideClass('passlist', hide);
+		if ($('#ips_mode').val() == 'ips_mode_inline') {
+			hideCheckbox('blockoffenderskill', true);
+			hideCheckbox('block_drops_only', true);
+			hideSelect('blockoffendersip', true);
+			hideClass('passlist', true);
+			hideInput('intf_snaplen', true);
+			if (hide) {
+				$('#eve_log_drop').parent().hide();
+			}
+			else {
+				$('#eve_log_drop').parent().show();
+			}
+		}
+		else {
+			$('#eve_log_drop').parent().hide();
+			hideInput('intf_snaplen', false);
+		}
+	}
+
+	function toggle_system_log() {
+		var hide = ! $('#alertsystemlog').prop('checked');
+		hideSelect('alertsystemlog_facility', hide);
+		hideSelect('alertsystemlog_priority', hide);
+	}
+
+	function toggle_dns_log() {
+		var hide = ! $('#enable_dns_log').prop('checked');
+		hideCheckbox('append_dns_log', hide);
+	}
+
+	function toggle_stats_log() {
+		var hide = ! $('#enable_stats_log').prop('checked');
+		hideInput('stats_upd_interval', hide);
+		hideCheckbox('append_stats_log', hide);
+		disableInput('eve_log_stats',hide);
+		var hide_stats_eve = ! ($('#enable_stats_log').prop('checked') && $('#eve_log_stats').prop('checked'));
+		hideClass('eve_log_stats_details',hide_stats_eve);
+	}
+
+	function toggle_http_log() {
+		var hide = ! $('#enable_http_log').prop('checked');
+		hideCheckbox('append_http_log', hide);
+		hideCheckbox('http_log_extended', hide);
+	}
+
+	function toggle_tls_log() {
+		var hide = ! $('#enable_tls_log').prop('checked');
+		hideCheckbox('enable_tls_store', hide);
+		hideCheckbox('tls_log_extended', hide);
+	}
+
+	function toggle_json_file_log() {
+		var hide = ! $('#enable_json_file_log').prop('checked');
+		hideCheckbox('append_json_file_log', hide);
+		hideCheckbox('enable_tracked_files_magic', hide);
+		hideSelect('tracked_files_hash', hide);
+	}
+
+	function toggle_pcap_log() {
+		var hide = ! $('#enable_pcap_log').prop('checked');
+		hideInput('max_pcap_log_size', hide);
+		hideInput('max_pcap_log_files', hide);
+	}
+
+	function toggle_eve_log() {
+		var hide = ! $('#enable_eve_log').prop('checked');
+		hideSelect('eve_output_type', hide);
+		hideCheckbox('eve_log_alerts',hide);
+		hideCheckbox('eve_log_alerts_xff',hide);
+		hideClass('eve_log_info', hide);
+		toggle_eve_log_files();
+	}
+	function toggle_eve_syslog() {
+		var hide = ! ($('#enable_eve_log').prop('checked') && $('#eve_output_type').val() == "syslog");
+		hideSelect('eve_systemlog_facility',hide);
+		hideSelect('eve_systemlog_priority',hide);
+	}
+	function toggle_eve_redis() {
+		var hide = ! ($('#enable_eve_log').prop('checked') && $('#eve_output_type').val() == "redis");
+		hideClass('eve_redis_connection',hide);
+		hideSelect('eve_redis_mode',hide);
+		hideInput('eve_redis_key',hide);
+	}
+	function toggle_eve_log_alerts() {
+		var hide = ! ($('#eve_log_alerts').prop('checked') && $('#enable_eve_log').prop('checked'));
+		hideSelect('eve_log_alerts_payload',hide);
+		hideClass('eve_log_alerts_details',hide);
+	}
+
+	function toggle_eve_log_alerts_xff() {
+		var hide = ! ($('#eve_log_alerts_xff').prop('checked') && $('#eve_log_alerts').prop('checked') && $('#enable_eve_log').prop('checked'));
+		hideSelect('eve_log_alerts_xff_mode',hide);
+		hideSelect('eve_log_alerts_xff_deployment',hide);
+		hideInput('eve_log_alerts_xff_header', hide);
+	}
+
+	function toggle_eve_log_stats() {
+		var hide = ! ($('#eve_log_stats').prop('checked') && $('#enable_eve_log').prop('checked') && $('#enable_stats_log').prop('checked'));
+		hideClass('eve_log_stats_details',hide);
+	}
+
+	function toggle_eve_log_http() {
+		var disable = ! $('#eve_log_http').prop('checked');
+		disableInput('eve_log_http_extended',disable);
+		toggle_eve_log_http_extended();
+	}
+
+	function toggle_eve_log_tls() {
+		var disable = ! $('#eve_log_tls').prop('checked');
+		disableInput('eve_log_tls_extended',disable);
+	}
+
+	function toggle_eve_log_smtp() {
+		var disable = ! $('#eve_log_smtp').prop('checked');
+		disableInput('eve_log_smtp_extended',disable);
+		toggle_eve_log_smtp_extended();
+	}
+
+	function toggle_eve_log_files() {
+		var hide = ! ($('#eve_log_files').prop('checked') && $('#enable_eve_log').prop('checked'));
+		hideCheckbox('eve_log_files_magic',hide);
+		hideSelect('eve_log_files_hash',hide);
+	}
+
+	function toggle_eve_log_http_extended() {
+		var hide = ! ($('#eve_log_http_extended').prop('checked') && $('#enable_eve_log').prop('checked') && $('#eve_log_http').prop('checked'));
+		hideSelect('eve_log_http_extended_headers\\[\\]',hide);
+	}
+
+	function toggle_eve_log_smtp_extended() {
+		var hide = ! ($('#eve_log_smtp_extended').prop('checked') && $('#enable_eve_log').prop('checked') && $('#eve_log_smtp').prop('checked'));
+		hideSelect('eve_log_smtp_extended_fields\\[\\]',hide);
+	}
+
+	function enable_change() {
+		var disable = ! $('#enable').prop('checked');
+
+		disableInput('alertsystemlog', disable);
+		disableInput('alertsystemlog_facility', disable);
+		disableInput('alertsystemlog_priority', disable);
+		disableInput('blockoffenders', disable);
+		disableInput('ips_mode', disable);
+		disableInput('blockoffenderskill', disable);
+		disableInput('block_drops_only', disable);
+		disableInput('blockoffendersip', disable);
+		disableInput('performance', disable);
+		disableInput('max_pending_packets', disable);
+		disableInput('detect_eng_profile', disable);
+		disableInput('inspect_recursion_limit', disable);
+		disableInput('mpm_algo', disable);
+		disableInput('sgh_mpm_context', disable);
+		disableInput('delayed_detect', disable);
+		disableInput('intf_promisc_mode', disable);
+		disableInput('intf_snaplen', disable);
+		disableInput('fpm_split_any_any', disable);
+		disableInput('fpm_search_optimize', disable);
+		disableInput('fpm_no_stream_inserts', disable);
+		disableInput('cksumcheck', disable);
+		disableInput('externallistname', disable);
+		disableInput('homelistname', disable);
+		disableInput('suppresslistname', disable);
+		disableInput('btnHomeNet', disable);
+		disableInput('btnExternalNet', disable);
+		disableInput('btnSuppressList', disable);
+		disableInput('passlistname', disable);
+		disableInput('btnPasslist', disable);
+		disableInput('configpassthru', disable);
+		disableInput('enable_dns_log', disable);
+		disableInput('append_dns_log', disable);
+		disableInput('enable_stats_log', disable);
+		disableInput('stats_upd_interval', disable);
+		disableInput('append_stats_log', disable);
+		disableInput('enable_http_log', disable);
+		disableInput('append_http_log', disable);
+		disableInput('http_log_extended', disable);
+		disableInput('enable_tls_log', disable);
+		disableInput('enable_tls_store', disable);
+		disableInput('tls_log_extended', disable);
+		disableInput('enable_json_file_log', disable);
+		disableInput('append_json_file_log', disable);
+		disableInput('enable_tracked_files_magic', disable);
+		disableInput('tracked_files_hash', disable);
+		disableInput('enable_file_store', disable);
+		disableInput('enable_pcap_log', disable);
+		disableInput('max_pcap_log_size', disable);
+		disableInput('max_pcap_log_files', disable);
+		disableInput('enable_eve_log', disable);
+		disableInput('eve_output_type', disable);
+		disableInput('eve_systemlog_facility', disable);
+		disableInput('eve_systemlog_priority', disable);
+		disableInput('eve_redis_mode', disable);
+		disableInput('eve_redis_key', disable);
+		disableInput('eve_redis_server', disable);
+		disableInput('eve_redis_port', disable);
+		disableInput('eve_log_info', disable);
+		disableInput('eve_log_alerts', disable);
+		disableInput('eve_log_alerts_payload', disable);
+		disableInput('eve_log_http', disable);
+		disableInput('eve_log_dns', disable);
+		disableInput('eve_log_nfs', disable);
+		disableInput('eve_log_tls', disable);
+		disableInput('eve_log_files', disable);
+		disableInput('eve_log_ssh', disable);
+		disableInput('eve_log_smtp', disable);
+		disableInput('eve_log_flow', disable);
+		disableInput('eve_log_drop', disable);
+		disableInput('eve_log_alerts_packet',disable)
+		disableInput('eve_log_alerts_payload',disable);
+		disableInput('eve_log_alerts_http',disable);
+		disableInput('eve_log_alerts_xff',disable);
+		disableInput('eve_log_alerts_xff_mode',disable);
+		disableInput('eve_log_alerts_xff_deployment',disable);
+		disableInput('eve_log_alerts_xff_header',disable);
+		disableInput('eve_log_files_magic',disable);
+		disableInput('eve_log_files_hash',disable);
+
+		var disable_http = ! $('#eve_log_http').prop('checked');
+		disableInput('eve_log_http_extended',disable||disable_http);
+
+		var disable_tls = ! $('#eve_log_tls').prop('checked');
+		disableInput('eve_log_tls_extended',disable||disable_tls);
+
+		var disable_smtp = ! $('#eve_log_smtp').prop('checked');
+		disableInput('eve_log_smtp_extended',disable||disable_smtp);
+
+		var disable_stats = ! $('#enable_stats_log').prop('checked');
+		disableInput('eve_log_stats',disable||disable_stats);
+
+		disableInput('eve_log_stats_totals',disable);
+		disableInput('eve_log_stats_deltas',disable);
+		disableInput('eve_log_stats_threads',disable);
+
+		disableInput('eve_log_http_extended_headers\\[\\]',disable);
+		disableInput('eve_log_smtp_extended_fields\\[\\]',disable);
+
+	}
+
+	// Call the list viewing page and write what it returns to the modal text area
+	function getListContents(listName, listType, ctrlID) {
+		var ajaxRequest;
+
+		ajaxRequest = $.ajax({
+			url: "/suricata/suricata_list_view.php",
+			type: "post",
+			data: { ajax: 	"ajax",
+			        wlist: 	listName,
+					type: 	listType,
+					id: 	"<?=$id?>"
+			}
+		});
+
+		// Display the results of the above ajax call
+		ajaxRequest.done(function (response, textStatus, jqXHR) {
+			// Write the list contents to the text control
+			$('#' + ctrlID).text(response);
+			$('#' + ctrlID).attr('readonly', true);
+		});
+	}
+
+	// ---------- Event triggers fired after the VIEW LIST modals are shown -----------------------
+	$('#homenet').on('shown.bs.modal', function() {
+		getListContents($('#homelistname option:selected' ).text(), 'homenet', 'homenet_text');
+	});
+
+	$('#externalnet').on('shown.bs.modal', function() {
+		getListContents($('#externallistname option:selected' ).text(), 'externalnet', 'externalnet_text');
+	});
+
+	$('#passlist').on('shown.bs.modal', function() {
+		getListContents($('#passlistname option:selected' ).text(), 'passlist', 'passlist_text');
+	});
+
+	$('#suppresslist').on('shown.bs.modal', function() {
+		getListContents($('#suppresslistname option:selected').text(), 'suppress', 'suppresslist_text');
+	});
+
+	// ---------- Click checkbox handlers ---------------------------------------------------------
+
+	/* When form control id is clicked, disable/enable it's associated form controls */
+
+	$('#enable').click(function() {
+		enable_change();
+	});
+
+	$('#alertsystemlog').click(function() {
+		toggle_system_log();
+	});
+
+	$('#enable_dns_log').click(function() {
+		toggle_dns_log();
+	});
+
+	$('#enable_stats_log').click(function() {
+		toggle_stats_log();
+	});
+
+	$('#enable_http_log').click(function() {
+		toggle_http_log();
+	});
+
+	$('#enable_tls_log').click(function() {
+		toggle_tls_log();
+	});
+
+	$('#enable_json_file_log').click(function() {
+		toggle_json_file_log();
+	});
+
+	$('#enable_pcap_log').click(function() {
+		toggle_pcap_log();
+	});
+
+	$('#enable_eve_log').click(function() {
+		toggle_eve_log();
+		toggle_eve_redis();
+		toggle_eve_syslog();
+		toggle_eve_log_alerts();
+		toggle_eve_log_alerts_xff();
+		toggle_eve_log_stats();
+		toggle_eve_log_http_extended();
+		toggle_eve_log_smtp_extended();
+	});
+
+	$('#eve_output_type').change(function() {
+		toggle_eve_redis();
+		toggle_eve_syslog();
+	});
+
+	$('#eve_log_alerts').click(function() {
+		toggle_eve_log_alerts();
+	});
+
+	$('#eve_log_alerts_xff').click(function() {
+		toggle_eve_log_alerts_xff();
+	});
+
+	$('#eve_log_stats').click(function() {
+		toggle_eve_log_stats();
+	});
+
+	$('#eve_log_http').click(function() {
+		toggle_eve_log_http();
+	});
+
+	$('#eve_log_tls').click(function() {
+		toggle_eve_log_tls();
+	});
+
+	$('#eve_log_smtp').click(function() {
+		toggle_eve_log_smtp();
+	});
+
+	$('#eve_log_files').click(function() {
+		toggle_eve_log_files();
+	});
+
+	$('#blockoffenders').click(function() {
+		enable_blockoffenders();
+	});
+
+	$('#eve_log_http_extended').click(function(){
+		toggle_eve_log_http_extended();
+	});
+
+	$('#eve_log_smtp_extended').click(function(){
+		toggle_eve_log_smtp_extended();
+	});
+
+	$('#ips_mode').on('change', function() {
+		if ($('#ips_mode').val() == 'ips_mode_inline') {
+			hideCheckbox('blockoffenderskill', true);
+			hideCheckbox('block_drops_only', true);
+			hideSelect('blockoffendersip', true);
+			hideClass('passlist', true);
+			hideInput('intf_snaplen', true);
+			$('#eve_log_drop').parent().show();
+			$('#ips_warn_dlg').modal('show');
+		}
+		else {
+			hideCheckbox('blockoffenderskill', false);
+			hideCheckbox('block_drops_only', false);
+			hideSelect('blockoffendersip', false);
+			hideInput('intf_snaplen', false);
+			hideClass('passlist', false);
+			$('#eve_log_drop').parent().hide();
+			$('#ips_warn_dlg').modal('hide');
+		}
+	});
+
+	// ---------- On initial page load ------------------------------------------------------------
+	enable_change();
+	enable_blockoffenders();
+	toggle_system_log();
+	toggle_dns_log();
+	toggle_stats_log();
+	toggle_http_log();
+	toggle_tls_log();
+	toggle_json_file_log();
+	toggle_pcap_log();
+	toggle_eve_log();
+	toggle_eve_redis();
+	toggle_eve_syslog();
+	toggle_eve_log_alerts();
+	toggle_eve_log_alerts_xff();
+	toggle_eve_log_stats();
+	toggle_eve_log_http();
+	toggle_eve_log_smtp();
+	toggle_eve_log_tls();
+	toggle_eve_log_files();
+
+});
+//]]>
+</script>
+
+<?php include("foot.inc"); ?>

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_logs_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_logs_mgmt.php
@@ -1,0 +1,534 @@
+<?php
+/*
+ * suricata_logs_mgmt.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2003-2004 Manuel Kasper
+ * Copyright (c) 2005 Bill Marquette
+ * Copyright (c) 2009 Robert Zelaya Sr. Developer
+ * Copyright (c) 2019 Bill Meeks
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once("guiconfig.inc");
+require_once("/usr/local/pkg/suricata/suricata.inc");
+
+global $g;
+
+$suricatadir = SURICATADIR;
+
+$pconfig = array();
+
+// Grab saved settings from configuration
+$pconfig['enable_log_mgmt'] = $config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 'off' ? 'off' : 'on';
+$pconfig['clearlogs'] = $config['installedpackages']['suricata']['config'][0]['clearlogs'] == 'on' ? 'on' : 'off';
+$pconfig['suricataloglimit'] = $config['installedpackages']['suricata']['config'][0]['suricataloglimit'] == 'on' ? 'on' : 'off';
+$pconfig['suricataloglimitsize'] = $config['installedpackages']['suricata']['config'][0]['suricataloglimitsize'];
+$pconfig['alert_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['alert_log_limit_size'];
+$pconfig['alert_log_retention'] = $config['installedpackages']['suricata']['config'][0]['alert_log_retention'];
+$pconfig['block_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['block_log_limit_size'];
+$pconfig['block_log_retention'] = $config['installedpackages']['suricata']['config'][0]['block_log_retention'];
+$pconfig['files_json_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['files_json_log_limit_size'];
+$pconfig['files_json_log_retention'] = $config['installedpackages']['suricata']['config'][0]['files_json_log_retention'];
+$pconfig['http_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['http_log_limit_size'];
+$pconfig['http_log_retention'] = $config['installedpackages']['suricata']['config'][0]['http_log_retention'];
+$pconfig['stats_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['stats_log_limit_size'];
+$pconfig['stats_log_retention'] = $config['installedpackages']['suricata']['config'][0]['stats_log_retention'];
+$pconfig['tls_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['tls_log_limit_size'];
+$pconfig['tls_log_retention'] = $config['installedpackages']['suricata']['config'][0]['tls_log_retention'];
+$pconfig['unified2_log_limit'] = $config['installedpackages']['suricata']['config'][0]['unified2_log_limit'];
+$pconfig['u2_archive_log_retention'] = $config['installedpackages']['suricata']['config'][0]['u2_archive_log_retention'];
+$pconfig['file_store_retention'] = $config['installedpackages']['suricata']['config'][0]['file_store_retention'];
+$pconfig['tls_certs_store_retention'] = $config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'];
+$pconfig['dns_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['dns_log_limit_size'];
+$pconfig['dns_log_retention'] = $config['installedpackages']['suricata']['config'][0]['dns_log_retention'];
+$pconfig['eve_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['eve_log_limit_size'];
+$pconfig['eve_log_retention'] = $config['installedpackages']['suricata']['config'][0]['eve_log_retention'];
+$pconfig['sid_changes_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['sid_changes_log_limit_size'];
+$pconfig['sid_changes_log_retention'] = $config['installedpackages']['suricata']['config'][0]['sid_changes_log_retention'];
+
+// Load up some arrays with selection values (we use these later).
+// The keys in the $retentions array are the retention period
+// converted to hours.  The keys in the $log_sizes array are
+// the file size limits in KB.
+$retentions = array( '0' => gettext('KEEP ALL'), '24' => gettext('1 DAY'), '168' => gettext('7 DAYS'), '336' => gettext('14 DAYS'),
+			 '720' => gettext('30 DAYS'), '1080' => gettext("45 DAYS"), '2160' => gettext('90 DAYS'), '4320' => gettext('180 DAYS'),
+			 '8766' => gettext('1 YEAR'), '26298' => gettext("3 YEARS") );
+$log_sizes = array( '0' => gettext('NO LIMIT'), '50' => gettext('50 KB'), '150' => gettext('150 KB'), '250' => gettext('250 KB'),
+			'500' => gettext('500 KB'), '750' => gettext('750 KB'), '1000' => gettext('1 MB'), '2000' => gettext('2 MB'),
+			'5000' => gettext("5 MB"), '10000' => gettext("10 MB") );
+
+// Set sensible defaults for any unset parameters
+if (empty($pconfig['enable_log_mgmt']))
+	$pconfig['enable_log_mgmt'] = 'on';
+if (empty($pconfig['suricataloglimit']))
+	$pconfig['suricataloglimit'] = 'on';
+if (empty($pconfig['suricataloglimitsize'])) {
+	// Set limit to 20% of slice that is unused */
+	$pconfig['suricataloglimitsize'] = round(exec('df -k /var | grep -v "Filesystem" | awk \'{print $4}\'') * .20 / 1024);
+}
+
+// Set default retention periods for rotated logs
+if (!isset($pconfig['alert_log_retention']))
+	$pconfig['alert_log_retention'] = "336";
+if (!isset($pconfig['block_log_retention']))
+	$pconfig['block_log_retention'] = "336";
+if (!isset($pconfig['files_json_log_retention']))
+	$pconfig['files_json_log_retention'] = "168";
+if (!isset($pconfig['http_log_retention']))
+	$pconfig['http_log_retention'] = "168";
+if (!isset($pconfig['dns_log_retention']))
+	$pconfig['dns_log_retention'] = "168";
+if (!isset($pconfig['stats_log_retention']))
+	$pconfig['stats_log_retention'] = "168";
+if (!isset($pconfig['tls_log_retention']))
+	$pconfig['tls_log_retention'] = "336";
+if (!isset($pconfig['u2_archive_log_retention']))
+	$pconfig['u2_archive_log_retention'] = "168";
+if (!isset($pconfig['file_store_retention']))
+	$pconfig['file_store_retention'] = "168";
+if (!isset($pconfig['tls_certs_store_retention']))
+	$pconfig['tls_certs_store_retention'] = "168";
+if (!isset($pconfig['eve_log_retention']))
+	$pconfig['eve_log_retention'] = "168";
+if (!isset($pconfig['sid_changes_log_retention']))
+	$pconfig['sid_changes_log_retention'] = "336";
+
+// Set default log file size limits
+if (!isset($pconfig['alert_log_limit_size']))
+	$pconfig['alert_log_limit_size'] = "500";
+if (!isset($pconfig['block_log_limit_size']))
+	$pconfig['block_log_limit_size'] = "500";
+if (!isset($pconfig['files_json_log_limit_size']))
+	$pconfig['files_json_log_limit_size'] = "1000";
+if (!isset($pconfig['http_log_limit_size']))
+	$pconfig['http_log_limit_size'] = "1000";
+if (!isset($pconfig['dns_log_limit_size']))
+	$pconfig['dns_log_limit_size'] = "750";
+if (!isset($pconfig['stats_log_limit_size']))
+	$pconfig['stats_log_limit_size'] = "500";
+if (!isset($pconfig['tls_log_limit_size']))
+	$pconfig['tls_log_limit_size'] = "500";
+if (!isset($pconfig['unified2_log_limit']))
+	$pconfig['unified2_log_limit'] = "32";
+if (!isset($pconfig['eve_log_limit_size']))
+	$pconfig['eve_log_limit_size'] = "5000";
+if (!isset($pconfig['sid_changes_log_limit_size']))
+	$pconfig['sid_changes_log_limit_size'] = "250";
+
+if (isset($_POST['ResetAll'])) {
+
+	// Reset all settings to their defaults
+	$pconfig['alert_log_retention'] = "336";
+	$pconfig['block_log_retention'] = "336";
+	$pconfig['files_json_log_retention'] = "168";
+	$pconfig['http_log_retention'] = "168";
+	$pconfig['dns_log_retention'] = "168";
+	$pconfig['stats_log_retention'] = "168";
+	$pconfig['tls_log_retention'] = "336";
+	$pconfig['u2_archive_log_retention'] = "168";
+	$pconfig['file_store_retention'] = "168";
+	$pconfig['tls_certs_store_retention'] = "168";
+	$pconfig['eve_log_retention'] = "168";
+	$pconfig['sid_changes_log_retention'] = "336";
+
+	$pconfig['alert_log_limit_size'] = "500";
+	$pconfig['block_log_limit_size'] = "500";
+	$pconfig['files_json_log_limit_size'] = "1000";
+	$pconfig['http_log_limit_size'] = "1000";
+	$pconfig['dns_log_limit_size'] = "750";
+	$pconfig['stats_log_limit_size'] = "500";
+	$pconfig['tls_log_limit_size'] = "500";
+	$pconfig['unified2_log_limit'] = "32";
+	$pconfig['eve_log_limit_size'] = "5000";
+	$pconfig['sid_changes_log_limit_size'] = "250";
+
+	/* Log a message at the top of the page to inform the user */
+	$savemsg = gettext("All log management settings on this page have been reset to their defaults.  Click APPLY if you wish to keep these new settings.");
+}
+
+if (isset($_POST['save']) || isset($_POST['apply'])) {
+	if ($_POST['enable_log_mgmt'] != 'on') {
+		$config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] = $_POST['enable_log_mgmt'] ? 'on' :'off';
+		write_config("Suricata pkg: saved updated configuration for LOGS MGMT.");
+		conf_mount_rw();
+		sync_suricata_package_config();
+		conf_mount_ro();
+
+		/* forces page to reload new settings */
+		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
+		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
+		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+		header( 'Cache-Control: post-check=0, pre-check=0', false );
+		header( 'Pragma: no-cache' );
+		header("Location: /suricata/suricata_logs_mgmt.php");
+		exit;
+	}
+
+	if ($_POST['suricataloglimit'] == 'on') {
+		if (!is_numericint($_POST['suricataloglimitsize']) || $_POST['suricataloglimitsize'] < 1)
+			$input_errors[] = gettext("The 'Log Directory Size Limit' must be an integer value greater than zero.");
+	}
+
+	// Validate unified2 log file limit
+	if (!is_numericint($_POST['unified2_log_limit']) || $_POST['unified2_log_limit'] < 1)
+			$input_errors[] = gettext("The value for 'Unified2 Log Limit' must be an integer value greater than zero.");
+
+	if (!$input_errors) {
+		$config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] = $_POST['enable_log_mgmt'] ? 'on' :'off';
+		$config['installedpackages']['suricata']['config'][0]['clearlogs'] = $_POST['clearlogs'] ? 'on' : 'off';
+		$config['installedpackages']['suricata']['config'][0]['suricataloglimit'] = $_POST['suricataloglimit'] ? 'on' :'off';
+		$config['installedpackages']['suricata']['config'][0]['suricataloglimitsize'] = $_POST['suricataloglimitsize'];
+		$config['installedpackages']['suricata']['config'][0]['alert_log_limit_size'] = $_POST['alert_log_limit_size'];
+		$config['installedpackages']['suricata']['config'][0]['alert_log_retention'] = $_POST['alert_log_retention'];
+		$config['installedpackages']['suricata']['config'][0]['block_log_limit_size'] = $_POST['block_log_limit_size'];
+		$config['installedpackages']['suricata']['config'][0]['block_log_retention'] = $_POST['block_log_retention'];
+		$config['installedpackages']['suricata']['config'][0]['files_json_log_limit_size'] = $_POST['files_json_log_limit_size'];
+		$config['installedpackages']['suricata']['config'][0]['files_json_log_retention'] = $_POST['files_json_log_retention'];
+		$config['installedpackages']['suricata']['config'][0]['http_log_limit_size'] = $_POST['http_log_limit_size'];
+		$config['installedpackages']['suricata']['config'][0]['http_log_retention'] = $_POST['http_log_retention'];
+		$config['installedpackages']['suricata']['config'][0]['stats_log_limit_size'] = $_POST['stats_log_limit_size'];
+		$config['installedpackages']['suricata']['config'][0]['stats_log_retention'] = $_POST['stats_log_retention'];
+		$config['installedpackages']['suricata']['config'][0]['tls_log_limit_size'] = $_POST['tls_log_limit_size'];
+		$config['installedpackages']['suricata']['config'][0]['tls_log_retention'] = $_POST['tls_log_retention'];
+		$config['installedpackages']['suricata']['config'][0]['unified2_log_limit'] = $_POST['unified2_log_limit'];
+		$config['installedpackages']['suricata']['config'][0]['u2_archive_log_retention'] = $_POST['u2_archive_log_retention'];
+		$config['installedpackages']['suricata']['config'][0]['file_store_retention'] = $_POST['file_store_retention'];
+		$config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'] = $_POST['tls_certs_store_retention'];
+		$config['installedpackages']['suricata']['config'][0]['dns_log_limit_size'] = $_POST['dns_log_limit_size'];
+		$config['installedpackages']['suricata']['config'][0]['dns_log_retention'] = $_POST['dns_log_retention'];
+		$config['installedpackages']['suricata']['config'][0]['eve_log_limit_size'] = $_POST['eve_log_limit_size'];
+		$config['installedpackages']['suricata']['config'][0]['eve_log_retention'] = $_POST['eve_log_retention'];
+		$config['installedpackages']['suricata']['config'][0]['sid_changes_log_limit_size'] = $_POST['sid_changes_log_limit_size'];
+		$config['installedpackages']['suricata']['config'][0]['sid_changes_log_retention'] = $_POST['sid_changes_log_retention'];
+
+		write_config("Suricata pkg: saved updated configuration for LOGS MGMT.");
+		conf_mount_rw();
+		sync_suricata_package_config();
+		conf_mount_ro();
+
+		/* forces page to reload new settings */
+		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
+		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
+		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+		header( 'Cache-Control: post-check=0, pre-check=0', false );
+		header( 'Pragma: no-cache' );
+		header("Location: /suricata/suricata_logs_mgmt.php");
+		exit;
+	}
+}
+
+$pgtitle = array(gettext("Services"), gettext("Suricata"), gettext("Logs Management"));
+include_once("head.inc");
+
+/* Display Alert message, under form tag or no refresh */
+if ($input_errors)
+	print_input_errors($input_errors);
+
+if ($savemsg) {
+	/* Display save message */
+	print_info_box($savemsg);
+}
+
+	$tab_array = array();
+	$tab_array[] = array(gettext("Interfaces"), false, "/suricata/suricata_interfaces.php");
+	$tab_array[] = array(gettext("Global Settings"), false, "/suricata/suricata_global.php");
+	$tab_array[] = array(gettext("Updates"), false, "/suricata/suricata_download_updates.php");
+	$tab_array[] = array(gettext("Alerts"), false, "/suricata/suricata_alerts.php");
+	$tab_array[] = array(gettext("Blocks"), false, "/suricata/suricata_blocked.php");
+	$tab_array[] = array(gettext("Pass Lists"), false, "/suricata/suricata_passlist.php");
+	$tab_array[] = array(gettext("Suppress"), false, "/suricata/suricata_suppress.php");
+	$tab_array[] = array(gettext("Logs View"), false, "/suricata/suricata_logs_browser.php");
+	$tab_array[] = array(gettext("Logs Mgmt"), true, "/suricata/suricata_logs_mgmt.php");
+	$tab_array[] = array(gettext("SID Mgmt"), false, "/suricata/suricata_sid_mgmt.php");
+	$tab_array[] = array(gettext("Sync"), false, "/pkg_edit.php?xml=suricata/suricata_sync.xml");
+	$tab_array[] = array(gettext("IP Lists"), false, "/suricata/suricata_ip_list_mgmt.php");
+	display_top_tabs($tab_array, true);
+
+$form = new Form;
+
+$section = new Form_Section('General Settings');
+$section->addInput(new Form_Checkbox(
+	'clearlogs',
+	'Remove Suricata Logs On Package Uninstall',
+	'Suricata log files will be removed when the Suricata package is uninstalled.  Default is not checked.',
+	$pconfig['clearlogs'] == 'on' ? true:false,
+	'on'
+));
+$section->addInput(new Form_Checkbox(
+	'enable_log_mgmt',
+	'Auto Log Management',
+	'Enable automatic unattended management of Suricata logs using parameters specified below.  Default is checked.',
+	$pconfig['enable_log_mgmt'] == 'on' ? true:false,
+	'on'
+));
+$form->add($section);
+
+$section = new Form_Section("Log Directory Size Limit");
+$section->addInput(new Form_Checkbox(
+	'suricataloglimit',
+	'Log Directory Size Limit',
+	'Enable Directory Size Limit',
+	$pconfig['suricataloglimit'] == 'on' ? true:false,
+	'on'
+));
+$section->addInput(new Form_Input(
+	'suricataloglimitsize',
+	'Log Limit Size in MB',
+	'text',
+	$pconfig['suricataloglimitsize']
+))->setHelp('This setting imposes a hard-limit on the combined log directory size of all Suricata interfaces.  When the size limit set is reached, rotated logs for all interfaces will be removed, and any active logs pruned to zero-length.   (default is 20% of available free disk space)');
+$form->add($section);
+
+$section = new Form_Section("Log Size and Retention Limits");
+$group = new Form_Group('alert');
+$group->add(new Form_Select(
+	'alert_log_limit_size',
+	'Max Size',
+	$pconfig['alert_log_limit_size'],
+	$log_sizes
+))->setHelp('Max Size. Default is 500 KB.');
+$group->add(new Form_Select(
+	'alert_log_retention',
+	'Retention',
+	$pconfig['alert_log_retention'],
+	$retentions
+))->setHelp('Retention. Default is 14 DAYS.');
+$group->setHelp('Suricata alerts and event details');
+$section->add($group);
+
+$group = new Form_Group('block');
+$group->add(new Form_Select(
+	'block_log_limit_size',
+	'Max Size',
+	$pconfig['block_log_limit_size'],
+	$log_sizes
+))->setHelp('Max Size. Default is 500 KB.');
+$group->add(new Form_Select(
+	'block_log_retention',
+	'Retention',
+	$pconfig['block_log_retention'],
+	$retentions
+))->setHelp('Retention. Default is 14 DAYS.');
+$group->setHelp('Suricata blocked IPs and event details');
+$section->add($group);
+
+$group = new Form_Group('dns');
+$group->add(new Form_Select(
+	'dns_log_limit_size',
+	'Max Size',
+	$pconfig['dns_log_limit_size'],
+	$log_sizes
+))->setHelp('Max Size. Default is 750 KB.');
+$group->add(new Form_Select(
+	'dns_log_retention',
+	'Retention',
+	$pconfig['dns_log_retention'],
+	$retentions
+))->setHelp('Retention. Default is 7 DAYS.');
+$group->setHelp('DNS request/reply details');
+$section->add($group);
+
+$group = new Form_Group('eve-json');
+$group->add(new Form_Select(
+	'eve_log_limit_size',
+	'Max Size',
+	$pconfig['eve_log_limit_size'],
+	$log_sizes
+))->setHelp('Max Size. Default is 5 MB.');
+$group->add(new Form_Select(
+	'eve_log_retention',
+	'Retention',
+	$pconfig['eve_log_retention'],
+	$retentions
+))->setHelp('Retention. Default is 7 DAYS.');
+$group->setHelp('Eve-JSON (JavaScript Object Notation) data');
+$section->add($group);
+
+$group = new Form_Group('files-json');
+$group->add(new Form_Select(
+	'files_json_log_limit_size',
+	'Max Size',
+	$pconfig['files_json_log_limit_size'],
+	$log_sizes
+))->setHelp('Max Size. Default is 1 MB.');
+$group->add(new Form_Select(
+	'files_json_log_retention',
+	'Retention',
+	$pconfig['files_json_log_retention'],
+	$retentions
+))->setHelp('Retention. Default is 7 DAYS.');
+$group->setHelp('Captured files info in JSON format');
+$section->add($group);
+
+$group = new Form_Group('http');
+$group->add(new Form_Select(
+	'http_log_limit_size',
+	'Max Size',
+	$pconfig['http_log_limit_size'],
+	$log_sizes
+))->setHelp('Max Size. Default is 1 MB.');
+$group->add(new Form_Select(
+	'http_log_retention',
+	'Retention',
+	$pconfig['http_log_retention'],
+	$retentions
+))->setHelp('Retention. Default is 7 DAYS.');
+$group->setHelp('Captured HTTP events and session info');
+$section->add($group);
+
+$group = new Form_Group('sid_changes');
+$group->add(new Form_Select(
+	'sid_changes_log_limit_size',
+	'Max Size',
+	$pconfig['sid_changes_log_limit_size'],
+	$log_sizes
+))->setHelp('Max Size. Default is 250 KB.');
+$group->add(new Form_Select(
+	'sid_changes_log_retention',
+	'Retention',
+	$pconfig['sid_changes_log_retention'],
+	$retentions
+))->setHelp('Retention. Default is 14 DAYS.');
+$group->setHelp('Log of SID changes made by SID Mgmt conf files');
+$section->add($group);
+
+$group = new Form_Group('stats');
+$group->add(new Form_Select(
+	'stats_log_limit_size',
+	'Max Size',
+	$pconfig['stats_log_limit_size'],
+	$log_sizes
+))->setHelp('Max Size. Default is 500 KB.');
+$group->add(new Form_Select(
+	'stats_log_retention',
+	'Retention',
+	$pconfig['stats_log_retention'],
+	$retentions
+))->setHelp('Retention. Default is 7 DAYS.');
+$group->setHelp('Suricata performance statistics');
+$section->add($group);
+
+$group = new Form_Group('tls');
+$group->add(new Form_Select(
+	'tls_log_limit_size',
+	'Max Size',
+	$pconfig['tls_log_limit_size'],
+	$log_sizes
+))->setHelp('Max Size. Default is 500 KB.');
+$group->add(new Form_Select(
+	'tls_log_retention',
+	'Retention',
+	$pconfig['tls_log_retention'],
+	$retentions
+))->setHelp('Retention. Default is 14 DAYS.');
+$group->setHelp('SMTP TLS handshake details');
+$section->add($group);
+
+$section->addInput(new Form_StaticText(
+	'',
+	'Settings will be ignored for any log in the list above not enabled on the Interface Settings tab. When a log reaches the Max Size limit, it will be rotated and tagged with a timestamp. The Retention period determines how long rotated logs are kept before they are automatically deleted.'
+));
+
+$section->addInput(new Form_Input(
+	'unified2_log_limit',
+	'Unified2 Log Limit',
+	'text',
+	$pconfig['unified2_log_limit']
+))->setHelp('Log file size limit in megabytes (MB). Default is 32 MB. This sets the maximum size for a unified2 log file before it is rotated and a new one created.');
+$section->addInput(new Form_Select(
+	'u2_archive_log_retention',
+	'Unified2 Archived Log Retention Period',
+	$pconfig['u2_archive_log_retention'],
+	$retentions
+))->setHelp('Choose retention period for archived Barnyard2 binary log files. Default is 7 days. When file capture and store is enabled, Suricata captures downloaded files from HTTP sessions and stores them, along with metadata, for later analysis. This setting determines how long files remain in the File Store folder before they are automatically deleted.');
+$section->addInput(new Form_Select(
+	'file_store_retention',
+	'Captured Files Retention Period',
+	$pconfig['file_store_retention'],
+	$retentions
+))->setHelp('Choose retention period for captured files in File Store. Default is 7 days. When file capture and store is enabled, Suricata captures downloaded files from HTTP sessions and stores them, along with metadata, for later analysis. This setting determines how long files remain in the File Store folder before they are automatically deleted.');
+$section->addInput(new Form_Select(
+	'tls_certs_store_retention',
+	'Captured TLS Certs Retention Period',
+	$pconfig['tls_certs_store_retention'],
+	$retentions
+))->setHelp('Choose retention period for captured TLS Certs. Default is 7 days. When custom rules with tls.store are enabled, Suricata captures Certificates, along with metadata, for later analysis. This setting determines how long files remain in the Certs folder before they are automatically deleted.');
+$form->add($section);
+
+print($form);
+
+?>
+
+<div class="infoblock">
+	<?=print_info_box('<strong>Note:</strong> Changing any settings on this page will affect all Suricata-configured interfaces.', 'info')?>
+</div>
+
+<script language="JavaScript">
+//<![CDATA[
+events.push(function(){
+
+	function enable_change() {
+		var hide = ! $('#enable_log_mgmt').prop('checked');
+		disableInput('alert_log_limit_size', hide);
+		disableInput('alert_log_retention', hide);
+		disableInput('block_log_limit_size', hide);
+		disableInput('block_log_retention', hide);
+		disableInput('files_json_log_limit_size', hide);
+		disableInput('files_json_log_retention', hide);
+		disableInput('http_log_limit_size', hide);
+		disableInput('http_log_retention', hide);
+		disableInput('stats_log_limit_size', hide);
+		disableInput('stats_log_retention', hide);
+		disableInput('tls_log_limit_size', hide);
+		disableInput('tls_log_retention', hide);
+		disableInput('unified2_log_limit', hide);
+		disableInput('u2_archive_log_retention', hide);
+		disableInput('dns_log_retention', hide);
+		disableInput('dns_log_limit_size', hide);
+		disableInput('eve_log_retention', hide);
+		disableInput('eve_log_limit_size', hide);
+		disableInput('sid_changes_log_retention', hide);
+		disableInput('sid_changes_log_limit_size', hide);
+		disableInput('file_store_retention', hide);
+		disableInput('tls_certs_store_retention', hide);
+	}
+
+	function enable_change_dirSize() {
+		var hide = ! $('#suricataloglimit').prop('checked');
+		disableInput('suricataloglimitsize', hide);
+	}
+
+	// ---------- Click checkbox handlers -------------------------------------------------------
+	// When 'enable_log_mgmt' is clicked, disable/enable the other page form controls
+	$('#enable_log_mgmt').click(function() {
+		enable_change();
+	});
+
+	// When 'suricataloglimit_on' is clicked, disable/enable the other page form controls
+	$('#suricataloglimit').click(function() {
+		enable_change_dirSize();
+	});
+
+	enable_change();
+	enable_change_dirSize();
+
+});
+//]]>
+</script>
+
+<?php include("foot.inc"); ?>
+

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_rulesets.php
@@ -1,0 +1,700 @@
+<?php
+/*
+ * suricata_rulesets.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2003-2004 Manuel Kasper
+ * Copyright (c) 2005 Bill Marquette
+ * Copyright (c) 2009 Robert Zelaya Sr. Developer
+ * Copyright (c) 2019 Bill Meeks
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once("guiconfig.inc");
+require_once("/usr/local/pkg/suricata/suricata.inc");
+
+global $g, $rebuild_rules;
+
+$suricatadir = SURICATADIR;
+$suricata_rules_dir = SURICATA_RULES_DIR;
+$flowbit_rules_file = FLOWBITS_FILENAME;
+
+// Array of default events rules for Suricata.
+// Note this is a modified list used when
+// Rust support is disabled in the binary.
+$default_rules = array( "app-layer-events.rules", "decoder-events.rules", "dnp3-events.rules", "dns-events.rules", "files.rules", "http-events.rules", 
+			"modbus-events.rules", "smtp-events.rules", "stream-events.rules", "tls-events.rules" );
+
+if (!is_array($config['installedpackages']['suricata']['rule'])) {
+	$config['installedpackages']['suricata']['rule'] = array();
+}
+
+$a_nat = &$config['installedpackages']['suricata']['rule'];
+
+if (isset($_POST['id']) && is_numericint($_POST['id']))
+	$id = $_POST['id'];
+elseif (isset($_GET['id']) && is_numericint($_GET['id']))
+	$id = htmlspecialchars($_GET['id']);
+if (is_null($id))
+	$id = 0;
+
+if (isset($id) && $a_nat[$id]) {
+	$pconfig['autoflowbits'] = $a_nat[$id]['autoflowbitrules'];
+	$pconfig['ips_policy_enable'] = $a_nat[$id]['ips_policy_enable'];
+	$pconfig['ips_policy'] = $a_nat[$id]['ips_policy'];
+	$pconfig['ips_policy_mode'] = $a_nat[$id]['ips_policy_mode'];
+}
+
+$if_real = get_real_interface($a_nat[$id]['interface']);
+$suricata_uuid = $a_nat[$id]['uuid'];
+$snortdownload = $config['installedpackages']['suricata']['config'][0]['enable_vrt_rules'] == 'on' ? 'on' : 'off';
+$emergingdownload = $config['installedpackages']['suricata']['config'][0]['enable_etopen_rules'] == 'on' ? 'on' : 'off';
+$etpro = $config['installedpackages']['suricata']['config'][0]['enable_etpro_rules'] == 'on' ? 'on' : 'off';
+$snortcommunitydownload = $config['installedpackages']['suricata']['config'][0]['snortcommunityrules'] == 'on' ? 'on' : 'off';
+
+$no_emerging_files = false;
+$no_snort_files = false;
+
+$enabled_rulesets_array = explode("||", $a_nat[$id]['rulesets']);
+
+/* Test rule categories currently downloaded to SURICATA_RULES_DIR and set appropriate flags */
+if ($emergingdownload == 'on') {
+	$test = glob("{$suricata_rules_dir}" . ET_OPEN_FILE_PREFIX . "*.rules");
+	$et_type = "ET Open";
+}
+elseif ($etpro == 'on') {
+	$test = glob("{$suricata_rules_dir}" . ET_PRO_FILE_PREFIX . "*.rules");
+	$et_type = "ET Pro";
+}
+else
+	$et_type = "Emerging Threats";
+
+if (empty($test))
+	$no_emerging_files = true;
+
+$test = glob("{$suricata_rules_dir}" . VRT_FILE_PREFIX . "*.rules");
+if (empty($test))
+	$no_snort_files = true;
+
+if (!file_exists("{$suricata_rules_dir}" . GPL_FILE_PREFIX . "community.rules"))
+	$no_community_files = true;
+
+// If a Snort rules policy is enabled and selected, remove all Snort
+// rules from the configured rule sets to allow automatic selection.
+if ($a_nat[$id]['ips_policy_enable'] == 'on') {
+	if (isset($a_nat[$id]['ips_policy'])) {
+		$disable_vrt_rules = "disabled";
+		$enabled_sets = explode("||", $a_nat[$id]['rulesets']);
+
+		foreach ($enabled_sets as $k => $v) {
+			if (substr($v, 0, 6) == "suricata_")
+				unset($enabled_sets[$k]);
+		}
+		$a_nat[$id]['rulesets'] = implode("||", $enabled_sets);
+	}
+}
+else
+	$disable_vrt_rules = "";
+
+if (isset($_POST["save"])) {
+	if ($_POST['ips_policy_enable'] == "on") {
+		$a_nat[$id]['ips_policy_enable'] = 'on';
+		$a_nat[$id]['ips_policy'] = $_POST['ips_policy'];
+		$a_nat[$id]['ips_policy_mode'] = $_POST['ips_policy_mode'];
+	}
+	else {
+		$a_nat[$id]['ips_policy_enable'] = 'off';
+		unset($a_nat[$id]['ips_policy']);
+		unset($a_nat[$id]['ips_policy_mode']);
+	}
+
+	// Always start with the default events and files rules
+	$enabled_items = implode("||", $default_rules);
+	if (is_array($_POST['toenable']))
+		$enabled_items .= "||" . implode("||", $_POST['toenable']);
+	else
+		$enabled_items .=  "||{$_POST['toenable']}";
+
+	$a_nat[$id]['rulesets'] = $enabled_items;
+
+	if ($_POST['autoflowbits'] == "on") {
+		$a_nat[$id]['autoflowbitrules'] = 'on';
+	}
+	else {
+		$a_nat[$id]['autoflowbitrules'] = 'off';
+		// Need this here so the GUI renders correctly after saving
+		$_POST['autoflowbits'] = "off";
+		unlink_if_exists("{$suricatadir}suricata_{$suricata_uuid}_{$if_real}/rules/{$flowbit_rules_file}");
+	}
+
+	write_config("Suricata pkg: save enabled rule categories for {$a_nat[$id]['interface']}.");
+
+	/*************************************************/
+	/* Update the suricata.yaml file and rebuild the */
+	/* rules for this interface.                     */
+	/*************************************************/
+	$rebuild_rules = true;
+	conf_mount_rw();
+	suricata_generate_yaml($a_nat[$id]);
+	conf_mount_ro();
+	$rebuild_rules = false;
+
+	/* Signal Suricata to "live reload" the rules */
+	suricata_reload_config($a_nat[$id]);
+
+	$pconfig = $_POST;
+	$enabled_rulesets_array = explode("||", $enabled_items);
+	if (suricata_is_running($suricata_uuid, $if_real))
+		$savemsg = gettext("Suricata is 'live-loading' the new rule set on this interface.");
+
+	// Sync to configured CARP slaves if any are enabled
+	suricata_sync_on_changes();
+} elseif (isset($_POST['unselectall'])) {
+	if ($_POST['ips_policy_enable'] == "on") {
+		$a_nat[$id]['ips_policy_enable'] = 'on';
+		$a_nat[$id]['ips_policy'] = $_POST['ips_policy'];
+		$a_nat[$id]['ips_policy_mode'] = $_POST['ips_policy_mode'];
+	}
+	else {
+		$a_nat[$id]['ips_policy_enable'] = 'off';
+		unset($a_nat[$id]['ips_policy']);
+		unset($a_nat[$id]['ips_policy_mode']);
+	}
+
+	$pconfig['autoflowbits'] = $_POST['autoflowbits'];
+	$pconfig['ips_policy_enable'] = $_POST['ips_policy_enable'];
+	$pconfig['ips_policy'] = $_POST['ips_policy'];
+	$pconfig['ips_policy_mode'] = $_POST['ips_policy_mode'];
+
+	// Remove all but the default events and files rules
+	$enabled_rulesets_array = array();
+	$enabled_rulesets_array = implode("||", $default_rules);
+
+	$savemsg = gettext("All rule categories have been de-selected.  ");
+	if ($_POST['ips_policy_enable'] == "on")
+		$savemsg .= gettext("Only the rules included in the selected IPS Policy will be used.");
+	else
+		$savemsg .= gettext("There currently are no inspection rules enabled for this Suricata instance!");
+} elseif (isset($_POST['selectall'])) {
+	if ($_POST['ips_policy_enable'] == "on") {
+		$a_nat[$id]['ips_policy_enable'] = 'on';
+		$a_nat[$id]['ips_policy'] = $_POST['ips_policy'];
+		$a_nat[$id]['ips_policy_mode'] = $_POST['ips_policy_mode'];
+	}
+	else {
+		$a_nat[$id]['ips_policy_enable'] = 'off';
+		unset($a_nat[$id]['ips_policy']);
+		unset($a_nat[$id]['ips_policy_mode']);
+	}
+
+	$pconfig['autoflowbits'] = $_POST['autoflowbits'];
+	$pconfig['ips_policy_enable'] = $_POST['ips_policy_enable'];
+	$pconfig['ips_policy'] = $_POST['ips_policy'];
+	$pconfig['ips_policy_mode'] = $_POST['ips_policy_mode'];
+
+	// Start with the required default events and files rules
+	$enabled_rulesets_array = $default_rules;
+
+	if ($emergingdownload == 'on') {
+		$files = glob("{$suricata_rules_dir}" . ET_OPEN_FILE_PREFIX . "*.rules");
+		foreach ($files as $file)
+			$enabled_rulesets_array[] = basename($file);
+	}
+	elseif ($etpro == 'on') {
+		$files = glob("{$suricata_rules_dir}" . ET_PRO_FILE_PREFIX . "*.rules");
+		foreach ($files as $file)
+			$enabled_rulesets_array[] = basename($file);
+	}
+
+	if ($snortcommunitydownload == 'on') {
+		$files = glob("{$suricata_rules_dir}" . GPL_FILE_PREFIX . "community.rules");
+		foreach ($files as $file)
+			$enabled_rulesets_array[] = basename($file);
+	}
+
+	/* Include the Snort rules only if enabled and no IPS policy is set */
+	if ($snortdownload == 'on' && empty($_POST['ips_policy_enable'])) {
+		$files = glob("{$suricata_rules_dir}" . VRT_FILE_PREFIX . "*.rules");
+		foreach ($files as $file)
+			$enabled_rulesets_array[] = basename($file);
+	}
+}
+
+// Get any automatic rule category enable/disable modifications
+// if auto-SID Mgmt is enabled.
+$cat_mods = suricata_sid_mgmt_auto_categories($a_nat[$id], FALSE);
+
+$if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']);
+$pgtitle = array(gettext("Suricata IDS"), gettext(" Interface {$if_friendly} - Categories"));
+include_once("head.inc");
+
+if ($input_errors) {
+	print_input_errors($input_errors);
+}
+
+if ($savemsg) {
+	print_info_box($savemsg);
+}
+
+$tab_array = array();
+$tab_array[] = array(gettext("Interfaces"), true, "/suricata/suricata_interfaces.php");
+$tab_array[] = array(gettext("Global Settings"), false, "/suricata/suricata_global.php");
+$tab_array[] = array(gettext("Updates"), false, "/suricata/suricata_download_updates.php");
+$tab_array[] = array(gettext("Alerts"), false, "/suricata/suricata_alerts.php?instance={$id}");
+$tab_array[] = array(gettext("Blocks"), false, "/suricata/suricata_blocked.php");
+$tab_array[] = array(gettext("Pass Lists"), false, "/suricata/suricata_passlist.php");
+$tab_array[] = array(gettext("Suppress"), false, "/suricata/suricata_suppress.php");
+$tab_array[] = array(gettext("Logs View"), false, "/suricata/suricata_logs_browser.php?instance={$id}");
+$tab_array[] = array(gettext("Logs Mgmt"), false, "/suricata/suricata_logs_mgmt.php");
+$tab_array[] = array(gettext("SID Mgmt"), false, "/suricata/suricata_sid_mgmt.php");
+$tab_array[] = array(gettext("Sync"), false, "/pkg_edit.php?xml=suricata/suricata_sync.xml");
+$tab_array[] = array(gettext("IP Lists"), false, "/suricata/suricata_ip_list_mgmt.php");
+display_top_tabs($tab_array, true);
+
+$menu_iface=($if_friendly?substr($if_friendly,0,5)." ":"Iface ");
+$tab_array = array();
+$tab_array[] = array($menu_iface . gettext("Settings"), false, "/suricata/suricata_interfaces_edit.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("Categories"), true, "/suricata/suricata_rulesets.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("Rules"), false, "/suricata/suricata_rules.php?id={$id}");
+    $tab_array[] = array($menu_iface . gettext("Flow/Stream"), false, "/suricata/suricata_flow_stream.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("App Parsers"), false, "/suricata/suricata_app_parsers.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("Variables"), false, "/suricata/suricata_define_vars.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("Barnyard2"), false, "/suricata/suricata_barnyard.php?id={$id}");
+$tab_array[] = array($menu_iface . gettext("IP Rep"), false, "/suricata/suricata_ip_reputation.php?id={$id}");
+display_top_tabs($tab_array, true);
+
+$isrulesfolderempty = glob("{$suricata_rules_dir}*.rules");
+$iscfgdirempty = array();
+
+if (file_exists("{$suricatadir}suricata_{$suricata_uuid}_{$if_real}/rules/custom.rules")) {
+	$iscfgdirempty = (array)("{$suricatadir}suricata_{$suricata_uuid}_{$if_real}/rules/custom.rules");
+}
+
+if (empty($isrulesfolderempty)):
+	print_info_box(sprintf(gettext("# The rules directory is empty:  %s%srules%s"), '<strong>', $suricatadir,'</strong>') . "<br/><br/>" .
+		gettext("Please go to the ") . '<a href="suricata_download_updates.php"><strong>' . gettext("Updates") .
+		'</strong></a>' . gettext(" tab to download the rules configured on the ") .
+		'<a href="suricata_interfaces_global.php"><strong>' . gettext("Global") .
+		'</strong></a>' . gettext(" tab."), 'warning');
+
+else:
+?>
+<form action="/suricata/suricata_rulesets.php" method="post" enctype="multipart/form-data" name="iform" id="iform" class="form-horizontal">
+<input type="hidden" name="id" id="id" value="<?=$id;?>" />
+<?php
+
+	$section = new Form_Section("Automatic flowbit resolution");
+
+	$section->addInput(new Form_Checkbox(
+		'autoflowbits',
+		'Resolve Flowbits',
+		'Auto-enable rules required for checked flowbits',
+		$pconfig['autoflowbits'] != 'off' ? true : false,
+		'on'
+	))->setHelp(' Default is Checked. Suricata will examine the enabled rules in your chosen rule categories for checked flowbits. ' .
+					'Any rules that set these dependent flowbits will be automatically enabled and added to the list of files in the interface rules directory.');
+
+	$viewbtn = new Form_Button(
+		'View',
+		'View',
+		'suricata_rules_flowbits.php?id=' . $id . '&returl=' . urlencode($_SERVER['PHP_SELF']),
+		'fa-file-text-o'
+	);
+
+	$viewbtn->removeClass('btn-primary')->addClass('btn-success btn-sm')
+	  ->setHelp('Click to view auto-enabled rules required to satisfy flowbit dependencies' . '<br /><br />' .
+	  			'<span class="text-danger"><strong>' . gettext('Note:  ') . '</strong></span>' .
+	  			gettext('Auto-enabled rules generating unwanted alerts should have their GID:SID added to the Suppression List for the interface.'));
+
+
+	// See if we have any Auto-Flowbit rules and enable
+	// the VIEW button if we do.
+	if ($pconfig['autoflowbits'] == 'on') {
+		if (file_exists("{$suricatadir}suricata_{$suricata_uuid}_{$if_real}/rules/{$flowbit_rules_file}") &&
+		    filesize("{$suricatadir}suricata_{$suricata_uuid}_{$if_real}/rules/{$flowbit_rules_file}") > 0) {
+			$viewbtn->setAttribute('title', gettext("View flowbit-required rules"));
+		}
+		else
+			$viewbtn->setDisabled();
+	}
+	else
+		$viewbtn->setDisabled();
+
+	$section->addInput(new Form_StaticText(
+		'View rules',
+		$viewbtn
+	));
+
+	print($section);
+
+	if ($snortdownload == 'on') {
+
+		$section = new Form_Section("Snort IPS Policy selection");
+		$chkips = new Form_Checkbox(
+			'ips_policy_enable',
+			'Use IPS Policy',
+			'Use rules from one of three pre-defined Snort IPS policies',
+			($a_nat[$id]['ips_policy_enable'] == "on"),
+			'on'
+		);
+		$chkips->setHelp('<span class="text-danger"><strong>' . gettext("Note:  ") . '</strong></span>' . gettext('You must be using the Snort rules to use this option.' . '<br />' .
+					'Selecting this option disables manual selection of Snort rules categories in the list below, ' .
+						'although Emerging Threats categories may still be selected if enabled on the Global Settings tab.  ' .
+						'These will be added to the pre-defined Snort IPS policy rules from the Snort rules set.'));
+		$section->addInput($chkips);
+		$section->addInput(new Form_Select(
+			'ips_policy',
+			'IPS Policy Selection',
+			$pconfig['ips_policy'],
+			array(	'connectivity' => 'Connectivity',
+				'balanced'  => 'Balanced',
+				'security'  => 'Security',
+				'max-detect' => 'Maximum Detection')
+			))->setHelp('Connectivity blocks most major threats with few or no false positives. Balanced is a good starter policy. ' .
+						'It is speedy, has good base coverage level, and covers most threats of the day. It includes all rules in Connectivity. Security is a stringent policy. ' .
+						'It contains everything in the first two plus policy-type rules such as Flash in an Excel file.  Maximum Detection encompasses vulnerabilities from 2005 ' .
+						'or later with a CVSS score of at least 7.5 along with critical malware and exploit kit rules.  The Maximum Detection policy favors detection over rated ' .
+						'throughput. In some situations this policy can and will cause significant throughput reductions.');
+		$section->addInput(new Form_Select(
+			'ips_policy_mode',
+			'IPS Policy Mode',
+			$pconfig['ips_policy_mode'],
+			array(  'alert' => 'Alert',
+				'policy'  => 'Policy')
+			))->setHelp('When Policy is selected, this will automatically change the action for rules in the selected IPS Policy from their default action of alert to the action specified ' .
+					'in the policy metadata (typically drop, but may be alert for some policy rules).');
+
+		print($section);
+	}
+
+?>
+
+<div class="panel panel-default">
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext("Select the rulesets (Categories) Suricata will load at startup")?></h2></div>
+	<div class="panel-body">
+		<div class="table-responsive col-sm-12">
+			<i class="fa fa-adn text-success"></i>&nbsp;<?=gettext('- Category is auto-enabled by SID Mgmt conf files'); ?><br/>
+			<i class="fa fa-adn text-danger"></i>&nbsp;<?=gettext('- Category is auto-disabled by SID Mgmt conf files'); ?>
+		</div>
+		<nav class="action-buttons">
+			<button type="submit" id="selectall" name="selectall" class="btn btn-info btn-sm" title="<?=gettext('Add all categories to enforcing rules');?>">
+				<?=gettext('Select All');?>
+			</button>
+			<button type="submit" id="unselectall" name="unselectall" class="btn btn-warning btn-sm" title="<?=gettext('Remove all categories from enforcing rules');?>">
+				<?=gettext('Unselect All');?>
+			</button>
+			<button type="submit" id="save" name="save" class="btn btn-primary btn-sm" title="<?=gettext('Click to Save changes and rebuild rules');?>">
+				<i class="fa fa-save icon-embed-btn"></i>
+				<?=gettext(' Save');?>
+			</button>
+		</nav>
+
+<!-- Process GPLv2 Community Rules if enabled -->
+			<?php if ($no_community_files)
+				$msg_community = gettext("NOTE: Snort Community Rules have not been downloaded.  Perform a Rules Update to enable them.");
+			      else
+				$msg_community = gettext("Snort GPLv2 Community Rules (Talos-certified)");
+			      $community_rules_file = gettext(GPL_FILE_PREFIX . "community.rules");
+			?>
+
+	<?php if ($snortcommunitydownload == 'on'): ?>
+		<div class="table-responsive col-sm-12">
+			<table class="table table-striped table-hover table-condensed">
+				<thead>
+					<tr>
+						<th><?=gettext("Enabled"); ?></th>
+						<th><?=gettext('Ruleset: Snort GPLv2 Community Rules'); ?></th>
+						<th></th>
+						<th></th>
+					</tr>
+				</thead>
+				<tbody>
+			<?php if (isset($cat_mods[$community_rules_file])): ?>
+				<?php if ($cat_mods[$community_rules_file] == 'enabled') : ?>
+					<tr>
+						<td>
+							<i class="fa fa-adn text-success" title="<?=gettext('Auto-enabled by settings on SID Mgmt tab'); ?>"></i>
+						</td>
+						<td colspan="4">
+						<?php if ($no_community_files): ?>
+							<?php echo gettext("{$msg_community}"); ?>
+						<?php else: ?>
+							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?=gettext('{$msg_community}');?></a>
+						<?php endif; ?>
+						</td>
+					</tr>
+				<?php else: ?>
+					<tr>
+						<td>
+							<i class="fa fa-adn text-danger" title="<?=gettext("Auto-disabled by settings on SID Mgmt tab");?>"><i>
+						</td>
+						<td colspan="4">
+						<?php if ($no_community_files): ?>
+							<?php echo gettext("{$msg_community}"); ?>
+						<?php else: ?>
+							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext("{$msg_community}"); ?></a>
+						<?php endif; ?>
+						</td>
+					</tr>
+				<?php endif; ?>
+			<?php elseif (in_array($community_rules_file, $enabled_rulesets_array)): ?>
+				<tr>
+					<td>
+						<input type="checkbox" name="toenable[]" value="<?=$community_rules_file;?>" checked="checked"/>
+					</td>
+					<td colspan="4">
+						<?php if ($no_community_files): ?>
+							<?php echo gettext("{$msg_community}"); ?>
+						<?php else: ?>
+							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?php echo gettext("{$msg_community}"); ?></a>
+						<?php endif; ?>
+					</td>
+				</tr>
+			<?php else: ?>
+				<tr>
+					<td>
+						<input type="checkbox" name="toenable[]" value="<?=$community_rules_file; ?>" />
+					</td>
+					<td colspan="4">
+						<?php if ($no_community_files): ?>
+							<?php echo gettext("{$msg_community}"); ?>
+						<?php else: ?>
+							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext("{$msg_community}"); ?></a>
+						<?php endif; ?>
+					</td>
+				</tr>
+			<?php endif; ?>
+				</tbody>
+			</table>
+		</div>
+	<?php endif;
+?>
+
+<!-- End of GPLv2 Community rules -->
+
+<!-- Set strings for rules file state of "not enabled" or "not downloaded" -->
+			<?php if ($no_emerging_files && ($emergingdownload == 'on' || $etpro == 'on'))
+				  $msg_emerging = "have not been downloaded.";
+			      else
+				  $msg_emerging = "are not enabled.";
+			      if ($no_snort_files && $snortdownload == 'on')
+				  $msg_snort = "have not been downloaded.";
+			      else
+				  $msg_snort = "are not enabled.";
+			?>
+<!-- End of rules file state -->
+
+<!-- Write out the header row -->
+		<div class="table-responsive col-sm-12">
+			<table class="table table-striped table-hover table-condensed">
+				<thead>
+					<tr>
+					<?php if ($emergingdownload == 'on' && !$no_emerging_files): ?>
+						<th><?=gettext("Enabled"); ?></th>
+						<th><?=gettext('Ruleset: ET Open Rules');?></th>
+					<?php elseif ($etpro == 'on' && !$no_emerging_files): ?>
+						<th><?=gettext("Enabled"); ?></th>
+						<th><?=gettext('Ruleset: ET Pro Rules');?></th>
+					<?php else: ?>
+						<th colspan="2"><?=gettext("{$et_type} rules {$msg_emerging}"); ?></th>
+					<?php endif; ?>
+					<?php if ($snortdownload == 'on' && !$no_snort_files): ?>
+						<th><?=gettext("Enabled"); ?></th>
+						<th><?=gettext('Ruleset: Snort Text Rules');?></th>
+					<?php else: ?>
+						<th colspan="2"><?=gettext("Snort Rules {$msg_snort}"); ?></th>
+					<?php endif; ?>
+					</tr>
+				</thead>
+<!-- End of header row -->
+
+				<tbody>
+<?php
+
+				$emergingrules = array();
+				$snortrules = array();
+				if (empty($isrulesfolderempty))
+					$dh  = opendir("{$suricatadir}suricata_{$suricata_uuid}_{$if_real}/rules/");
+				else
+					$dh  = opendir("{$suricata_rules_dir}");
+
+				while (false !== ($filename = readdir($dh))) {
+					$filename = basename($filename);
+					if (substr($filename, -5) != "rules")
+						continue;
+					if (strstr($filename, ET_OPEN_FILE_PREFIX) && $emergingdownload == 'on')
+						$emergingrules[] = $filename;
+					else if (strstr($filename, ET_PRO_FILE_PREFIX) && $etpro == 'on')
+						$emergingrules[] = $filename;
+					else if (strstr($filename, VRT_FILE_PREFIX) && $snortdownload == 'on') {
+						$snortrules[] = $filename;
+					}
+				}
+
+				sort($emergingrules);
+				sort($snortrules);
+				$i = count($emergingrules);
+
+				if ($i < count($snortrules))
+					$i = count($snortrules);
+
+				// Walk the rules file names arrays and output the
+				// the file names and associated form controls in
+				// an HTML table.
+
+				for ($j = 0; $j < $i; $j++) {
+					echo "<tr>\n";
+					if (!empty($emergingrules[$j])) {
+						$file = $emergingrules[$j];
+						echo "<td>";
+						if(is_array($enabled_rulesets_array)) {
+							if(in_array($file, $enabled_rulesets_array) && !isset($cat_mods[$file]))
+								$CHECKED = " checked=\"checked\"";
+							else
+								$CHECKED = "";
+						} else
+							$CHECKED = "";
+
+						// If the rule category file is covered by a SID mgmt configuration,
+						// place an appropriate icon beside the category.
+						if (isset($cat_mods[$file])) {
+							// If the category is part of the enabled rulesets array,
+							// make sure we include a hidden field to reference it
+							// so we do not unset it during a post-back.
+							if (in_array($file, $enabled_rulesets_array))
+								echo "<input type='hidden' name='toenable[]' value='{$file}' />\n";
+							if ($cat_mods[$file] == 'enabled') {
+								$CHECKED = "enabled";
+								echo "	\n<i class=\"fa fa-adn text-success\" title=\"" . gettext('Auto-enabled by settings on SID Mgmt tab') . "\"></i>\n";
+							}
+							elseif ($cat_mods[$file] == 'disabled') {
+								echo "	\n<i class=\"fa fa-adn text-danger\" title=\"" . gettext('Auto-disabled by settings on SID Mgmt tab') . "\"></i>\n";
+							}
+						}
+						else {
+							echo "	\n<input type=\"checkbox\" name=\"toenable[]\" value=\"{$file}\" {$CHECKED} />\n";
+						}
+						echo "</td>\n";
+						echo "<td>\n";
+						if (empty($CHECKED))
+							echo "<a href='suricata_rules_edit.php?id={$id}&openruleset=" . urlencode($file) . "' target='_blank' rel='noopener noreferrer'>{$file}</a>\n";
+						else
+							echo "<a href='suricata_rules.php?id={$id}&openruleset=" . urlencode($file) . "'>{$file}</a>\n";
+						echo "</td>\n";
+					} else
+						echo "<td colspan='2'><br/></td>\n";
+
+					if (!empty($snortrules[$j])) {
+						$file = $snortrules[$j];
+						echo "<td>";
+						if(is_array($enabled_rulesets_array)) {
+							if (!empty($disable_vrt_rules))
+								$CHECKED = $disable_vrt_rules;
+							elseif(in_array($file, $enabled_rulesets_array) && !isset($cat_mods[$file]))
+								$CHECKED = " checked=\"checked\"";
+							else
+								$CHECKED = "";
+						} else
+							$CHECKED = "";
+						if (isset($cat_mods[$file])) {
+							if (in_array($file, $enabled_rulesets_array))
+								echo "<input type='hidden' name='toenable[]' value='{$file}' />\n";
+							if ($cat_mods[$file] == 'enabled') {
+								$CHECKED = "enabled";
+								echo "	\n<i class=\"fa fa-adn text-success\" title=\"" . gettext('Auto-enabled by settings on SID Mgmt tab') . "\"></i>\n";
+							}
+							else {
+								echo "	\n<i class=\"fa fa-adn text-danger\" title=\"" . gettext('Auto-disabled by settings on SID Mgmt tab') . "\"></i>\n";
+							}
+						}
+						else {
+							if ($CHECKED == "disabled") {
+								echo "	\n<input type='checkbox' name='toenable[]' value='{$file}' {$CHECKED} title='" . gettext('Disabled because an IPS Policy is selected') . "' />\n";
+							}
+							else {
+								echo "	\n<input type='checkbox' name='toenable[]' value='{$file}' {$CHECKED} />\n";
+							}
+						}
+						echo "</td>\n";
+						echo "<td>\n";
+						if (empty($CHECKED) || $CHECKED == "disabled")
+							echo "<a href='suricata_rules_edit.php?id={$id}&openruleset=" . urlencode($file) . "' target='_blank' rel='noopener noreferrer'>{$file}</a>\n";
+						else
+							echo "<a href='suricata_rules.php?id={$id}&openruleset=" . urlencode($file) . "'>{$file}</a>\n";
+						echo "</td>\n";
+					} else
+						echo "<td colspan='2'><br/></td>\n";
+
+					echo "</tr>\n";
+				}
+			?>
+				</tbody>
+			</table>
+		</div>
+	</div>
+</div>
+
+<div class="col-sm-10 col-sm-offset-2">
+	<button type="submit" id="save" name="save" class="btn btn-primary btn-sm" title="<?=gettext('Click to Save changes and rebuild rules');?>">
+		<i class="fa fa-save icon-embed-btn"></i>
+		<?=gettext(' Save');?>
+	</button>
+</div>
+
+</form>
+
+<script language="javascript" type="text/javascript">
+//<![CDATA[
+
+events.push(function() {
+
+	function enable_change()
+	{
+		var endis = !($('#ips_policy_enable').prop('checked'));
+
+		hideInput('ips_policy', endis);
+		hideInput('ips_policy_mode', endis);
+
+		$('input[type="checkbox"]').each(function() {
+			var str = $(this).val();
+
+			if (str.substr(0,6) == "snort_") {
+				$(this).attr('disabled', !endis);
+				if (!endis) {
+					$(this).prop('title', 'Disabled because an IPS Policy is selected');
+				}
+				else {
+					$(this).prop('title', '');
+				}
+			}
+		});
+	}
+
+	//------- Click handlers -----------------------------------------
+	//
+	$('#ips_policy_enable').click(function() {
+		enable_change();
+	});
+
+	// Set initial state of dynamic HTML form controls
+	enable_change();
+
+});
+//]]>
+</script>
+<?php
+endif;
+include("foot.inc");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
@@ -24,7 +24,7 @@
  */
 
 /* This product includes GeoLite2 data created by MaxMind, available from 
- * http://www.maxmind.com
+ * https://www.maxmind.com
 */
 
 require_once("config.inc");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -3,11 +3,11 @@
  * suricata_global.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -385,7 +385,7 @@ $section->addInput(new Form_Checkbox(
 	'Enable downloading of free GeoIP Country Database updates. Default is Checked',
 	$pconfig['autogeoipupdate'] == 'on' ? true:false,
 	'on'
-))->setHelp('When enabled, Suricata will automatically download updates for the free legacy GeoIP country database on the 8th of each month at midnight.<br /><br />If you have a subscription for more current GeoIP updates, uncheck this option and instead create your own process to place the required database files in /usr/local/share/GeoIP/.');
+))->setHelp('When enabled, Suricata will automatically download updates for the free GeoLite2 IP country database.<br /><br />If you have a subscription for more current GeoIP2 updates, uncheck this option and instead create your own process to place the required database file in /usr/local/share/suricata/GeoLite2/.');
 $form->add($section);
 
 $section = new Form_Section('General Settings');


### PR DESCRIPTION
### pfSense-pkg-suricata-4.1.2_1
This updates the GUI package to work with both Rust-enabled and non-Rust-enabled binary builds.  Detection of the target system's architecture is performed by the installation routine and customized PHP files are copied in for non-Rust support.  These custom source code files remove several logging options and app-layer protocol analyzers from the package for non-Rust builds.

For Rust-supported platforms, full logging and app-layer protocol support is provided including the new dhcp, ikev2, krb5, nfs, ntp, and tftp protocols.