### PR TITLE
pfSense-pkg-suricata-4.1.4_2 -- Add SEVERITY LEVEL to logs and miscellaneous bug fixes

### DIFF
--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -46,7 +46,7 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 	$suricatalogdirsizeKB = suricata_Getdirsize(SURICATALOGDIR);
 
 	if ($suricatalogdirsizeKB > 0 && $suricatalogdirsizeKB > $suricataloglimitsizeKB) {
-		log_error(gettext("[Suricata] Log directory size exceeds configured limit of " . number_format($suricataloglimitsize) . " MB set on Global Settings tab. Starting cleanup of Suricata logs."));
+		syslog(LOG_NOTICE, gettext("[Suricata] Log directory size exceeds configured limit of " . number_format($suricataloglimitsize) . " MB set on Global Settings tab. Starting cleanup of Suricata logs."));
 
 		// Initialize an array of the log files we want to prune
 		$logs = array ( "alerts.log", "block.log", "dns.log", "eve.json", "http.log", "files-json.log", "sid_changes.log", "stats.log", "tls.log" );
@@ -56,12 +56,12 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 			$if_real = get_real_interface($value['interface']);
 			$suricata_uuid = $value['uuid'];
 			$suricata_log_dir = SURICATALOGDIR . "suricata_{$if_real}{$suricata_uuid}";
-			log_error(gettext("[Suricata] Cleaning logs for {$value['descr']} ({$if_real})..."));
+			syslog(LOG_NOTICE, gettext("[Suricata] Cleaning logs for {$value['descr']} ({$if_real})..."));
 			suricata_post_delete_logs($suricata_uuid);
 
 			foreach ($logs as $file) {
 				// Cleanup any rotated logs
-				log_error(gettext("[Suricata] Deleting rotated log files except last for {$value['descr']} ({$if_real}) $file..."));
+				syslog(LOG_NOTICE, gettext("[Suricata] Deleting rotated log files except last for {$value['descr']} ({$if_real}) $file..."));
 				$filelist = glob("{$suricata_log_dir}/{$file}.*");
 				// Keep most recent file
 				unset($filelist[count($filelist) - 1]);
@@ -83,7 +83,7 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 		}
 
 		// Cleanup any rotated logs not caught above
-		log_error(gettext("[Suricata] Deleting any additional rotated log files..."));
+		syslog(LOG_NOTICE, gettext("[Suricata] Deleting any additional rotated log files..."));
 		unlink_if_exists("{$suricata_log_dir}/suricata_*/*.log.*");
 		unlink_if_exists("{$suricata_log_dir}/suricata_*/*.json.*");
 
@@ -106,7 +106,7 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 					try {
 						file_put_contents("{$suricata_log_dir}/{$file}", "");
 					} catch (Exception $e) {
-						log_error("[Suricata] Failed to truncate file '{$suricata_log_dir}/{$file}' -- error was {$e->getMessage()}");
+						syslog(LOG_ERR, "[Suricata] ERROR: Failed to truncate file '{$suricata_log_dir}/{$file}' -- error was {$e->getMessage()}");
 					}
 				}
 
@@ -122,14 +122,14 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 
 		// Truncate the Rules Update Log file if it exists
 		if (file_exists(SURICATA_RULES_UPD_LOGFILE)) {
-			log_error(gettext("[Suricata] Truncating the Rules Update Log file..."));
+			syslog(LOG_NOTICE, gettext("[Suricata] Truncating the Rules Update Log file..."));
 			@file_put_contents(SURICATA_RULES_UPD_LOGFILE, "");
 		}
 
 		cleanupExit:
 		// This is needed if suricata is run as suricata user
 		mwexec('/bin/chmod 660 /var/log/suricata/*', true);
-		log_error(gettext("[Suricata] Automatic clean-up of Suricata logs completed."));
+		syslog(LOG_NOTICE, gettext("[Suricata] Automatic clean-up of Suricata logs completed."));
 	}
 }
 
@@ -163,7 +163,7 @@ function suricata_check_rotate_log($log_file, $log_limit, $retention) {
 			copy($log_file, $newfile);
 			file_put_contents($log_file, "");
 		} catch (Exception $e) {
-			log_error("[Suricata] Failed to rotate file '{$log_file}' -- error was {$e->getMessage()}");
+			syslog(LOG_ERR, "[Suricata] ERROR: Failed to rotate file '{$log_file}' -- error was {$e->getMessage()}");
 		}
 	}
 
@@ -238,7 +238,7 @@ if ($config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 
 				}
 			}
 			if ($prune_count > 0)
-				log_error(gettext("[Suricata] Barnyard2 archived logs cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/barnyard2/archive/..."));
+				syslog(LOG_NOTICE, gettext("[Suricata] Barnyard2 archived logs cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/barnyard2/archive/..."));
 			unset($files);
 		}
 
@@ -255,7 +255,7 @@ if ($config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 
 				}
 			}
 			if ($prune_count > 0)
-				log_error(gettext("[Suricata] File Store cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/files/..."));
+				syslog(LOG_NOTICE, gettext("[Suricata] File Store cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/files/..."));
 			unset($files);
 		}
 
@@ -272,7 +272,7 @@ if ($config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 
 				}
 			}
 			if ($prune_count > 0)
-				log_error(gettext("[Suricata] TLS Certs Store cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/certs/..."));
+				syslog(LOG_NOTICE, gettext("[Suricata] TLS Certs Store cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/certs/..."));
 			unset($files);
 		}
 
@@ -291,7 +291,7 @@ if ($config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 
 				unlink_if_exists($f);
 			}
 			if ($prune_count > 0)
-				log_error(gettext("[Suricata] Packet Capture log cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/..."));
+				syslog(LOG_NOTICE, gettext("[Suricata] Packet Capture log cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/..."));
 			unset($files, $remove_files);
 		}
 

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -683,13 +683,13 @@ else {
 					elseif (is_ipaddrv4($addr) || is_subnetv4($addr))
 						$engine .= "{$addr}, ";
 					else
-						log_error("[suricata] WARNING: invalid IP address value '{$addr}' in Alias {$v['bind_to']} will be ignored.");
+						syslog(LOG_WARN, "[suricata] WARNING: invalid IP address value '{$addr}' in Alias {$v['bind_to']} will be ignored.");
 				}
 				$engine = trim($engine, ' ,');
 				$engine .= "]";
 			}
 			else {
-				log_error("[suricata] WARNING: unable to resolve IP List Alias '{$v['bind_to']}' for Host OS Policy '{$v['name']}' ... ignoring this entry.");
+				syslog(LOG_WARN, "[suricata] WARNING: unable to resolve IP List Alias '{$v['bind_to']}' for Host OS Policy '{$v['name']}' ... ignoring this entry.");
 				continue;
 			}
 		}
@@ -729,7 +729,7 @@ else {
 					elseif (is_ipaddrv4($addr) || is_subnetv4($addr))
 						$engine .= "{$addr}, ";
 					else {
-						log_error("[suricata] WARNING: invalid IP address value '{$addr}' in Alias {$v['bind_to']} will be ignored.");
+						syslog(LOG_WARN, "[suricata] WARNING: invalid IP address value '{$addr}' in Alias {$v['bind_to']} will be ignored.");
 						continue;
 					}
 				}
@@ -743,7 +743,7 @@ else {
 				$http_hosts_policy .= "   {$engine}\n";
 			}
 			else {
-				log_error("[suricata] WARNING: unable to resolve IP List Alias '{$v['bind_to']}' for Host OS Policy '{$v['name']}' ... ignoring this entry.");
+				syslog(LOG_WARN, "[suricata] WARNING: unable to resolve IP List Alias '{$v['bind_to']}' for Host OS Policy '{$v['name']}' ... ignoring this entry.");
 				continue;
 			}
 		}

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -49,7 +49,7 @@ $rule = &$config['installedpackages']['suricata']['rule'];
 /****************************************************************************/
 
 $updated_cfg = false;
-log_error("[Suricata] Checking configuration settings version...");
+syslog(LOG_NOTICE, "[Suricata] Checking configuration settings version...");
 
 // Check the configuration version to see if XMLRPC Sync should be
 // auto-disabled as part of the upgrade due to config format changes.
@@ -57,7 +57,7 @@ if ($config['installedpackages']['suricata']['config'][0]['suricata_config_ver']
     ($config['installedpackages']['suricatasync']['config'][0]['varsynconchanges'] == 'auto' ||
      $config['installedpackages']['suricatasync']['config'][0]['varsynconchanges'] == 'manual')) {
 	$config['installedpackages']['suricatasync']['config'][0]['varsynconchanges'] = "disabled";
-	log_error("[Suricata] Turning off Suricata Sync on this host due to configuration format changes in this update.  Upgrade all Suricata Sync targets to this same Suricata package version before re-enabling Suricata Sync.");
+	syslog(LOG_NOTICE, "[Suricata] Turning off Suricata Sync on this host due to configuration format changes in this update.  Upgrade all Suricata Sync targets to this same Suricata package version before re-enabling Suricata Sync.");
 	$updated_cfg = true;
 }
 
@@ -671,10 +671,10 @@ unset($r);
 // Log a message indicating what we did
 if ($updated_cfg) {
 	write_config("Updated Suricata package settings to new configuration format.");
-	log_error("[Suricata] Settings successfully migrated to new configuration format.");
+	syslog(LOG_NOTICE, "[Suricata] Settings successfully migrated to new configuration format.");
 }
 else {
-	log_error("[Suricata] Configuration version is current.");
+	syslog(LOG_NOTICE, "[Suricata] Configuration version is current.");
 }
 
 ?>

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_post_install.php
@@ -76,6 +76,17 @@ safe_mkdir(SURICATALOGDIR);
 safe_mkdir(SURICATA_SID_MODS_PATH);
 safe_mkdir(SURICATA_IPREP_PATH);
 
+/*****************************************************************/
+/* In the event this is a reinstall (or update), then recreate   */
+/* critical config files from the package sample templates.      */
+/*****************************************************************/
+$map_files = array( "classification.config", "reference.config", "threshold.config" );
+foreach ($map_files as $f) {
+	if (file_exists(SURICATADIR . $f . ".sample") && !file_exists(SURICATADIR . $f)) {
+		copy(SURICATADIR . $f . ".sample", SURICATADIR . $f);
+	}
+}
+
 // Download the latest GeoIP DB updates and create cron task if the feature is not disabled
 if ($config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] != 'off') {
 	log_error(gettext("[Suricata] Installing free GeoLite2 country IP database file in /usr/local/share/suricata/GeoLite2/..."));

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_post_install.php
@@ -89,14 +89,14 @@ foreach ($map_files as $f) {
 
 // Download the latest GeoIP DB updates and create cron task if the feature is not disabled
 if ($config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] != 'off') {
-	log_error(gettext("[Suricata] Installing free GeoLite2 country IP database file in /usr/local/share/suricata/GeoLite2/..."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Installing free GeoLite2 country IP database file in /usr/local/share/suricata/GeoLite2/..."));
 	include("/usr/local/pkg/suricata/suricata_geoipupdate.php");
 	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_geoipupdate.php", TRUE, 0, 6, "*", "*", "*", "root");
 }
 
 // Download the latest ET IQRisk updates and create cron task if the feature is not disabled
 if ($config['installedpackages']['suricata']['config'][0]['et_iqrisk_enable'] == 'on') {
-	log_error(gettext("[Suricata] Installing Emerging Threats IQRisk IP List..."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Installing Emerging Threats IQRisk IP List..."));
 	include("/usr/local/pkg/suricata/suricata_etiqrisk_update.php");
 	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_etiqrisk_update.php", TRUE, 0, "*/6", "*", "*", "*", "root");
 }
@@ -120,7 +120,7 @@ while (suricata_cron_job_exists($suri_pf_table, FALSE)) {
 }
 
 if ($cron_count > 0) {
-	log_error(gettext("[Suricata] Removed {$cron_count} duplicate 'remove_blocked_hosts' cron task(s)."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Removed {$cron_count} duplicate 'remove_blocked_hosts' cron task(s)."));
 }
 
 /*********************************************************/
@@ -146,7 +146,7 @@ if (!is_array($config['installedpackages']['suricata']['config'][0])) {
 
 // remake saved settings if previously flagged
 if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] == 'on') {
-	log_error(gettext("[Suricata] Saved settings detected... rebuilding installation with saved settings."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Saved settings detected... rebuilding installation with saved settings."));
 	update_status(gettext("Saved settings detected...") . "\n");
 
 	/****************************************************************/
@@ -194,7 +194,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 	update_status(gettext("Migrating settings to new configuration..."));
 	include('/usr/local/pkg/suricata/suricata_migrate_config.php');
 	update_status(gettext(" done.") . "\n");
-	log_error(gettext("[Suricata] Downloading and updating configured rule types."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Downloading and updating configured rule types."));
 	include('/usr/local/pkg/suricata/suricata_check_for_rule_updates.php');
 	update_status(gettext("Generating suricata.yaml configuration file from saved settings.") . "\n");
 	$rebuild_rules = true;
@@ -266,7 +266,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 
 	$rebuild_rules = false;
 	update_status(gettext("Finished rebuilding Suricata configuration from saved settings.") . "\n");
-	log_error(gettext("[Suricata] Finished rebuilding installation from saved settings."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Finished rebuilding installation from saved settings."));
 }
 
 // If this is first install and "forcekeepsettings" is empty,
@@ -314,7 +314,7 @@ write_config("Suricata pkg v{$config['installedpackages']['package'][get_package
 
 // Done with post-install, so clear flag
 unset($g['suricata_postinstall']);
-log_error(gettext("[Suricata] Package post-installation tasks completed."));
+syslog(LOG_NOTICE, gettext("[Suricata] Package post-installation tasks completed."));
 return true;
 
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -68,7 +68,7 @@ function suricata_barnyard_stop($suricatacfg, $if_real) {
 
 	$suricata_uuid = $suricatacfg['uuid'];
 	if (isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}{$suricata_uuid}.pid")) {
-		log_error("[Suricata] Barnyard2 STOP for {$suricatacfg['descr']}({$if_real})...");
+		syslog(LOG_NOTICE, "[Suricata] Barnyard2 STOP for {$suricatacfg['descr']}({$if_real})...");
 		killbypid("{$g['varrun_path']}/barnyard2_{$if_real}{$suricata_uuid}.pid");
 	}
 }
@@ -78,7 +78,7 @@ function suricata_stop($suricatacfg, $if_real) {
 
 	$suricata_uuid = $suricatacfg['uuid'];
 	if (isvalidpid("{$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid")) {
-		log_error("[Suricata] Suricata STOP for {$suricatacfg['descr']}({$if_real})...");
+		syslog(LOG_NOTICE, "[Suricata] Suricata STOP for {$suricatacfg['descr']}({$if_real})...");
 		killbypid("{$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid");
 		sleep(1);
 
@@ -103,7 +103,7 @@ function suricata_barnyard_start($suricatacfg, $if_real) {
 	$suricatabindir = SURICATA_PBI_BINDIR;
 
 	if ($suricatacfg['barnyard_enable'] == 'on') {
-		log_error("[Suricata] Barnyard2 START for {$suricatacfg['descr']}({$if_real})...");
+		syslog(LOG_NOTICE, "[Suricata] Barnyard2 START for {$suricatacfg['descr']}({$if_real})...");
 		mwexec_bg("{$suricatabindir}barnyard2 -r {$suricata_uuid} -f unified2.alert --pid-path {$g['varrun_path']} --nolock-pidfile -c {$suricatadir}/barnyard2.conf -d {$suricatalogdir} -D -q");
 	}
 }
@@ -120,7 +120,7 @@ function suricata_start($suricatacfg, $if_real) {
 		// Truncate suricata.log file for this interface.
 		file_put_contents("{$suricatalogdir}/suricata.log", '');
 		$run_mode = $suricatacfg['ips_mode'] == 'ips_mode_inline' ? '--netmap' : '-i ' . $if_real;
-		log_error("[Suricata] Suricata START for {$suricatacfg['descr']}({$if_real})...");
+		syslog(LOG_NOTICE, "[Suricata] Suricata START for {$suricatacfg['descr']}({$if_real})...");
 		mwexec_bg("{$suricatabindir}suricata {$run_mode} -D -c {$suricatadir}suricata_{$suricata_uuid}_{$if_real}/suricata.yaml --pidfile {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid");
 	} else {
 		return;
@@ -212,7 +212,7 @@ function suricata_reload_config($suricatacfg, $signal="USR2") {
 	/* we can find a valid PID for the process.           */
 	/******************************************************/
 	if (isvalidpid("{$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid")) {
-		log_error("[Suricata] Suricata LIVE RULE RELOAD initiated for {$suricatacfg['descr']} ({$if_real})...");
+		syslog("LOG_NOTICE, [Suricata] Suricata LIVE RULE RELOAD initiated for {$suricatacfg['descr']} ({$if_real})...");
 		mwexec_bg("/bin/pkill -{$signal} -F {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid");
 	}
 }
@@ -240,7 +240,7 @@ function suricata_barnyard_reload_config($suricatacfg, $signal="HUP") {
 	/* we can find a valid PID for the process.           */
 	/******************************************************/
 	if (isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}{$suricata_uuid}.pid")) {
-		log_error("[Suricata] Barnyard2 CONFIG RELOAD initiated for {$suricatacfg['descr']} ({$if_real})...");
+		syslog(LOG_NOTICE, "[Suricata] Barnyard2 CONFIG RELOAD initiated for {$suricatacfg['descr']} ({$if_real})...");
 		mwexec_bg("/bin/pkill -{$signal} -F {$g['varrun_path']}/barnyard2_{$if_real}{$suricata_uuid}.pid");
 	}
 }
@@ -1773,7 +1773,7 @@ function suricata_resolve_flowbits($rules, $active_rules) {
 
 	// Check $rules array to be sure it is filled.
 	if (empty($rules)) {
-		log_error(gettext("[Suricata] WARNING: Flowbit resolution not done - no rules in ". SURICATA_RULES_DIR . " ..."));
+		syslog(LOG_WARNING, gettext("[Suricata] WARNING: Flowbit resolution not done - no rules in ". SURICATA_RULES_DIR . " ..."));
 		return array();
 	}
 
@@ -1971,7 +1971,7 @@ function suricata_parse_sidconf_file($sidconf_file,$split_lines=TRUE) {
 	// we can read like a normal file.
 	$fd = fopen("php://temp", "r+");
 	if ($fd == FALSE) {
-		log_error("[Suricata] Failed to open SID MGMT list '{$sidconf_file}' for processing.");
+		syslog(LOG_ERR, "[Suricata] Failed to open SID MGMT list '{$sidconf_file}' for processing.");
 		return $sid_mods;
 	}
 	fwrite($fd, base64_decode($list['content']));
@@ -2125,7 +2125,7 @@ function suricata_sid_mgmt_auto_categories($suricatacfg, $log_results = FALSE) {
 				// Attempt to open the 'disable_sid_file' for the interface
 				// Verify the assigned SID Mgmt List still exists in the firewall configuration
 				if (!suricata_sid_mgmt_list_exist($suricatacfg['disable_sid_file'])) {
-					log_error(gettext("[Suricata] Error - unable to open disable_sid list \"{$suricatacfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+					syslog(LOG_ERR, gettext("[Suricata] ERROR: unable to open disable_sid list \"{$suricatacfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 					if ($log_results == TRUE) {
 						error_log(gettext("Unable to find disable_sid list \"{$suricatacfg['disable_sid_file']}\".\n"), 3, $log_file);
 					}
@@ -2146,7 +2146,7 @@ function suricata_sid_mgmt_auto_categories($suricatacfg, $log_results = FALSE) {
 
 				// Attempt to open the 'enable_sid_file' for the interface
 				if (!suricata_sid_mgmt_list_exist($suricatacfg['enable_sid_file'])) {
-					log_error(gettext("[Suricata] Error - unable to open enable_sid list \"{$suricatacfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+					syslog(LOG_ERR, gettext("[Suricata] ERROR: unable to open enable_sid list \"{$suricatacfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 					if ($log_results == TRUE) {
 						error_log(gettext("Unable to find enable_sid list \"{$suricatacfg['enable_sid_file']}\".\n"), 3, $log_file);
 					}
@@ -2170,7 +2170,7 @@ function suricata_sid_mgmt_auto_categories($suricatacfg, $log_results = FALSE) {
 
 				// Attempt to open the 'enable_sid_file' for the interface
 				if (!suricata_sid_mgmt_list_exist($suricatacfg['enable_sid_file'])) {
-					log_error(gettext("[Suricata] Error - unable to find enable_sid list \"{$suricatacfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+					syslog(LOG_ERR, gettext("[Suricata] ERROR: unable to find enable_sid list \"{$suricatacfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 					if ($log_results == TRUE) {
 						error_log(gettext("Unable to open enable_sid list \"{$suricatacfg['enable_sid_file']}\".\n"), 3, $log_file);
 					}
@@ -2191,7 +2191,7 @@ function suricata_sid_mgmt_auto_categories($suricatacfg, $log_results = FALSE) {
 
 				// Attempt to open the 'disable_sid_file' for the interface
 				if (!suricata_sid_mgmt_list_exist($suricatacfg['disable_sid_file'])) {
-					log_error(gettext("[Suricata] Error - unable to open disable_sid list \"{$suricatacfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+					syslog(LOG_ERR, gettext("[Suricata] ERROR: unable to open disable_sid list \"{$suricatacfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 					if ($log_results == TRUE) {
 						error_log(gettext("Unable to find disable_sid list \"{$suricatacfg['disable_sid_file']}\".\n"), 3, $log_file);
 					}
@@ -2209,7 +2209,7 @@ function suricata_sid_mgmt_auto_categories($suricatacfg, $log_results = FALSE) {
 			break;
 
 		default:
-			log_error(gettext("[Suricata] Unrecognized 'sid_state_order' value.  Skipping auto CATEGORY mgmt step for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+			syslog(LOG_ERR, gettext("[Suricata] Unrecognized 'sid_state_order' value.  Skipping auto CATEGORY mgmt step for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 			if ($log_results == TRUE) {
 				error_log(gettext("ERROR: unrecognized 'sid_state_order' value.  Skipping auto CATEGORY mgmt step for ") . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']). ".\n", 3, $log_file);
 			}
@@ -2416,7 +2416,7 @@ function suricata_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results 
 			break;
 
 		default:
-			log_error(gettext("[Suricata] Error - unknown action '{$action}' supplied to suricata_modify_sid_state() function...no SIDs modified."));
+			syslog(LOG_WARN, gettext("[Suricata] WARNING - unknown action '{$action}' supplied to suricata_modify_sid_state() function...no SIDs modified."));
 			return $sids;
 	}
 
@@ -2715,7 +2715,7 @@ function suricata_process_enablesid(&$rule_map, $suricatacfg, $log_results = FAL
 
 	// Verify the 'enable_sid' list for the interface exists
 	if (!suricata_sid_mgmt_list_exist($suricatacfg['enable_sid_file'])) {
-		log_error(gettext("[Suricata] Error - unable to find enable_sid list \"{$suricatacfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+		syslog(LOG_ERR, gettext("[Suricata] ERROR: unable to find enable_sid list \"{$suricatacfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 		return;
 	}
 	else
@@ -2762,7 +2762,7 @@ function suricata_process_disablesid(&$rule_map, $suricatacfg, $log_results = FA
 
 	// Verify the 'disable_sid' list for the interface exists
 	if (!suricata_sid_mgmt_list_exist($suricatacfg['disable_sid_file'])) {
-		log_error(gettext("[Suricata] Error - unable to find disable_sid list \"{$suricatacfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+		syslog(LOG_ERR, gettext("[Suricata] ERROR: unable to find disable_sid list \"{$suricatacfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 		return;
 	} else {
 		$sid_mods = suricata_parse_sidconf_file($suricatacfg['disable_sid_file']);
@@ -2809,7 +2809,7 @@ function suricata_process_modifysid(&$rule_map, $suricatacfg, $log_results = FAL
 
 	// Verify the 'modify_sid' list for the interface exists
 	if (!suricata_sid_mgmt_list_exist($suricatacfg['modify_sid_file'])) {
-		log_error(gettext("[Suricata] Error - unable to find modify_sid list \"{$suricatacfg['modify_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+		syslog(LOG_ERR, gettext("[Suricata] ERROR: unable to find modify_sid list \"{$suricatacfg['modify_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 		return;
 	} else {
 		$sid_mods = suricata_parse_sidconf_file($suricatacfg['modify_sid_file'],FALSE);
@@ -2856,7 +2856,7 @@ function suricata_process_dropsid(&$rule_map, $suricatacfg, $log_results = FALSE
 
 	// Verify the 'drop_sid' list for the interface exists
 	if (!suricata_sid_mgmt_list_exist($suricatacfg['drop_sid_file'])) {
-		log_error(gettext("[Suricata] Error - unable to find drop_sid list \"{$suricatacfg['drop_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+		syslog(LOG_ERR, gettext("[Suricata] ERROR: unable to find drop_sid list \"{$suricatacfg['drop_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 		return;
 	} else {
 		$sid_mods = suricata_parse_sidconf_file($suricatacfg['drop_sid_file']);
@@ -2903,7 +2903,7 @@ function suricata_process_rejectsid(&$rule_map, $suricatacfg, $log_results = FAL
 
 	// Verify the 'reject_sid' list for the interface exists
 	if (!suricata_sid_mgmt_list_exist($suricatacfg['reject_sid_file'])) {
-		log_error(gettext("[Suricata] Error - unable to find reject_sid list \"{$suricatacfg['reject_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+		syslog(LOG_ERR, gettext("[Suricata] ERROR: unable to find reject_sid list \"{$suricatacfg['reject_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 		return;
 	} else {
 		$sid_mods = suricata_parse_sidconf_file($suricatacfg['reject_sid_file']);
@@ -3033,9 +3033,9 @@ function suricata_auto_sid_mgmt(&$rule_map, $suricatacfg, $log_results = FALSE) 
 				break;
 
 			default:
-				log_error(gettext("[Suricata] Unrecognized 'sid_state_order' value.  Skipping auto SID mgmt step for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
+				syslog(LOG_WARN, gettext("[Suricata] WARNING: Unrecognized 'sid_state_order' value.  Skipping auto SID mgmt step for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface'])));
 				if ($log_results == TRUE) {
-					error_log(gettext("ERROR: unrecognized 'sid_state_order' value.  Skipping auto SID mgmt step for ") . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']). ".\n", 3, $log_file);
+					error_log(gettext("WARNING: unrecognized 'sid_state_order' value.  Skipping auto SID mgmt step for ") . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']). ".\n", 3, $log_file);
 				}
 				$result = FALSE;
 		}
@@ -3323,7 +3323,7 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 		return;
 
 	// Log a message for rules rebuild in progress
-	log_error(gettext("[Suricata] Updating rules configuration for: " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . " ..."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Updating rules configuration for: " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . " ..."));
 
 	// Get any automatic rule category enable/disable modifications
 	// if auto-SID Mgmt is enabled and conf files exist for the interface.
@@ -3441,7 +3441,7 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 
 		// If auto-flowbit resolution is enabled, generate the dependent flowbits rules file.
 		if ($suricatacfg['autoflowbitrules'] == 'on') {
-			log_error('[Suricata] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . '...');
+			syslog(LOG_NOTICE, '[Suricata] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . '...');
 			$fbits = suricata_resolve_flowbits($all_rules, $enabled_rules);
 
 			// Check for and disable any flowbit-required rules the user has
@@ -3473,7 +3473,7 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 
 			// If auto-flowbit resolution is enabled, generate the dependent flowbits rules file.
 			if ($suricatacfg['autoflowbitrules'] == 'on') {
-				log_error('[Suricata] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . '...');
+				syslog(LOG_NOTICE, '[Suricata] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . '...');
 
 				// Load up all rules into a Rules Map array for flowbits assessment
 				$all_rules = suricata_load_rules_map(SURICATA_RULES_DIR);
@@ -3509,12 +3509,12 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 
 	// Log a warning if the interface has no rules defined or enabled
 	if ($no_rules_defined) {
-		log_error(gettext("[Suricata] Warning - no text rules selected for: " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . " ..."));
+		syslog(LOG_WARN, gettext("[Suricata] WARNING: - no text rules selected for: " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . " ..."));
 	}
 
 	// Build a new sid-msg.map file from the enabled
 	// rules and copy it to the interface directory.
-	log_error(gettext("[Suricata] Building new sid-msg.map file for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . "..."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Building new sid-msg.map file for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . "..."));
 	suricata_build_sid_msg_map("{$suricatacfgdir}/rules/", "{$suricatacfgdir}/sid-msg.map");
 }
 
@@ -3986,7 +3986,7 @@ function suricata_remove_dead_rules() {
 	}
 
 	// Log how many obsoleted files were removed
-	log_error(gettext("[Suricata] Removed {$count} obsoleted rules category files."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Removed {$count} obsoleted rules category files."));
 
 	// Now remove any dead rules files from the interface configurations
 	if (!empty($cats) && is_array($config['installedpackages']['suricata']['rule'])) {
@@ -4013,7 +4013,7 @@ function suricata_sync_on_changes() {
 
 	/* Do not attempt a package sync while booting up or installing package */
 	if ($g['booting'] || $g['suricata_postinstall'] == TRUE) {
-		log_error("[suricata] Skipping XMLRPC sync when booting up or during package reinstallation.");
+		syslog(LOG_NOTICE, "[suricata] Skipping XMLRPC sync when booting up or during package reinstallation.");
 		return;
 	}
 
@@ -4027,7 +4027,7 @@ function suricata_sync_on_changes() {
 				if (is_array($suricata_sync['row'])) {
 					$rs = $suricata_sync['row'];
 				} else {
-					log_error("[suricata] XMLRPC sync is enabled but there are no hosts configured as replication targets.");
+					syslog(LOG_NOTICE, "[suricata] XMLRPC sync is enabled but there are no hosts configured as replication targets.");
 					return;
 				}
 				break;
@@ -4048,13 +4048,13 @@ function suricata_sync_on_changes() {
 						$rs[0]['varsyncport'] = $config['system']['webgui']['port'] ?: '443';
 					}
 					if ($system_carp['synchronizetoip'] == "") {
-						log_error("[suricata] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+						syslog(LOG_NOTICE, "[suricata] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
 						return;
 					} else {
 						$rs[0]['varsyncdestinenable'] = TRUE;
 					}
 				} else {
-					log_error("[suricata] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+					syslog(LOG_NOTICE, "[suricata] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
 					return;
 				}
 				break;			
@@ -4063,7 +4063,7 @@ function suricata_sync_on_changes() {
 				break;
 		}
 		if (is_array($rs)) {
-			log_error("[suricata] XMLRPC sync is starting.");
+			syslog(LOG_NOTICE, "[suricata] XMLRPC sync is starting.");
 			foreach ($rs as $sh) {
 				// Only sync enabled replication targets
 				if ($sh['varsyncdestinenable']) {
@@ -4094,11 +4094,11 @@ function suricata_sync_on_changes() {
 					if ($success) {
 						suricata_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol, $username, $password, $synctimeout, $syncstartsuricata);
 					} else {
-						log_error("[suricata] XMLRPC sync with '{$sync_to_ip}' aborted due to the following error(s): {$error}");
+						syslog(LOG_ERR, "[suricata] ERROR: XMLRPC sync with '{$sync_to_ip}' aborted due to the following error(s): {$error}");
 					}
 				}
 			}
-			log_error("[suricata] XMLRPC sync completed.");
+			syslog(LOG_NOTICE, "[suricata] XMLRPC sync completed.");
 		}
  	}
 }
@@ -4115,12 +4115,12 @@ function suricata_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protoc
 
 	/* Do not attempt a package sync while booting up or installing package */
 	if ($g['booting'] || isset($g['suricata_postinstall'])) {
-		log_error("[suricata] Skipping XMLRPC sync when booting up or during package reinstallation.");
+		syslog(LOG_NOTICE, "[suricata] Skipping XMLRPC sync when booting up or during package reinstallation.");
 		return;
 	}
 
 	if ($username == "" || $password == "" || $sync_to_ip == "" || $port == "" || $protocol == "") {
-		log_error("[suricata] A required XMLRPC sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
+		syslog(LOG_ERR, "[suricata] ERROR: A required XMLRPC sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
 		return;
 	}
 
@@ -4133,17 +4133,17 @@ function suricata_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protoc
 	
 	$downloadrulescmd = "";
 	if ($syncdownloadrules == "yes") {
-		$downloadrulescmd = "log_error(gettext(\"[suricata] XMLRPC pkg sync: Update of downloaded rule sets requested...\"));\n";
+		$downloadrulescmd = "syslog(LOG_NOTICE, gettext(\"[suricata] XMLRPC pkg sync: Update of downloaded rule sets requested...\"));\n";
 		$downloadrulescmd .= "\tinclude_once(\"/usr/local/pkg/suricata/suricata_check_for_rule_updates.php\");\n";
 	}
 	$suricatastart = "";
 	if ($syncstartsuricata == "ON") {
-		$suricatastart = "log_error(gettext(\"[suricata] XMLRPC pkg sync: Checking Suricata status...\"));\n";
+		$suricatastart = "syslog(LOG_NOTICE, gettext(\"[suricata] XMLRPC pkg sync: Checking Suricata status...\"));\n";
 		$suricatastart .= "\tif (!is_process_running(\"suricata\")) {\n";
-		$suricatastart .= "\t\tlog_error(gettext(\"[suricata] XMLRPC pkg sync: Suricata not running. Sending a start command...\"));\n";
+		$suricatastart .= "\t\tsyslog(LOG_NOTICE, gettext(\"[suricata] XMLRPC pkg sync: Suricata not running. Sending a start command...\"));\n";
 		$suricatastart .= "\t\t\$sh_script = RCFILEPREFIX . \"suricata.sh\";\n";
 		$suricatastart .= "\t\tmwexec_bg(\"{\$sh_script} start\");\n\t}\n";
-		$suricatastart .= "\telse {\n\t\tlog_error(gettext(\"[suricata] XMLRPC pkg sync: Suricata is running...\"));\n\t}\n";
+		$suricatastart .= "\telse {\n\t\tsyslog(LOG_NOTICE, gettext(\"[suricata] XMLRPC pkg sync: Suricata is running...\"));\n\t}\n";
 	}
 
 	/*************************************************/
@@ -4163,12 +4163,12 @@ function suricata_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protoc
 	\$pkg_interface = "console";
 	{$downloadrulescmd}
 	unset(\$g["suricata_postinstall"]);
-	log_error(gettext("[suricata] XMLRPC pkg sync: Generating suricata.yaml file using Master Host settings..."));
+	syslog(LOG_NOTICE, gettext("[suricata] XMLRPC pkg sync: Generating suricata.yaml file using Master Host settings..."));
 	\$rebuild_rules = true;
 	sync_suricata_package_config();
 	\$rebuild_rules = false;
 	{$suricatastart}
-	log_error(gettext("[suricata] XMLRPC pkg sync process on this host is complete..."));
+	syslog(LOG_NOTICE, gettext("[suricata] XMLRPC pkg sync process on this host is complete..."));
 	\$pkg_interface = \$orig_pkg_interface;
 	unset(\$g["suricata_sync_in_progress"]);
 	return true;
@@ -4244,25 +4244,25 @@ EOD;
 			$method = 'pfsense.exec_php';
 			$params = array( XML_RPC_encode($password), XML_RPC_encode($payload) );
 
-			log_error("[suricata] XMLRPC sync sending auto-SID conf files to {$url}:{$port}.");
+			syslog(LOG_NOTICE, "[suricata] XMLRPC sync sending auto-SID conf files to {$url}:{$port}.");
 			$msg = new XML_RPC_Message($method, $params);
 			$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 			$cli->setCredentials($username, $password);
 			$resp = $cli->send($msg, $synctimeout);
 			$error = "";
 			if (!$resp) {
-				$error = "A communications error occurred while attempting Suricata XMLRPC sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
-				log_error($error);
+				$error = "ERROR: A communications error occurred while attempting Suricata XMLRPC sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
+				syslog(LOG_ERR, $error);
 				file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 			} elseif ($resp->faultCode()) {
-				$error = "An error code was received while attempting Suricata XMLRPC sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
-				log_error($error);
+				$error = "ERROR: An error was received while attempting Suricata XMLRPC sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
+				syslog(LOG_ERR, $error);
 				file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 			}
 		}
 
 		if (!empty($sid_files) && $error == "") {
-			log_error("[suricata] XMLRPC sync auto-SID conf files success with {$url}:{$port} (pfsense.exec_php).");
+			syslog(LOG_NOTICE, "[suricata] XMLRPC sync auto-SID conf files success with {$url}:{$port} (pfsense.exec_php).");
 		}
 
 		/*************************************************/
@@ -4277,25 +4277,25 @@ EOD;
 			$method = 'pfsense.exec_php';
 			$params = array( XML_RPC_encode($password), XML_RPC_encode($payload) );
 
-			log_error("[suricata] Suricata XMLRPC sync sending IPREP files to {$url}:{$port}.");
+			syslog(LOG_NOTICE, "[suricata] Suricata XMLRPC sync sending IPREP files to {$url}:{$port}.");
 			$msg = new XML_RPC_Message($method, $params);
 			$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 			$cli->setCredentials($username, $password);
 			$resp = $cli->send($msg, $synctimeout);
 			$error = "";
 			if (!$resp) {
-				$error = "A communications error occurred while attempting Suricata XMLRPC sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
-				log_error($error);
+				$error = "ERROR: A communications error occurred while attempting Suricata XMLRPC sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
+				syslog(LOG_ERR, $error);
 				file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 			} elseif ($resp->faultCode()) {
-				$error = "An error code was received while attempting Suricata XMLRPC sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
-				log_error($error);
+				$error = "ERROR: An error was received while attempting Suricata XMLRPC sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
+				syslog(LOG_ERR, $error);
 				file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 			}
 		}
 
 		if (!empty($iprep_files) && $error == "") {
-			log_error("[suricata] XMLRPC sync IPREP files success with {$url}:{$port} (pfsense.exec_php).");
+			syslog(LOG_NOTICE, "[suricata] XMLRPC sync IPREP files success with {$url}:{$port} (pfsense.exec_php).");
 		}
 
 		/* assemble xmlrpc payload */
@@ -4304,7 +4304,7 @@ EOD;
 			XML_RPC_encode($xml)
 		);
 
-		log_error("[suricata] Beginning package configuration XMLRPC sync to {$url}:{$port}.");
+		syslog(LOG_NOTICE, "[suricata] Beginning package configuration XMLRPC sync to {$url}:{$port}.");
 		$method = 'pfsense.merge_installedpackages_section_xmlrpc';
 		$msg = new XML_RPC_Message($method, $params);
 		$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
@@ -4313,15 +4313,15 @@ EOD;
 		/* send our XMLRPC message and timeout after defined sync timeout value*/
 		$resp = $cli->send($msg, $synctimeout);
 		if (!$resp) {
-			$error = "A communications error occurred while attempting Suricata XMLRPC sync with {$url}:{$port}.";
-			log_error($error);
+			$error = "ERROR: A communications error occurred while attempting Suricata XMLRPC sync with {$url}:{$port}.";
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 		} elseif ($resp->faultCode()) {
-			$error = "An error code was received while attempting Suricata XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-			log_error($error);
+			$error = "ERROR: An error code was received while attempting Suricata XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 		} else {
-			log_error("[suricata] Package configuration XMLRPC sync successfully completed with {$url}:{$port}.");
+			syslog(LOG_NOTICE, "[suricata] Package configuration XMLRPC sync successfully completed with {$url}:{$port}.");
 		}
 
 		/* assemble xmlrpc payload */
@@ -4331,40 +4331,40 @@ EOD;
 			XML_RPC_encode($execcmd)
 		);
 
-		log_error("[suricata] XMLRPC sync sending reload configuration cmd set as a file to {$url}:{$port}.");
+		syslog(LOG_NOTICE, "[suricata] XMLRPC sync sending reload configuration cmd set as a file to {$url}:{$port}.");
 		$msg = new XML_RPC_Message($method, $params);
 		$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 		$cli->setCredentials($username, $password);
 		$resp = $cli->send($msg, $synctimeout);
 		if (!$resp) {
-			$error = "A communications error occurred while attempting Suricata XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
-			log_error($error);
+			$error = "ERROR: A communications error occurred while attempting Suricata XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 		} elseif ($resp->faultCode()) {
-			$error = "An error code was received while attempting Suricata XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-			log_error($error);
+			$error = "ERROR: An error code was received while attempting Suricata XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 		} else {
-			log_error("[suricata] XMLRPC sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
+			syslog(LOG_NOTICE, "[suricata] XMLRPC sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
 		}
 
 		$params2 = array(
 			XML_RPC_encode($password),
 			XML_RPC_encode($execcmd2)
 		);
-		log_error("[suricata] XMLRPC sync sending {$url}:{$port} cmd to execute configuration reload.");
+		syslog(LOG_NOTICE, "[suricata] XMLRPC sync sending {$url}:{$port} cmd to execute configuration reload.");
 		$msg2 = new XML_RPC_Message($method, $params2);
 		$resp = $cli->send($msg2, $synctimeout);
 		if (!$resp) {
-			$error = "A communications error occurred while attempting Suricata XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
-			log_error($error);
+			$error = "ERROR: A communications error occurred while attempting Suricata XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 		} elseif ($resp->faultCode()) {
-			$error = "An error code was received while attempting Suricata XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-			log_error($error);
+			$error = "ERROR: An error code was received while attempting Suricata XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 		} else {
-			log_error("[suricata] XMLRPC sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
+			syslog(LOG_NOTICE, "[suricata] XMLRPC sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
 		}
 	}
 }

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -3,11 +3,11 @@
  * suricata_check_cron_misc.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2018 Bill Meeks
+ * Copyright (C) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,7 +46,7 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 	$suricatalogdirsizeKB = suricata_Getdirsize(SURICATALOGDIR);
 
 	if ($suricatalogdirsizeKB > 0 && $suricatalogdirsizeKB > $suricataloglimitsizeKB) {
-		log_error(gettext("[Suricata] Log directory size exceeds configured limit of " . number_format($suricataloglimitsize) . " MB set on Global Settings tab. Starting cleanup of Suricata logs."));
+		syslog(LOG_NOTICE, gettext("[Suricata] Log directory size exceeds configured limit of " . number_format($suricataloglimitsize) . " MB set on Global Settings tab. Starting cleanup of Suricata logs."));
 
 		// Initialize an array of the log files we want to prune
 		$logs = array ( "alerts.log", "block.log", "dns.log", "eve.json", "http.log", "files-json.log", "sid_changes.log", "stats.log", "tls.log" );
@@ -56,12 +56,12 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 			$if_real = get_real_interface($value['interface']);
 			$suricata_uuid = $value['uuid'];
 			$suricata_log_dir = SURICATALOGDIR . "suricata_{$if_real}{$suricata_uuid}";
-			log_error(gettext("[Suricata] Cleaning logs for {$value['descr']} ({$if_real})..."));
+			syslog(LOG_NOTICE, gettext("[Suricata] Cleaning logs for {$value['descr']} ({$if_real})..."));
 			suricata_post_delete_logs($suricata_uuid);
 
 			foreach ($logs as $file) {
 				// Cleanup any rotated logs
-				log_error(gettext("[Suricata] Deleting rotated log files except last for {$value['descr']} ({$if_real}) $file..."));
+				syslog(LOG_NOTICE, gettext("[Suricata] Deleting rotated log files except last for {$value['descr']} ({$if_real}) $file..."));
 				$filelist = glob("{$suricata_log_dir}/{$file}.*");
 				// Keep most recent file
 				unset($filelist[count($filelist) - 1]);
@@ -83,7 +83,7 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 		}
 
 		// Cleanup any rotated logs not caught above
-		log_error(gettext("[Suricata] Deleting any additional rotated log files..."));
+		syslog(LOG_NOTICE, gettext("[Suricata] Deleting any additional rotated log files..."));
 		unlink_if_exists("{$suricata_log_dir}/suricata_*/*.log.*");
 		unlink_if_exists("{$suricata_log_dir}/suricata_*/*.json.*");
 
@@ -106,7 +106,7 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 					try {
 						file_put_contents("{$suricata_log_dir}/{$file}", "");
 					} catch (Exception $e) {
-						log_error("[Suricata] Failed to truncate file '{$suricata_log_dir}/{$file}' -- error was {$e->getMessage()}");
+						syslog(LOG_ERR, "[Suricata] ERROR: Failed to truncate file '{$suricata_log_dir}/{$file}' -- error was {$e->getMessage()}");
 					}
 				}
 
@@ -122,14 +122,14 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 
 		// Truncate the Rules Update Log file if it exists
 		if (file_exists(SURICATA_RULES_UPD_LOGFILE)) {
-			log_error(gettext("[Suricata] Truncating the Rules Update Log file..."));
+			syslog(LOG_NOTICE, gettext("[Suricata] Truncating the Rules Update Log file..."));
 			@file_put_contents(SURICATA_RULES_UPD_LOGFILE, "");
 		}
 
 		cleanupExit:
 		// This is needed if suricata is run as suricata user
 		mwexec('/bin/chmod 660 /var/log/suricata/*', true);
-		log_error(gettext("[Suricata] Automatic clean-up of Suricata logs completed."));
+		syslog(LOG_NOTICE, gettext("[Suricata] Automatic clean-up of Suricata logs completed."));
 	}
 }
 
@@ -163,7 +163,7 @@ function suricata_check_rotate_log($log_file, $log_limit, $retention) {
 			copy($log_file, $newfile);
 			file_put_contents($log_file, "");
 		} catch (Exception $e) {
-			log_error("[Suricata] Failed to rotate file '{$log_file}' -- error was {$e->getMessage()}");
+			syslog(LOG_ERR, "[Suricata] ERROR: Failed to rotate file '{$log_file}' -- error was {$e->getMessage()}");
 		}
 	}
 
@@ -236,7 +236,7 @@ if ($config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 
 				}
 			}
 			if ($prune_count > 0)
-				log_error(gettext("[Suricata] Barnyard2 archived logs cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/barnyard2/archive/..."));
+				syslog(LOG_NOTICE, gettext("[Suricata] Barnyard2 archived logs cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/barnyard2/archive/..."));
 			unset($files);
 		}
 
@@ -253,7 +253,7 @@ if ($config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 
 				}
 			}
 			if ($prune_count > 0)
-				log_error(gettext("[Suricata] File Store cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/files/..."));
+				syslog(LOG_NOTICE, gettext("[Suricata] File Store cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/files/..."));
 			unset($files);
 		}
 
@@ -270,7 +270,7 @@ if ($config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 
 				}
 			}
 			if ($prune_count > 0)
-				log_error(gettext("[Suricata] TLS Certs Store cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/certs/..."));
+				syslog(LOG_NOTICE, gettext("[Suricata] TLS Certs Store cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/certs/..."));
 			unset($files);
 		}
 
@@ -289,7 +289,7 @@ if ($config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 
 				unlink_if_exists($f);
 			}
 			if ($prune_count > 0)
-				log_error(gettext("[Suricata] Packet Capture log cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/..."));
+				syslog(LOG_NOTICE, gettext("[Suricata] Packet Capture log cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/..."));
 			unset($files, $remove_files);
 		}
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_etiqrisk_update.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_etiqrisk_update.php
@@ -57,10 +57,10 @@ function suricata_check_iprep_md5($filename) {
 		if ($new_md5 != $old_md5)
 			return TRUE;
 		else
-			log_error(gettext("[Suricata] IPREP file '{$filename}' is up to date."));
+			syslog(LOG_NOTICE, gettext("[Suricata] IPREP file '{$filename}' is up to date."));
 	}
 	else
-		log_error(gettext("[Suricata] An error occurred downloading {$et_iqrisk_url}{$filename}.md5sum for IPREP.  Update of {$filename} file will be skipped."));
+		syslog(LOG_ERR, gettext("[Suricata] ERROR: An error occurred downloading {$et_iqrisk_url}{$filename}.md5sum for IPREP.  Update of {$filename} file will be skipped."));
 
 	return FALSE;
 }
@@ -84,14 +84,14 @@ if (!is_array($config['installedpackages']['suricata']['config'][0]))
 if ($config['installedpackages']['suricata']['config'][0]['et_iqrisk_enable'] == "off")
 	return(0);
 else
-	log_error(gettext("[Suricata] Updating the Emerging Threats IQRisk IP List..."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Updating the Emerging Threats IQRisk IP List..."));
 
 // Construct the download URL using the saved ET IQRisk Subscriber Code
 if (!empty($config['installedpackages']['suricata']['config'][0]['iqrisk_code'])) {
 	$et_iqrisk_url = str_replace("_xxx_", $config['installedpackages']['suricata']['config'][0]['iqrisk_code'], ET_IQRISK_DNLD_URL);
 }
 else {
-	log_error(gettext("[Suricata] No IQRisk subscriber code found!  Aborting scheduled update of Emerging Threats IQRisk IP List."));
+	syslog(gettext(LOG_ALERT, "[Suricata] ALERT: No IQRisk subscriber code found!  Aborting scheduled update of Emerging Threats IQRisk IP List."));
 	return(0);
 }
 
@@ -101,9 +101,9 @@ safe_mkdir("$iqRisk_tmppath");
 // Test the posted MD5 checksum file against our local copy
 // to see if an update has been posted for 'categories.txt'.
 if (suricata_check_iprep_md5("categories.txt")) {
-	log_error(gettext("[Suricata] An updated IPREP 'categories.txt' file is available...downloading new file."));
+	syslog(LOG_NOTICE, gettext("[Suricata] An updated IPREP 'categories.txt' file is available...downloading new file."));
 	if (download_file("{$et_iqrisk_url}categories.txt", "{$iqRisk_tmppath}categories.txt") != true)
-		log_error(gettext("[Suricata] An error occurred downloading the 'categories.txt' file for IQRisk."));
+		syslog(LOG_ERR, gettext("[Suricata] ERROR: An error occurred downloading the 'categories.txt' file for IQRisk."));
 	else {
 		// If the files downloaded successfully, unpack them and store
 		// the list files in the SURICATA_IPREP_PATH directory.
@@ -113,10 +113,10 @@ if (suricata_check_iprep_md5("categories.txt")) {
 				@rename("{$iqRisk_tmppath}categories.txt", "{$iprep_path}categories.txt");
 				@rename("{$iqRisk_tmppath}categories.txt.md5", "{$iprep_path}categories.txt.md5");
 				$success = TRUE;
-				log_error(gettext("[Suricata] Successfully updated IPREP file 'categories.txt'."));
+				syslog(LOG_NOTICE, gettext("[Suricata] Successfully updated IPREP file 'categories.txt'."));
 			}
 			else
-				log_error(gettext("[Suricata] MD5 integrity check of downloaded 'categories.txt' file failed!  Skipping update of this IPREP file."));
+				syslog(gettext(LOG_ALERT, "[Suricata] ALERT: MD5 integrity check of downloaded 'categories.txt' file failed!  Skipping update of this IPREP file."));
 		}
 	}
 }
@@ -124,9 +124,9 @@ if (suricata_check_iprep_md5("categories.txt")) {
 // Test the posted MD5 checksum file against our local copy
 // to see if an update has been posted for 'iprepdata.txt.gz'.
 if (suricata_check_iprep_md5("iprepdata.txt.gz")) {
-	log_error(gettext("[Suricata] An updated IPREP 'iprepdata.txt' file is available...downloading new file."));
+	syslog(LOG_NOTICE, gettext("[Suricata] An updated IPREP 'iprepdata.txt' file is available...downloading new file."));
 	if (download_file("{$et_iqrisk_url}iprepdata.txt.gz", "{$iqRisk_tmppath}iprepdata.txt.gz") != true)
-		log_error(gettext("[Suricata] An error occurred downloading the 'iprepdata.txt.gz' file for IQRisk."));
+		syslog(LOG_ERR, gettext("[Suricata] ERROR: An error occurred downloading the 'iprepdata.txt.gz' file for IQRisk."));
 	else {
 		// If the files downloaded successfully, unpack them and store
 		// the list files in the SURICATA_IPREP_PATH directory.
@@ -137,10 +137,10 @@ if (suricata_check_iprep_md5("iprepdata.txt.gz")) {
 				@rename("{$iqRisk_tmppath}iprepdata.txt", "{$iprep_path}iprepdata.txt");
 				@rename("{$iqRisk_tmppath}iprepdata.txt.gz.md5", "{$iprep_path}iprepdata.txt.gz.md5");
 				$success = TRUE;
-				log_error(gettext("[Suricata] Successfully updated IPREP file 'iprepdata.txt'."));
+				syslog(LOG_NOTICE, gettext("[Suricata] Successfully updated IPREP file 'iprepdata.txt'."));
 			}
 			else
-				log_error(gettext("[Suricata] MD5 integrity check of downloaded 'iprepdata.txt.gz' file failed!  Skipping update of this IPREP file."));
+				syslog(LOG_ALERT, gettext("[Suricata] ALERT: MD5 integrity check of downloaded 'iprepdata.txt.gz' file failed!  Skipping update of this IPREP file."));
 		}
 	}
 }
@@ -148,7 +148,7 @@ if (suricata_check_iprep_md5("iprepdata.txt.gz")) {
 // Cleanup the tmp directory path
 rmdir_recursive("$iqRisk_tmppath");
 
-log_error(gettext("[Suricata] Emerging Threats IQRisk IP List update finished."));
+syslog(LOG_NOTICE, gettext("[Suricata] Emerging Threats IQRisk IP List update finished."));
 
 // If successful, signal any running Suricata process to live reload the rules and IP lists
 if ($success == TRUE && is_process_running("suricata")) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -701,13 +701,13 @@ else {
 					elseif (is_ipaddrv4($addr) || is_subnetv4($addr))
 						$engine .= "{$addr}, ";
 					else
-						log_error("[suricata] WARNING: invalid IP address value '{$addr}' in Alias {$v['bind_to']} will be ignored.");
+						syslog(LOG_WARN, "[suricata] WARNING: invalid IP address value '{$addr}' in Alias {$v['bind_to']} will be ignored.");
 				}
 				$engine = trim($engine, ' ,');
 				$engine .= "]";
 			}
 			else {
-				log_error("[suricata] WARNING: unable to resolve IP List Alias '{$v['bind_to']}' for Host OS Policy '{$v['name']}' ... ignoring this entry.");
+				syslog(LOG_WARN, "[suricata] WARNING: unable to resolve IP List Alias '{$v['bind_to']}' for Host OS Policy '{$v['name']}' ... ignoring this entry.");
 				continue;
 			}
 		}
@@ -747,7 +747,7 @@ else {
 					elseif (is_ipaddrv4($addr) || is_subnetv4($addr))
 						$engine .= "{$addr}, ";
 					else {
-						log_error("[suricata] WARNING: invalid IP address value '{$addr}' in Alias {$v['bind_to']} will be ignored.");
+						syslog(LOG_WARN, "[suricata] WARNING: invalid IP address value '{$addr}' in Alias {$v['bind_to']} will be ignored.");
 						continue;
 					}
 				}
@@ -761,7 +761,7 @@ else {
 				$http_hosts_policy .= "   {$engine}\n";
 			}
 			else {
-				log_error("[suricata] WARNING: unable to resolve IP List Alias '{$v['bind_to']}' for Host OS Policy '{$v['name']}' ... ignoring this entry.");
+				syslog(LOG_WARN, "[suricata] WARNING: unable to resolve IP List Alias '{$v['bind_to']}' for Host OS Policy '{$v['name']}' ... ignoring this entry.");
 				continue;
 			}
 		}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -49,7 +49,7 @@ $rule = &$config['installedpackages']['suricata']['rule'];
 /****************************************************************************/
 
 $updated_cfg = false;
-log_error("[Suricata] Checking configuration settings version...");
+syslog(LOG_NOTICE, "[Suricata] Checking configuration settings version...");
 
 // Check the configuration version to see if XMLRPC Sync should be
 // auto-disabled as part of the upgrade due to config format changes.
@@ -57,7 +57,7 @@ if ($config['installedpackages']['suricata']['config'][0]['suricata_config_ver']
     ($config['installedpackages']['suricatasync']['config'][0]['varsynconchanges'] == 'auto' ||
      $config['installedpackages']['suricatasync']['config'][0]['varsynconchanges'] == 'manual')) {
 	$config['installedpackages']['suricatasync']['config'][0]['varsynconchanges'] = "disabled";
-	log_error("[Suricata] Turning off Suricata Sync on this host due to configuration format changes in this update.  Upgrade all Suricata Sync targets to this same Suricata package version before re-enabling Suricata Sync.");
+	syslog(LOG_NOTICE, "[Suricata] Turning off Suricata Sync on this host due to configuration format changes in this update.  Upgrade all Suricata Sync targets to this same Suricata package version before re-enabling Suricata Sync.");
 	$updated_cfg = true;
 }
 
@@ -690,10 +690,10 @@ unset($r);
 // Log a message indicating what we did
 if ($updated_cfg) {
 	write_config("Updated Suricata package settings to new configuration format.");
-	log_error("[Suricata] Settings successfully migrated to new configuration format.");
+	syslog(LOG_NOTICE, "[Suricata] Settings successfully migrated to new configuration format.");
 }
 else {
-	log_error("[Suricata] Configuration version is current.");
+	syslog(LOG_NOTICE, "[Suricata] Configuration version is current.");
 }
 
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -76,6 +76,17 @@ safe_mkdir(SURICATALOGDIR);
 safe_mkdir(SURICATA_SID_MODS_PATH);
 safe_mkdir(SURICATA_IPREP_PATH);
 
+/*****************************************************************/
+/* In the event this is a reinstall (or update), then recreate   */
+/* critical config files from the package sample templates.      */
+/*****************************************************************/
+$map_files = array( "classification.config", "reference.config", "threshold.config" );
+foreach ($map_files as $f) {
+	if (file_exists(SURICATADIR . $f . ".sample") && !file_exists(SURICATADIR . $f)) {
+		copy(SURICATADIR . $f . ".sample", SURICATADIR . $f);
+	}
+}
+
 // Download the latest GeoIP DB updates and create cron task if the feature is not disabled
 if ($config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] != 'off') {
 	log_error(gettext("[Suricata] Installing free GeoLite2 country IP database file in /usr/local/share/suricata/GeoLite2/..."));

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -89,14 +89,14 @@ foreach ($map_files as $f) {
 
 // Download the latest GeoIP DB updates and create cron task if the feature is not disabled
 if ($config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] != 'off') {
-	log_error(gettext("[Suricata] Installing free GeoLite2 country IP database file in /usr/local/share/suricata/GeoLite2/..."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Installing free GeoLite2 country IP database file in /usr/local/share/suricata/GeoLite2/..."));
 	include("/usr/local/pkg/suricata/suricata_geoipupdate.php");
 	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_geoipupdate.php", TRUE, 0, 6, "*", "*", "*", "root");
 }
 
 // Download the latest ET IQRisk updates and create cron task if the feature is not disabled
 if ($config['installedpackages']['suricata']['config'][0]['et_iqrisk_enable'] == 'on') {
-	log_error(gettext("[Suricata] Installing Emerging Threats IQRisk IP List..."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Installing Emerging Threats IQRisk IP List..."));
 	include("/usr/local/pkg/suricata/suricata_etiqrisk_update.php");
 	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_etiqrisk_update.php", TRUE, 0, "*/6", "*", "*", "*", "root");
 }
@@ -120,7 +120,7 @@ while (suricata_cron_job_exists($suri_pf_table, FALSE)) {
 }
 
 if ($cron_count > 0) {
-	log_error(gettext("[Suricata] Removed {$cron_count} duplicate 'remove_blocked_hosts' cron task(s)."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Removed {$cron_count} duplicate 'remove_blocked_hosts' cron task(s)."));
 }
 
 /*********************************************************/
@@ -146,7 +146,7 @@ if (!is_array($config['installedpackages']['suricata']['config'][0])) {
 
 // remake saved settings if previously flagged
 if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] == 'on') {
-	log_error(gettext("[Suricata] Saved settings detected... rebuilding installation with saved settings."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Saved settings detected... rebuilding installation with saved settings."));
 	update_status(gettext("Saved settings detected...") . "\n");
 
 	/****************************************************************/
@@ -183,7 +183,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 	update_status(gettext("Migrating settings to new configuration..."));
 	include('/usr/local/pkg/suricata/suricata_migrate_config.php');
 	update_status(gettext(" done.") . "\n");
-	log_error(gettext("[Suricata] Downloading and updating configured rule types."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Downloading and updating configured rule types."));
 	include('/usr/local/pkg/suricata/suricata_check_for_rule_updates.php');
 	update_status(gettext("Generating suricata.yaml configuration file from saved settings.") . "\n");
 	$rebuild_rules = true;
@@ -255,7 +255,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 
 	$rebuild_rules = false;
 	update_status(gettext("Finished rebuilding Suricata configuration from saved settings.") . "\n");
-	log_error(gettext("[Suricata] Finished rebuilding installation from saved settings."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Finished rebuilding installation from saved settings."));
 }
 
 // If this is first install and "forcekeepsettings" is empty,
@@ -303,7 +303,7 @@ write_config("Suricata pkg v{$config['installedpackages']['package'][get_package
 
 // Done with post-install, so clear flag
 unset($g['suricata_postinstall']);
-log_error(gettext("[Suricata] Package post-installation tasks completed."));
+syslog(LOG_NOTICE, gettext("[Suricata] Package post-installation tasks completed."));
 return true;
 
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
@@ -35,12 +35,12 @@ $rcdir = RCFILEPREFIX;
 $suricata_rules_upd_log = SURICATA_RULES_UPD_LOGFILE;
 $suri_pf_table = SURICATA_PF_TABLE;
 
-log_error(gettext("[Suricata] Suricata package uninstall in progress..."));
+syslog(LOG_NOTICE, gettext("[Suricata] Suricata package uninstall in progress..."));
 
 /* Make sure all active Suricata processes are terminated */
 /* Log a message only if a running process is detected */
 if (is_service_running("suricata"))
-	log_error(gettext("[Suricata] Suricata STOP for all interfaces..."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Stopping Suricata on all configured interfaces..."));
 killbyname("suricata");
 sleep(1);
 
@@ -51,7 +51,7 @@ unlink_if_exists("{$g['varrun_path']}/suricata*.lck");
 /* Make sure all active Barnyard2 processes are terminated */
 /* Log a message only if a running process is detected     */
 if (is_service_running("barnyard2"))
-	log_error(gettext("[Suricata] Barnyard2 STOP for all interfaces..."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Stopping Barnyard2 on all configured interfaces..."));
 killbyname("barnyard2");
 sleep(1);
 
@@ -67,7 +67,7 @@ install_cron_job("suricata_etiqrisk_update.php", false);
 
 /* See if we are to keep Suricata log files on uninstall */
 if ($config['installedpackages']['suricata']['config'][0]['clearlogs'] == 'on') {
-	log_error(gettext("[Suricata] Clearing all Suricata-related log files..."));
+	syslog(LOG_NOTICE, gettext("[Suricata] Clearing all Suricata-related log files..."));
 	unlink_if_exists("{$suricata_rules_upd_log}");
 	rmdir_recursive("{$suricatalogdir}");
 }
@@ -122,14 +122,14 @@ if (!empty($widgets)) {
 
 /* Keep this as a last step */
 if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] != 'on') {
-	log_error(gettext("Not saving settings... all Suricata configuration info and logs deleted..."));
+	syslog(LOG_NOTICE, gettext("Not saving settings... all Suricata configuration info and logs deleted..."));
 	unset($config['installedpackages']['suricata']);
 	unset($config['installedpackages']['suricatasync']);
 	unlink_if_exists("{$suricata_rules_upd_log}");
 	rmdir_recursive("{$suricatalogdir}");
 	rmdir_recursive("{$g['vardb_path']}/suricata");
 	write_config("Removing Suricata configuration");
-	log_error(gettext("[Suricata] The package has been removed from this system..."));
+	syslog(LOG_NOTICE, gettext("[Suricata] The package has been removed from this system..."));
 }
 
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -147,7 +147,7 @@ if (!$input_errors) {
 
 		// If deprecated rules should be removed, then do it
 		if ($config['installedpackages']['suricata']['config'][0]['hide_deprecated_rules'] == "on") {
-			log_error(gettext("[Suricata] Hide Deprecated Rules is enabled.  Removing obsoleted rules categories."));
+			syslog(gettext(LOG_NOTICE, "[Suricata] Hide Deprecated Rules is enabled.  Removing obsoleted rules categories."));
 			suricata_remove_dead_rules();
 		}
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -314,7 +314,7 @@ $section->addInput(new Form_Input(
 	'Snort Rules Filename',
 	'text',
 	$pconfig['snort_rules_file']
-))->setHelp('Enter the rules tarball filename (filename only, do not include the URL.)<br />Example: snortrules-snapshot-29120.tar.gz');
+))->setHelp('Enter the rules tarball filename (filename only, do not include the URL.)<br />Example: snortrules-snapshot-29130.tar.gz<br />DO NOT specify a Snort3 rules file!  Snort3 rules are incompatible witih Suricata 4.x and will break your installation!');
 $section->addInput(new Form_Input(
 	'oinkcode',
 	'Snort Oinkmaster Code',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -3,11 +3,11 @@
  * suricata_interfaces.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -91,14 +91,14 @@ if (isset($_POST['del_x'])) {
 		$if_real = get_real_interface($a_nat[$delbtn_list]['interface']);
 		$if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$delbtn_list]['interface']);
 		$suricata_uuid = $a_nat[$delbtn_list]['uuid'];
-		log_error("Stopping Suricata on {$if_friendly}({$if_real}) due to interface deletion...");
+		syslog(LOG_NOTICE, "Stopping Suricata on {$if_friendly}({$if_real}) due to interface deletion...");
 		suricata_stop($a_nat[$delbtn_list], $if_real);
 		rmdir_recursive("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}");
 		rmdir_recursive("{$suricatadir}suricata_{$suricata_uuid}_{$if_real}");
 
 		// Finally delete the interface's config entry entirely
 		unset($a_nat[$delbtn_list]);
-		log_error("Deleted Suricata instance on {$if_friendly}({$if_real}) per user request...");
+		syslog(LOG_NOTICE, "Deleted Suricata instance on {$if_friendly}({$if_real}) per user request...");
 
 		// Save updated configuration
 		write_config("Suricata pkg: deleted one or more Suricata interfaces.");
@@ -122,17 +122,17 @@ if ($_POST['by2toggle']) {
 
 	if (!suricata_is_running($suricatacfg['uuid'], $if_real, 'barnyard2')) {
 		if ($if_friendly == $suricatacfg['descr']) {
-			log_error("Toggle (barnyard starting) for {$if_friendly}...");
+			syslog(LOG_NOTICE, "Toggle (barnyard starting) for {$if_friendly}...");
 		}
 		else {
-			log_error("Toggle (barnyard starting) for {$if_friendly}({$suricatacfg['descr']})...");
+			syslog(LOG_NOTICE, "Toggle (barnyard starting) for {$if_friendly}({$suricatacfg['descr']})...");
 		}
 		// No need to rebuild Suricata rules for Barnyard2,
 		// so flag that task as "off" to save time.
 		$rebuild_rules = false;
 		sync_suricata_package_config();
 		suricata_barnyard_start($suricatacfg, $if_real);
-		$by2_starting[$id] = 'TRUE';
+		$by2_starting[$id] = TRUE;
 	} else {
 		if ($if_friendly == $suricatacfg['descr']) {
 			log_error("Toggle (barnyard stopping) for {$if_friendly}...");
@@ -191,9 +191,9 @@ EOD;
 				log_error("Starting Suricata on {$if_friendly}({$if_real}) per user request...");
 				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/suricata_{$if_real}{$suricatacfg['uuid']}_startcmd.php");
 			}
-			$suri_starting[$id] = 'TRUE';
+			$suri_starting[$id] = TRUE;
 			if ($suricatacfg['barnyard_enable'] == 'on' && !isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}{$suricata_uuid}.pid")) {
-				$by2_starting[$id] = 'TRUE';
+				$by2_starting[$id] = TRUE;
 			}
 			break;
 		case 'stop':
@@ -221,14 +221,15 @@ if ($_POST['status'] == 'check') {
 	// Iterate configured Suricata interfaces and get status of each
 	// into an associative array.  Return the array to the Ajax
 	// caller as a JSON object.
-	foreach ($a_nat as $natent) {
-		$intf_key = "suricata_" . get_real_interface($natent['interface']) . $natent['uuid'];
-		if ($natent['enable'] == "on") {
-			if (suricata_is_running($natent['uuid'], get_real_interface($natent['interface']))) {
+	foreach ($a_nat as $intf) {
+		$intf_key = "suricata_" . get_real_interface($intf['interface']) . $intf['uuid'];
+		if ($intf['enable'] == "on") {
+			if (suricata_is_running($intf['uuid'], get_real_interface($intf['interface']))) {
 				$list[$intf_key] = "RUNNING";
 			}
 			elseif (file_exists("{$g['varrun_path']}/{$intf_key}_starting.lck") || file_exists("{$g['varrun_path']}/suricata_pkg_starting.lck")) {
 				$list[$intf_key] = "STARTING";
+				$suri_starting[$id] = TRUE;
 			}
 			else {
 				$list[$intf_key] = "STOPPED";
@@ -237,17 +238,14 @@ if ($_POST['status'] == 'check') {
 		else {
 			$list[$intf_key] = "DISABLED";
 		}
-	}
 
-	// Iterate configured Barnyard2 interfaces and add status of each
-	// to the JSON array object.
-	foreach ($a_nat as $natent) {
-		$intf_key = "barnyard2_" . get_real_interface($natent['interface']) . $natent['uuid'];
-		if ($natent['barnyard_enable'] == "on") {
-			if (suricata_is_running($natent['uuid'], get_real_interface($natent['interface']), 'barnyard2')) {
+		// Now check and set Barnyard2 status for the interface
+		$intf_key = "barnyard2_" . get_real_interface($intf['interface']) . $intf['uuid'];
+		if ($intf['barnyard_enable'] == "on") {
+			if (suricata_is_running($intf['uuid'], get_real_interface($intf['interface']), 'barnyard2')) {
 				$list[$intf_key] = "RUNNING";
 			}
-			elseif (file_exists("{$g['varrun_path']}/{$intf_key}_starting.lck") || file_exists("{$g['varrun_path']}/suricata_pkg_starting.lck")) {
+			elseif ($suri_starting[$id] == TRUE || file_exists("{$g['varrun_path']}/suricata_pkg_starting.lck")) {
 				$list[$intf_key] = "STARTING";
 			}
 			else {
@@ -311,10 +309,10 @@ include_once("head.inc"); ?>
 				<tr id="frheader">
 					<th>&nbsp;</th>
 					<th><?=gettext("Interface"); ?></th>
-					<th><?=gettext("Suricata"); ?></th>
+					<th><?=gettext("Suricata Status"); ?></th>
 					<th><?=gettext("Pattern Match"); ?></th>
-					<th><?=gettext("Block"); ?></th>
-					<th><?=gettext("Barnyard2"); ?></th>
+					<th><?=gettext("Blocking Mode"); ?></th>
+					<th><?=gettext("Barnyard2 Status"); ?></th>
 					<th><?=gettext("Description"); ?></th>
 					<th><?=gettext("Actions")?></th>
 				</tr>
@@ -381,30 +379,26 @@ include_once("head.inc"); ?>
 ?>
 					</td>
 
-					<td id="frd<?=$nnats?>"
-					ondblclick="document.location='suricata_interfaces_edit.php?id=<?=$nnats?>';">
-<?php
-					$check_suricata_info = $config['installedpackages']['suricata']['rule'][$nnats]['enable'];
-?>
-					<?php if ($check_suricata_info == "on") : ?>
+					<td id="frd<?=$nnats?>" ondblclick="document.location='suricata_interfaces_edit.php?id=<?=$nnats?>';">
+					<?php if ($config['installedpackages']['suricata']['rule'][$nnats]['enable'] == "on") : ?>
 						<?php if (suricata_is_running($suricata_uuid, $if_real)) : ?>
 							<i id="suricata_<?=$if_real.$suricata_uuid;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('suricata is running on this interface');?>"></i>
 							&nbsp;
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart suricata on this interface');?>"></i>
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start suricata on this interface');?>"></i>
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop suricata on this interface');?>"></i>
-						<?php elseif ($suri_starting[$nnats] == 'TRUE' || file_exists("{$g['varrun_path']}/suricata_pkg_starting.lck")) : ?>
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>" class="fa fa-cog fa-spin text-success icon-primary" title="<?=gettext('suricata is starting on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>', this);" title="<?=gettext('Restart suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>', this);" title="<?=gettext('Start suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>', this);" title="<?=gettext('Stop suricata on this interface');?>"></i>
+						<?php elseif ($suri_starting[$nnats] == TRUE || file_exists("{$g['varrun_path']}/suricata_pkg_starting.lck")) : ?>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>" class="fa fa-cog fa-spin text-info icon-primary" title="<?=gettext('suricata is starting on this interface');?>"></i>
 							&nbsp;
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart suricata on this interface');?>"></i>
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start suricata on this interface');?>"></i>
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>', this);" title="<?=gettext('Restart suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>', this);" title="<?=gettext('Start suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>', this);" title="<?=gettext('Stop suricata on this interface');?>"></i>
 						<?php else: ?>
 							<i class="fa fa-times-circle text-danger icon-primary" title="<?=gettext('suricata is stopped on this interface');?>"></i>
 							&nbsp;
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart suricata on this interface');?>"></i>
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start suricata on this interface');?>"></i>
-							<i id="suricata_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>', this);" title="<?=gettext('Restart suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info" onclick="javascript:suricata_iface_toggle('start', '<?=$nnats?>', this);" title="<?=gettext('Start suricata on this interface');?>"></i>
+							<i id="suricata_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info hidden" onclick="javascript:suricata_iface_toggle('stop', '<?=$nnats?>', this);" title="<?=gettext('Stop suricata on this interface');?>"></i>
 						<?php endif; ?>
 					<?php else : ?>
 						<?=gettext('DISABLED');?>&nbsp;
@@ -412,36 +406,22 @@ include_once("head.inc"); ?>
 
 					</td>
 
-					<td
-					id="frd<?=$nnats?>"
-					ondblclick="document.location='suricata_interfaces_edit.php?id=<?=$nnats?>';">
-<?php
-					$check_performance_info = $config['installedpackages']['suricata']['rule'][$nnats]['mpm_algo'];
-
-					if ($check_performance_info != "") {
-						$check_performance = $check_performance_info;
-					}else{
-						$check_performance = "unknown";
-					}
-
-?>
-						<?=strtoupper($check_performance)?>
+					<td id="frd<?=$nnats?>" ondblclick="document.location='suricata_interfaces_edit.php?id=<?=$nnats?>';">
+						<?php if ($config['installedpackages']['suricata']['rule'][$nnats]['mpm_algo'] != "") : ?>
+							<?=gettext(strtoupper($config['installedpackages']['suricata']['rule'][$nnats]['mpm_algo']));?>
+						<?php else : ?>
+							<?=gettext('UNKNOWN');?>
+						<?php endif; ?>
 					</td>
 
-					<td
-					id="frd<?=$nnats?>"
-					ondblclick="document.location='suricata_interfaces_edit.php?id=<?=$nnats?>';">
-					<?php
-					$check_blockoffenders_info = $config['installedpackages']['suricata']['rule'][$nnats]['blockoffenders'];
-
-					if ($check_blockoffenders_info == "on")
-					{
-						$check_blockoffenders = 'enabled';
-					} else {
-						$check_blockoffenders = 'disabled';
-					}
-?>
-					<?=strtoupper($check_blockoffenders)?>
+					<td id="frd<?=$nnats?>" ondblclick="document.location='suricata_interfaces_edit.php?id=<?=$nnats?>';">
+						<?php if ($config['installedpackages']['suricata']['rule'][$nnats]['blockoffenders'] == 'on' && $config['installedpackages']['suricata']['rule'][$nnats]['ips_mode'] == 'ips_mode_legacy') : ?>
+							<?=gettext('LEGACY MODE');?>
+						<?php elseif ($config['installedpackages']['suricata']['rule'][$nnats]['blockoffenders'] == 'on' && $config['installedpackages']['suricata']['rule'][$nnats]['ips_mode'] == 'ips_mode_inline') : ?>
+							<?=gettext('INLINE IPS');?>
+						<?php else : ?>
+							<?=gettext('DISABLED');?>
+						<?php endif; ?>
 					</td>
 
 					<td id="frd<?=$nnats?>" ondblclick="document.location='suricata_interfaces_edit.php?id=<?=$nnats?>';">
@@ -449,29 +429,29 @@ include_once("head.inc"); ?>
 							<?php if (suricata_is_running($suricata_uuid, $if_real, 'barnyard2')) : ?>
 								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('barnyard2 is running on this interface');?>"></i>
 								&nbsp;
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop barnyard2 on this interface');?>"></i>
-							<?php elseif ($by2_starting[$nnats] == 'TRUE'  || file_exists("{$g['varrun_path']}/suricata_pkg_starting.lck")) : ?>
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('barnyard2 is starting on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>', this);" title="<?=gettext('Restart barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>', this);" title="<?=gettext('Start barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>', this);" title="<?=gettext('Stop barnyard2 on this interface');?>"></i>
+							<?php elseif ($by2_starting[$nnats] == TRUE  || file_exists("{$g['varrun_path']}/suricata_pkg_starting.lck")) : ?>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>" class="fa fa-cog fa-spin text-info icon-primary" title="<?=gettext('barnyard2 is starting on this interface');?>"></i>
 								&nbsp;
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>', this);" title="<?=gettext('Restart barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>', this);" title="<?=gettext('Start barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>', this);" title="<?=gettext('Stop barnyard2 on this interface');?>"></i>
 							<?php else: ?>
 								<i class="fa fa-times-circle text-danger icon-primary" title="<?=gettext('barnyard2 is stopped on this interface');?>"></i>
 								&nbsp;
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>', this);" title="<?=gettext('Restart barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$nnats?>', this);" title="<?=gettext('Start barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real.$suricata_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('stop', '<?=$nnats?>', this);" title="<?=gettext('Stop barnyard2 on this interface');?>"></i>
 							<?php endif; ?>
 						<?php else : ?>
 							<?=gettext('DISABLED');?>&nbsp;
 						<?php endif; ?>
 					</td>
 
-					<td ondblclick="document.location='suricata_interfaces_edit.php?id=<?=$nnats?>';">
-					<?=htmlspecialchars($natent['descr'])?>
+					<td class="text-info" ondblclick="document.location='suricata_interfaces_edit.php?id=<?=$nnats?>';">
+						<?=htmlspecialchars($natent['descr'])?>
 					</td>
 
 					<td>
@@ -578,6 +558,10 @@ include_once("head.inc"); ?>
 		// control IDs using "key" followed by the icon's function.  These
 		// control IDs are used in the code below to alter icon appearance
 		// depending on the service status.
+		//
+		// Because an interface name in FreeBSD can contain CSS special characters
+		// such as a period, any CSS special characters in an interface name are
+		// escaped by double-backslashes in the code below.
 
 		var data = jQuery.parseJSON(responseData);
 
@@ -586,40 +570,55 @@ include_once("head.inc"); ?>
 			var service_name = key.substring(0, key.indexOf('_'));
 			if (data[key] != 'DISABLED') {
 				if (data[key] == 'STOPPED') {
-					$('#' + key).removeClass('fa-check-circle fa-cog fa-spin text-success text-info');
-					$('#' + key).addClass('fa-times-circle text-danger');
-					$('#' + key).prop('title', service_name + ' is stopped on this interface');
-					$('#' + key + '_restart').addClass('hidden');
-					$('#' + key + '_stop').addClass('hidden');
-					$('#' + key + '_start').removeClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).removeClass('fa-check-circle fa-cog fa-spin text-success text-info');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).addClass('fa-times-circle text-danger');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).prop('title', service_name + ' is stopped on this interface');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_restart').addClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_stop').addClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_start').removeClass('hidden');
 				}
 				if (data[key] == 'STARTING') {
-					$('#' + key).removeClass('fa-check-circle fa-times-circle text-info text-danger');
-					$('#' + key).addClass('fa-cog fa-spin text-success');
-					$('#' + key).prop('title', service_name + ' is starting on this interface');
-					$('#' + key + '_restart').addClass('hidden');
-					$('#' + key + '_start').addClass('hidden');
-					$('#' + key + '_stop').removeClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).removeClass('fa-check-circle fa-times-circle text-success text-danger');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).addClass('fa-cog fa-spin text-info');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).prop('title', service_name + ' is starting on this interface');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_restart').addClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_start').addClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_stop').removeClass('hidden');
 				}
 				if (data[key] == 'RUNNING') {
-					$('#' + key).addClass('fa-check-circle text-success');
-					$('#' + key).removeClass('fa-times-circle fa-cog fa-spin text-danger text-info');
-					$('#' + key).prop('title', service_name + ' is running on this interface');
-					$('#' + key + '_restart').removeClass('hidden');
-					$('#' + key + '_stop').removeClass('hidden');
-					$('#' + key + '_start').addClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).addClass('fa-check-circle text-success');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).removeClass('fa-times-circle fa-cog fa-spin text-danger text-info');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).prop('title', service_name + ' is running on this interface');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_restart').removeClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_stop').removeClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_start').addClass('hidden');
 				}
 			}
 		}
 	}
 
-	function suricata_iface_toggle(action, id) {
+	function suricata_iface_toggle(action, id, intf) {
+		if (action == "stop") {
+			$(intf).removeClass('fa-stop-circle-o fa-check-circle text-success text-danger');
+			$(intf).addClass('fa-cog fa-spin text-info');
+			$(intf).prop('title', 'Suricata is shutting down on this interface');
+		}
 		$('#toggle').val(action);
 		$('#id').val(id);
 		$('#iform').submit();
 	}
 
-	function by2_iface_toggle(action, id) {
+	function by2_iface_toggle(action, id, intf) {
+		if (action == "stop") {
+			$(intf).removeClass('fa-stop-circle-o fa-check-circle text-success text-danger');
+			$(intf).addClass('fa-cog fa-spin text-info');
+			$(intf).prop('title', 'Barnyard2 is shutting down on this interface');
+		}
+		if (action == "start") {
+			$(intf).removeClass('fa-stop-circle-o fa-check-circle text-success text-danger');
+			$(intf).addClass('fa-cog fa-spin text-info');
+			$(intf).prop('title', 'Barnyard2 is starting on this interface');
+		}
 		$('#by2toggle').val(action);
 		$('#id').val(id);
 		$('#iform').submit();

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -135,10 +135,10 @@ if ($_POST['by2toggle']) {
 		$by2_starting[$id] = TRUE;
 	} else {
 		if ($if_friendly == $suricatacfg['descr']) {
-			log_error("Toggle (barnyard stopping) for {$if_friendly}...");
+			syslog(LOG_NOTICE, "Toggle (barnyard stopping) for {$if_friendly}...");
 		}
 		else {
-			log_error("Toggle (barnyard stopping) for {$if_friendly}({$suricatacfg['descr']})...");
+			syslog(LOG_NOTICE, "Toggle (barnyard stopping) for {$if_friendly}({$suricatacfg['descr']})...");
 		}
 		suricata_barnyard_stop($suricatacfg, $if_real);
 		unset($by2_starting[$id]);
@@ -183,12 +183,12 @@ EOD;
 		case 'start':
 			file_put_contents("{$g['tmp_path']}/suricata_{$if_real}{$suricatacfg['uuid']}_startcmd.php", $suricata_start_cmd);
 			if (suricata_is_running($suricatacfg['uuid'], $if_real)) {
-				log_error("Restarting Suricata on {$if_friendly}({$if_real}) per user request...");
+				syslog(LOG_NOTICE, "Restarting Suricata on {$if_friendly}({$if_real}) per user request...");
 				suricata_stop($suricatacfg, $if_real);
 				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/suricata_{$if_real}{$suricatacfg['uuid']}_startcmd.php");
 			}
 			else {
-				log_error("Starting Suricata on {$if_friendly}({$if_real}) per user request...");
+				syslog(LOG_NOTICE, "Starting Suricata on {$if_friendly}({$if_real}) per user request...");
 				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/suricata_{$if_real}{$suricatacfg['uuid']}_startcmd.php");
 			}
 			$suri_starting[$id] = TRUE;
@@ -198,7 +198,7 @@ EOD;
 			break;
 		case 'stop':
 			if (suricata_is_running($suricatacfg['uuid'], $if_real)) {
-				log_error("Stopping Suricata on {$if_friendly}({$if_real}) per user request...");
+				syslog(LOG_NOTICE, "Stopping Suricata on {$if_friendly}({$if_real}) per user request...");
 				suricata_stop($suricatacfg, $if_real);
 			}
 			unset($suri_starting[$id]);


### PR DESCRIPTION
### pfSense-pkg-suricata v4.1.4_2
This update to the GUI package incorporates the use of the PHP _syslog()_ function for logging both informational and error messages so that a SEVERITY_LEVEL flag can be associated with each message.  This lets users sending the logs for automated analysis on remote systems parse log messages by Severity (LOG_ERR, LOG_ALERT, LOG_WARN or LOG_NOTICE).  Formerly all Suricata log messages were logged with Severity LOG_ERR, even those that were merely informational in nature.

This update also includes two bug fixes.

**Changes Log:**
1.  Update the example Snort 2.9.x rules snapshot filename on the GLOBAL SETTINGS tab in the Snort Subsriber Rules section to the most recent Snort 2.9.x version.

2.  Add a warning under the Snort rules snapshot filename text box advising the user to not use Snort3 rules as they are incompatible with Suricata and will break the Suricata installation if installed.

**New Features:**
1.  Suricata log messages to the system log now contain SEVERITY LEVEL to facilitate parsing of the messages using remote log analysis tools.  Redmine Issue #8501.

**Bug Fixes:**
1.  Fix display of Suricata and Barnyard2 status icons on the INTERFACES tab so that icons update properly when the underlying interface is a VLAN.

2.  On a package re-install, check for missing _classification.config_, _reference.config_ or _threshold.config_ files in each interface sub-directory and restore any missing files by copying in the *.config.sample equivalent.  This prevents subsequent start-up errors for missing files.  See Redmine Issues #9195 and #9202.