### PR TITLE
Add options to configure TIMEOUTclose and debug (log level)

### DIFF
--- a/security/pfSense-pkg-stunnel/Makefile
+++ b/security/pfSense-pkg-stunnel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-stunnel
 PORTVERSION=	5.47
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.inc
+++ b/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.inc
@@ -65,7 +65,10 @@ function stunnel_save() {
 		}
 		fwrite($fout, "accept = " . ($pkgconfig['localip'] ? $pkgconfig['localip'] . ":" : "")  . $pkgconfig['localport'] . "\n");
 		fwrite($fout, "connect = " . $pkgconfig['redirectip'] . ":" . $pkgconfig['redirectport'] . "\n");
-		fwrite($fout, "TIMEOUTclose = 0\n\n");
+		fwrite($fout, "debug = " . $pkgconfig['loglevel'] . "\n");
+		if ($pkgconfig['timeoutclose'] != "") {
+			fwrite($fout, "TIMEOUTclose = " . $pkgconfig['timeoutclose'] . "\n");
+		}
 	}
 	fclose($fout);
 

--- a/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.xml
+++ b/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.xml
@@ -126,6 +126,30 @@
 			<description>Enter the source IP address for outgoing connections.</description>
 			<type>input</type>
 		</field>
+		<field>
+				<fielddescr>Log Level</fielddescr>
+				<fieldname>loglevel</fieldname>
+				<type>select</type>
+				<default_value>5</default_value>
+				<options>
+						<option><name>EMERGENCY</name><value>0</value></option>
+						<option><name>ALERT</name><value>1</value></option>
+						<option><name>CRITICAL</name><value>2</value></option>
+						<option><name>ERROR</name><value>3</value></option>
+						<option><name>WARNING</name><value>4</value></option>
+						<option><name>NOTICE</name><value>5</value></option>
+						<option><name>INFO</name><value>6</value></option>
+						<option><name>DEBUG</name><value>7</value></option>
+				</options>
+				<description>Logging level</description>
+		</field>
+		<field>
+			<fielddescr>TIMEOUT close</fielddescr>
+			<fieldname>timeoutclose</fieldname>
+			<description>Time to wait for close_notify (set to 0 for buggy MSIE)</description>
+			<type>input</type>
+			<default_value>0</default_value>
+		</field>
 	</fields>
 	<custom_add_php_command_late>
 		stunnel_save();

--- a/security/pfSense-pkg-stunnel/files/usr/local/share/pfSense-pkg-stunnel/info.xml
+++ b/security/pfSense-pkg-stunnel/files/usr/local/share/pfSense-pkg-stunnel/info.xml
@@ -2,7 +2,7 @@
 <pfsensepkgs>
 	<package>
 		<name>stunnel</name>
-		<pkginfolink>https://doc.pfsense.org/index.php/Sudo_Package</pkginfolink>
+		<pkginfolink>https://doc.pfsense.org/index.php/Stunnel_package</pkginfolink>
 		<descr><![CDATA[SSL encryption wrapper between remote client and local or remote servers.]]></descr>
 		<website>http://www.stunnel.org/</website>
 		<version>%%PKGVERSION%%</version>


### PR DESCRIPTION
Hello all...

This PR add options to configure TIMEOUTclose and debug (log level) and fix package URL documentation on package manifest.

I had too much logging being generated from stunnel and I preferred to decrease the log level to warning instead of notice. I also added the timeoutclose option so people can not set or set a different timeout if they want.

Note that the defaults are set to both options, maintaining old behaviour with NOTICE loglevel and TIMEOUTclose=0, so people upgrading shouldn't have any impact.

BR,
Wagner Sartori Junior