### PR TITLE
pfSense-pkg-snort-4.0_1 -- Fix VLAN and PPPoE interface startup error (PID suffix too long)

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.0
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -501,50 +501,48 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
 }
 
 /* checks to see if service is running */
-function snort_is_running($snort_uuid, $if_real, $type = 'snort') {
+function snort_is_running($if_real, $type = 'snort') {
 	global $config, $g;
 
-	return isvalidpid("{$g['varrun_path']}/{$type}_{$if_real}{$snort_uuid}.pid");
+	return isvalidpid("{$g['varrun_path']}/{$type}_{$if_real}.pid");
 }
 
 function snort_barnyard_stop($snortcfg, $if_real) {
 	global $config, $g;
 
-	$snort_uuid = $snortcfg['uuid'];
-	if (isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid")) {
+	if (isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}.pid")) {
 		log_error("[Snort] Barnyard2 STOP for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
-		killbypid("{$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid");
+		killbypid("{$g['varrun_path']}/barnyard2_{$if_real}.pid");
 
 		// Now wait up to 5 seconds for Barnyard2 to actually stop and clear its PID file
 		$count = 0;
 		do {
-			if (!isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid"))
+			if (!isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}.pid"))
 				break;
 			sleep(1);
 			$count++;
 		} while ($count < 5);
 	}
-	unlink_if_exists("{$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid");
+	unlink_if_exists("{$g['varrun_path']}/barnyard2_{$if_real}.pid");
 }
 
 function snort_stop($snortcfg, $if_real) {
 	global $config, $g;
 
-	$snort_uuid = $snortcfg['uuid'];
-	if (isvalidpid("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid")) {
+	if (isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid")) {
 		log_error("[Snort] Snort STOP for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
-		killbypid("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid");
+		killbypid("{$g['varrun_path']}/snort_{$if_real}.pid");
 
 		// Now wait up to 10 seconds for Snort to actually stop and clear its PID file
 		$count = 0;
 		do {
-			if (!isvalidpid("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid"))
+			if (!isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid"))
 				break;
 			sleep(1);
 			$count++;
 		} while ($count < 10);
 	}
-	unlink_if_exists("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid");
+	unlink_if_exists("{$g['varrun_path']}/snort_{$if_real}.pid");
 
 	snort_barnyard_stop($snortcfg, $if_real);
 }
@@ -557,12 +555,12 @@ function snort_barnyard_start($snortcfg, $if_real, $background=FALSE) {
 	$snort_uuid = $snortcfg['uuid'];
 	$snortbindir = SNORT_PBI_BINDIR;
 
-	if ($snortcfg['barnyard_enable'] == 'on' && !isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid")) {
+	if ($snortcfg['barnyard_enable'] == 'on' && !isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}.pid")) {
 		log_error("[Snort] Barnyard2 START for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
 		if ($background)
-			mwexec_bg("{$snortbindir}barnyard2 -r {$snort_uuid} -f \"snort_{$snort_uuid}_{$if_real}.u2\" --pid-path {$g['varrun_path']} --nolock-pidfile -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/barnyard2.conf -d {$snortlogdir}/snort_{$if_real}{$snort_uuid} -D -q");
+			mwexec_bg("{$snortbindir}barnyard2 -f \"snort_{$snort_uuid}_{$if_real}.u2\" --pid-path {$g['varrun_path']} --nolock-pidfile -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/barnyard2.conf -d {$snortlogdir}/snort_{$if_real}{$snort_uuid} -D -q");
 	else
-			mwexec("{$snortbindir}barnyard2 -r {$snort_uuid} -f \"snort_{$snort_uuid}_{$if_real}.u2\" --pid-path {$g['varrun_path']} --nolock-pidfile -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/barnyard2.conf -d {$snortlogdir}/snort_{$if_real}{$snort_uuid} -D -q");
+			mwexec("{$snortbindir}barnyard2 -f \"snort_{$snort_uuid}_{$if_real}.u2\" --pid-path {$g['varrun_path']} --nolock-pidfile -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/barnyard2.conf -d {$snortlogdir}/snort_{$if_real}{$snort_uuid} -D -q");
 	}
 }
 
@@ -579,7 +577,7 @@ function snort_start($snortcfg, $if_real, $background=FALSE) {
 	else
 		$quiet = "-q --suppress-config-log";
 
-	if ($snortcfg['enable'] == 'on' && !isvalidpid("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid")) {
+	if ($snortcfg['enable'] == 'on' && !isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid")) {
 
 		// Adjust the interface specification and DAQ type according to operating mode
 		if ($snortcfg['ips_mode'] == "ips_mode_inline" && $snortcfg['blockoffenders7'] == "on") {
@@ -593,9 +591,9 @@ function snort_start($snortcfg, $if_real, $background=FALSE) {
 
 		log_error("[Snort] Snort START for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
 		if ($background)
-			mwexec_bg("{$snortbindir}snort -R _{$if_real}{$snort_uuid} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface}");
+			mwexec_bg("{$snortbindir}snort -R _{$if_real} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface}");
 		else
-			mwexec("{$snortbindir}snort -R _{$if_real}{$snort_uuid} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface}");
+			mwexec("{$snortbindir}snort -R _{$if_real} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface}");
 		snort_barnyard_start($snortcfg, $if_real, $background);
 	}
 }
@@ -678,9 +676,9 @@ function snort_reload_config($snortcfg, $signal="SIGHUP") {
 	/* Only send the SIGHUP if Snort is running and we    */
 	/* can find a valid PID for the process.              */
 	/******************************************************/
-	if (isvalidpid("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid")) {
+	if (isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid")) {
 		log_error("[Snort] Snort RELOAD CONFIG for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
-		mwexec_bg("/bin/pkill -{$signal} -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid");
+		mwexec_bg("/bin/pkill -{$signal} -F {$g['varrun_path']}/snort_{$if_real}.pid");
 	}
 }
 
@@ -699,16 +697,15 @@ function snort_barnyard_reload_config($snortcfg, $signal="HUP") {
 	global $g;
 
 	$snortdir = SNORTDIR;
-	$snort_uuid = $snortcfg['uuid'];
 	$if_real = get_real_interface($snortcfg['interface']);
 
 	/******************************************************/
 	/* Only send the SIGHUP if Barnyard2 is running and   */
 	/* we can find a valid PID for the process.           */
 	/******************************************************/
-	if (isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid")) {
+	if (isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}.pid")) {
 		log_error("[Snort] Barnyard2 CONFIG RELOAD initiated for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
-		mwexec_bg("/bin/pkill -{$signal} -F {$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid");
+		mwexec_bg("/bin/pkill -{$signal} -F {$g['varrun_path']}/barnyard2_{$if_real}.pid");
 	}
 }
 
@@ -3261,22 +3258,20 @@ function snort_create_rc() {
 		$start_barnyard = <<<EOE
 
 	sleep 2
-	if [ ! -f {$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid ]; then
-		pid=`/bin/pgrep -fn "barnyard2 -r {$snort_uuid} "`
-	else
-		pid=`/bin/pgrep -F {$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid`
+	if [ ! -f {$g['varrun_path']}/barnyard2_{$if_real}.pid ]; then
+		pid=`/bin/pgrep -F {$g['varrun_path']}/barnyard2_{$if_real}.pid`
 	fi
 	if [ -z \$pid ]; then
-		/usr/bin/logger -p daemon.info -i -t SnortStartup "Barnyard2 START for {$value['descr']}({$snort_uuid}_{$if_real})..."
-		{$snortbindir}barnyard2 -r {$snort_uuid} -f snort_{$snort_uuid}_{$if_real}.u2 --pid-path {$g['varrun_path']} --nolock-pidfile -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/barnyard2.conf -d {$snortlogdir}/snort_{$if_real}{$snort_uuid} -D -q > /dev/null 2>&1
+		/usr/bin/logger -p daemon.info -i -t SnortStartup "Barnyard2 START for {$value['descr']}({$if_real})..."
+		{$snortbindir}barnyard2 -f snort_{$snort_uuid}_{$if_real}.u2 --pid-path {$g['varrun_path']} --nolock-pidfile -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/barnyard2.conf -d {$snortlogdir}/snort_{$if_real}{$snort_uuid} -D -q > /dev/null 2>&1
 	fi
 EOE;
 		$stop_barnyard2 = <<<EOE
 
-	if [ -f {$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid ]; then
-		/usr/bin/logger -p daemon.info -i -t SnortStartup "Barnyard2 STOP for {$value['descr']}({$snort_uuid}_{$if_real})..."
-		pid=`/bin/pgrep -F {$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid`
-                /bin/pkill -F {$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid -a
+	if [ -f {$g['varrun_path']}/barnyard2_{$if_real}.pid ]; then
+		/usr/bin/logger -p daemon.info -i -t SnortStartup "Barnyard2 STOP for {$value['descr']}({$if_real})..."
+		pid=`/bin/pgrep -F {$g['varrun_path']}/barnyard2_{$if_real}.pid`
+                /bin/pkill -F {$g['varrun_path']}/barnyard2_{$if_real}.pid -a
 		time=0 timeout=30
 		while kill -0 \$pid 2>/dev/null; do
 			sleep 1
@@ -3285,21 +3280,8 @@ EOE;
 				break
 			fi
 		done
-		if [ -f {$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid ]; then
-			/bin/rm {$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid
-		fi
-	else
-		pid=`/bin/pgrep -fn "barnyard2 -r {$snort_uuid} "`
-		if [ ! -z \$pid ]; then
-			/bin/pkill -f "barnyard2 -r {$snort_uuid} "
-			time=0 timeout=30
-			while kill -0 \$pid 2>/dev/null; do
-				sleep 1
-				time=\$((time+1))
-				if [ \$time -gt \$timeout ]; then
-					break
-				fi
-			done
+		if [ -f {$g['varrun_path']}/barnyard2_{$if_real}.pid ]; then
+			/bin/rm {$g['varrun_path']}/barnyard2_{$if_real}.pid
 		fi
         fi
 EOE;
@@ -3311,15 +3293,15 @@ EOE;
 		$start_snort_iface_start[] = <<<EOE
 
 	# Start snort and barnyard2 for {$value['descr']}
-	if [ ! -f {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid ]; then
-		pid=`/bin/pgrep -fn "snort -R {$if_real}{$snort_uuid} "`
+	if [ ! -f {$g['varrun_path']}/snort_{$if_real}.pid ]; then
+		pid=`/bin/pgrep -fn "snort -R {$if_real} "`
 	else
-		pid=`/bin/pgrep -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid`
+		pid=`/bin/pgrep -F {$g['varrun_path']}/snort_{$if_real}.pid`
 	fi
 
 	if [ -z \$pid ]; then
-		/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort START for {$value['descr']}({$snort_uuid}_{$if_real})..."
-		{$snortbindir}snort -R _{$if_real}{$snort_uuid} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface} > /dev/null 2>&1
+		/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort START for {$value['descr']}({$if_real})..."
+		{$snortbindir}snort -R _{$if_real} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface} > /dev/null 2>&1
 	fi
 
 	{$start_barnyard2}
@@ -3328,10 +3310,10 @@ EOE;
 		$start_snort_iface_stop[] = <<<EOE
 
 	# Stop snort and barnyard2 for {$value['descr']}
-	if [ -f {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid ]; then
-		pid=`/bin/pgrep -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid`
-		/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort STOP for {$value['descr']}({$snort_uuid}_{$if_real})..."
-		/bin/pkill -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid -a
+	if [ -f {$g['varrun_path']}/snort_{$if_real}.pid ]; then
+		pid=`/bin/pgrep -F {$g['varrun_path']}/snort_{$if_real}.pid`
+		/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort STOP for {$value['descr']}({$if_real})..."
+		/bin/pkill -F {$g['varrun_path']}/snort_{$if_real}.pid -a
 		time=0 timeout=30
 		while kill -0 \$pid 2>/dev/null; do
 			sleep 1
@@ -3340,14 +3322,14 @@ EOE;
 				break
 			fi
 		done
-		if [ -f {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid ]; then
-			/bin/rm {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid
+		if [ -f {$g['varrun_path']}/snort_{$if_real}.pid ]; then
+			/bin/rm {$g['varrun_path']}/snort_{$if_real}.pid
 		fi
 	else
-		pid=`/bin/pgrep -fn "snort -R {$if_real}{$snort_uuid} "`
+		pid=`/bin/pgrep -fn "snort -R {$if_real} "`
 		if [ ! -z \$pid ]; then
 			/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort STOP for {$value['descr']}({$snort_uuid}_{$if_real})..."
-			/bin/pkill -fn "snort -R {$if_real}{$snort_uuid} "
+			/bin/pkill -fn "snort -R {$if_real} "
 			time=0 timeout=30
 			while kill -0 \$pid 2>/dev/null; do
 				sleep 1

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -3,9 +3,9 @@
  * snort_check_for_rule_updates.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009 Robert Zelaya
- * Copyright (c) 2013-2018 Bill Meeks
+ * Copyright (c) 2013-2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -429,13 +429,13 @@ if ($openappid_detectors == 'on') {
 	else
 		$openappid_detectors = 'off';
 }
-/*  Check for and download any new Snort OpenAppID RULES detectors */
+/*  Check for and download any new Snort AppID Open Text Rules */
 if ($openappid_rules_detectors == 'on') {
-        if (snort_check_rule_md5("{$snort_openappid_rules_url}{$snort_openappid_rules_filename}.md5", "{$tmpfname}/{$snort_openappid_rules_filename_md5}", "Snort OpenAppID RULES detectors")) {
+        if (snort_check_rule_md5("{$snort_openappid_rules_url}{$snort_openappid_rules_filename}.md5", "{$tmpfname}/{$snort_openappid_rules_filename_md5}", "Snort AppID Open Text Rules")) {
                 $file_md5 = trim(file_get_contents("{$tmpfname}/{$snort_openappid_rules_filename_md5}"));
                 file_put_contents("{$tmpfname}/{$snort_openappid_rules_filename_md5}", $file_md5);
                 /* download snort-openappid file rules */
-                if (!snort_fetch_new_rules("{$snort_openappid_rules_url}{$snort_openappid_rules_filename}", "{$tmpfname}/{$snort_openappid_rules_filename}", $file_md5, "Snort OpenAppID RULES detectors"))
+                if (!snort_fetch_new_rules("{$snort_openappid_rules_url}{$snort_openappid_rules_filename}", "{$tmpfname}/{$snort_openappid_rules_filename}", $file_md5, "Snort AppID Open Text Rules"))
                         $openappid_rules_detectors = 'off';
         }
         else
@@ -565,13 +565,13 @@ if ($openappid_detectors == 'on') {
 		error_log(gettext("\tInstallation of Snort OpenAppID detectors completed.\n"), 3, SNORT_RULES_UPD_LOGFILE);
 	}
 }
-/* Untar Snort OpenAppID detectors file to SNORT_APPID_ODP_PATH */
+/* Untar Snort AppID Open Text Rules file to SNORT_APPID_RULES_PATH */
 if ($openappid_rules_detectors == 'on') {
         // If we have a valid downloaded file, then first cleanup the old directory
         if (file_exists("{$tmpfname}/{$snort_openappid_rules_filename}")) {
-                snort_update_status(gettext("Installing Snort OpenAppID RULES detectors..."));
+                snort_update_status(gettext("Installing Snort OpenAppID Rules..."));
                 $snort_openappid_rules_path = SNORT_APPID_RULES_PATH;
-                error_log(gettext("\tExtracting and installing Snort OpenAppID detectors...\n"), 3, SNORT_RULES_UPD_LOGFILE);
+                error_log(gettext("\tExtracting and installing Snort AppID Open Text Rules...\n"), 3, SNORT_RULES_UPD_LOGFILE);
                 exec("/usr/bin/tar oxzf {$tmpfname}/{$snort_openappid_rules_filename} -C {$snort_openappid_rules_path}");
                 if (file_exists("{$tmpfname}/{$snort_openappid_rules_filename_md5}")) {
                         snort_update_status(gettext("Copying md5 signature to snort directory..."));
@@ -579,7 +579,7 @@ if ($openappid_rules_detectors == 'on') {
                 }
                 snort_update_status(gettext(" done.") . "\n");
                 unlink_if_exists("{$tmpfname}/{$snort_openappid_rules_filename}");
-                error_log(gettext("\tInstallation of Snort OpenAppID detectors completed.\n"), 3, SNORT_RULES_UPD_LOGFILE);
+                error_log(gettext("\tInstallation of Snort AppID Open Text Rules completed.\n"), 3, SNORT_RULES_UPD_LOGFILE);
         }
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_barnyard.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_barnyard.php
@@ -3,10 +3,10 @@
  * snort_barnyard.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>
  * Copyright (c) 2008-2009 Robert Zelaya
- * Copyright (c) 2014-2018 Bill Meeks
+ * Copyright (c) 2014-2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -210,7 +210,7 @@ if ($_POST['save']) {
 			snort_barnyard_stop($a_nat[$id], get_real_interface($a_nat[$id]['interface']));
 		}
 		elseif ($a_nat[$id]['barnyard_enable'] == "on") {
-			if (snort_is_running($a_nat[$id]['uuid'], get_real_interface($a_nat[$id]['interface']), "barnyard2"))
+			if (snort_is_running(get_real_interface($a_nat[$id]['interface']), "barnyard2"))
 				snort_barnyard_reload_config($a_nat[$id], "HUP");
 			else {
 				// Notify user a Snort restart is required if enabling Barnyard2 for the first time	

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
@@ -243,7 +243,7 @@ display_top_tabs($tab_array, true);
 					<td><?=gettext($openappid_detectors_sig_date);?></td>
 				</tr>
 				<tr>
-                                        <td><?=gettext("Snort OpenAppID RULES Detectors");?></td>
+                                        <td><?=gettext("Snort AppID Open Text Rules");?></td>
                                         <td><?=trim($openappid_detectors_rules_sig_chk_local);?></td>
                                         <td><?=gettext($openappid_detectors_rules_sig_date);?></td>
                                 </tr>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
@@ -3,10 +3,10 @@
  * snort_interfaces_global.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2011-2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2011-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2006 Manuel Kasper <mk@neon1.net>.
- * Copyright (c) 2018 Bill Meeks
  * Copyright (c) 2008-2009 Robert Zelaya
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -270,21 +270,21 @@ $section->addInput(new Form_Checkbox(
 ));
 $section->addInput(new Form_StaticText(
 	null,
-	'The OpenAppID package contains the application signatures required by the AppID preprocessor.'
+	'The OpenAppID Detectors package contains the application signatures required by the AppID preprocessor and the OpenAppID text rules.'
 ));
 $section->addInput(new Form_StaticText(
 	'OpenAppID Version',
 	$openappid_ver
 ));
-$group = new Form_Group('Enable RULES OpenAppID');
+$group = new Form_Group('Enable AppID Open Text Rules');
 $group->add(new Form_Checkbox(
         'openappid_rules_detectors',
         'Enable RULES OpenAppID',
-        'Click to enable download of APPID Open rules',
+        'Click to enable download of the AppID Open Text Rules',
         $pconfig['openappid_rules_detectors'] == 'on' ? true:false,
         'on'
 ));
-$group->setHelp('Note - the AppID Open Rules file is maintained by a volunteer contributor and hosted by the pfSense team.  ' . 
+$group->setHelp('Note - the AppID Open Text Rules file is maintained by a volunteer contributor and hosted by the pfSense team.  ' . 
 'The URL for the file ' . 'is <a href="' . SNORT_OPENAPPID_RULES_URL . SNORT_OPENAPPID_RULES_FILENAME . '" target="_blank">' . 
 SNORT_OPENAPPID_RULES_URL . SNORT_OPENAPPID_RULES_FILENAME . '</a>.');
 $section->add($group);

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ip_reputation.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ip_reputation.php
@@ -140,7 +140,7 @@ if ($_POST['apply']) {
 	snort_generate_conf($a_nat[$id]);
 
 	// If Snort is already running, must restart to change IP REP preprocessor configuration.
-	if (snort_is_running($snort_uuid, $if_real)) {
+	if (snort_is_running($if_real)) {
 		log_error(gettext("Snort: restarting on interface " . convert_real_interface_to_friendly_descr($if_real) . " due to IP REP preprocessor configuration change."));
 		snort_stop($a_nat[$id], $if_real);
 		snort_start($a_nat[$id], $if_real, TRUE);
@@ -183,7 +183,7 @@ if ($_POST['save']) {
 		snort_generate_conf($a_nat[$id]);
 
 		// If Snort is already running, must restart to change IP REP preprocessor configuration.
-		if (snort_is_running($snort_uuid, $if_real)) {
+		if (snort_is_running($if_real)) {
 			log_error(gettext("Snort: restarting on interface " . convert_real_interface_to_friendly_descr($if_real) . " due to IP REP preprocessor configuration change."));
 			snort_stop($a_nat[$id], $if_real);
 			snort_start($a_nat[$id], $if_real, TRUE);

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
@@ -726,7 +726,7 @@ if ($_POST['save']) {
 		/* in order to pick up any preprocessor setting */
 		/* changes.                                     */
 		$if_real = get_real_interface($a_nat[$id]['interface']);
-		if (snort_is_running($a_nat[$id]['uuid'], $if_real)) {
+		if (snort_is_running($if_real)) {
 			log_error(gettext("Snort: restarting on interface " . convert_real_interface_to_friendly_descr($if_real) . " due to Preprocessor configuration change."));
 			snort_stop($a_nat[$id], $if_real);
 			snort_start($a_nat[$id], $if_real, TRUE);

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
@@ -930,7 +930,7 @@ elseif ($_POST['apply']) {
 	// Sync to configured CARP slaves if any are enabled
 	snort_sync_on_changes();
 
-	if (snort_is_running($snort_uuid, $if_real))
+	if (snort_is_running($if_real))
 		$savemsg = gettext("Snort is 'live-reloading' the new rule set.");
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
@@ -159,7 +159,7 @@ if (isset($_POST["save"])) {
 
 	$pconfig = $_POST;
 	$enabled_rulesets_array = explode("||", $enabled_items);
-	if (snort_is_running($snort_uuid, $if_real))
+	if (snort_is_running($if_real))
 		$savemsg = gettext("Snort is 'live-reloading' the new rule set.");
 
 	// Sync to configured CARP slaves if any are enabled


### PR DESCRIPTION
### pfSense-pkg-snort-4.0_1
This update to the Snort GUI package corrects an issue that produces a fatal exit error when attempting to start Snort on an interface such as a VLAN or PPPoE connection due to the real interface name, when combined with the Snort package UUID value, exceeding the built-in Snort limit on a PID file suffix.

**Change Log:**
1.  Edit references to the OpenAppID text rules on the GLOBAL SETTINGS to use a more appropriate description.

2.  On the INTERFACES tab, indicate the type of blocking mode (_Inline IPS_ or _Legacy Mode_) currently configured for the interface.

3.  Deprecate the use of the interface UUID parameter for determining the current status of Snort or Barnyard2 on an interface (stopped or running).

**New Features:**
None

**Bug Fixes:**
1.  Remove use of UUID parameter as part of the Snort PID filename in **/var/run** to prevent Snort startup failure due to the PID filename suffix exceeding 11 characters when running Snort on VLAN or PPPoE interfaces.

2.  Fix cosmetic icon display bug on INTERFACES tab that prevented update of Snort and Barnyard2 status for real interface names containing a period such as VLAN interfaces.