### PR TITLE
pfSense-pkg-snort-4.0 -- Add support for Inline IPS mode and fix miscellaneous bugs

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-snort
-PORTVERSION=	3.2.9.8
-PORTREVISION=	6
+PORTVERSION=	4.0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +12,7 @@ COMMENT=	pfSense package snort
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	snort>=2.9.13:security/snort \
+RUN_DEPENDS=	snort>=2.9.13_1:security/snort \
 		barnyard2>=0:security/barnyard2
 
 NO_BUILD=	yes
@@ -136,6 +135,10 @@ do-install:
 	${INSTALL_DATA} ${FILESDIR}/var/db/snort/sidmods/enablesid-sample.conf \
 		${STAGEDIR}/var/db/snort/sidmods
 	${INSTALL_DATA} ${FILESDIR}/var/db/snort/sidmods/modifysid-sample.conf \
+		${STAGEDIR}/var/db/snort/sidmods
+	${INSTALL_DATA} ${FILESDIR}/var/db/snort/sidmods/dropsid-sample.conf \
+		${STAGEDIR}/var/db/snort/sidmods
+	${INSTALL_DATA} ${FILESDIR}/var/db/snort/sidmods/rejectsid-sample.conf \
 		${STAGEDIR}/var/db/snort/sidmods
 	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \
 		${STAGEDIR}${DATADIR}

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -580,11 +580,22 @@ function snort_start($snortcfg, $if_real, $background=FALSE) {
 		$quiet = "-q --suppress-config-log";
 
 	if ($snortcfg['enable'] == 'on' && !isvalidpid("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid")) {
+
+		// Adjust the interface specification and DAQ type according to operating mode
+		if ($snortcfg['ips_mode'] == "ips_mode_inline" && $snortcfg['blockoffenders7'] == "on") {
+			$iface = $if_real . "^:" . $if_real;
+			$daq_type = "-Q --daq netmap";
+		}
+		else {
+			$iface = $if_real;
+			$daq_type = "--daq pcap --daq-mode passive --treat-drop-as-alert";
+		}
+
 		log_error("[Snort] Snort START for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
 		if ($background)
-			mwexec_bg("{$snortbindir}snort -R {$snort_uuid} -D {$quiet} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$if_real}");
+			mwexec_bg("{$snortbindir}snort -R _{$if_real}{$snort_uuid} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface}");
 		else
-			mwexec("{$snortbindir}snort -R {$snort_uuid} -D {$quiet} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$if_real}");
+			mwexec("{$snortbindir}snort -R _{$if_real}{$snort_uuid} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface}");
 		snort_barnyard_start($snortcfg, $if_real, $background);
 	}
 }
@@ -1752,7 +1763,7 @@ function snort_write_flowbit_rules_file($flowbit_rules, $rule_file) {
 	}
 }
 
-function snort_load_vrt_policy($policy, $all_rules=null) {
+function snort_load_vrt_policy($policy, $mode='alert', $all_rules=null) {
 
 	/************************************************/
 	/* This function returns an array of all rules  */
@@ -1763,6 +1774,12 @@ function snort_load_vrt_policy($policy, $all_rules=null) {
 	/*                  2.  balanced                */
 	/*                  3.  security                */
 	/*                  4.  max-detect              */
+	/*                                              */
+	/*      $mode --> determines rule action        */
+	/*                  1. alert = all rules alert  */
+	/*                  2. policy = rule action     */
+	/*                              set according   */
+	/*                              policy spec.    */
 	/*                                              */
 	/* $all_rules --> optional Rules Map array of   */
 	/*                rules to scan for policy.     */
@@ -1798,6 +1815,19 @@ function snort_load_vrt_policy($policy, $all_rules=null) {
 					if ($arulem2['disabled'] == 1) {
 						$vrt_policy_rules[$k1][$k2]['rule'] = ltrim(substr($arulem2['rule'], strpos($arulem2['rule'], "#") + 1));
 						$vrt_policy_rules[$k1][$k2]['disabled'] = 0;
+					}
+
+					// If policy mode is enabled, grab the suggested action
+					// for this policy and set it as the rule action.
+					if ($mode == 'policy') {
+						$matches = array();
+						if (preg_match('/' . "policy {$policy}-ips" . '([^,|^;]*)/', $arulem2['rule'], $matches)) {
+							if ($tmp = preg_replace('/^\s*alert\s/', trim($matches[1]) . ' ', $vrt_policy_rules[$k1][$k2]['rule'], 1)) {
+								$vrt_policy_rules[$k1][$k2]['rule'] = $tmp;
+								$vrt_policy_rules[$k1][$k2]['action'] = trim($matches[1]);
+								$vrt_policy_rules[$k1][$k2]['modified'] = 1;
+							}
+						}
 					}
 				}
 			}
@@ -1981,6 +2011,100 @@ function snort_sid_mgmt_list_exist($sid_mgmt_list) {
 		}
 	}
 	return FALSE;
+}
+
+function snort_process_dropsid(&$rule_map, $snortcfg, $log_results = FALSE, $log_file = NULL) {
+
+	/**********************************************/
+	/* This function loads and processes the list */
+	/* specified by 'drop_sid_file' for the       */
+	/* interface.  The list is assumed to be a    */
+	/* valid dropsid.conf list containing         */
+	/* instructions for modifying the action for  */
+	/* matching rule SIDs.                        */
+	/*                                            */
+	/*     $rule_map ==> reference to array of    */
+	/*                   current rules            */
+	/*  $snortcfg ==> interface config params     */
+	/*  $log_results ==> [optional] 'yes' to log  */
+	/*                   results to $log_file     */
+	/*     $log_file ==> full path and filename   */
+	/*                   of log file to write to  */
+	/*                                            */
+	/*     On Return ==> suitably modified        */
+	/*                   $rule_map array          */
+	/**********************************************/
+
+	$snortlogdir = SNORTLOGDIR;
+	$sid_mods = array();
+
+	// If no rules in $rule_map, then nothing to do
+	if (empty($rule_map)) {
+		return;
+	}
+
+	// Verify the 'drop_sid' list for the interface exists
+	if (!snort_sid_mgmt_list_exist($snortcfg['drop_sid_file'])) {
+		log_error(gettext("[Snort] Error - unable to find drop_sid list \"{$snortcfg['drop_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+		return;
+	} else {
+		$sid_mods = snort_parse_sidconf_file($snortcfg['drop_sid_file']);
+	}
+
+	if (!empty($sid_mods)) {
+		snort_modify_sid_state($rule_map, $sid_mods, "drop", $log_results, $log_file);
+	} elseif ($log_results == TRUE && !empty($log_file)) {
+		error_log(gettext("WARNING: no valid SID match tokens found in list \"{$snortcfg['drop_sid_file']}\".\n"), 3, $log_file);
+	}
+
+	unset($sid_mods);
+}
+
+function snort_process_rejectsid(&$rule_map, $snortcfg, $log_results = FALSE, $log_file = NULL) {
+
+	/**********************************************/
+	/* This function loads and processes the list */
+	/* specified by 'reject_sid_file' for the     */
+	/* interface.  The list is assumed to be a    */
+	/* valid rejectsid.conf list containing       */
+	/* instructions for modifying the action for  */
+	/* matching rule SIDs.                        */
+	/*                                            */
+	/*     $rule_map ==> reference to array of    */
+	/*                   current rules            */
+	/*  $snortcfg ==> interface config params     */
+	/*  $log_results ==> [optional] 'yes' to log  */
+	/*                   results to $log_file     */
+	/*     $log_file ==> full path and filename   */
+	/*                   of log file to write to  */
+	/*                                            */
+	/*     On Return ==> suitably modified        */
+	/*                   $rule_map array          */
+	/**********************************************/
+
+	$snortlogdir = SNORTLOGDIR;
+	$sid_mods = array();
+
+	// If no rules in $rule_map, then nothing to do
+	if (empty($rule_map)) {
+		return;
+	}
+
+	// Verify the 'reject_sid' list for the interface exists
+	if (!snort_sid_mgmt_list_exist($snortcfg['reject_sid_file'])) {
+		log_error(gettext("[Snort] Error - unable to find reject_sid list \"{$snortcfg['reject_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+		return;
+	} else {
+		$sid_mods = snort_parse_sidconf_file($snortcfg['reject_sid_file']);
+	}
+
+	if (!empty($sid_mods)) {
+		snort_modify_sid_state($rule_map, $sid_mods, "reject", $log_results, $log_file);
+	} elseif ($log_results == TRUE && !empty($log_file)) {
+		error_log(gettext("WARNING: no valid SID match tokens found in list \"{$snortcfg['reject_sid_file']}\".\n"), 3, $log_file);
+	}
+
+	unset($sid_mods);
 }
 
 function snort_sid_mgmt_auto_categories($snortcfg, $log_results = FALSE) {
@@ -2288,7 +2412,8 @@ function snort_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results = F
 	/*                  tokens                    */
 	/*      $action ==> modification action for   */
 	/*                  matching SID targets:     */
-	/*                  'enable' or 'disable'     */
+	/*                  'enable', 'disable',      */
+	/*		    'drop' or 'reject'.       */
 	/* $log_results ==> [optional] 'yes' to log   */
 	/*                   results to $log_file     */
 	/*    $log_file ==> full path and filename    */
@@ -2315,9 +2440,23 @@ function snort_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results = F
 	switch ($action) {
 
 		case "enable":
+			$log_what = 'state';
+			$log_action = 'enabled';
 			break;
 
 		case "disable":
+			$log_what = 'state';
+			$log_action = 'disabled';
+			break;
+
+		case "drop":
+			$log_what = 'action';
+			$log_action = 'drop';
+			break;
+
+		case "reject":
+			$log_what = 'action';
+			$log_action = 'reject';
 			break;
 
 		default:
@@ -2438,13 +2577,33 @@ function snort_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results = F
 					$changecount++;
 					$modcount++;
 				}
+				elseif ($action == 'drop' && $rule_map[$k1][$k2]['action'] != 'drop') {
+					if ($tmp = preg_replace('/\s*alert\s*/', 'drop ', $rule_map[$k1][$k2]['rule'], 1)) {
+						$rule_map[$k1][$k2]['rule'] = $tmp;
+						$rule_map[$k1][$k2]['action'] = 'drop';
+						$rule_map[$k1][$k2]['managed'] = 1;
+						$rule_map[$k1][$k2]['modified'] = 1;
+						$changecount++;
+						$modcount++;
+					}
+				}
+				elseif ($action == 'reject' && $rule_map[$k1][$k2]['action'] != 'reject') {
+					if ($tmp = preg_replace('/\s*alert\s*/', 'reject ', $rule_map[$k1][$k2]['rule'], 1)) {
+						$rule_map[$k1][$k2]['rule'] = $tmp;
+						$rule_map[$k1][$k2]['action'] = 'reject';
+						$rule_map[$k1][$k2]['managed'] = 1;
+						$rule_map[$k1][$k2]['modified'] = 1;
+						$changecount++;
+						$modcount++;
+					}
+				}
 			}
 		}
 	}
 
 	if ($log_results == TRUE && !empty($log_file)) {
 		error_log(gettext("    Found {$modcount} matching SIDs in the active rules.\n"), 3, $log_file);
-		error_log(gettext("    Changed state for {$changecount} SIDs to '{$action}d'.\n"), 3, $log_file);
+		error_log(gettext("    Changed {$log_what} for {$changecount} SIDs to '{$log_action}'.\n"), 3, $log_file);
 	}
 
 	// Return the array of matching SIDs
@@ -2718,7 +2877,7 @@ function snort_auto_sid_mgmt(&$rule_map, $snortcfg, $log_results = FALSE) {
 	// for the interface.
 	if ($config['installedpackages']['snortglobal']['auto_manage_sids'] == 'on' &&
 	    (!empty($snortcfg['disable_sid_file']) || !empty($snortcfg['enable_sid_file']) || 
-	    !empty($snortcfg['modify_sid_file']))) {
+	    !empty($snortcfg['modify_sid_file']) || !empty($snortcfg['drop_sid_file']) || !empty($snortcfg['reject_sid_file']))) {
 		if ($log_results == TRUE) {
 			error_log(gettext("********************************************************\n"), 3, $log_file);
 			error_log(gettext("Starting auto SID management for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) ."\n"), 3, $log_file);
@@ -2742,6 +2901,18 @@ function snort_auto_sid_mgmt(&$rule_map, $snortcfg, $log_results = FALSE) {
 						error_log(gettext("Processing modify_sid list: {$snortcfg['modify_sid_file']}\n"), 3, $log_file);
 					snort_process_modifysid($rule_map, $snortcfg, $log_results, $log_file);
 				}
+				if (!empty($snortcfg['drop_sid_file']) && ($snortcfg['blockoffenders7'] == 'on' && $snortcfg['ips_mode'] == 'ips_mode_inline')) {
+					if ($log_results == TRUE) {
+						error_log(gettext("Processing drop_sid list: {$snortcfg['drop_sid_file']}\n"), 3, $log_file);
+					}
+					snort_process_dropsid($rule_map, $snortcfg, $log_results, $log_file);
+				}
+				if (!empty($snortcfg['reject_sid_file']) && $snortcfg['blockoffenders7'] == 'on' && $snortcfg['ips_mode'] == 'ips_mode_inline') {
+					if ($log_results == TRUE) {
+						error_log(gettext("Processing reject_sid list: {$snortcfg['reject_sid_file']}\n"), 3, $log_file);
+					}
+					snort_process_rejectsid($rule_map, $snortcfg, $log_results, $log_file);
+				}
 				$result = TRUE;
 				break;
 
@@ -2760,6 +2931,18 @@ function snort_auto_sid_mgmt(&$rule_map, $snortcfg, $log_results = FALSE) {
 					if ($log_results == TRUE)
 						error_log(gettext("Processing modify_sid list: {$snortcfg['modify_sid_file']}\n"), 3, $log_file);
 					snort_process_modifysid($rule_map, $snortcfg, $log_results, $log_file);
+				}
+				if (!empty($snortcfg['drop_sid_file']) && ($snortcfg['blockoffenders7'] == 'on' && $snortcfg['ips_mode'] == 'ips_mode_inline')) {
+					if ($log_results == TRUE) {
+						error_log(gettext("Processing drop_sid list: {$snortcfg['drop_sid_file']}\n"), 3, $log_file);
+					}
+					snort_process_dropsid($rule_map, $snortcfg, $log_results, $log_file);
+				}
+				if (!empty($snortcfg['reject_sid_file']) && $snortcfg['blockoffenders7'] == 'on' && $snortcfg['ips_mode'] == 'ips_mode_inline') {
+					if ($log_results == TRUE) {
+						error_log(gettext("Processing reject_sid list: {$snortcfg['reject_sid_file']}\n"), 3, $log_file);
+					}
+					snort_process_rejectsid($rule_map, $snortcfg, $log_results, $log_file);
 				}
 				$result = TRUE;
 				break;
@@ -2862,14 +3045,174 @@ function snort_modify_sids(&$rule_map, $snortcfg) {
 	unset($enablesid, $disablesid);
 }
 
+function snort_modify_sids_action(&$rule_map, $snortcfg) {
+
+	/***********************************************/
+	/* This function modifies the rules in the     */
+	/* passed rules_map array based on values in   */
+	/* the alertsid/dropsid configuration          */
+	/* parameters for the interface.               */
+	/*                                             */
+	/*  $rule_map = array of current rules         */
+	/*  $snortcfg = interface config settings      */
+	/***********************************************/
+
+	if (!isset($snortcfg['rule_sid_force_alert']) && 
+	    !isset($snortcfg['rule_sid_force_drop']) && 
+	    !isset($snortcfg['rule_sid_force_reject'])) {
+		return;
+	}
+
+	/* Load up our SID forced action arrays with manually changed SID actions */
+	$alertsid = snort_load_sid_mods($snortcfg['rule_sid_force_alert']);
+
+	/* DROP is only applicable when blocking offenders is enabled and when    */
+	/* 'block drops only' is enabled, or when using Inline IPS Mode.          */
+	if ($snortcfg['blockoffenders7'] == 'on' && $snortcfg['ips_mode'] == 'ips_mode_inline') {
+		$dropsid = snort_load_sid_mods($snortcfg['rule_sid_force_drop']);
+	}
+	else {
+		$dropsid = array();
+	}
+
+	/* REJECT is only applicable when blocking offenders is enabled and when  */
+	/* Inline IPS Mode is also enabled.                                       */
+	if ($snortcfg['blockoffenders7'] == 'on' && $snortcfg['ips_mode'] == 'ips_mode_inline') {
+		$rejectsid = snort_load_sid_mods($snortcfg['rule_sid_force_reject']);
+	}
+	else {
+		$rejectsid = array();
+	}
+
+	/* Change action for any rules that need to be */
+	/* forced to "alert" with alertsid mods.       */
+	if (!empty($alertsid)) {
+		foreach ($rule_map as $k1 => $rulem) {
+			foreach ($rulem as $k2 => $v) {
+				if (isset($alertsid[$k1][$k2]) && $v['action'] != 'alert') {
+					$matches = array();
+					if (preg_match('/^\s*#*\s*(drop|pass|reject)/i', $v['rule'], $matches)) {
+						$txt_regx = '/^\s*' . "{$matches[1]}" . '\s/';
+						if ($tmp = preg_replace($txt_regx, 'alert ', $v['rule'], 1)) {
+							$rule_map[$k1][$k2]['rule'] = $tmp;
+							$rule_map[$k1][$k2]['action'] = 'alert';
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/* Change action for any rules that need to be */
+	/* forced to "drop" with dropsid mods.         */
+	if (!empty($dropsid)) {
+		foreach ($rule_map as $k1 => $rulem) {
+			foreach ($rulem as $k2 => $v) {
+				if (isset($dropsid[$k1][$k2]) && $v['action'] != 'drop') {
+					$matches = array();
+					if (preg_match('/^\s*#*\s*(alert|pass|reject)/i', $v['rule'], $matches)) {
+						$txt_regx = '/^\s*' . "{$matches[1]}" . '\s/';
+						if ($tmp = preg_replace($txt_regx, 'drop ', $v['rule'], 1)) {
+							$rule_map[$k1][$k2]['rule'] = $tmp;
+							$rule_map[$k1][$k2]['action'] = 'drop';
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/* Change action for any rules that need to be */
+	/* forced to "reject" with rejectsid mods.     */
+	if (!empty($rejectsid)) {
+		foreach ($rule_map as $k1 => $rulem) {
+			foreach ($rulem as $k2 => $v) {
+				if (isset($rejectsid[$k1][$k2]) && $v['action'] != 'reject') {
+					$matches = array();
+					if (preg_match('/^\s*#*\s*(alert|pass|drop)/i', $v['rule'], $matches)) {
+						$txt_regx = '/^\s*' . "{$matches[1]}" . '\s/';
+						if ($tmp = preg_replace($txt_regx, 'reject ', $v['rule'], 1)) {
+							$rule_map[$k1][$k2]['rule'] = $tmp;
+							$rule_map[$k1][$k2]['action'] = 'reject';
+						}
+					}
+				}
+			}
+		}
+	}
+
+	unset($alertsid, $dropsid, $rejectsid);
+}
+
+function snort_get_filtered_rules($rules, $filter) {
+
+	/************************************************/
+	/* This function returns a rules_map array of   */
+	/* of rules filtered using the GID:SID pairs    */
+	/* found in the passed filter criteria array.   */
+	/*                                              */
+	/*   $rules --> file, a directory or an array   */
+	/*              containing rules files to scan  */
+	/*                                              */
+	/*  $filter --> array of GID:SID pairs to use   */
+	/*              for filtering returned rules    */
+	/*              map array.                      */
+	/*                                              */
+	/*  Returns --> rules_map array                 */
+	/************************************************/
+
+	$tmp_map = array();
+	$filtered_map = array();
+
+	// If the filter array is empty, just
+	// return an empty result to save time
+	// since nothing would match.
+	if (empty($filter)) {
+		return $filtered_map;
+	}
+
+	// Load up all the rules from the location passed
+	$tmp_map = snort_load_rules_map($rules);
+
+	// Now walk the loaded filter list and copy
+	// matching GID:SID rules from the target list
+	// over to the filtered array.
+	foreach ($filter as $k1 => $rulem) {
+		foreach($rulem as $k2 => $v) {
+			if (isset($tmp_map[$k1][$k2])) {
+				if (!is_array($filtered_map[$k1])) {
+					$filtered_map[$k1] = array();
+				}
+				if (!is_array($filtered_map[$k1][$k2])) {
+					$filtered_map[$k1][$k2] = array();
+				}
+				$filtered_map[$k1][$k2]['rule'] = $tmp_map[$k1][$k2]['rule'];
+				$filtered_map[$k1][$k2]['category'] = $tmp_map[$k1][$k2]['category'];
+				$filtered_map[$k1][$k2]['action'] = $tmp_map[$k1][$k2]['action'];
+				$filtered_map[$k1][$k2]['modified'] = $tmp_map[$k1][$k2]['modified'];
+				$filtered_map[$k1][$k2]['disabled'] = $tmp_map[$k1][$k2]['disabled'];
+				$filtered_map[$k1][$k2]['flowbits'] = $tmp_map[$k1][$k2]['flowbits'];
+				$filtered_map[$k1][$k2]['managed'] = $tmp_map[$k1][$k2]['managed'];
+				$filtered_map[$k1][$k2]['state_toggled'] = $tmp_map[$k1][$k2]['state_toggled'];
+				$filtered_map[$k1][$k2]['default_state'] = $tmp_map[$k1][$k2]['default_state'];
+				$filtered_map[$k1][$k2]['default_action'] = $tmp_map[$k1][$k2]['default_action'];
+			}
+		}
+	}
+
+	// Clean up and return the filtered list of rules
+	unset($tmp_map);
+	return $filtered_map;
+}
+
 function snort_create_rc() {
 
-/*********************************************************/
-/* This function builds the /usr/local/etc/rc.d/snort.sh */
-/* shell script for starting and stopping Snort.  The    */
-/* script is rebuilt on each package sync operation and  */
-/* after any changes to snort.conf saved in the GUI.     */
-/*********************************************************/
+	/*********************************************************/
+	/* This function builds the /usr/local/etc/rc.d/snort.sh */
+	/* shell script for starting and stopping Snort.  The    */
+	/* script is rebuilt on each package sync operation and  */
+	/* after any changes to snort.conf saved in the GUI.     */
+	/*********************************************************/
 
 	global $config, $g;
 
@@ -2904,6 +3247,16 @@ function snort_create_rc() {
 			continue;
 		$snort_uuid = $value['uuid'];
 		$if_real = get_real_interface($value['interface']);
+
+		// Adjust the interface specification and DAQ type according to operating mode
+		if ($value['ips_mode'] == "ips_mode_inline" && $value['blockoffenders7'] == "on") {
+			$iface = $if_real . "^:" . $if_real;
+			$daq_type = "-Q --daq netmap";
+		}
+		else {
+			$iface = $if_real;
+			$daq_type = "--daq pcap --daq-mode passive --treat-drop-as-alert";
+		}
 
 		$start_barnyard = <<<EOE
 
@@ -2959,14 +3312,14 @@ EOE;
 
 	# Start snort and barnyard2 for {$value['descr']}
 	if [ ! -f {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid ]; then
-		pid=`/bin/pgrep -fn "snort -R {$snort_uuid} "`
+		pid=`/bin/pgrep -fn "snort -R {$if_real}{$snort_uuid} "`
 	else
 		pid=`/bin/pgrep -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid`
 	fi
 
 	if [ -z \$pid ]; then
 		/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort START for {$value['descr']}({$snort_uuid}_{$if_real})..."
-		{$snortbindir}snort -R {$snort_uuid} -D {$quiet} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$if_real} > /dev/null 2>&1
+		{$snortbindir}snort -R _{$if_real}{$snort_uuid} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface} > /dev/null 2>&1
 	fi
 
 	{$start_barnyard2}
@@ -2991,10 +3344,10 @@ EOE;
 			/bin/rm {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid
 		fi
 	else
-		pid=`/bin/pgrep -fn "snort -R {$snort_uuid} "`
+		pid=`/bin/pgrep -fn "snort -R {$if_real}{$snort_uuid} "`
 		if [ ! -z \$pid ]; then
 			/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort STOP for {$value['descr']}({$snort_uuid}_{$if_real})..."
-			/bin/pkill -fn "snort -R {$snort_uuid} "
+			/bin/pkill -fn "snort -R {$if_real}{$snort_uuid} "
 			time=0 timeout=30
 			while kill -0 \$pid 2>/dev/null; do
 				sleep 1
@@ -3189,67 +3542,6 @@ EOD;
 	unset($barnyard2_conf_text);
 }
 
-function snort_get_filtered_rules($rules, $filter) {
-
-	/************************************************/
-	/* This function returns a rules_map array of   */
-	/* of rules filtered using the GID:SID pairs    */
-	/* found in the passed filter criteria array.   */
-	/*                                              */
-	/*   $rules --> file, a directory or an array   */
-	/*              containing rules files to scan  */
-	/*                                              */
-	/*  $filter --> array of GID:SID pairs to use   */
-	/*              for filtering returned rules    */
-	/*              map array.                      */
-	/*                                              */
-	/*  Returns --> rules_map array                 */
-	/************************************************/
-
-	$tmp_map = array();
-	$filtered_map = array();
-
-	// If the filter array is empty, just
-	// return an empty result to save time
-	// since nothing would match.
-	if (empty($filter)) {
-		return $filtered_map;
-	}
-
-	// Load up all the rules from the location passed
-	$tmp_map = snort_load_rules_map($rules);
-
-	// Now walk the loaded filter list and copy
-	// matching GID:SID rules from the target list
-	// over to the filtered array.
-	foreach ($filter as $k1 => $rulem) {
-		foreach($rulem as $k2 => $v) {
-			if (isset($tmp_map[$k1][$k2])) {
-				if (!is_array($filtered_map[$k1])) {
-					$filtered_map[$k1] = array();
-				}
-				if (!is_array($filtered_map[$k1][$k2])) {
-					$filtered_map[$k1][$k2] = array();
-				}
-				$filtered_map[$k1][$k2]['rule'] = $tmp_map[$k1][$k2]['rule'];
-				$filtered_map[$k1][$k2]['category'] = $tmp_map[$k1][$k2]['category'];
-				$filtered_map[$k1][$k2]['action'] = $tmp_map[$k1][$k2]['action'];
-				$filtered_map[$k1][$k2]['modified'] = $tmp_map[$k1][$k2]['modified'];
-				$filtered_map[$k1][$k2]['disabled'] = $tmp_map[$k1][$k2]['disabled'];
-				$filtered_map[$k1][$k2]['flowbits'] = $tmp_map[$k1][$k2]['flowbits'];
-				$filtered_map[$k1][$k2]['managed'] = $tmp_map[$k1][$k2]['managed'];
-				$filtered_map[$k1][$k2]['state_toggled'] = $tmp_map[$k1][$k2]['state_toggled'];
-				$filtered_map[$k1][$k2]['default_state'] = $tmp_map[$k1][$k2]['default_state'];
-				$filtered_map[$k1][$k2]['default_action'] = $tmp_map[$k1][$k2]['default_action'];
-			}
-		}
-	}
-
-	// Clean up and return the filtered list of rules
-	unset($tmp_map);
-	return $filtered_map;
-}
-
 function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 
 	/***********************************************************/
@@ -3311,9 +3603,8 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 	/* into the $enabled_rules array.                     */
 	$enabled_rules = snort_load_rules_map("{$snortcfgdir}/preproc_rules/");
 
-	/* Only rebuild rules if some are selected or an IPS Policy is enabled  */
+	/* Process CATEGORIES rules if some are selected or an IPS Policy is enabled  */
 	if (!empty($snortcfg['rulesets']) || $snortcfg['ips_policy_enable'] == 'on') {
-		$no_rules_defined = false;
 
 		/* Load up all the text rules into a Rules Map array. */
 		$all_rules = snort_load_rules_map("{$snortdir}/rules/");
@@ -3377,8 +3668,14 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 
 		/* Check if a pre-defined Snort Subscriber rules policy is selected. */
 		/* If so, add all the VRT policy rules to our enforcing rule set.    */
-		if (!empty($snortcfg['ips_policy'])) {
-			$policy_rules = snort_load_vrt_policy($snortcfg['ips_policy'], $all_rules);
+		if ($snortcfg['ips_policy_enable'] == 'on' && !empty($snortcfg['ips_policy'])) {
+			if ($snortcfg['blockoffenders7'] == 'on' && $snortcfg['ips_mode'] == 'ips_mode_inline') {
+				$policy_mode = $snortcfg['ips_policy_mode'];
+			}
+			else {
+				$policy_mode = 'alert';
+			}
+			$policy_rules = snort_load_vrt_policy($snortcfg['ips_policy'], $policy_mode, $all_rules);
 			foreach ($policy_rules as $k1 => $policy) {
 				foreach ($policy as $k2 => $p) {
 					if (!is_array($enabled_rules[$k1]))
@@ -3399,6 +3696,7 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 		// Do the auto-SID managment first, if enabled, then do any manual SID state changes.
 		snort_auto_sid_mgmt($enabled_rules, $snortcfg, TRUE);
 		snort_modify_sids($enabled_rules, $snortcfg);
+		snort_modify_sids_action($enabled_rules, $snortcfg);
 
 		/* Check for and disable any rules dependent upon disabled preprocessors if  */
 		/* this option is enabled for the interface.                                 */
@@ -3432,58 +3730,45 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 			snort_write_flowbit_rules_file(array(), "{$snortcfgdir}/rules/{$flowbit_rules_file}");
 		unset($all_rules);
 	}
-	// If no rule categories were enabled, then use auto-SID management if enabled, since it may enable some rules
-	elseif ($config['installedpackages']['snortglobal']['auto_manage_sids'] == 'on' &&
-		(!empty($snortcfg['disable_sid_file']) || !empty($snortcfg['enable_sid_file']) || 
-		!empty($snortcfg['modify_sid_file']))) {
 
-		snort_auto_sid_mgmt($enabled_rules, $snortcfg, TRUE);
-		if (!empty($enabled_rules)) {
-			// Auto-SID management generated some rules, so use them
-			$no_rules_defined = false;
-			snort_modify_sids($enabled_rules, $snortcfg);
+	// Process SID Management directives if enabled
+	snort_auto_sid_mgmt($enabled_rules, $snortcfg, TRUE);
+	if (!empty($enabled_rules)) {
+		// Auto-SID management generated some rules, so use them
+		snort_modify_sids($enabled_rules, $snortcfg);
+		snort_modify_sids_action($enabled_rules, $snortcfg);
 
-			// Write the enforcing rules file to the Snort interface's "rules" directory.
-			snort_write_enforcing_rules_file($enabled_rules, "{$snortcfgdir}/rules/{$snort_enforcing_rules_file}");
+		// Write the enforcing rules file to the Snort interface's "rules" directory.
+		snort_write_enforcing_rules_file($enabled_rules, "{$snortcfgdir}/rules/{$snort_enforcing_rules_file}");
 
-			// If auto-flowbit resolution is enabled, generate the dependent flowbits rules file.
-			if ($snortcfg['autoflowbitrules'] == 'on') {
-				log_error('[Snort] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
+		// If auto-flowbit resolution is enabled, generate the dependent flowbits rules file.
+		if ($snortcfg['autoflowbitrules'] == 'on') {
+			log_error('[Snort] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
 
-				// Load up all rules into a Rules Map array for flowbits assessment
-				$all_rules = snort_load_rules_map("{$snortdir}/rules/");
-				$fbits = snort_resolve_flowbits($all_rules, $enabled_rules);
+			// Load up all rules into a Rules Map array for flowbits assessment
+			$all_rules = snort_load_rules_map("{$snortdir}/rules/");
+			$fbits = snort_resolve_flowbits($all_rules, $enabled_rules);
 
-				// Check for and disable any flowbit-required rules the
-				// user has manually forced to a disabled state.
-				snort_modify_sids($fbits, $snortcfg);
-				snort_write_flowbit_rules_file($fbits, "{$snortcfgdir}/rules/{$flowbit_rules_file}");
-				unset($all_rules, $fbits);
-			} else
-				// Just put an empty file to always have the file present
-			snort_write_flowbit_rules_file(array(), "{$snortcfgdir}/rules/{$flowbit_rules_file}");
-		}
-		else {
-			snort_write_enforcing_rules_file(array(), "{$snortcfgdir}/rules/{$snort_enforcing_rules_file}");
-			snort_write_flowbit_rules_file(array(), "{$snortcfgdir}/rules/{$flowbit_rules_file}");
-		}
+			// Check for and disable any flowbit-required rules the
+			// user has manually forced to a disabled state.
+			snort_modify_sids($fbits, $snortcfg);
+			snort_write_flowbit_rules_file($fbits, "{$snortcfgdir}/rules/{$flowbit_rules_file}");
+			unset($all_rules, $fbits);
+		} else
+			// Just put an empty file to always have the file present
+		snort_write_flowbit_rules_file(array(), "{$snortcfgdir}/rules/{$flowbit_rules_file}");
 	}
 	else {
-		/* No regular rules or policy were selected, so just use the decoder and preproc rules */
-		snort_write_enforcing_rules_file($enabled_rules, "{$snortcfgdir}/rules/{$snort_enforcing_rules_file}");
+		snort_write_enforcing_rules_file(array(), "{$snortcfgdir}/rules/{$snort_enforcing_rules_file}");
 		snort_write_flowbit_rules_file(array(), "{$snortcfgdir}/rules/{$flowbit_rules_file}");
 	}
 
 	if (!empty($snortcfg['customrules'])) {
 		@file_put_contents("{$snortcfgdir}/rules/custom.rules", base64_decode($snortcfg['customrules']));
-		$no_rules_defined = false;
 	}
-	else
+	else {
 		@file_put_contents("{$snortcfgdir}/rules/custom.rules", "");
-
-	/* Log a warning if the interface has no rules defined or enabled */
-	if ($no_rules_defined)
-		log_error(gettext("[Snort] Warning - no text rules or IPS-Policy selected for: " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . " ..."));
+	}
 
 	/* Build a new sid-msg.map file from the enabled */
 	/* rules and copy it to the interface directory. */

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_conf_template.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_conf_template.inc
@@ -30,6 +30,7 @@ config snaplen: {$snaplen}
 config disable_decode_alerts
 config disable_tcpopt_experimental_alerts
 config disable_tcpopt_obsolete_alerts
+config disable_tcpopt_ttcp_alerts
 config disable_ttcp_alerts
 config disable_tcpopt_alerts
 config disable_ipopt_alerts
@@ -37,6 +38,9 @@ config disable_decode_drops
 
 # Enable the GTP decoder #
 config enable_gtp
+
+# Configure maximum number of flowbit references.
+config flowbits_size: 2048
 
 # Configure PCRE match limitations
 config pcre_match_limit: 3500
@@ -62,12 +66,12 @@ dynamicengine directory {$snort_dirs['dynamicengine']}
 dynamicdetection directory {$snort_dirs['dynamicrules']}
 
 # Inline packet normalization. For more information, see README.normalize
-# Disabled since we do not use "inline" mode with pfSense
-# preprocessor normalize_ip4
-# preprocessor normalize_tcp: ips ecn stream
-# preprocessor normalize_icmp4
-# preprocessor normalize_ip6
-# preprocessor normalize_icmp6
+# Does nothing in IDS mode (Legacy Mode blocking)
+preprocessor normalize_ip4
+preprocessor normalize_tcp: ips ecn stream
+preprocessor normalize_icmp4
+preprocessor normalize_ip6
+preprocessor normalize_icmp6
 
 # Flow and stream #
 {$frag3_global}
@@ -90,7 +94,7 @@ dynamicdetection directory {$snort_dirs['dynamicrules']}
 {$host_attrib_config}
 
 # Snort Output Logs #
-output alert_csv: alert timestamp,sig_generator,sig_id,sig_rev,msg,proto,src,srcport,dst,dstport,id,classification,priority {$alert_log_limit_size}
+output alert_csv: alert timestamp,sig_generator,sig_id,sig_rev,msg,proto,src,srcport,dst,dstport,id,classification,priority,action,disposition {$alert_log_limit_size}
 {$alertsystemlog_type}
 {$snortunifiedlog_type}
 {$spoink_type}

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
@@ -174,6 +174,12 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 		$snortcfgdir = "{$snortdir}/snort_{$snort_uuid}_{$if_real}";
 		update_status(gettext("Generating configuration for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . "..."));
 
+		// Remove any existing dynamic preprocessor library files from
+		// the snort_dynamicpreprocessor directory for the interface.
+		// The snort.conf file generation code farther down will copy
+		// in new ones from '/usr/local/lib/snort_dynamicpreprocessor'.
+		mwexec("/bin/rm -rf {$snortcfgdir}/snort_dynamicpreprocessor/*.so");
+
 		// Pull in the PHP code that generates the snort.conf file
 		// variables that will be substituted further down below.
 		include("/usr/local/pkg/snort/snort_generate_conf.php");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ip_reputation.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ip_reputation.php
@@ -35,15 +35,26 @@ if (is_null($id)) {
 	exit;
 }
 
-init_config_arr('installedpackages', 'snortglobal', 'rule', $id, 'wlist_files');
-init_config_arr('installedpackages', 'snortglobal', 'rule', $id, 'blist_files');
-
 $a_nat = &$config['installedpackages']['snortglobal']['rule'];
 
 $pconfig = $a_nat[$id];
 $iprep_path = SNORT_IPREP_PATH;
 $if_real = get_real_interface($a_nat[$id]['interface']);
 $snort_uuid = $config['installedpackages']['snortglobal']['rule'][$id]['uuid'];
+
+// Init 'blist_files' and 'wlist_files' arrays if necessary
+if (!is_array($a_nat[$id]['blist_files'])) {
+	$a_nat[$id]['blist_files'] = array();
+}
+if (!is_array($a_nat[$id]['blist_files']['item'])) {
+	$a_nat[$id]['blist_files']['item'] = array();
+}
+if (!is_array($a_nat[$id]['wlist_files'])) {
+	$a_nat[$id]['wlist_files'] = array();
+}
+if (!is_array($a_nat[$id]['wlist_files']['item'])) {
+	$a_nat[$id]['wlist_files']['item'] = array();
+}
 
 // Set sensible defaults for any empty parameters
 if (empty($pconfig['iprep_memcap']))
@@ -176,6 +187,7 @@ if ($_POST['save']) {
 			log_error(gettext("Snort: restarting on interface " . convert_real_interface_to_friendly_descr($if_real) . " due to IP REP preprocessor configuration change."));
 			snort_stop($a_nat[$id], $if_real);
 			snort_start($a_nat[$id], $if_real, TRUE);
+			$savemsg = gettext("Snort has been restarted on interface " . convert_real_interface_to_friendly_descr($if_real) . " because IP Reputation preprocessor changes require a restart.");
 		}
 
 		// Sync to configured CARP slaves if any are enabled
@@ -246,6 +258,19 @@ if (is_subsystem_dirty('snort_iprep')) {
 	$msg .= '</div>';
 	$msg .= '<div class="pull-right"><button type="submit" class="btn btn-default btn-warning" name="apply" value="Apply Changes">Apply Changes</button></div>';
 	print '<div class="alert-warning clearfix" role="alert">' . $msg . '<br/></div>';
+}
+
+if (!is_array($pconfig['blist_files'])) {
+	$pconfig['blist_files'] = array();
+}
+if (!is_array($pconfig['blist_files']['item'])) {
+	$pconfig['blist_files']['item'] = array();
+}
+if (!is_array($pconfig['wlist_files'])) {
+	$pconfig['wlist_files'] = array();
+}
+if (!is_array($pconfig['wlist_files']['item'])) {
+	$pconfig['wlist_files']['item'] = array();
 }
 
 if ($g['platform'] == "nanobsd") {

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
@@ -3,9 +3,9 @@
  * snort_rulesets.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009 Robert Zelaya
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,6 +54,7 @@ if (isset($id) && $a_nat[$id]) {
 		$pconfig['autoflowbitrules'] = $a_nat[$id]['autoflowbitrules'] == 'on' ? 'on' : 'off';;
 	$pconfig['ips_policy_enable'] = $a_nat[$id]['ips_policy_enable'] == 'on' ? 'on' : 'off';;
 	$pconfig['ips_policy'] = $a_nat[$id]['ips_policy'];
+	$pconfig['ips_policy_mode'] = $a_nat[$id]['ips_policy_mode'];
 }
 
 $if_real = get_real_interface($pconfig['interface']);
@@ -119,10 +120,12 @@ if (isset($_POST["save"])) {
 	if ($_POST['ips_policy_enable'] == "on") {
 		$a_nat[$id]['ips_policy_enable'] = 'on';
 		$a_nat[$id]['ips_policy'] = $_POST['ips_policy'];
+		$a_nat[$id]['ips_policy_mode'] = $_POST['ips_policy_mode'];
 	}
 	else {
 		$a_nat[$id]['ips_policy_enable'] = 'off';
 		unset($a_nat[$id]['ips_policy']);
+		unset($a_nat[$id]['ips_policy_mode']);
 	}
 
 	$enabled_items = "";
@@ -169,15 +172,18 @@ if (isset($_POST['unselectall'])) {
 	if ($_POST['ips_policy_enable'] == "on") {
 		$a_nat[$id]['ips_policy_enable'] = 'on';
 		$a_nat[$id]['ips_policy'] = $_POST['ips_policy'];
+		$a_nat[$id]['ips_policy_mode'] = $_POST['ips_policy_mode'];
 	}
 	else {
 		$a_nat[$id]['ips_policy_enable'] = 'off';
 		unset($a_nat[$id]['ips_policy']);
+		unset($a_nat[$id]['ips_policy_mode']);
 	}
 
 	$pconfig['autoflowbits'] = $_POST['autoflowbits'];
 	$pconfig['ips_policy_enable'] = $_POST['ips_policy_enable'];
 	$pconfig['ips_policy'] = $_POST['ips_policy'];
+	$pconfig['ips_policy_mode'] = $_POST['ips_policy_mode'];
 	$enabled_rulesets_array = array();
 
 	$savemsg = gettext("All rule categories have been de-selected.  ");
@@ -191,10 +197,12 @@ if (isset($_POST['selectall'])) {
 	if ($_POST['ips_policy_enable'] == "on") {
 		$a_nat[$id]['ips_policy_enable'] = 'on';
 		$a_nat[$id]['ips_policy'] = $_POST['ips_policy'];
+		$a_nat[$id]['ips_policy_mode'] = $_POST['ips_policy_mode'];
 	}
 	else {
 		$a_nat[$id]['ips_policy_enable'] = 'off';
 		unset($a_nat[$id]['ips_policy']);
+		unset($a_nat[$id]['ips_policy_mode']);
 	}
 
 	$pconfig['autoflowbits'] = $_POST['autoflowbits'];
@@ -379,6 +387,14 @@ if ($snortdownload == "on") {
 		'in an Excel file.  Max-Detect is a policy created for testing network traffic through your ' . 
 		'device.  This policy should be used with caution on production systems!</span>'
 	));
+	$section->addInput(new Form_Select(
+		'ips_policy_mode',
+		'IPS Policy Mode',
+		$pconfig['ips_policy_mode'],
+		array(  'alert' => 'Alert',
+			'policy'  => 'Policy')
+		))->setHelp('When Policy is selected, this will automatically change the action for rules in the selected IPS Policy from their default action of alert to the action specified ' .
+				'in the policy metadata (typically drop, but may be alert for some policy rules).');
 	print($section);
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
@@ -3,11 +3,11 @@
  * snort_sid_mgmt.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -76,6 +76,19 @@ function snort_is_sidmodslist_active($sidlist) {
 		if ($rule['modify_sid_file'] == $sidlist) {
 			return TRUE;
 		}
+
+		// The tests below let the user remove an assigned
+		// DROP_SID or REJECT_SID list from an interface
+		// that now uses a mode where these list types
+		// are no longer applicable.
+		if ($rule['blockoffenders7'] == 'on' && $rule['ips_mode'] == 'ips_mode_inline') {
+			if ($rule['drop_sid_file'] == $sidlist) {
+				return TRUE;
+			}
+			if ($rule['reject_sid_file'] == $sidlist) {
+				return TRUE;
+			}
+		}
 	}
 	return FALSE;
 }
@@ -109,6 +122,16 @@ if (isset($_POST['upload'])) {
 
 if (isset($_POST['sidlist_delete']) && isset($a_list[$_POST['sidlist_id']])) {
 	if (!snort_is_sidmodslist_active($a_list[$_POST['sidlist_id']]['name'])) {
+
+		// Remove the list from DROP_SID or REJECT_SID if assigned on any interface.
+		foreach($a_nat as $k => $rule) {
+			if ($rule['drop_sid_file'] == $a_list[$_POST['sidlist_id']]['name']) {
+				unset($a_nat[$k]['drop_sid_file']);
+			}
+			if ($rule['reject_sid_file'] == $a_list[$_POST['sidlist_id']]['name']) {
+				unset($a_nat[$k]['reject_sid_file']);
+			}
+		}
 		unset($a_list[$_POST['sidlist_id']]);
 
 		// Write the new configuration
@@ -190,6 +213,26 @@ if (isset($_POST['save_auto_sid_conf'])) {
 				continue;
 			}
 			$a_nat[$k]['modify_sid_file'] = $v;
+		}
+	}
+
+	if (is_array($_POST['drop_sid_file'])) {
+		foreach ($_POST['drop_sid_file'] as $k => $v) {
+			if ($v == "None") {
+				unset($a_nat[$k]['drop_sid_file']);
+				continue;
+			}
+			$a_nat[$k]['drop_sid_file'] = $v;
+		}
+	}
+
+	if (is_array($_POST['reject_sid_file'])) {
+		foreach ($_POST['reject_sid_file'] as $k => $v) {
+			if ($v == "None") {
+				unset($a_nat[$k]['reject_sid_file']);
+				continue;
+			}
+			$a_nat[$k]['reject_sid_file'] = $v;
 		}
 	}
 
@@ -500,6 +543,8 @@ print($section);
 					<th><?=gettext("Enable SID List")?></th>
 					<th><?=gettext("Disable SID List")?></th>
 					<th><?=gettext("Modify SID List")?></th>
+					<th><?=gettext("Drop SID List")?></th>
+					<th><?=gettext("Reject SID List")?></th>
 				   </tr>
 				</thead>
 				<tbody>
@@ -565,6 +610,46 @@ print($section);
 							?>
 						</select>
 					</td>
+					<td>
+						<?php if ($natent['blockoffenders7'] == 'on' && $natent['ips_mode'] == 'ips_mode_inline') : ?>
+							<select name="drop_sid_file[<?=$k?>]" class="form-control" id="drop_sid_file[<?=$k?>]">
+								<?php
+									foreach ($sidmodselections as $choice) {
+										if ($choice == $natent['drop_sid_file'])
+											echo "<option value='{$choice}' selected>";
+										else
+											echo "<option value='{$choice}'>";
+
+										echo htmlspecialchars(gettext($choice)) . '</option>';
+									}
+								?>
+							</select>
+						<?php else : ?>
+							<input type="hidden" name="drop_sid_file[<?=$k?>]" id="drop_sid_file[<?=$k?>]" value="<?=isset($natent['drop_sid_file']) ? $natent['drop_sid_file'] : 'none';?>">
+							<span class="text-center"><?=gettext("N/A")?></span>
+						<?php endif; ?>
+					</td>
+					<td>
+						<?php if ($natent['blockoffenders7'] == 'on' && $natent['ips_mode'] == 'ips_mode_inline') : ?>
+							<select name="reject_sid_file[<?=$k?>]" class="form-control" id="reject_sid_file[<?=$k?>]">
+								<?php
+									foreach ($sidmodselections as $choice) {
+										if ($choice == $natent['reject_sid_file'])
+											echo "<option value='{$choice}' selected>";
+										else
+											echo "<option value='{$choice}'>";
+
+										echo htmlspecialchars(gettext($choice)) . '</option>';
+									}
+								?>
+							</select>
+						<?php else : ?>
+							<input type="hidden" name="reject_sid_file[<?=$k?>]" id="reject_sid_file[<?=$k?>]" value="<?=isset($natent['reject_sid_file']) ? $natent['reject_sid_file'] : 'none';?>">
+							<span class="text-center"><?=gettext("N/A")?></span>
+						<?php endif; ?>
+					</td>
+
+
 				</tr>
 			   <?php endforeach; ?>
 				</tbody>
@@ -592,7 +677,7 @@ print($section);
 					" In this case you would choose 'disable,enable' for the State Order.  Note that the last action performed takes priority.") .
 			'</p>' .
 			'<p>' .
-				gettext("The Enable SID File, Disable SID File, Modify SID File and Drop SID File drop-down controls specify which rule modification lists are run automatically for the interface.  Setting a list control to 'None' disables that modification. " . 
+				gettext("The Enable SID File, Disable SID File, Modify SID File, Drop SID File and Reject SID File drop-down controls specify which rule modification lists are run automatically for the interface.  Setting a list control to 'None' disables that modification. " . 
 					"Setting all list controls for an interface to 'None' disables automatic SID state management for the interface.") .
 			'</p>', 'info', false);
 	?>

--- a/security/pfSense-pkg-snort/files/usr/local/www/widgets/widgets/snort_alerts.widget.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/widgets/widgets/snort_alerts.widget.php
@@ -119,14 +119,14 @@ function snort_widget_get_alerts() {
 
 			if (file_exists("/tmp/alert_snort{$snort_uuid}")) {
 
-				/*              0         1            2      3       4   5     6   7       8   9       10 11             12       */
-				/* File format: timestamp,generator_id,sig_id,sig_rev,msg,proto,src,srcport,dst,dstport,id,classification,priority */
+				/*              0         1            2      3       4   5     6   7       8   9       10 11             12       13     14          */
+				/* File format: timestamp,generator_id,sig_id,sig_rev,msg,proto,src,srcport,dst,dstport,id,classification,priority,action,disposition */
 				if (!$fd = fopen("/tmp/alert_snort{$snort_uuid}", "r")) {
 					log_error(gettext("[Snort Widget] Failed to open file /tmp/alert_snort{$snort_uuid}"));
 					continue;
 				}
 				while (($fields = fgetcsv($fd, 1000, ',', '"')) !== FALSE) {
-					if(count($fields) < 13)
+					if(count($fields) < 14 || count($fields) > 15)
 						continue;
 
 					// Get the Snort interface this alert was received from

--- a/security/pfSense-pkg-snort/files/var/db/snort/sidmods/dropsid-sample.conf
+++ b/security/pfSense-pkg-snort/files/var/db/snort/sidmods/dropsid-sample.conf
@@ -1,0 +1,45 @@
+# Note: This file is used to specify what rules you wish to be set to have
+# an action of drop rather than alert.
+
+# Example of modifying action for individual rules
+# 1:1034,1:9837,1:1270,1:3390,1:710,1:1249,3:13010
+
+# Example of modifying action for rule ranges
+# 1:220-1:3264,3:13010-3:13013
+
+# Comments are allowed in this file, and can also be on the same line
+# as the modify action syntax, as long as it is a trailing comment
+# 1:1011 # I Modified this rule action because I could!
+
+# Example of modifying action for MS and cve rules, note the use of the : 
+# in cve. This will modify MS09-008, cve 2009-0233, bugtraq 21301,
+# and all MS00 and all cve 2000 related sids!  These support regular expression
+# matching only after you have specified what you are looking for, i.e. 
+# MS00-<regex> or cve:<regex>, the first section CANNOT contain a regular
+# expression (MS\d{2}-\d+) will NOT work, use the pcre: keyword (below)
+# for this.
+# MS09-008,cve:2009-0233,bugtraq:21301,MS00-\d+,cve:2000-\d+
+
+# Example of using the pcre: keyword to modify rule action.  the pcre keyword 
+# allows for full use of regular expression syntax, you do not need to designate
+# with / and all pcre searches are treated as case insensitive. For more information 
+# about regular expression syntax: http://www.regular-expressions.info/
+# The following example modifies action for all MS07 through MS10 
+# pcre:MS(0[7-9]|10)-\d+
+
+# The following example modifies action for Snort VRT rules tagged with IPS 
+# Policy Security and ips drop.  Note the better way to accomplish this is
+# by setting the option "IPS Policy Mode" to "policy" on the CATEGORIES tab.
+# -----------------
+# pcre:"pcre:security-ips\s*drop"
+
+# Example of modifying action for specific categories entirely
+# VRT-web-iis,ET-shellcode,ET-emergingthreats-smtp,Custom-shellcode,Custom-emergingthreats-smtp
+
+# Any of the above values can be on a single line or multiple lines, when 
+# on a single line they simply need to be separated by a ,
+# 1:9837,1:220-1:3264,3:13010-3:13013,pcre:MS(0[0-7])-\d+,MS09-008,cve:2009-0233
+
+# The modifications in this file are for sample/example purposes only and
+# should not actively be used, you need to modify this file to fit your 
+# environment.

--- a/security/pfSense-pkg-snort/files/var/db/snort/sidmods/rejectsid-sample.conf
+++ b/security/pfSense-pkg-snort/files/var/db/snort/sidmods/rejectsid-sample.conf
@@ -1,0 +1,44 @@
+# Note: This file is used to specify what rules you wish to be set to have
+# an action of reject rather than alert.
+
+# Example of modifying action for individual rules
+# 1:1034,1:9837,1:1270,1:3390,1:710,1:1249,3:13010
+
+# Example of modifying action for rule ranges
+# 1:220-1:3264,3:13010-3:13013
+
+# Comments are allowed in this file, and can also be on the same line
+# as the modify action syntax, as long as it is a trailing comment
+# 1:1011 # I Modified this rule action to reject because I could!
+
+# Example of modifying action for MS and cve rules, note the use of the : 
+# in cve. This will modify MS09-008, cve 2009-0233, bugtraq 21301,
+# and all MS00 and all cve 2000 related sids!  These support regular expression
+# matching only after you have specified what you are looking for, i.e. 
+# MS00-<regex> or cve:<regex>, the first section CANNOT contain a regular
+# expression (MS\d{2}-\d+) will NOT work, use the pcre: keyword (below)
+# for this.
+# MS09-008,cve:2009-0233,bugtraq:21301,MS00-\d+,cve:2000-\d+
+
+# Example of using the pcre: keyword to modify rule action.  the pcre keyword 
+# allows for full use of regular expression syntax, you do not need to designate
+# with / and all pcre searches are treated as case insensitive. For more information 
+# about regular expression syntax: http://www.regular-expressions.info/
+# The following example modifies action for all MS07 through MS10 
+# pcre:MS(0[7-9]|10)-\d+
+
+# The following example modifies action to reject for Snort VRT rules tagged with 
+# IPS Policy Security and ips drop.
+# -----------------
+# pcre:"pcre:security-ips\s*drop"
+
+# Example of modifying action for specific categories entirely
+# VRT-web-iis,ET-shellcode,ET-emergingthreats-smtp,Custom-shellcode,Custom-emergingthreats-smtp
+
+# Any of the above values can be on a single line or multiple lines, when 
+# on a single line they simply need to be separated by a ,
+# 1:9837,1:220-1:3264,3:13010-3:13013,pcre:MS(0[0-7])-\d+,MS09-008,cve:2009-0233
+
+# The modifications in this file are for sample/example purposes only and
+# should not actively be used, you need to modify this file to fit your 
+# environment.

--- a/security/pfSense-pkg-snort/pkg-plist
+++ b/security/pfSense-pkg-snort/pkg-plist
@@ -49,6 +49,8 @@ www/widgets/include/widget-snort.inc
 /var/db/snort/sidmods/disablesid-sample.conf
 /var/db/snort/sidmods/enablesid-sample.conf
 /var/db/snort/sidmods/modifysid-sample.conf
+/var/db/snort/sidmods/dropsid-sample.conf
+/var/db/snort/sidmods/rejectsid-sample.conf
 %%DATADIR%%/info.xml
 @dir /etc/inc/priv
 @dir /etc/inc


### PR DESCRIPTION
### pfSense-pkg-snort-4.0
This update to the Snort GUI package introduces a new _Inline IPS_ mode of operation using the DAQ netmap module.  With Inline IPS operation, rules with the ALERT action will generate alerts but will **not** block the associated traffic.  Rules with the DROP action will generate alerts and block the associated traffic by dropping the packet and not transmitting it on to the operating system stack.  Rules with the REJECT action will generate an alert, drop the packet by not forwarding it to the OS stack, and will send a RST back to the sender for TCP traffic or a "Destination port unreachable" for UDP/ICMP traffic.

This update also includes a five bug fixes.

**New Features:**
1.  Support for Inline IPS mode operation using the DAQ netmap module.  This mode is configured on the INTERFACE SETTINGS tab for an interface in the **Block Settings** area.  You must have a supported NIC (network interface card) to use this new feature.  Currently FreeBSD 12 supports netmap operation with the following NIC drivers:  _em_, _igb_, _ixgb_, _ixl_, _lem_, _re_ and _cxgbe_.
2.  Enabled the **normalize** preprocessor for Inline IPS mode operation.  This preprocessor does nothing when Legacy Mode blocking is used.

**Bug Fixes:**
1.  Host Attribute Table XML file fails load.  See Redmine issue [#9546](https://redmine.pfsense.org/issues/9546).
2.  Interface IP REP tab shows "_invalid foreach parameter_" error message if no blacklists or whitelists are assigned to the interface.
3.  The _snort_prepare_rule_files()_ function does not process enabled or disabled preprocessor or decoder rules when no other rule categories nor an IPS Policy are selected.
4.  Config setting CONFIG FLOWBITS_SIZE now set to maximum value (2048).  See this [Netgate Forums post](https://forum.netgate.com/topic/143103/flowbit-ids-in-the-current-ruleset-exceeds-the-maximum-number-of-ids-that-are-allowed-1024/2) for details.
5.  Snort sometimes fails to live reload rule updates and logs a spurious "_Snort Reload:  Changes to dynamic preprocessors require a restart_" error message in the system log.
