### PR TITLE
daq-2.2.2_1 -- Add host stack OS endpoint support for DAQ netmap module

### DIFF
--- a/net/daq/Makefile
+++ b/net/daq/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=	daq
 PORTVERSION=	2.2.2
-PORTREVISION=	0
+PORTREVISION=	1
 CATEGORIES=	net
 MASTER_SITES=	https://snort.org/downloads/snortplus/ \
 		ZI

--- a/net/daq/files/patch-daq22-netmap.diff
+++ b/net/daq/files/patch-daq22-netmap.diff
@@ -1,0 +1,408 @@
+diff -ruN ./daq-2.2.2.orig/os-daq-modules/daq_netmap.c ./daq-2.2.2/os-daq-modules/daq_netmap.c
+--- ./daq-2.2.2.orig/os-daq-modules/daq_netmap.c	2017-02-08 17:04:18.000000000 -0500
++++ ./os-daq-modules/daq_netmap.c	2019-05-27 12:55:22.000000000 -0400
+@@ -1,6 +1,7 @@
+ /*
+ ** Copyright (C) 2014 Cisco and/or its affiliates. All rights reserved.
+ ** Author: Michael R. Altizer <mialtize@cisco.com>
++** Author: Bill Meeks <billmeeks8@gmail.com>
+ **
+ ** This program is free software; you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License Version 2 as
+@@ -37,41 +38,25 @@
+ #include <sfbpf_dlt.h>
+ 
+ #include <net/netmap.h>
++#define NETMAP_WITH_LIBS
+ #include <net/netmap_user.h>
+ 
+-#define DAQ_NETMAP_VERSION      3
++#define DAQ_NETMAP_VERSION      4
+ 
+ /* Hi! I'm completely arbitrary! */
+ #define NETMAP_MAX_INTERFACES       32
+ 
+-/* FreeBSD 10.0 uses an old version of netmap, so work around it accordingly. */
+-#if NETMAP_API < 10
+-#define nm_ring_next(r, i)      NETMAP_RING_NEXT(r, i)
+-#define nm_ring_empty(r)        ((r)->avail == 0)
+-#endif
+-
+ typedef struct _netmap_instance
+ {
+     struct _netmap_instance *next;
+     struct _netmap_instance *peer;
+-    int fd;
+ #define NMINST_FWD_BLOCKED     0x1
+ #define NMINST_TX_BLOCKED      0x2
+     uint32_t flags;
+     int index;
+-    struct netmap_if *nifp;
+-    /* TX ring info */
+-    uint16_t first_tx_ring;
+-    uint16_t last_tx_ring;
+-    uint16_t cur_tx_ring;
+-    /* RX ring info */
+-    uint16_t first_rx_ring;
+-    uint16_t last_rx_ring;
+-    uint16_t cur_rx_ring;
+-    /* MMAP'd memory */
+-    void *mem;
+-    uint32_t memsize;
+-    struct nmreq req;
++    int done_mmap;
++    char nm_port_name[NETMAP_REQ_IFNAMSIZ];
++    struct nm_desc *ndesc;
+     unsigned long long fwd_tx_blocked;
+ } NetmapInstance;
+ 
+@@ -93,37 +78,39 @@
+ 
+ static inline void nminst_inc_rx_ring(NetmapInstance *instance)
+ {
+-    instance->cur_rx_ring++;
+-    if (instance->cur_rx_ring > instance->last_rx_ring)
+-        instance->cur_rx_ring = instance->first_rx_ring;
++    instance->ndesc->cur_rx_ring++;
++    if (instance->ndesc->cur_rx_ring > instance->ndesc->last_rx_ring)
++        instance->ndesc->cur_rx_ring = instance->ndesc->first_rx_ring;
+ }
+ 
+ static inline void nminst_inc_tx_ring(NetmapInstance *instance)
+ {
+-    instance->cur_tx_ring++;
+-    if (instance->cur_tx_ring > instance->last_tx_ring)
+-        instance->cur_tx_ring = instance->first_tx_ring;
++    instance->ndesc->cur_tx_ring++;
++    if (instance->ndesc->cur_tx_ring > instance->ndesc->last_tx_ring)
++        instance->ndesc->cur_tx_ring = instance->ndesc->first_tx_ring;
+ }
+ 
+ static void destroy_instance(NetmapInstance *instance)
+ {
+     if (instance)
+     {
+-        /* Unmap the packet memory region.  If we had a peer, notify them that
+-            the shared mapping has been freed and that we no longer exist. */
+-        if (instance->mem)
++        /* Check for an active peer. */
++        if (instance->peer)
+         {
+-            munmap(instance->mem, instance->memsize);
+-            if (instance->peer)
++            /* Close our peer's netmap connection first. */
++            if (instance->peer->ndesc != NULL)
+             {
+-                instance->peer->mem = MAP_FAILED;
+-                instance->peer->memsize = 0;
++                nm_close(instance->peer->ndesc);
++                instance->peer->ndesc = NULL;
++                instance->peer->peer = NULL;
++                instance->peer->done_mmap = 0;
+             }
+         }
+-        if (instance->peer)
+-            instance->peer->peer = NULL;
+-        if (instance->fd != -1)
+-            close(instance->fd);
++
++        /* Now close our netmap connection if open. */
++	if (instance->ndesc != NULL)
++            nm_close(instance->ndesc);
++
+         free(instance);
+     }
+ }
+@@ -142,7 +129,7 @@
+         if (nmc->debug)
+         {
+             printf("Netmap instance %s (%d) blocked %llu times on TX while forwarding.\n",
+-                    instance->req.nr_name, instance->index, instance->fwd_tx_blocked);
++                    instance->nm_port_name, instance->index, instance->fwd_tx_blocked);
+         }
+         destroy_instance(instance);
+     }
+@@ -157,44 +144,26 @@
+ static NetmapInstance *create_instance(const char *device, NetmapInstance *parent, char *errbuf, size_t errlen)
+ {
+     NetmapInstance *instance;
+-    struct nmreq *req;
+     static int index = 0;
+ 
+     instance = calloc(1, sizeof(NetmapInstance));
+     if (!instance)
+     {
+         snprintf(errbuf, errlen, "%s: Could not allocate a new instance structure.", __func__);
+-        goto err;
++        return NULL;
+     }
+ 
+     /* Initialize the instance, including an arbitrary and unique device index. */
+-    instance->mem = MAP_FAILED;
+     instance->index = index;
+     index++;
+ 
+-    /* Open /dev/netmap for communications to the driver. */
+-    instance->fd = open("/dev/netmap", O_RDWR);
+-    if (instance->fd < 0)
+-    {
+-        snprintf(errbuf, errlen, "%s: Could not open /dev/netmap: %s (%d)",
+-                    __func__, strerror(errno), errno);
+-        goto err;
+-    }
++    instance->ndesc = NULL;
++    instance->done_mmap = 0;
+ 
+-    /* Initialize the netmap request object. */
+-    req = &instance->req;
+-    strncpy(req->nr_name, device, sizeof(req->nr_name));
+-    req->nr_version = NETMAP_API;
+-    req->nr_ringid = 0;
+-#if NETMAP_API >= 11
+-    req->nr_flags = NR_REG_ALL_NIC;
+-#endif
++    /* Initialize the netmap port name. */
++    strncpy(instance->nm_port_name, device, sizeof(instance->nm_port_name));
+ 
+     return instance;
+-
+-err:
+-    destroy_instance(instance);
+-    return NULL;
+ }
+ 
+ static int create_bridge(Netmap_Context_t *nmc, const char *device_name1, const char *device_name2)
+@@ -204,9 +173,9 @@
+     peer1 = peer2 = NULL;
+     for (instance = nmc->instances; instance; instance = instance->next)
+     {
+-        if (!strcmp(instance->req.nr_name, device_name1))
++        if (!strcmp(instance->nm_port_name, device_name1))
+             peer1 = instance;
+-        else if (!strcmp(instance->req.nr_name, device_name2))
++        else if (!strcmp(instance->nm_port_name, device_name2))
+             peer2 = instance;
+     }
+ 
+@@ -221,67 +190,56 @@
+ 
+ static int start_instance(Netmap_Context_t *nmc, NetmapInstance *instance)
+ {
+-    if (ioctl(instance->fd, NIOCREGIF, &instance->req))
+-    {
+-        DPE(nmc->errbuf, "%s: Netmap registration for %s failed: %s (%d)",
+-                __func__, instance->req.nr_name, strerror(errno), errno);
+-        return DAQ_ERROR;
+-    }
+-
+     /* Only mmap the packet memory region for the first interface in a pair. */
+-    if (instance->peer && instance->peer->mem != MAP_FAILED)
++    if (instance->peer && instance->peer->done_mmap)
+     {
+-        instance->memsize = instance->peer->memsize;
+-        instance->mem = instance->peer->mem;
++        if ((instance->ndesc = nm_open(instance->nm_port_name, NULL, NM_OPEN_NO_MMAP, instance->peer->ndesc)) == NULL) 
++        {
++            DPE(nmc->errbuf, "%s: Netmap registration for port %s failed: %s (%d)",
++                    __func__, instance->nm_port_name, strerror(errno), errno);
++            return DAQ_ERROR;
++        }
+     }
+     else
+     {
+-        instance->memsize = instance->req.nr_memsize;
+-        instance->mem = mmap(0, instance->memsize, PROT_WRITE | PROT_READ, MAP_SHARED, instance->fd, 0);
+-        if (instance->mem == MAP_FAILED)
++        if ((instance->ndesc = nm_open(instance->nm_port_name, NULL, 0, NULL)) == NULL) 
+         {
+-            DPE(nmc->errbuf, "%s: Could not MMAP the buffer memory region for %s: %s (%d)",
+-                    __func__, instance->req.nr_name, strerror(errno), errno);
++            DPE(nmc->errbuf, "%s: Netmap registration for port %s failed: %s (%d)",
++                    __func__, instance->nm_port_name, strerror(errno), errno);
+             return DAQ_ERROR;
+         }
++        instance->done_mmap = instance->ndesc->done_mmap;
+     }
+ 
+-    instance->nifp = NETMAP_IF(instance->mem, instance->req.nr_offset);
+-
+-    instance->first_tx_ring = 0;
+-    instance->first_rx_ring = 0;
+-    instance->last_tx_ring = instance->req.nr_tx_rings - 1;
+-    instance->last_rx_ring = instance->req.nr_rx_rings - 1;
+-
+     if (nmc->debug)
+     {
+         struct netmap_ring *ring;
+         int i;
+ 
+-        printf("[%s]\n", instance->req.nr_name);
+-        printf("  nr_tx_slots: %u\n", instance->req.nr_tx_slots);
+-        printf("  nr_rx_slots: %u\n", instance->req.nr_rx_slots);
+-        printf("  nr_tx_rings: %hu\n", instance->req.nr_tx_rings);
+-        for (i = instance->first_tx_ring; i <= instance->last_tx_ring; i++)
++        printf("[%s]\n", instance->ndesc->req.nr_name);
++        printf("  nr_tx_slots: %u\n", instance->ndesc->req.nr_tx_slots);
++        printf("  nr_rx_slots: %u\n", instance->ndesc->req.nr_rx_slots);
++        printf("  nr_tx_rings: %hu\n", instance->ndesc->req.nr_tx_rings);
++        for (i = instance->ndesc->first_tx_ring; i <= instance->ndesc->last_tx_ring; i++)
+         {
+-            ring = NETMAP_TXRING(instance->nifp, i);
++            ring = NETMAP_TXRING(instance->ndesc->nifp, i);
+             printf("  [TX Ring %d]\n", i);
+             printf("    buf_ofs = %zu\n", ring->buf_ofs);
+             printf("    num_slots = %u\n", ring->num_slots);
+             printf("    nr_buf_size = %u\n", ring->nr_buf_size);
+             printf("    flags = 0x%x\n", ring->flags);
+         }
+-        printf("  nr_rx_rings: %hu\n", instance->req.nr_rx_rings);
+-        for (i = instance->first_rx_ring; i <= instance->last_rx_ring; i++)
++        printf("  nr_rx_rings: %hu\n", instance->ndesc->req.nr_rx_rings);
++        for (i = instance->ndesc->first_rx_ring; i <= instance->ndesc->last_rx_ring; i++)
+         {
+-            ring = NETMAP_RXRING(instance->nifp, i);
++            ring = NETMAP_RXRING(instance->ndesc->nifp, i);
+             printf("  [RX Ring %d]\n", i);
+             printf("    buf_ofs = %zu\n", ring->buf_ofs);
+             printf("    num_slots = %u\n", ring->num_slots);
+             printf("    nr_buf_size = %u\n", ring->nr_buf_size);
+             printf("    flags = 0x%x\n", ring->flags);
+         }
+-        printf("  memsize:     %u\n", instance->memsize);
++        printf("  memsize:     %u\n", instance->ndesc->memsize);
+         printf("  index:       %d\n", instance->index);
+     }
+ 
+@@ -343,7 +301,7 @@
+                             __func__, NETMAP_MAX_INTERFACES);
+                 goto err;
+             }
+-            snprintf(intf, len + 1, "%s", dev);
++            snprintf(intf, len + 8, "netmap:%s", dev);
+             instance = create_instance(intf, nmc->instances, errbuf, errlen);
+             if (!instance)
+                 goto err;
+@@ -355,8 +313,8 @@
+             {
+                 if (num_intfs == 2)
+                 {
+-                    name1 = nmc->instances->next->req.nr_name;
+-                    name2 = nmc->instances->req.nr_name;
++                    name1 = nmc->instances->next->nm_port_name;
++                    name2 = nmc->instances->nm_port_name;
+ 
+                     if (create_bridge(nmc, name1, name2) != DAQ_SUCCESS)
+                     {
+@@ -487,7 +445,7 @@
+ 
+         for (instance = nmc->instances; instance; instance = instance->next)
+         {
+-            start_rx_ring = instance->cur_rx_ring;
++            start_rx_ring = instance->ndesc->cur_rx_ring;
+             do
+             {
+                 /* Has breakloop() been called? */
+@@ -497,7 +455,7 @@
+                     return 0;
+                 }
+ 
+-                rx_ring = NETMAP_RXRING(instance->nifp, instance->cur_rx_ring);
++                rx_ring = NETMAP_RXRING(instance->ndesc->nifp, instance->ndesc->cur_rx_ring);
+                 if (nm_ring_empty(rx_ring))
+                 {
+                     nminst_inc_rx_ring(instance);
+@@ -561,11 +519,11 @@
+                     int sent = 0;
+ 
+                     peer = instance->peer;
+-                    start_tx_ring = peer->cur_tx_ring;
++                    start_tx_ring = peer->ndesc->cur_tx_ring;
+ 
+                     do
+                     {
+-                        tx_ring = NETMAP_TXRING(peer->nifp, peer->cur_tx_ring);
++                        tx_ring = NETMAP_TXRING(peer->ndesc->nifp, peer->ndesc->cur_tx_ring);
+                         nminst_inc_tx_ring(peer);
+                         if (nm_ring_empty(tx_ring))
+                             continue;
+@@ -582,13 +540,9 @@
+                         rx_slot->flags |= NS_BUF_CHANGED;
+ 
+                         tx_ring->cur = nm_ring_next(tx_ring, tx_cur);
+-#if NETMAP_API >= 10
+                         tx_ring->head = tx_ring->cur;
+-#else
+-                        tx_ring->avail--;
+-#endif
+                         sent = 1;
+-                    } while (peer->cur_tx_ring != start_tx_ring && !sent);
++                    } while (peer->ndesc->cur_tx_ring != start_tx_ring && !sent);
+ 
+                     /* If we couldn't find a TX slot to use, hold on to this packet and
+                         wait for TX slots to become available. */
+@@ -604,16 +558,12 @@
+                 }
+ 
+                 rx_ring->cur = nm_ring_next(rx_ring, rx_cur);
+-#if NETMAP_API >= 10
+                 rx_ring->head = rx_ring->cur;
+-#else
+-                rx_ring->avail--;
+-#endif
+ 
+                 /* Increment the current RX ring pointer on successfully completed processing. */
+                 nminst_inc_rx_ring(instance);
+ 
+-            } while (instance->cur_rx_ring != start_rx_ring);
++            } while (instance->ndesc->cur_rx_ring != start_rx_ring);
+         }
+ 
+         if (!got_one && !ignored_one)
+@@ -621,7 +571,7 @@
+ poll:
+             for (i = 0, instance = nmc->instances; instance; i++, instance = instance->next)
+             {
+-                pfd[i].fd = instance->fd;
++                pfd[i].fd = instance->ndesc->fd;
+                 pfd[i].events = 0;
+                 pfd[i].revents = 0;
+ 
+@@ -700,10 +650,10 @@
+     }
+ 
+     /* Find a TX ring with space to send on. */
+-    start_tx_ring = instance->cur_tx_ring;
++    start_tx_ring = instance->ndesc->cur_tx_ring;
+     do
+     {
+-        tx_ring = NETMAP_TXRING(instance->nifp, instance->cur_tx_ring);
++        tx_ring = NETMAP_TXRING(instance->ndesc->nifp, instance->ndesc->cur_tx_ring);
+         nminst_inc_tx_ring(instance);
+         if (nm_ring_empty(tx_ring))
+             continue;
+@@ -715,15 +665,11 @@
+         memcpy(NETMAP_BUF(tx_ring, tx_buf_idx), packet_data, len);
+ 
+         tx_ring->cur = nm_ring_next(tx_ring, tx_cur);
+-#if NETMAP_API >= 10
+         tx_ring->head = tx_ring->cur;
+-#else
+-        tx_ring->avail--;
+-#endif
+         nmc->stats.packets_injected++;
+ 
+         return DAQ_SUCCESS;
+-    } while (instance->cur_tx_ring != start_tx_ring);
++    } while (instance->ndesc->cur_tx_ring != start_tx_ring);
+ 
+     /* If we got here, it means we couldn't find an available TX slot, so tell the user to try again. */
+     DPE(nmc->errbuf, "%s: Could not find an available TX slot.  Try again.", __func__);
+@@ -826,7 +772,7 @@
+ 
+     for (instance = nmc->instances; instance; instance = instance->next)
+     {
+-        if (!strcmp(device, instance->req.nr_name))
++        if (!strcmp(device, instance->nm_port_name))
+             return instance->index;
+     }
+ 


### PR DESCRIPTION
### daq-2.2.2_1
This update adds support in the DAQ netmap module for using the host OS stack as a netmap pipe endpoint in the netmap device specification.  For example, the device string:

   em0^:em0

creates a netmap pipe between the host operating system's network stack and the NIC driver for physical interface _em0_.  The caret character ('^') indicates to netmap that the host OS stack endpoint is requested for the physical interface.

Existing DAQ netmap functionality is retained and any legacy device string specifications for netmap will still function.  This code update impacts only the DAQ netmap module.  No other changes were made in any of the other DAQ source code files.