### PR TITLE
pfSense-pkg-snort-3.2.9.8_6

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	3.2.9.8
-PORTREVISION=	5
+PORTREVISION=	6
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package snort
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	snort>=2.9.12:security/snort \
+RUN_DEPENDS=	snort>=2.9.13:security/snort \
 		barnyard2>=0:security/barnyard2
 
 NO_BUILD=	yes

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -3,9 +3,9 @@
  * snort_defs.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2018 Bill Meeks
+ * Copyright (c) 2013-2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,7 +73,7 @@ if (!defined("VRT_DNLD_URL"))
 if (!defined("ET_VERSION"))
 	define("ET_VERSION", "2.9.0");
 if (!defined("ET_BASE_DNLD_URL"))
-	define("ET_BASE_DNLD_URL", "http://rules.emergingthreats.net/"); 
+	define("ET_BASE_DNLD_URL", "https://rules.emergingthreats.net/"); 
 if (!defined("ETPRO_BASE_DNLD_URL"))
 	define("ETPRO_BASE_DNLD_URL", "https://rules.emergingthreatspro.com/"); 
 if (!defined("SNORT_ET_DNLD_FILENAME"))
@@ -89,7 +89,7 @@ if (!defined("SNORT_OPENAPPID_DNLD_URL"))
 if (!defined("SNORT_OPENAPPID_DNLD_FILENAME"))
 	define("SNORT_OPENAPPID_DNLD_FILENAME", "snort-openappid.tar.gz");
 if (!defined("SNORT_OPENAPPID_RULES_URL"))
-	define("SNORT_OPENAPPID_RULES_URL", "http://files.pfsense.org/openappid/");
+	define("SNORT_OPENAPPID_RULES_URL", "https://files.pfsense.org/openappid/");
 if (!defined("SNORT_OPENAPPID_RULES_FILENAME"))
 	define("SNORT_OPENAPPID_RULES_FILENAME", "appid_rules.tar.gz");
 if (!defined("SNORT_RULES_UPD_LOGFILE"))

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -47,7 +47,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 		define("SNORT_BIN_VERSION", $matches[0]);
 	}
 	else {
-		define("SNORT_BIN_VERSION", "2.9.12");
+		define("SNORT_BIN_VERSION", "2.9.13");
 	}
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
@@ -3,9 +3,9 @@
  * snort_post_install.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2016 Bill Meeks
+ * Copyright (c) 2013-2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,23 +64,13 @@ unlink_if_exists("{$g['varrun_path']}/snort_pkg_starting.lck");
 /* Set flag for post-install in progress */
 $g['snort_postinstall'] = true;
 
-/* cleanup default files */
-@rename("{$snortdir}/snort.conf-sample", "{$snortdir}/snort.conf");
-@rename("{$snortdir}/threshold.conf-sample", "{$snortdir}/threshold.conf");
-@rename("{$snortdir}/sid-msg.map-sample", "{$snortdir}/sid-msg.map");
-@rename("{$snortdir}/unicode.map-sample", "{$snortdir}/unicode.map");
-@rename("{$snortdir}/file_magic.conf-sample", "{$snortdir}/file_magic.conf");
-@rename("{$snortdir}/classification.config-sample", "{$snortdir}/classification.config");
-@rename("{$snortdir}/generators-sample", "{$snortdir}/generators");
-@rename("{$snortdir}/reference.config-sample", "{$snortdir}/reference.config");
-@rename("{$snortdir}/gen-msg.map-sample", "{$snortdir}/gen-msg.map");
-@rename("{$snortdir}/attribute_table.dtd-sample", "{$snortdir}/attribute_table.dtd");
-
-/* fix up the preprocessor rules filenames from a PBI package install */
-$preproc_rules = array("decoder.rules", "preprocessor.rules", "sensitive-data.rules");
-foreach ($preproc_rules as $file) {
-	if (file_exists("{$snortdir}/preproc_rules/{$file}-sample"))
-		@rename("{$snortdir}/preproc_rules/{$file}-sample", "{$snortdir}/preproc_rules/{$file}");
+/* In the event this is a reinstall (or update), then recreate   */
+/* critical map files from the package sample templates.         */
+$map_files = array("unicode.map", "gen-msg.map", "classification.config", "reference.config", "attribute_table.dtd");
+foreach ($map_files as $f) {
+	if (file_exists(SNORTDIR . "/" . $f . "-sample") && !file_exists(SNORTDIR . "/" . $f)) {
+		copy(SNORTDIR . "/" . $f . "-sample", SNORTDIR . "/" . $f);
+	}
 }
 
 /* Remove any previously installed scripts since we rebuild them */

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_iprep_list_browser.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_iprep_list_browser.php
@@ -3,8 +3,8 @@
  * snort_iprep_list_browser.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2016 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2014 Bill Meeks
+ * Copyright (c) 2019 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,11 +53,11 @@ $target = htmlspecialchars($_POST['target']);
 	<table class="table table-striped table-hover table-condensed">
 		<thead>
 			<tr>
-				<th><img src="/filebrowser/images/icon_home.gif" alt="Home" title="Home" /></th>
+				<th><img src="/vendor/filebrowser/images/icon_home.gif" alt="Home" title="Home" /></th>
 				<th><b><?=$path;?></b></th>
 				<th><b><?=gettext('File Size'); ?></th>
 				<th class="fbClose pull-right">
-					<img onClick="$('<?=$container;?>').hide();" border="0" src="/filebrowser/images/icon_cancel.gif" alt="Close" title="Close" />
+					<img onClick="$('<?=$container;?>').hide();" border="0" src="/vendor/filebrowser/images/icon_cancel.gif" alt="Close" title="Close" />
 				</th>
 			</tr>
 		</thead>
@@ -103,7 +103,7 @@ $target = htmlspecialchars($_POST['target']);
 				<td class="fbFile" id="<?=$fqpn;?>">
 					<?php $filename = str_replace("//","/", "{$path}/{$file}"); ?>
 					<div onClick="$('<?=$target;?>').value='<?=$filename?>'; $('<?=$container;?>').hide();">
-						<img src="/filebrowser/images/file_<?=$type;?>.gif" alt="" title="">&nbsp;<?=$file;?>
+						<img src="/vendor/filebrowser/images/file_<?=$type;?>.gif" alt="" title="">&nbsp;<?=$file;?>
 					</div>
 				</td>
 				<td><?=$size;?></td>


### PR DESCRIPTION
### pfSense-pkg-snort-3.2.9.8_6
This Snort GUI package update contains three features and two bug fixes.

**New Features**
1. Change the base URL for ET-Open rules to use HTTPS (https://rules.emergingthreats.net/).
2. Change the base URL for OpenAppID free rules to use HTTPS (https://files.pfsense.org/openappid/).
3. Change the IP REP tab code so IP Reputation preprocessor configuration edits restart Snort instead of causing it to stop when already running.  This is necessary because any IP REP changes require a Snort restart on the interface.

**Bug Fixes**
1. IP REPUTATION tab has cosmetic issues when choosing an IP blacklist for the interface.
2. When updating package (via a reinstall) without Snort VRT rule download enabled the _unicode.map_ file is clobbered rendering Snort unable to start.
