### PR TITLE
Replace \r\n EOL values on openVPN tls key with proper EOL values during openvpn-client-export

### DIFF
--- a/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
+++ b/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
@@ -468,7 +468,7 @@ EOF;
 					$tls_keydir = "key-direction 1{$nl}";
 				}
 				$conf .= $tls_keydir;
-				$conf .= "<{$tls_directive}>{$nl}" . trim(base64_decode($settings['tls'])) . "{$nl}</{$tls_directive}>{$nl}";
+				$conf .= "<{$tls_directive}>{$nl}" . trim(str_replace("\r\n",$nl,base64_decode($settings['tls']))) . "{$nl}</{$tls_directive}>{$nl}";
 			}
 			return $conf;
 		// "yealink" creates: "/client.tar"


### PR DESCRIPTION
It looks like when the openVPN server is created the TLS key has EOL values of "\r\n", this causes the following error when trying to import the file into openVPN on ios.

**Failed to import profile**
Failed to import OVPN profile from selected
file.Profile import failed : line too long

after investigating I found that the TLS Key had the wrong EOL delimiters. Changing this in the export fixed the issue with importing these files into ios.

As it appears this is the default value for these I put in a generic replace if you feel the values should be tested before replacing, then a more robust fix will need to be created. Please let me know. PHP is not my first language so I tried to keep the changes simple.