### PR TITLE
pfSense-pkg-suricata - Update to version 4.1.4

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	4.1.3
+PORTVERSION=	4.1.4
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -12,7 +12,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=4.1.3:security/suricata \
+RUN_DEPENDS=	suricata>=4.1.4:security/suricata \
 		barnyard2:security/barnyard2
 
 NO_BUILD=	yes


### PR DESCRIPTION
### pfSense-pkg-suricata-4.1.4
This update to the Suricata GUI package contains one bug fix and no new features.

**New Features**
None

**Bug Fixes**
1.  On the SID MGMT tab, when the blocking mode for an interface does not meet all the criteria, the user can be prevented from deleting a previously assigned DROP SID or REJECT_SID list even if the list is no longer applicable for the selected blocking mode.