### PR TITLE
pfSense-pkg-suricata-4.1.4_4 -- Bug Fix Update

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.1.4
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -104,7 +104,7 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 				// Truncate the log file if it exists
 				if (file_exists("{$suricata_log_dir}/{$file}")) {
 					try {
-						file_put_contents("{$suricata_log_dir}/{$file}", "");
+						fclose(fopen("{$suricata_log_dir}/{$file}", 'w'));
 					} catch (Exception $e) {
 						syslog(LOG_ERR, "[Suricata] ERROR: Failed to truncate file '{$suricata_log_dir}/{$file}' -- error was {$e->getMessage()}");
 					}
@@ -123,7 +123,11 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 		// Truncate the Rules Update Log file if it exists
 		if (file_exists(SURICATA_RULES_UPD_LOGFILE)) {
 			syslog(LOG_NOTICE, gettext("[Suricata] Truncating the Rules Update Log file..."));
-			@file_put_contents(SURICATA_RULES_UPD_LOGFILE, "");
+			try {
+				fclose(fopen(SURICATA_RULES_UPD_LOGFILE, 'w'));
+			} catch (Exception $e) {
+				syslog(LOG_ERR, "[Suricata] ERROR: Failed to truncate Rules Update Log '" . SURICATA_RULES_UPD_LOGFILE . "' -- error was {$e->getMessage()}");
+			}
 		}
 
 		cleanupExit:
@@ -160,8 +164,8 @@ function suricata_check_rotate_log($log_file, $log_limit, $retention) {
 	if (($log_limit > 0) && (filesize($log_file) >= $log_limit)) {
 		$newfile = $log_file . "." . date('Y_md_Hi');
 		try {
-			copy($log_file, $newfile);
-			file_put_contents($log_file, "");
+			rename($log_file, $newfile);
+			touch($log_file);
 		} catch (Exception $e) {
 			syslog(LOG_ERR, "[Suricata] ERROR: Failed to rotate file '{$log_file}' -- error was {$e->getMessage()}");
 		}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -104,7 +104,7 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 				// Truncate the log file if it exists
 				if (file_exists("{$suricata_log_dir}/{$file}")) {
 					try {
-						file_put_contents("{$suricata_log_dir}/{$file}", "");
+						fclose(fopen("{$suricata_log_dir}/{$file}", 'w'));
 					} catch (Exception $e) {
 						syslog(LOG_ERR, "[Suricata] ERROR: Failed to truncate file '{$suricata_log_dir}/{$file}' -- error was {$e->getMessage()}");
 					}
@@ -123,7 +123,11 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 		// Truncate the Rules Update Log file if it exists
 		if (file_exists(SURICATA_RULES_UPD_LOGFILE)) {
 			syslog(LOG_NOTICE, gettext("[Suricata] Truncating the Rules Update Log file..."));
-			@file_put_contents(SURICATA_RULES_UPD_LOGFILE, "");
+			try {
+				fclose(fopen(SURICATA_RULES_UPD_LOGFILE, 'w'));
+			} catch (Exception $e) {
+				syslog(LOG_ERR, "[Suricata] ERROR: Failed to truncate Rules Update Log '" . SURICATA_RULES_UPD_LOGFILE . "' -- error was {$e->getMessage()}");
+			}
 		}
 
 		cleanupExit:
@@ -160,8 +164,8 @@ function suricata_check_rotate_log($log_file, $log_limit, $retention) {
 	if (($log_limit > 0) && (filesize($log_file) >= $log_limit)) {
 		$newfile = $log_file . "." . date('Y_md_Hi');
 		try {
-			copy($log_file, $newfile);
-			file_put_contents($log_file, "");
+			rename($log_file, $newfile);
+			touch($log_file);
 		} catch (Exception $e) {
 			syslog(LOG_ERR, "[Suricata] ERROR: Failed to rotate file '{$log_file}' -- error was {$e->getMessage()}");
 		}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
@@ -74,22 +74,18 @@ if ($config['installedpackages']['suricata']['config'][0]['clearlogs'] == 'on') 
 
 /*********************************************************/
 /* Remove files we placed in the Suricata directories.   */
-/* pkgng will clean up the base install files.           */
+/* pkg will clean up the base install files.             */
 /*********************************************************/
 unlink_if_exists("{$suricatadir}*.gz.md5");
 unlink_if_exists("{$suricatadir}gen-msg.map");
-unlink_if_exists("{$suricatadir}unicode.map");
 unlink_if_exists("{$suricatadir}classification.config");
 unlink_if_exists("{$suricatadir}reference.config");
-unlink_if_exists("{$suricatadir}rules/*.txt");
-unlink_if_exists("{$suricatadir}rules/" . VRT_FILE_PREFIX . "*.rules");
-unlink_if_exists("{$suricatadir}rules/" . ET_OPEN_FILE_PREFIX . "*.rules");
-unlink_if_exists("{$suricatadir}rules/" . ET_PRO_FILE_PREFIX . "*.rules");
-unlink_if_exists("{$suricatadir}rules/" . GPL_FILE_PREFIX . "*.rules");
-unlink_if_exists(SURICATA_RULES_DIR . "*.rules");
 unlink_if_exists(SURICATA_RULES_DIR . "*.txt");
+unlink_if_exists(SURICATA_RULES_DIR . VRT_FILE_PREFIX . "*.rules");
+unlink_if_exists(SURICATA_RULES_DIR . ET_OPEN_FILE_PREFIX . "*.rules");
+unlink_if_exists(SURICATA_RULES_DIR . ET_PRO_FILE_PREFIX . "*.rules");
+unlink_if_exists(SURICATA_RULES_DIR . GPL_FILE_PREFIX . "*.rules");
 unlink_if_exists("/usr/local/share/suricata/GeoLite2/GeoLite2-Country.mmdb");
-rmdir_recursive(SURICATA_RULES_DIR);
 rmdir_recursive("/usr/local/share/suricata/GeoLite2");
 
 if (is_array($config['installedpackages']['suricata']['rule'])) {


### PR DESCRIPTION
### pfSense-pkg-suricata-4.1.4_4
This update corrects one bug (Redmine Issue [#9581](https://redmine.pfsense.org/issues/9581)) and enhances an existing feature.

**Changes Log:**
1.  Replace copy and empty string file write calls with more efficient rename/touch calls in the log rotation code within the Log Management cron task code.

**New Features:**
None

**Bug Fixes:**
1.  Upgrade of Suricata GUI package removes default Suricata _*-events.rules_ files installed by the base Suricata binary package.  Redmine issue [#9581](https://redmine.pfsense.org/issues/9581).
