### PR TITLE
FRR: Show IPv4 and IPv6 BGP Summary

### DIFF
--- a/net/pfSense-pkg-frr/files/usr/local/bin/frrctl
+++ b/net/pfSense-pkg-frr/files/usr/local/bin/frrctl
@@ -189,7 +189,7 @@ bgp*)
 		;;
 	sum*)
 		shift; shift;
-		daemon_command ${BGP_PORT} ${BGP_PASSWORD} "show ip bgp summary $*"
+		daemon_command ${BGP_PORT} ${BGP_PASSWORD} "show bgp summary $*"
 		;;
 	nexth*)
 		shift; shift;


### PR DESCRIPTION
Change "show ip bgp summary $*" to "show bgp summary $*" so Summary page will show both IPv4 and IPv6 Info.

https://redmine.pfsense.org/issues/9244