### PR TITLE
pfSense-pkg-Telegraf - Add support for Ping and Netstat modules

### DIFF
--- a/net-mgmt/pfSense-pkg-Telegraf/Makefile
+++ b/net-mgmt/pfSense-pkg-Telegraf/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-Telegraf
-PORTVERSION=	0.8
+PORTVERSION=	0.9
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.inc
+++ b/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.inc
@@ -96,6 +96,34 @@ EOD;
 		$cfg .= "\n";
 	}
 
+        /* Ping Monitor Configuration */
+        if ($telegraf_conf["ping_enable"]) {
+                if (!empty($telegraf_conf['ping_host_1'])) {
+                        $monitor_hosts[] = '"' . $telegraf_conf["ping_host_1"] . '"';
+                }
+                if (!empty($telegraf_conf['ping_host_2'])) {
+                        $monitor_hosts[] = '"' . $telegraf_conf["ping_host_2"] . '"';
+                }
+                if (!empty($telegraf_conf['ping_host_3'])) {
+                        $monitor_hosts[] = '"' . $telegraf_conf["ping_host_3"] . '"';
+                }
+                if (!empty($telegraf_conf['ping_host_4'])) {
+                        $monitor_hosts[] = '"' . $telegraf_conf["ping_host_4"] . '"';
+                }
+
+                $monitor_hosts = implode(",", $monitor_hosts);
+
+                $cfg .= "\n[[inputs.ping]]\n";
+                $cfg .= "\turls = [" . $monitor_hosts . "]";
+                $cfg .= "\n\tdeadline = 0\n\n"; /* deadline (-w) function not supported in BSD ping */
+        }
+
+        /* Netstat Configuration */
+        if ($telegraf_conf["netstat_enable"]) {
+
+                $cfg .= "[[inputs.netstat]]\n\n";  
+        }
+
 	if ((is_array($telegraf_conf['telegraf_output']) && in_array("influxdb", $telegraf_conf['telegraf_output'])) || $telegraf_conf['telegraf_output'] == "influxdb") {
 		$cfg .= "[[outputs.influxdb]]\n";
 		$cfg .= "\turls = [\"" . $telegraf_conf['influx_server'] . "\"]\n";

--- a/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.xml
+++ b/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.xml
@@ -128,6 +128,38 @@
            <description>Port number where HAProxy status is available (default: 2200)</description>
         </field>
         <field>
+           <fielddescr>Enable Netstat Monitor</fielddescr>
+           <fieldname>netstat_enable</fieldname>
+           <type>checkbox</type>
+        </field>
+        <field>
+           <fielddescr>Enable Ping Monitor</fielddescr>
+           <fieldname>ping_enable</fieldname>
+           <type>checkbox</type>
+           <description>Enable Ping Monitor (up to 4 hosts (IPs), entered below)</description>
+           <enablefields>ping_host_1,ping_host_2,ping_host_3,ping_host_4</enablefields>
+        </field>
+        <field>
+           <fielddescr>Ping Host 1</fielddescr>
+           <fieldname>ping_host_1</fieldname>
+           <type>input</type>
+        </field>
+        <field>
+           <fielddescr>Ping Host 2 (optional)</fielddescr>
+           <fieldname>ping_host_2</fieldname>
+           <type>input</type>
+        </field>
+        <field>
+           <fielddescr>Ping Host 3 (optional)</fielddescr>
+           <fieldname>ping_host_3</fieldname>
+           <type>input</type>
+        </field>
+        <field>
+           <fielddescr>Ping Host 4 (optional)</fielddescr>
+           <fieldname>ping_host_4</fieldname>
+           <type>input</type>
+        </field>
+        <field>
             <fielddescr>Additional configuration for Telegraf</fielddescr>
             <fieldname>telegraf_raw_config</fieldname>
             <type>textarea</type>


### PR DESCRIPTION
I use the ping and netstat modules for my grafana dashboard, and figured others may as well for statistical purposes.

I couldn't really find a better way, seeing as the config page is plain XML, to enter in multiple hosts, but I made the best of what I could with a list of 4 hosts, which adjusts accordingly if some are empty or not.

Feel free to comment if you think there's a better way for adding an arbitrary number of hosts.