### PR TITLE
Stunnel custom options

### DIFF
--- a/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.inc
+++ b/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.inc
@@ -69,6 +69,10 @@ function stunnel_save() {
 		if ($pkgconfig['timeoutclose'] != "") {
 			fwrite($fout, "TIMEOUTclose = " . $pkgconfig['timeoutclose'] . "\n");
 		}
+		if ($pkgconfig['protocol']) {
+			fwrite($fout, "protocol = " . $pkgconfig['protocol'] . "\n");
+		}
+		fwrite($fout, base64_decode($pkgconfig['custom_options']) . "\n");
 	}
 	fclose($fout);
 

--- a/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.xml
+++ b/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.xml
@@ -97,6 +97,13 @@
 			<description>Enter the local port to bind this redirection to.</description>
 			<type>input</type>
 		</field>
+		</field>
+			<field>
+			<fielddescr>Protocol</fielddescr>
+			<fieldname>protocol</fieldname>
+			<description>Select a specific application protocol (https://www.stunnel.org/static/stunnel.html#protocol-PROTO)</description>
+			<type>input</type>
+		</field>
 		<field>
 			<fielddescr>Certificate</fielddescr>
 			<fieldname>certificate</fieldname>
@@ -149,6 +156,13 @@
 			<description>Time to wait for close_notify (set to 0 for buggy MSIE)</description>
 			<type>input</type>
 			<default_value>0</default_value>
+		</field>
+		<field>
+			<fielddescr>Custom Options</fielddescr>
+			<fieldname>custom_options</fieldname>
+			<type>textarea</type>
+			<description>Custom service level options (https://www.stunnel.org/static/stunnel.html#SERVICE-LEVEL-OPTIONS)</description>
+			<encoding>base64</encoding>
 		</field>
 	</fields>
 	<custom_add_php_command_late>


### PR DESCRIPTION
First time using github. Sorry if my approach is ruff.

Custom options is needed for stunnel as it is very well rounded tool. Personally I use stunnel to add TLS to SMTP (old copiers) so will use protocol option often but reviewing the stunnel documentation I foresee myself and other users may need additional features.


