### PR TITLE
pfSense-pkg-suricata-4.1.2_2 -- Fix SID MGMT changes not being applied due to new RULES path in 4.1.2.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.1.2
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -1773,7 +1773,7 @@ function suricata_resolve_flowbits($rules, $active_rules) {
 
 	// Check $rules array to be sure it is filled.
 	if (empty($rules)) {
-		log_error(gettext("[Suricata] WARNING: Flowbit resolution not done - no rules in {$suricatadir}rules/ ..."));
+		log_error(gettext("[Suricata] WARNING: Flowbit resolution not done - no rules in ". SURICATA_RULES_DIR . " ..."));
 		return array();
 	}
 
@@ -2263,7 +2263,6 @@ function suricata_get_auto_category_mods($categories, $sid_mods, $action, $log_r
 	/*                                                  */
 	/****************************************************/
 
-	$suricatadir = SURICATADIR;
 	$all_cats = array();
 	$changes = array();
 	$counter = 0;
@@ -2271,7 +2270,7 @@ function suricata_get_auto_category_mods($categories, $sid_mods, $action, $log_r
 
 	// Get a list of all possible categories by loading all rules files
 	foreach (array( VRT_FILE_PREFIX, ET_OPEN_FILE_PREFIX, ET_PRO_FILE_PREFIX, GPL_FILE_PREFIX ) as $prefix) {
-		$files = glob("{$suricatadir}rules/{$prefix}*.rules");
+		$files = glob(SURICATA_RULES_DIR . "{$prefix}*.rules");
 		foreach ($files as $file) {
 			$all_cats[] = basename($file);
 		}
@@ -3311,7 +3310,6 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 
 	global $config, $rebuild_rules;
 
-	$suricatadir = SURICATADIR;
 	$flowbit_rules_file = FLOWBITS_FILENAME;
 	$suricata_enforcing_rules_file = SURICATA_ENFORCING_RULES_FILENAME;
 	$enabled_rules = array();
@@ -3478,7 +3476,7 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 				log_error('[Suricata] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . '...');
 
 				// Load up all rules into a Rules Map array for flowbits assessment
-				$all_rules = suricata_load_rules_map("{$suricatadir}rules/");
+				$all_rules = suricata_load_rules_map(SURICATA_RULES_DIR);
 				$fbits = suricata_resolve_flowbits($all_rules, $enabled_rules);
 
 				// Check for and disable any flowbit-required rules the


### PR DESCRIPTION
### pfSense-pkg-suricata v4.1.2_2
This update corrects an issue with the new RULES_DIR path not being correctly applied when processing SID MGMT customizations.  There are no new features or feature changes in this release.

**New Features:**
None

**Bug Fixes:**
1. SID MGMT changes not being applied to rules due to incorrect legacy RULES_DIR path being used.