### PR TITLE
pfSense-pkg-suricata-4.1.4_3 -- Fix PHP warning caused by typo in syslog() function call

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.1.4
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -212,7 +212,7 @@ function suricata_reload_config($suricatacfg, $signal="USR2") {
 	/* we can find a valid PID for the process.           */
 	/******************************************************/
 	if (isvalidpid("{$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid")) {
-		syslog("LOG_NOTICE, [Suricata] Suricata LIVE RULE RELOAD initiated for {$suricatacfg['descr']} ({$if_real})...");
+		syslog(LOG_NOTICE, "[Suricata] Suricata LIVE RULE RELOAD initiated for {$suricatacfg['descr']} ({$if_real})...");
 		mwexec_bg("/bin/pkill -{$signal} -F {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid");
 	}
 }


### PR DESCRIPTION
### pfSense-pkg-suricata-4.1.4_3
This update corrects a typo in a function call to the _syslog()_ function.  The SEVERITY parameter was indavertently included within the quotation marks of the message string, so _syslog()_ complains about receiving only one parameter when it expects two.

**New Features:**
None

**Bug Fixes:**
1.  PHP warning message generated when signalling Suricata to live-reload its configuration via the GUI.
