### PR TITLE
Add Zabbix 4.2 (agent and proxy) packages

### DIFF
--- a/net-mgmt/pfSense-pkg-zabbix-agent/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/Makefile
@@ -13,7 +13,8 @@ COMMENT=	pfSense package zabbix-agent
 LICENSE=	APACHE20
 
 CONFLICTS?=	pfSense-pkg-zabbix-agent22 \
-		pfSense-pkg-zabbix-agent4
+		pfSense-pkg-zabbix-agent4 \
+		pfSense-pkg-zabbix-agent42
 
 RUN_DEPENDS?=	zabbix_agentd:net-mgmt/zabbix3-agent
 

--- a/net-mgmt/pfSense-pkg-zabbix-agent22/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent22/Makefile
@@ -5,7 +5,8 @@ MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-agent
 PORTNAME=	pfSense-pkg-zabbix-agent${ZABBIXVERSION}
 
 CONFLICTS=	pfSense-pkg-zabbix-agent \
-		pfSense-pkg-zabbix-agent4
+		pfSense-pkg-zabbix-agent4 \
+		pfSense-pkg-zabbix-agent42
 
 RUN_DEPENDS=	zabbix_agentd:net-mgmt/zabbix${ZABBIXVERSION}-agent
 

--- a/net-mgmt/pfSense-pkg-zabbix-agent4/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent4/Makefile
@@ -5,7 +5,8 @@ MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-agent
 PORTNAME=	pfSense-pkg-zabbix-agent4
 
 CONFLICTS=	pfSense-pkg-zabbix-agent \
-		pfSense-pkg-zabbix-agent22
+		pfSense-pkg-zabbix-agent22 \
+		pfSense-pkg-zabbix-agent42
 
 RUN_DEPENDS=	zabbix_agentd:net-mgmt/zabbix4-agent
 

--- a/net-mgmt/pfSense-pkg-zabbix-agent42/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent42/Makefile
@@ -1,0 +1,17 @@
+# $FreeBSD$
+
+MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-agent
+
+PORTNAME=	pfSense-pkg-zabbix-agent42
+
+CONFLICTS=	pfSense-pkg-zabbix-agent \
+		pfSense-pkg-zabbix-agent22 \
+		pfSense-pkg-zabbix-agent4
+
+RUN_DEPENDS=	zabbix_agentd:net-mgmt/zabbix42-agent
+
+ZABBIXINTERNALNAME=	zabbix-agent42
+ZABBIXTITLE=	Zabbix Agent 4.2
+ZABBIXVERSION=	42
+
+.include "${MASTERDIR}/Makefile"

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/Makefile
@@ -13,7 +13,8 @@ COMMENT=	pfSense package zabbix-proxy
 LICENSE=	APACHE20
 
 CONFLICTS?=	pfSense-pkg-zabbix-proxy22 \
-		pfSense-pkg-zabbix-proxy4
+		pfSense-pkg-zabbix-proxy4 \
+		pfSense-pkg-zabbix-proxy42
 
 RUN_DEPENDS?=	zabbix_proxy:net-mgmt/zabbix3-proxy
 

--- a/net-mgmt/pfSense-pkg-zabbix-proxy22/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy22/Makefile
@@ -5,7 +5,8 @@ MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-proxy
 PORTNAME=	pfSense-pkg-zabbix-proxy${ZABBIXVERSION}
 
 CONFLICTS=	pfSense-pkg-zabbix-proxy \
-		pfSense-pkg-zabbix-proxy4
+		pfSense-pkg-zabbix-proxy4 \
+		pfSense-pkg-zabbix-proxy42
 
 RUN_DEPENDS=	zabbix_proxy:net-mgmt/zabbix${ZABBIXVERSION}-proxy
 

--- a/net-mgmt/pfSense-pkg-zabbix-proxy4/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy4/Makefile
@@ -5,7 +5,8 @@ MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-proxy
 PORTNAME=	pfSense-pkg-zabbix-proxy4
 
 CONFLICTS=	pfSense-pkg-zabbix-proxy \
-		pfSense-pkg-zabbix-proxy22
+		pfSense-pkg-zabbix-proxy22 \
+		pfSense-pkg-zabbix-proxy42
 
 RUN_DEPENDS=	zabbix_proxy:net-mgmt/zabbix4-proxy
 

--- a/net-mgmt/pfSense-pkg-zabbix-proxy42/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy42/Makefile
@@ -1,0 +1,17 @@
+# $FreeBSD$
+
+MASTERDIR=	${.CURDIR}/../pfSense-pkg-zabbix-proxy
+
+PORTNAME=	pfSense-pkg-zabbix-proxy42
+
+CONFLICTS=	pfSense-pkg-zabbix-proxy \
+		pfSense-pkg-zabbix-proxy22 \
+		pfSense-pkg-zabbix-proxy4
+
+RUN_DEPENDS=	zabbix_proxy:net-mgmt/zabbix42-proxy
+
+ZABBIXINTERNALNAME=	zabbix-proxy42
+ZABBIXTITLE=	Zabbix Proxy 4.2
+ZABBIXVERSION=	42
+
+.include "${MASTERDIR}/Makefile"


### PR DESCRIPTION
What's new in Zabbix 4.2:
https://www.zabbix.com/documentation/4.2/manual/introduction/whatsnew420
 
Depends on [pfsense/pfsense#4065](https://github.com/pfsense/pfsense/pull/4065)

Bump PORTREVISION due CONFLICTS change
 
https://redmine.pfsense.org/issues/9451