### PR TITLE
Suricata 4.1.2_1 - fix geioip memory leak, disable optimization on armv6/v7 platforms.

### DIFF
--- a/security/suricata/Makefile
+++ b/security/suricata/Makefile
@@ -3,6 +3,7 @@
 
 PORTNAME=	suricata
 DISTVERSION=	4.1.2
+PORTREVISION=   1
 CATEGORIES=	security
 MASTER_SITES=	https://www.openinfosecfoundation.org/download/
 

--- a/security/suricata/files/patch-geoip2.diff
+++ b/security/suricata/files/patch-geoip2.diff
@@ -1,6 +1,71 @@
+diff -ruN ./suricata-4.1.2.orig/appveyor.yml ./suricata-4.1.2/appveyor.yml
+--- ./suricata-4.1.2.orig/appveyor.yml	1969-12-31 19:00:00.000000000 -0500
++++ ./appveyor.yml	2019-01-14 09:09:05.000000000 -0500
+@@ -0,0 +1,61 @@
++# Based on https://github.com/redis/hiredis/blob/master/appveyor.yml
++# and https://github.com/dokan-dev/dokany/pull/336/files
++# Appveyor configuration file for CI build of hiredis on Windows (under Cygwin)
++environment:
++    matrix:
++#       - CYG_ROOT: C:\cygwin64
++#         CYG_SETUP: setup-x86_64.exe
++#         CYG_MIRROR: http://cygwin.mirror.constant.com
++#         CYG_CACHE: C:\cygwin64\var\cache\setup
++#         CYG_BASH: C:\cygwin64\bin\bash
++#         CC: gcc
++        - CYG_ROOT: C:\cygwin
++          CYG_SETUP: setup-x86.exe
++          CYG_MIRROR: http://cygwin.mirror.constant.com
++          CYG_CACHE: C:\cygwin\var\cache\setup
++          CYG_BASH: C:\cygwin\bin\bash
++          CC: gcc
++          CFLAGS: -Wall -Wextra -Werror -Wshadow -Wno-unused-parameter -Wno-unused-function
++
++# Cache Cygwin files to speed up build
++cache:
++    - '%CYG_CACHE%'
++clone_depth: 1
++
++# Attempt to ensure we don't try to convert line endings to Win32 CRLF as this will cause build to fail
++init:
++    - git config --global core.autocrlf input
++#    - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
++
++# Install needed build dependencies. First update cygwin to avoid weird dll issues.
++install:
++    - ps: 'Start-FileDownload "http://cygwin.com/$env:CYG_SETUP" -FileName "$env:CYG_SETUP"'
++    - '%CYG_SETUP% -gqnNdO --quiet-mode --no-shortcuts --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" > NUL 2>&1'
++    - '%CYG_SETUP% --quiet-mode --no-shortcuts --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --packages automake,bison,gcc-core,libtool,make,gettext-devel,gettext,intltool,pkg-config,clang,llvm,libpcre-devel,file-devel,wget,zlib-devel,libnss-devel,libnspr-devel,libyaml-devel,luajit-devel,unzip,libiconv,libiconv-devel > NUL 2>&1'
++    - '%CYG_BASH% -lc "cygcheck -dc cygwin"'
++    - '%CYG_BASH% -lc "wget https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip && ls && unzip WpdPack_4_1_2.zip"'
++    - '%CYG_BASH% -lc "cp WpdPack/Lib/libpacket.a /usr/lib/"'
++    - '%CYG_BASH% -lc "cp WpdPack/Lib/libwpcap.a /usr/lib/libpcap.a"' # so -lpcap works
++#    - '%CYG_BASH% -lc "cp WpdPack/Lib/libwpcap.a /usr/lib/libwpcap.a"'
++    - '%CYG_BASH% -lc "cp WpdPack/Lib/Packet.lib /usr/lib/"'
++    - '%CYG_BASH% -lc "cp WpdPack/Lib/wpcap.lib /usr/lib/"'
++    - '%CYG_BASH% -lc "mkdir -p /usr/include/pcap"'
++    - '%CYG_BASH% -lc "cp -r WpdPack/Include/* /usr/include/"'
++    - choco install winpcap # userspace
++
++build_script:
++    - 'echo building...'
++    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; bash ./qa/travis-libhtp.sh"'
++    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; ./autogen.sh"'
++    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; ./configure --enable-unittests --disable-shared --disable-gccmarch-native --enable-luajit"'
++    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; exec 0</dev/null; make -j3 LDFLAGS=$LDFLAGS CC=$CC CFLAGS=$CFLAGS"'
++    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; file src/suricata.exe"'
++    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; ldd src/suricata.exe"'
++    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; src/suricata.exe --build-info"'
++    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; src/suricata.exe -u -l /tmp/"'
++    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; exec 0</dev/null; make -j3 DISTCHECK_CONFIGURE_FLAGS="--enable-unittests --disable-shared --disable-gccmarch-native" LDFLAGS=$LDFLAGS CC=$CC distcheck CFLAGS=$CFLAGS"'
++
++#on_finish:
++#    - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
++#    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; cat config.log"'
++
 diff -ruN ./suricata-4.1.2.orig/configure.ac ./suricata-4.1.2/configure.ac
 --- ./suricata-4.1.2.orig/configure.ac	2018-12-21 09:43:34.000000000 -0500
-+++ ./configure.ac	2019-01-04 12:33:58.000000000 -0500
++++ ./configure.ac	2019-01-16 15:43:52.000000000 -0500
 @@ -2032,43 +2032,43 @@
  
      AM_CONDITIONAL([HAVE_LUA], [test "x$enable_lua" != "xno"])
@@ -8,7 +73,8 @@ diff -ruN ./suricata-4.1.2.orig/configure.ac ./suricata-4.1.2/configure.ac
 -  # libgeoip
 +  # libmaxminddb
      AC_ARG_ENABLE(geoip,
- 	        AS_HELP_STRING([--enable-geoip],[Enable GeoIP support]),
+-	        AS_HELP_STRING([--enable-geoip],[Enable GeoIP support]),
++	        AS_HELP_STRING([--enable-geoip],[Enable GeoIP2 support]),
  	        [ enable_geoip="yes"],
  	        [ enable_geoip="no"])
 -    AC_ARG_WITH(libgeoip_includes,
@@ -46,15 +112,15 @@ diff -ruN ./suricata-4.1.2.orig/configure.ac ./suricata-4.1.2/configure.ac
              echo
 -            echo "   ERROR!  libgeoip library not found, go get it"
 -            echo "   from http://www.maxmind.com/en/geolite or your distribution:"
-+            echo "   ERROR!  libmaxminddb library not found, go get it"
++            echo "   ERROR!  libmaxminddb GeoIP2 library not found, go get it"
 +            echo "   from https://github.com/maxmind/libmaxminddb or your distribution:"
              echo
 -            echo "   Ubuntu: apt-get install libgeoip-dev"
 -            echo "   Fedora: dnf install GeoIP-devel"
 -            echo "   CentOS/RHEL: yum install GeoIP-devel"
-+            echo "   Ubuntu: apt-get install libmaxminddb"
-+            echo "   Fedora: dnf install libmaxminddb"
-+            echo "   CentOS/RHEL: yum install libmaxminddb"
++            echo "   Ubuntu: apt-get install libmaxminddb-dev"
++            echo "   Fedora: dnf install libmaxminddb-devel"
++            echo "   CentOS/RHEL: yum install libmaxminddb-devel"
              echo
              exit 1
          fi
@@ -69,14 +135,71 @@ diff -ruN ./suricata-4.1.2.orig/configure.ac ./suricata-4.1.2/configure.ac
    LUA support:                             ${enable_lua}
    libluajit:                               ${enable_luajit}
 -  libgeoip:                                ${enable_geoip}
-+  libmaxminddb:                            ${enable_geoip}
++  GeoIP2 support:                          ${enable_geoip}
    Non-bundled htp:                         ${enable_non_bundled_htp}
    Old barnyard2 support:                   ${enable_old_barnyard2}
    Hyperscan support:                       ${enable_hyperscan}
+diff -ruN ./suricata-4.1.2.orig/doc/userguide/rules/header-keywords.rst ./suricata-4.1.2/doc/userguide/rules/header-keywords.rst
+--- ./suricata-4.1.2.orig/doc/userguide/rules/header-keywords.rst	2018-12-21 09:43:33.000000000 -0500
++++ ./doc/userguide/rules/header-keywords.rst	2019-01-15 13:03:11.000000000 -0500
+@@ -137,8 +137,8 @@
+ ^^^^^
+ The geoip keyword enables (you) to match on the source, destination or
+ source and destination IP addresses of network traffic, and to see to
+-which country it belongs. To be able to do this, Suricata uses GeoIP
+-API of Maxmind.
++which country it belongs. To be able to do this, Suricata uses the GeoIP2
++API of MaxMind.
+ 
+ The syntax of geoip::
+ 
+@@ -156,8 +156,15 @@
+   dest: if the destination matches with the given geoip.
+   src: the source matches with the given geoip.
+ 
+-The keyword only supports IPv4. As it uses the GeoIP API of Maxmind,
+-libgeoip must be compiled in.
++The keyword only supports IPv4. As it uses the GeoIP2 API of MaxMind,
++libmaxminddb must be compiled in. You must download and install the
++GeoIP2 or GeoLite2 database editions desired. Visit the MaxMind site 
++at https://dev.maxmind.com/geoip/geoip2/geolite2/ for details.
++
++You must also supply the location of the GeoIP2 or GeoLite2 database 
++file on the local system in the YAML-file configuration (for example)::
++
++  geoip-database: /usr/local/share/GeoIP/GeoLite2-Country.mmdb
+ 
+ fragbits (IP fragmentation)
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 diff -ruN ./suricata-4.1.2.orig/src/detect-geoip.c ./suricata-4.1.2/src/detect-geoip.c
 --- ./suricata-4.1.2.orig/src/detect-geoip.c	2018-12-21 09:43:34.000000000 -0500
-+++ ./src/detect-geoip.c	2019-01-06 14:48:50.000000000 -0500
-@@ -59,7 +59,7 @@
++++ ./src/detect-geoip.c	2019-01-16 10:06:55.000000000 -0500
+@@ -1,4 +1,4 @@
+-/* Copyright (C) 2012 Open Information Security Foundation
++/* Copyright (C) 2012-2019 Open Information Security Foundation
+  *
+  * You can copy, redistribute or modify this Program under the terms of
+  * the GNU General Public License version 2 as published by the Free
+@@ -19,8 +19,10 @@
+  * \file
+  *
+  * \author Ignacio Sanchez <sanchezmartin.ji@gmail.com>
++ * \author Bill Meeks <billmeeks8@gmail.com>
+  *
+  * Implements the geoip keyword.
++ * Updated to use MaxMind GeoIP2 database.
+  */
+ 
+ #include "suricata-common.h"
+@@ -34,6 +36,7 @@
+ 
+ #include "detect-geoip.h"
+ 
++#include "util-mem.h"
+ #include "util-unittest.h"
+ #include "util-unittest-helper.h"
+ 
+@@ -59,7 +62,7 @@
  
  #else /* HAVE_GEOIP */
  
@@ -85,16 +208,16 @@ diff -ruN ./suricata-4.1.2.orig/src/detect-geoip.c ./suricata-4.1.2/src/detect-g
  
  static int DetectGeoipMatch(ThreadVars *, DetectEngineThreadCtx *, Packet *,
                              const Signature *, const SigMatchCtx *);
-@@ -84,27 +84,78 @@
+@@ -84,27 +87,85 @@
   * \internal
   * \brief This function is used to initialize the geolocation MaxMind engine
   *
 - * \retval NULL if the engine couldn't be initialized
 - * \retval (GeoIP *) to the geolocation engine
-+ * \retval FALSE if the engine couldn't be initialized
++ * \retval false if the engine couldn't be initialized
   */
 -static GeoIP *InitGeolocationEngine(void)
-+static int InitGeolocationEngine(DetectGeoipData *geoipdata)
++static bool InitGeolocationEngine(DetectGeoipData *geoipdata)
  {
 -    return GeoIP_new(GEOIP_MEMORY_CACHE);
 +    const char *filename = NULL;
@@ -103,9 +226,11 @@ diff -ruN ./suricata-4.1.2.orig/src/detect-geoip.c ./suricata-4.1.2/src/detect-g
 +    (void)ConfGet("geoip-database", &filename);
 +
 +    if (filename == NULL) {
-+        SCLogWarning(SC_ERR_INVALID_ARGUMENT, "Unable to locate a GeoIP2 database filename in YAML conf.  GeoIP rule matching is disabled.");
++        SCLogWarning(SC_ERR_INVALID_ARGUMENT, "Unable to locate a GeoIP2"  
++                     "database filename in YAML conf.  GeoIP rule matching "
++                     "is disabled.");
 +        geoipdata->mmdb_status = MMDB_FILE_OPEN_ERROR;
-+        return FALSE;
++        return false;
 +    }
 +
 +    /* Attempt to open MaxMind DB and save file handle if successful */
@@ -113,12 +238,14 @@ diff -ruN ./suricata-4.1.2.orig/src/detect-geoip.c ./suricata-4.1.2/src/detect-g
 +
 +    if (status == MMDB_SUCCESS) {
 +        geoipdata->mmdb_status = status;
-+        return TRUE;
++        return true;
 +    }
 +
-+    SCLogWarning(SC_ERR_INVALID_ARGUMENT, "Failed to open GeoIP2 database: %s.  Error was: %s.  GeoIP rule matching is disabled.", filename, MMDB_strerror(status));
++    SCLogWarning(SC_ERR_INVALID_ARGUMENT, "Failed to open GeoIP2 database: %s. " 
++                 "Error was: %s.  GeoIP rule matching is disabled.", filename, 
++                 MMDB_strerror(status));
 +    geoipdata->mmdb_status = status;
-+    return FALSE;
++    return false;
  }
  
  /**
@@ -149,20 +276,23 @@ diff -ruN ./suricata-4.1.2.orig/src/detect-geoip.c ./suricata-4.1.2/src/detect-g
 +        return NULL;
 +
 +    /* Attempt to find the IPv4 address in the database */
-+    result = MMDB_lookup_sockaddr((MMDB_s *)&geoipdata->mmdb, (struct sockaddr*)&sa, &mmdb_error);
++    result = MMDB_lookup_sockaddr((MMDB_s *)&geoipdata->mmdb, 
++                                  (struct sockaddr*)&sa, &mmdb_error);
 +    if (mmdb_error != MMDB_SUCCESS)
 +        return NULL;
 +
 +    /* The IPv4 address was found, so grab ISO country code if available */
 +    if (result.found_entry) {
-+        mmdb_error = MMDB_get_value(&result.entry, &entry_data, "country", "iso_code", NULL);
++        mmdb_error = MMDB_get_value(&result.entry, &entry_data, "country", 
++                                    "iso_code", NULL);
 +        if (mmdb_error != MMDB_SUCCESS)
 +            return NULL;
 +
 +        /* If ISO country code was found, then return it */
 +        if (entry_data.has_data) {
 +            if (entry_data.type == MMDB_DATA_TYPE_UTF8_STRING) {
-+                    char *country_code = strndup((char *)entry_data.utf8_string, entry_data.data_size);
++                    char *country_code = SCStrndup((char *)entry_data.utf8_string, 
++                                                    entry_data.data_size);
 +                    return country_code;
 +            }
 +        }
@@ -172,7 +302,7 @@ diff -ruN ./suricata-4.1.2.orig/src/detect-geoip.c ./suricata-4.1.2/src/detect-g
      return NULL;
  }
  
-@@ -125,16 +176,23 @@
+@@ -125,29 +186,43 @@
   * \internal
   * \brief This function is used to geolocate the IP using the MaxMind libraries
   *
@@ -185,31 +315,55 @@ diff -ruN ./suricata-4.1.2.orig/src/detect-geoip.c ./suricata-4.1.2/src/detect-g
  static int CheckGeoMatchIPv4(const DetectGeoipData *geoipdata, uint32_t ip)
  {
 -    const char *country;
-+    const char *country = NULL;
      int i;
 -    country = GeolocateIPv4(geoipdata->geoengine, ip);
 +
 +    /* Attempt country code lookup for the IP address */
-+    country = GeolocateIPv4(geoipdata, ip);
++    const char *country = GeolocateIPv4(geoipdata, ip);
 +
-+    /* Skip further checks if did not get a country code */
-+    if (country == NULL || geoipdata->mmdb_status != MMDB_SUCCESS)
++    /* Skip further checks if did not find a country code */
++    if (country == NULL)
 +        return 0;
 +
      /* Check if NOT NEGATED match-on condition */
      if ((geoipdata->flags & GEOIP_MATCH_NEGATED) == 0)
      {
-@@ -299,8 +357,7 @@
+-        for (i = 0; i < geoipdata->nlocations; i++)
+-            if (country != NULL && strcmp(country, (char *)geoipdata->location[i])==0)
++        for (i = 0; i < geoipdata->nlocations; i++) {
++            if (strcmp(country, (char *)geoipdata->location[i])==0) {
++                SCFree((void *)country);
+                 return 1;
++            }
++        }
+     } else {
+         /* Check if NEGATED match-on condition */
+-        for (i = 0; i < geoipdata->nlocations; i++)
+-            if (country != NULL && strcmp(country, (char *)geoipdata->location[i])==0)
++        for (i = 0; i < geoipdata->nlocations; i++) {
++            if (strcmp(country, (char *)geoipdata->location[i])==0) {
++                SCFree((void *)country);
+                 return 0; /* if one matches, rule does NOT match (negated) */
++            }
++        }
++        SCFree((void *)country);
+         return 1; /* returns 1 if no location matches (negated) */
+     }
++    SCFree((void *)country);
+     return 0;
+ }
+ 
+@@ -299,8 +374,7 @@
      }
  
      /* Initialize the geolocation engine */
 -    geoipdata->geoengine = InitGeolocationEngine();
 -    if (geoipdata->geoengine == NULL)
-+    if (InitGeolocationEngine(geoipdata) == FALSE)
++    if (InitGeolocationEngine(geoipdata) == false)
          goto error;
  
      return geoipdata;
-@@ -362,6 +419,8 @@
+@@ -362,6 +436,8 @@
  {
      if (ptr != NULL) {
          DetectGeoipData *geoipdata = (DetectGeoipData *)ptr;
@@ -220,8 +374,22 @@ diff -ruN ./suricata-4.1.2.orig/src/detect-geoip.c ./suricata-4.1.2/src/detect-g
  }
 diff -ruN ./suricata-4.1.2.orig/src/detect-geoip.h ./suricata-4.1.2/src/detect-geoip.h
 --- ./suricata-4.1.2.orig/src/detect-geoip.h	2018-12-21 09:43:34.000000000 -0500
-+++ ./src/detect-geoip.h	2019-01-05 12:15:24.000000000 -0500
-@@ -26,7 +26,7 @@
++++ ./src/detect-geoip.h	2019-01-15 11:56:18.000000000 -0500
+@@ -1,4 +1,4 @@
+-/* Copyright (C) 2012 Open Information Security Foundation
++/* Copyright (C) 2012-2019 Open Information Security Foundation
+  *
+  * You can copy, redistribute or modify this Program under the terms of
+  * the GNU General Public License version 2 as published by the Free
+@@ -19,6 +19,7 @@
+  * \file
+  *
+  * \author Ignacio Sanchez <sanchezmartin.ji@gmail.com>
++ * \author Bill Meeks <billmeeks8@gmail.com>
+  */
+ 
+ #ifndef __DETECT_GEOIP_H__
+@@ -26,7 +27,7 @@
  
  #ifdef HAVE_GEOIP
  
@@ -230,7 +398,7 @@ diff -ruN ./suricata-4.1.2.orig/src/detect-geoip.h ./suricata-4.1.2/src/detect-g
  #include "util-spm-bm.h"
  
  #define GEOOPTION_MAXSIZE 3 /* Country Code (2 chars) + NULL */
-@@ -34,9 +34,10 @@
+@@ -34,9 +35,10 @@
  
  typedef struct DetectGeoipData_ {
      uint8_t location[GEOOPTION_MAXLOCATIONS][GEOOPTION_MAXSIZE];  /** country code for now, null term.*/
@@ -243,17 +411,103 @@ diff -ruN ./suricata-4.1.2.orig/src/detect-geoip.h ./suricata-4.1.2/src/detect-g
  } DetectGeoipData;
  
  #endif
+diff -ruN ./suricata-4.1.2.orig/src/util-mem.h ./suricata-4.1.2/src/util-mem.h
+--- ./suricata-4.1.2.orig/src/util-mem.h	2018-12-21 09:43:34.000000000 -0500
++++ ./src/util-mem.h	2019-01-15 12:56:17.000000000 -0500
+@@ -1,4 +1,4 @@
+-/* Copyright (C) 2007-2014 Open Information Security Foundation
++/* Copyright (C) 2007-2019 Open Information Security Foundation
+  *
+  * You can copy, redistribute or modify this Program under the terms of
+  * the GNU General Public License version 2 as published by the Free
+@@ -19,12 +19,13 @@
+  * \file
+  *
+  * \author Pablo Rincon Crespo <pablo.rincon.crespo@gmail.com>
++ * \author Bill Meeks <billmeeks8@gmail.com>
+  *
+  * Utility Macros for memory management
+  *
+  * \todo Add wrappers for functions that allocate/free memory here.
+- * Currently we have malloc, calloc, realloc, strdup and free,
+- * but there are more.
++ * Currently we have malloc, calloc, realloc, strdup, strndup and 
++ * free, but there are more.
+  */
+ 
+ #ifndef __UTIL_MEM_H__
+@@ -38,6 +39,7 @@
+ #define SCRealloc realloc
+ #define SCFree free
+ #define SCStrdup strdup
++#define SCStrndup strndup
+ #define SCMallocAligned _mm_malloc
+ #define SCFreeAligned _mm_free
+ #else /* CPPCHECK */
+@@ -161,6 +163,30 @@
+     (void*)ptrmem; \
+ })
+ 
++#define SCStrndup(a, b) ({ \
++    char *ptrmem = NULL; \
++    extern size_t global_mem; \
++    extern uint8_t print_mem_flag; \
++    size_t len = (b); \
++    \
++    ptrmem = strndup((a), len); \
++    if (ptrmem == NULL) { \
++        SCLogError(SC_ERR_MEM_ALLOC, "SCStrndup failed: %s, while trying " \
++            "to allocate %"PRIuMAX" bytes", strerror(errno), (uintmax_t)len); \
++        if (SC_ATOMIC_GET(engine_stage) == SURICATA_INIT) {\
++            SCLogError(SC_ERR_FATAL, "Out of memory. The engine cannot be initialized. Exiting..."); \
++            exit(EXIT_FAILURE); \
++        } \
++    } \
++    \
++    global_mem += len; \
++    if (print_mem_flag == 1) {                              \
++        SCLogInfo("SCStrndup return at %p of size %"PRIuMAX, \
++            ptrmem, (uintmax_t)len); \
++    }                                \
++    (void*)ptrmem; \
++})
++
+ #define SCFree(a) ({ \
+     extern uint8_t print_mem_flag; \
+     if (print_mem_flag == 1) {          \
+@@ -233,6 +259,22 @@
+     (void*)ptrmem; \
+ })
+ 
++#define SCStrndup(a, b) ({ \
++    char *ptrmem = NULL; \
++    \
++    ptrmem = strndup((a), (b)); \
++    if (ptrmem == NULL) { \
++        if (SC_ATOMIC_GET(engine_stage) == SURICATA_INIT) {\
++            size_t _scstrdup_len = (b); \
++            SCLogError(SC_ERR_MEM_ALLOC, "SCStrndup failed: %s, while trying " \
++                "to allocate %"PRIuMAX" bytes", strerror(errno), (uintmax_t)_scstrdup_len); \
++            SCLogError(SC_ERR_FATAL, "Out of memory. The engine cannot be initialized. Exiting..."); \
++            exit(EXIT_FAILURE); \
++        } \
++    } \
++    (void*)ptrmem; \
++})
++
+ #define SCFree(a) ({ \
+     free(a); \
+ })
 diff -ruN ./suricata-4.1.2.orig/suricata.yaml.in ./suricata-4.1.2/suricata.yaml.in
 --- ./suricata-4.1.2.orig/suricata.yaml.in	2018-12-21 09:43:34.000000000 -0500
-+++ ./suricata.yaml.in	2019-01-05 01:01:13.000000000 -0500
-@@ -1122,6 +1122,11 @@
++++ ./suricata.yaml.in	2019-01-09 18:33:50.000000000 -0500
+@@ -1122,6 +1122,10 @@
  #magic-file: /usr/share/file/magic
  @e_magic_file_comment@magic-file: @e_magic_file@
  
 +# GeoIP2 database file. Specify path and filename of GeoIP2 database
 +# if using rules with "geoip" rule option.
 +#geoip-database: /usr/local/share/GeoLite2/GeoLite2-Country.mmdb
-+#geoip-database: 
 +
  legacy:
    uricontent: enabled

--- a/security/suricata/files/patch-pfSense-ARMv6_ARMv7.diff
+++ b/security/suricata/files/patch-pfSense-ARMv6_ARMv7.diff
@@ -1,0 +1,43 @@
+diff -ruN ./suricata-4.1.2.orig/configure.ac ./suricata-4.1.2/configure.ac
+--- ./suricata-4.1.2.orig/configure.ac	2018-12-21 09:43:34.000000000 -0500
++++ ./configure.ac	2019-01-17 18:18:06.000000000 -0500
+@@ -271,6 +271,23 @@
+     esac
+     AC_MSG_RESULT(ok)
+ 
++    # armv6/7 platform needs compiler optimization disabled for now.
++	NO_OPTIMIZE="no"
++    AC_MSG_CHECKING([for armv6/armv7 platform])
++	case "$host_cpu" in
++		armv6)
++			NO_OPTIMIZE="yes"
++			AC_MSG_RESULT([yes])
++			;;
++		armv7)
++			NO_OPTIMIZE="yes"
++			AC_MSG_RESULT([yes])
++			;;
++		*)
++			AC_MSG_RESULT([no])
++			NO_OPTIMIZE="no"
++	esac
++
+     # enable modifications for AFL fuzzing
+     AC_ARG_ENABLE(afl,
+            AS_HELP_STRING([--enable-afl], Enable AFL fuzzing logic[])], [enable_afl="$enableval"],[enable_afl=no])
+@@ -2364,6 +2381,15 @@
+         fi
+     fi
+ 
++# check if compiler optimization disabled for armv6/armv7
++if test "$NO_OPTIMIZE" != "no"; then
++	CFLAGS=`echo $CFLAGS | sed -e "s/-O./-O0/"`
++	# in case user override doesn't include -O
++	if echo $CFLAGS | grep -qve -O0 ; then
++		CFLAGS="${CFLAGS} -O0"
++	fi
++fi
++
+ AC_SUBST(CFLAGS)
+ AC_SUBST(LDFLAGS)
+ AC_SUBST(CPPFLAGS)


### PR DESCRIPTION
### Suricata 4.1.2_1
This update for the Suricata binary merges in GeoIP2 fixes submitted to upstream.  These fixes eliminate a small memory leak and update the source code formatting to match upstream coding standards.  It also includes auto-detection of target platform and disables compiler optimization for armv6 or armv7 platforms.

**New Features:**
None

**Bug Fixes:**
1. Add missing call to SCFree() to free allocated memory.
2. Add logic to configure.ac to detect when being compiled for armv6 or armv7 platforms and disable compiler optimizations on those platforms.