### PR TITLE
pfSense-pkg-suricata -- Update to version 4.1.3

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	4.1.2
-PORTREVISION=	3
+PORTVERSION=	4.1.3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +12,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=4.1.2:security/suricata \
+RUN_DEPENDS=	suricata>=4.1.3:security/suricata \
 		barnyard2:security/barnyard2
 
 NO_BUILD=	yes

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -484,6 +484,9 @@ if ($suricatacfg['eve_log_stats'] == 'on'){
 
 if ($suricatacfg['eve_log_flow'] == 'on') {
 	$eve_out_types .= "\n        - flow                        # Bi-directional flows";
+}
+
+if ($suricatacfg['eve_log_netflow'] == 'on') {
 	$eve_out_types .= "\n        - netflow                     # Uni-directional flows";
 }
 

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -30,6 +30,14 @@ default-packet-size: 1514
 # The default logging directory.
 default-log-dir: {$suricatalogdir}suricata_{$if_real}{$suricata_uuid}
 
+# global stats configuration
+stats:
+  enabled: {$stats_log_enabled}
+  interval: {$stats_upd_interval}
+  #decoder-events: true
+  decoder-events-prefix: "decoder.event"
+  #stream-events: false
+
 # Configure the type of alert (and other) logging.
 outputs:
 
@@ -81,10 +89,12 @@ outputs:
       certs-log-dir: certs
 
   - stats:
-      enabled: {$stats_log_enabled}
+      enabled: yes
       filename: stats.log
-      interval: {$stats_upd_interval}
       append: {$stats_log_append}
+      totals: yes
+      threads: no
+      #null-values: yes
 
   - syslog:
       enabled: {$alert_syslog}

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -177,6 +177,8 @@ if (empty($pconfig['eve_log_smtp']))
 	$pconfig['eve_log_smtp'] = "on";
 if (empty($pconfig['eve_log_flow']))
 	$pconfig['eve_log_flow'] = "off";
+if (empty($pconfig['eve_log_netflow']))
+	$pconfig['eve_log_netflow'] = "off";
 if (empty($pconfig['eve_log_stats']))
 	$pconfig['eve_log_stats'] = "off";
 if (empty($pconfig['eve_log_stats_totals']))
@@ -383,6 +385,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['eve_log_smtp'] == "on") { $natent['eve_log_smtp'] = 'on'; }else{ $natent['eve_log_smtp'] = 'off'; }
 		if ($_POST['eve_log_stats'] == "on") { $natent['eve_log_stats'] = 'on'; }else{ $natent['eve_log_stats'] = 'off'; }
 		if ($_POST['eve_log_flow'] == "on") { $natent['eve_log_flow'] = 'on'; }else{ $natent['eve_log_flow'] = 'off'; }
+		if ($_POST['eve_log_netflow'] == "on") { $natent['eve_log_netflow'] = 'on'; }else{ $natent['eve_log_netflow'] = 'off'; }
 		if ($_POST['eve_log_stats_totals'] == "on") { $natent['eve_log_stats_totals'] = 'on'; }else{ $natent['eve_log_stats_totals'] = 'off'; }
 		if ($_POST['eve_log_stats_deltas'] == "on") { $natent['eve_log_stats_deltas'] = 'on'; }else{ $natent['eve_log_stats_deltas'] = 'off'; }
 		if ($_POST['eve_log_stats_threads'] == "on") { $natent['eve_log_stats_threads'] = 'on'; }else{ $natent['eve_log_stats_threads'] = 'off'; }
@@ -1026,6 +1029,14 @@ $group->add(new Form_Checkbox(
 ));
 
 $group->add(new Form_Checkbox(
+	'eve_log_netflow',
+	'Net Flow',
+	'Net Flow',
+	$pconfig['eve_log_netflow'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
 	'eve_log_drop',
 	'Dropped Traffic',
 	'Dropped Traffic',
@@ -1661,6 +1672,7 @@ events.push(function(){
 		disableInput('eve_log_ssh', disable);
 		disableInput('eve_log_smtp', disable);
 		disableInput('eve_log_flow', disable);
+		disableInput('eve_log_netflow', disable);
 		disableInput('eve_log_drop', disable);
 		disableInput('eve_log_alerts_packet',disable)
 		disableInput('eve_log_alerts_payload',disable);

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_rulesets.php
@@ -428,9 +428,9 @@ else:
 						</td>
 						<td colspan="4">
 						<?php if ($no_community_files): ?>
-							<?php echo gettext("{$msg_community}"); ?>
+							<?php echo gettext($msg_community); ?>
 						<?php else: ?>
-							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?=gettext('{$msg_community}');?></a>
+							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?=gettext($msg_community);?></a>
 						<?php endif; ?>
 						</td>
 					</tr>
@@ -441,9 +441,9 @@ else:
 						</td>
 						<td colspan="4">
 						<?php if ($no_community_files): ?>
-							<?php echo gettext("{$msg_community}"); ?>
+							<?php echo gettext($msg_community); ?>
 						<?php else: ?>
-							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext("{$msg_community}"); ?></a>
+							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext($msg_community); ?></a>
 						<?php endif; ?>
 						</td>
 					</tr>
@@ -455,9 +455,9 @@ else:
 					</td>
 					<td colspan="4">
 						<?php if ($no_community_files): ?>
-							<?php echo gettext("{$msg_community}"); ?>
+							<?php echo gettext($msg_community); ?>
 						<?php else: ?>
-							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?php echo gettext("{$msg_community}"); ?></a>
+							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?php echo gettext($msg_community); ?></a>
 						<?php endif; ?>
 					</td>
 				</tr>
@@ -468,9 +468,9 @@ else:
 					</td>
 					<td colspan="4">
 						<?php if ($no_community_files): ?>
-							<?php echo gettext("{$msg_community}"); ?>
+							<?php echo gettext($msg_community); ?>
 						<?php else: ?>
-							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext("{$msg_community}"); ?></a>
+							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext($msg_community); ?></a>
 						<?php endif; ?>
 					</td>
 				</tr>

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_rulesets.php
@@ -428,9 +428,9 @@ else:
 						</td>
 						<td colspan="4">
 						<?php if ($no_community_files): ?>
-							<?php echo gettext($msg_community); ?>
+							<?php echo $msg_community; ?>
 						<?php else: ?>
-							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?=gettext($msg_community);?></a>
+							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?=$msg_community;?></a>
 						<?php endif; ?>
 						</td>
 					</tr>
@@ -441,9 +441,9 @@ else:
 						</td>
 						<td colspan="4">
 						<?php if ($no_community_files): ?>
-							<?php echo gettext($msg_community); ?>
+							<?php echo $msg_community; ?>
 						<?php else: ?>
-							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext($msg_community); ?></a>
+							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=$msg_community; ?></a>
 						<?php endif; ?>
 						</td>
 					</tr>
@@ -455,9 +455,9 @@ else:
 					</td>
 					<td colspan="4">
 						<?php if ($no_community_files): ?>
-							<?php echo gettext($msg_community); ?>
+							<?php echo $msg_community; ?>
 						<?php else: ?>
-							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?php echo gettext($msg_community); ?></a>
+							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?php echo $msg_community; ?></a>
 						<?php endif; ?>
 					</td>
 				</tr>
@@ -468,9 +468,9 @@ else:
 					</td>
 					<td colspan="4">
 						<?php if ($no_community_files): ?>
-							<?php echo gettext($msg_community); ?>
+							<?php echo $msg_community; ?>
 						<?php else: ?>
-							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext($msg_community); ?></a>
+							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=$msg_community; ?></a>
 						<?php endif; ?>
 					</td>
 				</tr>

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -502,6 +502,9 @@ if ($suricatacfg['eve_log_stats'] == 'on'){
 
 if ($suricatacfg['eve_log_flow'] == 'on') {
 	$eve_out_types .= "\n        - flow                        # Bi-directional flows";
+}
+
+if ($suricatacfg['eve_log_netflow'] == 'on') {
 	$eve_out_types .= "\n        - netflow                     # Uni-directional flows";
 }
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -254,6 +254,36 @@ if (empty($config['installedpackages']['suricata']['config'][0]['forcekeepsettin
 	$config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] = 'on';
 }
 
+/**********************************************************/
+/* Incorporate content of SID Mgmt example files in the   */
+/* /var/db/suricata/sidmods directory to Base64 encoded   */
+/* strings in SID_MGMT_LIST array in config.xml if this   */
+/* is a first-time green field install of Suricata.       */
+/**********************************************************/
+if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists'])) {
+	$config['installedpackages']['suricata']['sid_mgmt_lists'] = array();
+}
+if (empty($config['installedpackages']['suricata']['config'][0]['sid_list_migration']) && count($config['installedpackages']['suricata']['sid_mgmt_lists']) < 1) {
+	if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists']['item'])) {
+		$config['installedpackages']['suricata']['sid_mgmt_lists']['item'] = array();
+	}
+	$a_list = &$config['installedpackages']['suricata']['sid_mgmt_lists']['item'];
+	$sidmodfiles = array("disablesid-sample.conf", "dropsid-sample.conf", "enablesid-sample.conf", "modifysid-sample.conf");
+	foreach ($sidmodfiles as $sidfile) {
+		if (file_exists(SURICATA_SID_MODS_PATH . $sidfile)) {
+			$data = file_get_contents(SURICATA_SID_MODS_PATH . $sidfile);
+			if ($data !== FALSE) {
+				$tmp = array();
+				$tmp['name'] = basename($sidfile);
+				$tmp['modtime'] = filemtime(SURICATA_SID_MODS_PATH . $sidfile);
+				$tmp['content'] = base64_encode($data);
+				$a_list[] = $tmp;
+			}
+		}
+	}
+	$config['installedpackages']['suricata']['config'][0]['sid_list_migration'] = "1";
+}
+
 // Update Suricata package version in configuration
 update_status(gettext("  " . "Setting package version in configuration file.") . "\n");
 $config['installedpackages']['suricata']['config'][0]['suricata_config_ver'] = $config['installedpackages']['package'][get_package_id("suricata")]['version'];

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -30,6 +30,14 @@ default-packet-size: 1514
 # The default logging directory.
 default-log-dir: {$suricatalogdir}suricata_{$if_real}{$suricata_uuid}
 
+# global stats configuration
+stats:
+  enabled: {$stats_log_enabled}
+  interval: {$stats_upd_interval}
+  #decoder-events: true
+  decoder-events-prefix: "decoder.event"
+  #stream-events: false
+
 # Configure the type of alert (and other) logging.
 outputs:
 
@@ -81,10 +89,12 @@ outputs:
       certs-log-dir: certs
 
   - stats:
-      enabled: {$stats_log_enabled}
+      enabled: yes
       filename: stats.log
-      interval: {$stats_upd_interval}
       append: {$stats_log_append}
+      totals: yes
+      threads: no
+      #null-values: yes
 
   - syslog:
       enabled: {$alert_syslog}

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -314,7 +314,7 @@ $section->addInput(new Form_Input(
 	'Snort Rules Filename',
 	'text',
 	$pconfig['snort_rules_file']
-))->setHelp('Enter the rules tarball filename (filename only, do not include the URL.)<br />Example: snortrules-snapshot-29111.tar.gz');
+))->setHelp('Enter the rules tarball filename (filename only, do not include the URL.)<br />Example: snortrules-snapshot-29120.tar.gz');
 $section->addInput(new Form_Input(
 	'oinkcode',
 	'Snort Oinkmaster Code',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -187,6 +187,8 @@ if (empty($pconfig['eve_log_smtp']))
 	$pconfig['eve_log_smtp'] = "on";
 if (empty($pconfig['eve_log_flow']))
 	$pconfig['eve_log_flow'] = "off";
+if (empty($pconfig['eve_log_netflow']))
+	$pconfig['eve_log_netflow'] = "off";
 if (empty($pconfig['eve_log_stats']))
 	$pconfig['eve_log_stats'] = "off";
 if (empty($pconfig['eve_log_stats_totals']))
@@ -399,6 +401,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['eve_log_smtp'] == "on") { $natent['eve_log_smtp'] = 'on'; }else{ $natent['eve_log_smtp'] = 'off'; }
 		if ($_POST['eve_log_stats'] == "on") { $natent['eve_log_stats'] = 'on'; }else{ $natent['eve_log_stats'] = 'off'; }
 		if ($_POST['eve_log_flow'] == "on") { $natent['eve_log_flow'] = 'on'; }else{ $natent['eve_log_flow'] = 'off'; }
+		if ($_POST['eve_log_netflow'] == "on") { $natent['eve_log_netflow'] = 'on'; }else{ $natent['eve_log_netflow'] = 'off'; }
 		if ($_POST['eve_log_stats_totals'] == "on") { $natent['eve_log_stats_totals'] = 'on'; }else{ $natent['eve_log_stats_totals'] = 'off'; }
 		if ($_POST['eve_log_stats_deltas'] == "on") { $natent['eve_log_stats_deltas'] = 'on'; }else{ $natent['eve_log_stats_deltas'] = 'off'; }
 		if ($_POST['eve_log_stats_threads'] == "on") { $natent['eve_log_stats_threads'] = 'on'; }else{ $natent['eve_log_stats_threads'] = 'off'; }
@@ -1081,6 +1084,14 @@ $group->add(new Form_Checkbox(
 ));
 
 $group->add(new Form_Checkbox(
+	'eve_log_netflow',
+	'Net Flow',
+	'Net Flow',
+	$pconfig['eve_log_netflow'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
 	'eve_log_drop',
 	'Dropped Traffic',
 	'Dropped Traffic',
@@ -1727,6 +1738,7 @@ events.push(function(){
 		disableInput('eve_log_ssh', disable);
 		disableInput('eve_log_smtp', disable);
 		disableInput('eve_log_flow', disable);
+		disableInput('eve_log_netflow', disable);
 		disableInput('eve_log_drop', disable);
 		disableInput('eve_log_alerts_packet',disable)
 		disableInput('eve_log_alerts_payload',disable);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -426,9 +426,9 @@ else:
 						</td>
 						<td colspan="4">
 						<?php if ($no_community_files): ?>
-							<?php echo gettext("{$msg_community}"); ?>
+							<?php echo gettext($msg_community); ?>
 						<?php else: ?>
-							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?=gettext('{$msg_community}');?></a>
+							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?=gettext($msg_community);?></a>
 						<?php endif; ?>
 						</td>
 					</tr>
@@ -441,7 +441,7 @@ else:
 						<?php if ($no_community_files): ?>
 							<?php echo gettext("{$msg_community}"); ?>
 						<?php else: ?>
-							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext("{$msg_community}"); ?></a>
+							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext($msg_community); ?></a>
 						<?php endif; ?>
 						</td>
 					</tr>
@@ -453,9 +453,9 @@ else:
 					</td>
 					<td colspan="4">
 						<?php if ($no_community_files): ?>
-							<?php echo gettext("{$msg_community}"); ?>
+							<?php echo gettext($msg_community); ?>
 						<?php else: ?>
-							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?php echo gettext("{$msg_community}"); ?></a>
+							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?php echo gettext($msg_community); ?></a>
 						<?php endif; ?>
 					</td>
 				</tr>
@@ -466,9 +466,9 @@ else:
 					</td>
 					<td colspan="4">
 						<?php if ($no_community_files): ?>
-							<?php echo gettext("{$msg_community}"); ?>
+							<?php echo gettext($msg_community); ?>
 						<?php else: ?>
-							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext("{$msg_community}"); ?></a>
+							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext($msg_community); ?></a>
 						<?php endif; ?>
 					</td>
 				</tr>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -426,9 +426,9 @@ else:
 						</td>
 						<td colspan="4">
 						<?php if ($no_community_files): ?>
-							<?php echo gettext($msg_community); ?>
+							<?php echo $msg_community; ?>
 						<?php else: ?>
-							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?=gettext($msg_community);?></a>
+							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?=$msg_community;?></a>
 						<?php endif; ?>
 						</td>
 					</tr>
@@ -439,9 +439,9 @@ else:
 						</td>
 						<td colspan="4">
 						<?php if ($no_community_files): ?>
-							<?php echo gettext("{$msg_community}"); ?>
+							<?php echo $msg_community; ?>
 						<?php else: ?>
-							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext($msg_community); ?></a>
+							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=$msg_community; ?></a>
 						<?php endif; ?>
 						</td>
 					</tr>
@@ -453,9 +453,9 @@ else:
 					</td>
 					<td colspan="4">
 						<?php if ($no_community_files): ?>
-							<?php echo gettext($msg_community); ?>
+							<?php echo $msg_community; ?>
 						<?php else: ?>
-							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?php echo gettext($msg_community); ?></a>
+							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?php echo $msg_community; ?></a>
 						<?php endif; ?>
 					</td>
 				</tr>
@@ -466,9 +466,9 @@ else:
 					</td>
 					<td colspan="4">
 						<?php if ($no_community_files): ?>
-							<?php echo gettext($msg_community); ?>
+							<?php echo $msg_community; ?>
 						<?php else: ?>
-							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext($msg_community); ?></a>
+							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=$msg_community; ?></a>
 						<?php endif; ?>
 					</td>
 				</tr>


### PR DESCRIPTION
### pfSense-pkg-suricata-4.1.3
This update for the Suricata package introduces one modified new feature, fixes three bugs and brings the stats logging parameter settings in _suricata.yaml_ inline with the newest Suricata release.

**New Features**
1. Provide separate enable checkboxes for controlling the logging of flow and netflow data.  Formerly a single setting (Traffic Flows) was provided that either enabled or disabled both flow and netflow data logging simultaneously.  These two parameters can now be set independently of each other.  Reference Issue #9403 on the pfSense Redmine site.

**Modified Features**
1. Adjust stats logging config parameters in _suricata.yaml_ to bring them in ilne with the format expected by the Suricata 4.1.3 binary.

**Bug Fixes**
1. The sample conf files for SID MGMT provided in the package we not being read and installed properly on new green field installations of Suricata.  Thus there were no sample conf files present on the SID MGMT tab.

2. On the CATEGORIES tab, status messages for the Snort GPLv2 Community Rules were showing the variable name used to hold the status message instead of the content of the variable.

3.  Update Snort Subscriber Rules tarball filename in hint text to _snortrules-snapshot-29120.tar.gz_ to reflect the most recent Snort 2.9.x rules release.