### PR TITLE
Convert Windows line feeds in squid ca certificate

### DIFF
--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
@@ -1175,7 +1175,7 @@ function squid_resync_general() {
 					// Should never get here
 					$sslproxy_dhparams = "";
 				}
-				file_put_contents($crt_pk, str_replace("\r\n", "\n", base64_decode($srv_cert['prv']) . base64_decode($srv_cert['crt'])));
+				file_put_contents($crt_pk, unixnewlines(base64_decode($srv_cert['prv']) . "\n" . base64_decode($srv_cert['crt'])));
 				$sslcrtd_children = ($settings['sslcrtd_children'] ? $settings['sslcrtd_children'] : 5);
 				$ssl_interception .= "ssl-bump generate-host-certificates=on dynamic_cert_mem_cache_size=" . ($sslcrtd_children*2) . "MB cert={$crt_pk} capath={$crt_capath} cipher={$sslproxy_cipher} {$sslproxy_dhparams} options={$sslproxy_options}\n";
 				$interception_checks = "sslcrtd_program " . SQUID_LOCALBASE . "/libexec/squid/ssl_crtd -s " . SQUID_SSL_DB . " -M 4MB -b 2048\n";

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
@@ -1175,7 +1175,7 @@ function squid_resync_general() {
 					// Should never get here
 					$sslproxy_dhparams = "";
 				}
-				file_put_contents($crt_pk, base64_decode($srv_cert['prv']) . base64_decode($srv_cert['crt']));
+				file_put_contents($crt_pk, str_replace("\r\n", "\n", base64_decode($srv_cert['prv']) . base64_decode($srv_cert['crt'])));
 				$sslcrtd_children = ($settings['sslcrtd_children'] ? $settings['sslcrtd_children'] : 5);
 				$ssl_interception .= "ssl-bump generate-host-certificates=on dynamic_cert_mem_cache_size=" . ($sslcrtd_children*2) . "MB cert={$crt_pk} capath={$crt_capath} cipher={$sslproxy_cipher} {$sslproxy_dhparams} options={$sslproxy_options}\n";
 				$interception_checks = "sslcrtd_program " . SQUID_LOCALBASE . "/libexec/squid/ssl_crtd -s " . SQUID_SSL_DB . " -M 4MB -b 2048\n";


### PR DESCRIPTION
Avoid FATAL error No valid signing SSL certificate configured load squid with a CA certificate imported from Windows.

Issue described in this [Netgate Forum thread](https://forum.netgate.com/topic/142453/ssl-intercept-with-windows-certificate-no-valid-signing-ssl-certificate-configured-for-http_port).