### PR TITLE
acme, allow saving 100+ certificate SAN settings staying under 5000 POST variables by not submitting empty fields

### DIFF
--- a/security/pfSense-pkg-acme/files/usr/local/www/acme/acme_certificates_edit.php
+++ b/security/pfSense-pkg-acme/files/usr/local/www/acme/acme_certificates_edit.php
@@ -486,6 +486,14 @@ print $form;
 <script type="text/javascript">
 //<![CDATA[
 events.push(function() {
+	$('form').submit(function(event){
+		// disable all elements that dont have a value to avoid posting them as it could be sending 
+		// more than 5000 variables which is the php default max for less than 100 san's which acme does support
+		// p.s. the jquery .find(['value'='']) would not find newly added empty items) so we use .filter(...)
+		$(this).find(':input').filter(function() { return !this.value }).attr("disabled", "disabled")
+		return true;
+	});
+	
 	/*
 	$('#stats_enabled').click(function () {
 		updatevisibility();


### PR DESCRIPTION
acme, allow saving 100+ certificate SAN settings staying under 5000 POST variables by not submitting empty fields

- [x] Redmine Issue: https://redmine.pfsense.org/issues/9368
- [x] Ready for review