### PR TITLE
pfSense-pkg-snort-4.0_2 -- Bug fix and feature update

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.0
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -3,9 +3,9 @@
  * snort.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2018 Bill Meeks
+ * Copyright (c) 2013-2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -511,7 +511,7 @@ function snort_barnyard_stop($snortcfg, $if_real) {
 	global $config, $g;
 
 	if (isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}.pid")) {
-		log_error("[Snort] Barnyard2 STOP for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
+		syslog(LOG_NOTICE, "[Snort] Barnyard2 STOP for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
 		killbypid("{$g['varrun_path']}/barnyard2_{$if_real}.pid");
 
 		// Now wait up to 5 seconds for Barnyard2 to actually stop and clear its PID file
@@ -530,7 +530,7 @@ function snort_stop($snortcfg, $if_real) {
 	global $config, $g;
 
 	if (isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid")) {
-		log_error("[Snort] Snort STOP for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
+		syslog(LOG_NOTICE, "[Snort] Snort STOP for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
 		killbypid("{$g['varrun_path']}/snort_{$if_real}.pid");
 
 		// Now wait up to 10 seconds for Snort to actually stop and clear its PID file
@@ -556,7 +556,7 @@ function snort_barnyard_start($snortcfg, $if_real, $background=FALSE) {
 	$snortbindir = SNORT_PBI_BINDIR;
 
 	if ($snortcfg['barnyard_enable'] == 'on' && !isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}.pid")) {
-		log_error("[Snort] Barnyard2 START for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
+		syslog(LOG_NOTICE, "[Snort] Barnyard2 START for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
 		if ($background)
 			mwexec_bg("{$snortbindir}barnyard2 -f \"snort_{$snort_uuid}_{$if_real}.u2\" --pid-path {$g['varrun_path']} --nolock-pidfile -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/barnyard2.conf -d {$snortlogdir}/snort_{$if_real}{$snort_uuid} -D -q");
 	else
@@ -589,7 +589,7 @@ function snort_start($snortcfg, $if_real, $background=FALSE) {
 			$daq_type = "--daq pcap --daq-mode passive --treat-drop-as-alert";
 		}
 
-		log_error("[Snort] Snort START for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
+		syslog(LOG_NOTICE, "[Snort] Snort START for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
 		if ($background)
 			mwexec_bg("{$snortbindir}snort -R _{$if_real} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface}");
 		else
@@ -677,7 +677,7 @@ function snort_reload_config($snortcfg, $signal="SIGHUP") {
 	/* can find a valid PID for the process.              */
 	/******************************************************/
 	if (isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid")) {
-		log_error("[Snort] Snort RELOAD CONFIG for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
+		syslog(LOG_NOTICE, "[Snort] Snort RELOAD CONFIG for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
 		mwexec_bg("/bin/pkill -{$signal} -F {$g['varrun_path']}/snort_{$if_real}.pid");
 	}
 }
@@ -704,7 +704,7 @@ function snort_barnyard_reload_config($snortcfg, $signal="HUP") {
 	/* we can find a valid PID for the process.           */
 	/******************************************************/
 	if (isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}.pid")) {
-		log_error("[Snort] Barnyard2 CONFIG RELOAD initiated for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
+		syslog(LOG_NOTICE, "[Snort] Barnyard2 CONFIG RELOAD initiated for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
 		mwexec_bg("/bin/pkill -{$signal} -F {$g['varrun_path']}/barnyard2_{$if_real}.pid");
 	}
 }
@@ -1687,7 +1687,7 @@ function snort_resolve_flowbits($rules, $active_rules) {
 
 	/* Check $rules array to be sure it is filled.    */
 	if (empty($rules)) {
-		log_error(gettext("[Snort] WARNING: Flowbit resolution not done - no rules in {$snortdir}/rules/ ..."));
+		syslog(LOG_WARN, gettext("[Snort] WARNING: Flowbit resolution not done - no rules in {$snortdir}/rules/ ..."));
 		return array();
 	}
 
@@ -1932,7 +1932,7 @@ function snort_parse_sidconf_file($sidconf_file,$split_lines=TRUE) {
 	// we can read like a normal file.
 	$fd = fopen("php://temp", "r+");
 	if ($fd == FALSE) {
-		log_error("[Snort] Failed to open SID MGMT list '{$sidconf_file}' for processing.");
+		syslog(LOG_ERR, "[Snort] Failed to open SID MGMT list '{$sidconf_file}' for processing.");
 		return $sid_mods;
 	}
 	fwrite($fd, base64_decode($list['content']));
@@ -2042,7 +2042,7 @@ function snort_process_dropsid(&$rule_map, $snortcfg, $log_results = FALSE, $log
 
 	// Verify the 'drop_sid' list for the interface exists
 	if (!snort_sid_mgmt_list_exist($snortcfg['drop_sid_file'])) {
-		log_error(gettext("[Snort] Error - unable to find drop_sid list \"{$snortcfg['drop_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+		syslog(LOG_ERR, gettext("[Snort] Error - unable to find drop_sid list \"{$snortcfg['drop_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 		return;
 	} else {
 		$sid_mods = snort_parse_sidconf_file($snortcfg['drop_sid_file']);
@@ -2089,7 +2089,7 @@ function snort_process_rejectsid(&$rule_map, $snortcfg, $log_results = FALSE, $l
 
 	// Verify the 'reject_sid' list for the interface exists
 	if (!snort_sid_mgmt_list_exist($snortcfg['reject_sid_file'])) {
-		log_error(gettext("[Snort] Error - unable to find reject_sid list \"{$snortcfg['reject_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+		syslog(LOG_ERR, gettext("[Snort] Error - unable to find reject_sid list \"{$snortcfg['reject_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 		return;
 	} else {
 		$sid_mods = snort_parse_sidconf_file($snortcfg['reject_sid_file']);
@@ -2174,7 +2174,7 @@ function snort_sid_mgmt_auto_categories($snortcfg, $log_results = FALSE) {
 				// Attempt to open the 'disable_sid_file' for the interface
 				// Verify the assigned SID Mgmt List still exists in the firewall configuration
 				if (!snort_sid_mgmt_list_exist($snortcfg['disable_sid_file'])) {
-					log_error(gettext("[Snort] Error - unable to open disable_sid list \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+					syslog(LOG_ERR, gettext("[Snort] Error - unable to open disable_sid list \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 					if ($log_results == TRUE) {
 						error_log(gettext("Unable to find disable_sid list \"{$snortcfg['disable_sid_file']}\".\n"), 3, $log_file);
 					}
@@ -2194,7 +2194,7 @@ function snort_sid_mgmt_auto_categories($snortcfg, $log_results = FALSE) {
 
 				// Attempt to open the 'enable_sid_file' for the interface
 				if (!snort_sid_mgmt_list_exist($snortcfg['enable_sid_file'])) {
-					log_error(gettext("[snort] Error - unable to open enable_sid list \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+					syslog(LOG_ERR, gettext("[snort] Error - unable to open enable_sid list \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 					if ($log_results == TRUE) {
 						error_log(gettext("Unable to find enable_sid list \"{$snortcfg['enable_sid_file']}\".\n"), 3, $log_file);
 					}
@@ -2217,7 +2217,7 @@ function snort_sid_mgmt_auto_categories($snortcfg, $log_results = FALSE) {
 
 				// Attempt to open the 'enable_sid_file' for the interface
 				if (!snort_sid_mgmt_list_exist($snortcfg['enable_sid_file'])) {
-					log_error(gettext("[Snort] Error - unable to find enable_sid list \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+					syslog(LOG_ERR, gettext("[Snort] Error - unable to find enable_sid list \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 					if ($log_results == TRUE) {
 						error_log(gettext("Unable to open enable_sid list \"{$snortcfg['enable_sid_file']}\".\n"), 3, $log_file);
 					}
@@ -2238,7 +2238,7 @@ function snort_sid_mgmt_auto_categories($snortcfg, $log_results = FALSE) {
 
 				// Attempt to open the 'disable_sid_file' for the interface
 				if (!snort_sid_mgmt_list_exist($snortcfg['disable_sid_file'])) {
-					log_error(gettext("[Snort] Error - unable to open disable_sid list \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+					syslog(LOG_ERR, gettext("[Snort] Error - unable to open disable_sid list \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 					if ($log_results == TRUE) {
 						error_log(gettext("Unable to find disable_sid list \"{$snortcfg['disable_sid_file']}\".\n"), 3, $log_file);
 					}
@@ -2256,7 +2256,7 @@ function snort_sid_mgmt_auto_categories($snortcfg, $log_results = FALSE) {
 			break;
 
 		default:
-			log_error(gettext("[Snort] Unrecognized 'sid_state_order' value.  Skipping auto CATEGORY mgmt step for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+			syslog(LOG_ALERT, gettext("[Snort] Unrecognized 'sid_state_order' value.  Skipping auto CATEGORY mgmt step for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 			if ($log_results == TRUE) {
 				error_log(gettext("ERROR: unrecognized 'sid_state_order' value.  Skipping auto CATEGORY mgmt step for ") . convert_friendly_interface_to_friendly_descr($snortcfg['interface']). ".\n", 3, $log_file);
 			}
@@ -2457,7 +2457,7 @@ function snort_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results = F
 			break;
 
 		default:
-			log_error(gettext("[Snort] Error - unknown action '{$action}' supplied to snort_modify_sid_state() function...no SIDs modified."));
+			syslog(LOG_ALERT, gettext("[Snort] Error - unknown action '{$action}' supplied to snort_modify_sid_state() function...no SIDs modified."));
 			return $sids;
 	}
 
@@ -2730,7 +2730,7 @@ function snort_process_enablesid(&$rule_map, $snortcfg, $log_results = FALSE, $l
 
 	// Verify the 'enable_sid' list for the interface exists
 	if (!snort_sid_mgmt_list_exist($snortcfg['enable_sid_file'])) {
-		log_error(gettext("[Snort] Error - unable to find enable_sid list \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+		syslog(LOG_ERR, gettext("[Snort] Error - unable to find enable_sid list \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 		return;
 	}
 	else
@@ -2776,7 +2776,7 @@ function snort_process_disablesid(&$rule_map, $snortcfg, $log_results = FALSE, $
 
 	// Verify the 'disable_sid' list for the interface exists
 	if (!snort_sid_mgmt_list_exist($snortcfg['disable_sid_file'])) {
-		log_error(gettext("[Snort] Error - unable to find disable_sid list \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+		syslog(LOG_ERR, gettext("[Snort] Error - unable to find disable_sid list \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 		return;
 	}
 	else {
@@ -2823,7 +2823,7 @@ function snort_process_modifysid(&$rule_map, $snortcfg, $log_results = FALSE, $l
 
 	// Verify the 'modify_sid' list for the interface exists
 	if (!snort_sid_mgmt_list_exist($snortcfg['modify_sid_file'])) {
-		log_error(gettext("[Snort] Error - unable to find modify_sid list \"{$snortcfg['modify_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+		syslog(LOG_ERR, gettext("[Snort] Error - unable to find modify_sid list \"{$snortcfg['modify_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 		return;
 	} else {
 		$sid_mods = snort_parse_sidconf_file($snortcfg['modify_sid_file'],FALSE);
@@ -2945,7 +2945,7 @@ function snort_auto_sid_mgmt(&$rule_map, $snortcfg, $log_results = FALSE) {
 				break;
 
 			default:
-				log_error(gettext("[Snort] Unrecognized 'sid_state_order' value.  Skipping auto SID mgmt step for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+				syslog(LOG_ALERT, gettext("[Snort] Unrecognized 'sid_state_order' value.  Skipping auto SID mgmt step for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 				if ($log_results == TRUE) {
 					error_log(gettext("ERROR: unrecognized 'sid_state_order' value.  Skipping auto SID mgmt step for ") . convert_friendly_interface_to_friendly_descr($snortcfg['interface']). ".\n", 3, $log_file);
 				}
@@ -3555,7 +3555,7 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 		return;
 
 	/* Log a message for rules rebuild in progress */
-	log_error(gettext("[Snort] Updating rules configuration for: " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . " ..."));
+	syslog(LOG_NOTICE, gettext("[Snort] Updating rules configuration for: " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . " ..."));
 
 	// Get any automatic rule category enable/disable modifications
 	// if auto-SID Mgmt is enabled and conf files exist for the interface.
@@ -3683,7 +3683,7 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 		/* Check for and disable any rules dependent upon disabled preprocessors if  */
 		/* this option is enabled for the interface.                                 */
 		if ($snortcfg['preproc_auto_rule_disable'] == "on") {
-			log_error('[Snort] Checking for rules dependent on disabled preprocessors for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
+			syslog(LOG_NOTICE, '[Snort] Checking for rules dependent on disabled preprocessors for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
 			snort_filter_preproc_rules($snortcfg, $enabled_rules);
 		}
 
@@ -3692,7 +3692,7 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 
 		/* If auto-flowbit resolution is enabled, generate the dependent flowbits rules file. */
 		if ($snortcfg['autoflowbitrules'] == 'on') {
-			log_error('[Snort] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
+			syslog(LOG_NOTICE, '[Snort] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
 			$fbits = snort_resolve_flowbits($all_rules, $enabled_rules);
 
 			/* Check for and disable any flowbit-required rules the user has  */
@@ -3702,7 +3702,7 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 			/* Check for and disable any flowbit-required rules dependent upon     */
 			/* disabled preprocessors if this option is enabled for the interface. */
 			if ($snortcfg['preproc_auto_rule_disable'] == "on") {
-				log_error('[Snort] Checking flowbit rules dependent on disabled preprocessors for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
+				syslog(LOG_NOTICE, '[Snort] Checking flowbit rules dependent on disabled preprocessors for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
 				snort_filter_preproc_rules($snortcfg, $fbits, true);
 			}
 			snort_write_flowbit_rules_file($fbits, "{$snortcfgdir}/rules/{$flowbit_rules_file}");
@@ -3725,7 +3725,7 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 
 		// If auto-flowbit resolution is enabled, generate the dependent flowbits rules file.
 		if ($snortcfg['autoflowbitrules'] == 'on') {
-			log_error('[Snort] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
+			syslog(LOG_NOTICE, '[Snort] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
 
 			// Load up all rules into a Rules Map array for flowbits assessment
 			$all_rules = snort_load_rules_map("{$snortdir}/rules/");
@@ -3754,7 +3754,7 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 
 	/* Build a new sid-msg.map file from the enabled */
 	/* rules and copy it to the interface directory. */
-	log_error(gettext("[Snort] Building new sid-msg.map file for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . "..."));
+	syslog(LOG_NOTICE, gettext("[Snort] Building new sid-msg.map file for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . "..."));
 	snort_build_sid_msg_map("{$snortcfgdir}/rules/", "{$snortcfgdir}/sid-msg.map");
 }
 
@@ -3892,7 +3892,7 @@ function snort_filter_preproc_rules($snortcfg, &$active_rules, $persist_log = fa
 	/* than optimal with the preprocessors disabled.   */
 	/***************************************************/
 	if ($disabled_count > 0) {
-		log_error(gettext("[Snort] Warning: auto-disabled {$disabled_count} rules due to disabled preprocessor dependencies."));
+		syslog(LOG_WARN, gettext("[Snort] Warning: auto-disabled {$disabled_count} rules due to disabled preprocessor dependencies."));
 		natcasesort($log_msg);
 		if ($fp) {
 			/* Only write the header when not persisting the log */
@@ -3917,7 +3917,7 @@ function snort_filter_preproc_rules($snortcfg, &$active_rules, $persist_log = fa
 				@fwrite($fp, sprintf("%-30s  %-10s  %-20s  %s", $tmp[0], $tmp[1], $tmp[2], $tmp[3]) . "\n");
 			}
 		}
-		log_error(gettext("[Snort] See '{$file}' for list of auto-disabled rules."));
+		syslog(LOG_NOTICE, gettext("[Snort] See '{$file}' for list of auto-disabled rules."));
 		unset($log_msg);
 	}
 	if ($fp)
@@ -4015,7 +4015,7 @@ function snort_remove_dead_rules() {
 	}
 
 	// Log how many obsoleted files were removed
-	log_error(gettext("[Snort] Removed {$count} obsoleted rules category files."));
+	syslog(LOG_NOTICE, gettext("[Snort] Removed {$count} obsoleted rules category files."));
 
 	// Now remove any dead rules files from the interface configurations
 	if (!empty($cats) && is_array($config['installedpackages']['snortglobal']['rule'])) {
@@ -4041,7 +4041,7 @@ function snort_sync_on_changes() {
 
 	/* Do not attempt a package sync while booting up or installing package */
 	if ($g['booting'] || $g['snort_postinstall']) {
-		log_error("[snort] Skipping XMLRPC sync when booting up or during package reinstallation.");
+		syslog(LOG_NOTICE, "[snort] Skipping XMLRPC sync when booting up or during package reinstallation.");
 		return;
 	}
 
@@ -4055,7 +4055,7 @@ function snort_sync_on_changes() {
 				if (is_array($snort_sync['row'])){
 					$rs=$snort_sync['row'];
 				} else {
-					log_error("[snort] XMLRPC sync is enabled but there are no hosts configured as replication targets.");
+					syslog(LOG_NOTICE, "[snort] XMLRPC sync is enabled but there are no hosts configured as replication targets.");
 					return;
 				}
 				break;
@@ -4076,13 +4076,13 @@ function snort_sync_on_changes() {
 						$rs[0]['varsyncport'] = $config['system']['webgui']['port'] ?: '443';
 					}
 					if ($system_carp['synchronizetoip'] == "") {
-						log_error("[snort] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+						syslog(LOG_NOTICE, "[snort] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
 						return;
 					} else {
 						$rs[0]['varsyncdestinenable'] = TRUE;
 					}
 				} else {
-					log_error("[snort] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+					syslog(LOG_NOTICE, "[snort] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
 					return;
 				}
 				break;			
@@ -4091,7 +4091,7 @@ function snort_sync_on_changes() {
 				break;
 		}
 		if (is_array($rs)){
-			log_error("[snort] XMLRPC sync is starting.");
+			syslog(LOG_NOTICE, "[snort] XMLRPC sync is starting.");
 			foreach ($rs as $sh){
 				// Only sync enabled replication targets
 				if ($sh['varsyncdestinenable']) {
@@ -4122,11 +4122,11 @@ function snort_sync_on_changes() {
 					if ($success) {
 						snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol, $username, $password, $synctimeout, $syncstartsnort);
 					} else {
-						log_error("[snort] XMLRPC sync with '{$sync_to_ip}' aborted due to the following error(s): {$error}");
+						syslog(LOG_ERR, "[snort] XMLRPC sync with '{$sync_to_ip}' aborted due to the following error(s): {$error}");
 					}
 				}
 			}
-			log_error("[snort] XMLRPC sync completed.");
+			syslog(LOG_NOTICE, "[snort] XMLRPC sync completed.");
 		}
  	}
 }
@@ -4143,12 +4143,12 @@ function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol,
 
 	/* Do not attempt a package sync while booting up or installing package */
 	if ($g['booting'] || isset($g['snort_postinstall'])) {
-		log_error("[snort] Skipping XMLRPC sync when booting up or during package reinstallation.");
+		syslog(LOG_NOTICE, "[snort] Skipping XMLRPC sync when booting up or during package reinstallation.");
 		return;
 	}
 
 	if ($username == "" || $password == "" || $sync_to_ip == "" || $port == "" || $protocol == "") {
-		log_error("[snort] A required XMLRPC sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
+		syslog(LOG_ERR, "[snort] A required XMLRPC sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
 		return;
 	}
 
@@ -4161,17 +4161,17 @@ function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol,
 	
 	$downloadrulescmd = "";
 	if ($syncdownloadrules == "yes") {
-		$downloadrulescmd = "log_error(gettext(\"[snort] XMLRPC pkg sync: Update of downloaded rule sets requested...\"));\n";
+		$downloadrulescmd = "syslog(LOG_NOTICE, gettext(\"[snort] XMLRPC pkg sync: Update of downloaded rule sets requested...\"));\n";
 		$downloadrulescmd .= "\tinclude_once(\"/usr/local/pkg/snort/snort_check_for_rule_updates.php\");\n";
 	}
 	$snortstart = "";
 	if ($syncstartsnort == "ON") {
-		$snortstart = "log_error(gettext(\"[snort] XMLRPC pkg sync: Checking Snort status...\"));\n";
+		$snortstart = "syslog(LOG_NOTICE, gettext(\"[snort] XMLRPC pkg sync: Checking Snort status...\"));\n";
 		$snortstart .= "\tif (!is_process_running(\"snort\")) {\n";
-		$snortstart .= "\t\tlog_error(gettext(\"[snort] XMLRPC pkg sync: Snort not running. Sending a start command...\"));\n";
+		$snortstart .= "\t\tsyslog(LOG_NOTICE, gettext(\"[snort] XMLRPC pkg sync: Snort not running. Sending a start command...\"));\n";
 		$snortstart .= "\t\t\$sh_script = RCFILEPREFIX . \"snort.sh\";\n";
 		$snortstart .= "\t\tmwexec_bg(\"{\$sh_script} start\");\n\t}\n";
-		$snortstart .= "\telse {\n\t\tlog_error(gettext(\"[snort] XMLRPC pkg sync: Snort is running...\"));\n\t}\n";
+		$snortstart .= "\telse {\n\t\tsyslog(LOG_NOTICE, gettext(\"[snort] XMLRPC pkg sync: Snort is running...\"));\n\t}\n";
 	}
 
 	/*************************************************/
@@ -4191,12 +4191,12 @@ function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol,
 	\$pkg_interface = "console";
 	{$downloadrulescmd}
 	unset(\$g["snort_postinstall"]);
-	log_error(gettext("[snort] XMLRPC pkg sync: Generating snort.conf file using Master Host settings..."));
+	syslog(LOG_NOTICE, gettext("[snort] XMLRPC pkg sync: Generating snort.conf file using Master Host settings..."));
 	\$rebuild_rules = true;
 	sync_snort_package_config();
 	\$rebuild_rules = false;
 	{$snortstart}
-	log_error(gettext("[snort] XMLRPC pkg sync process on this host is complete..."));
+	syslog(LOG_NOTICE, gettext("[snort] XMLRPC pkg sync process on this host is complete..."));
 	\$pkg_interface = \$orig_pkg_interface;
 	unset(\$g["snort_sync_in_progress"]);
 	return true;
@@ -4272,7 +4272,7 @@ EOD;
 			$method = 'pfsense.exec_php';
 			$params = array( XML_RPC_encode($password), XML_RPC_encode($payload) );
 
-			log_error("[snort] XMLRPC sync sending auto-SID conf files to {$url}:{$port}.");
+			syslog(LOG_NOTICE, "[snort] XMLRPC sync sending auto-SID conf files to {$url}:{$port}.");
 			$msg = new XML_RPC_Message($method, $params);
 			$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 			$cli->setCredentials($username, $password);
@@ -4280,17 +4280,17 @@ EOD;
 			$error = "";
 			if (!$resp) {
 				$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
-				log_error($error);
+				syslog(LOG_ERR, $error);
 				file_notice("sync_settings", $error, "Snort Settings Sync", "");
 			} elseif ($resp->faultCode()) {
 				$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
-				log_error($error);
+				syslog(LOG_ERR, $error);
 				file_notice("sync_settings", $error, "Snort Settings Sync", "");
 			}
 		}
 
 		if (!empty($sid_files) && $error == "") {
-			log_error("[snort] XMLRPC sync auto-SID conf files success with {$url}:{$port} (pfsense.exec_php).");
+			syslog(LOG_NOTICE, "[snort] XMLRPC sync auto-SID conf files success with {$url}:{$port} (pfsense.exec_php).");
 		}
 
 		/*************************************************/
@@ -4305,7 +4305,7 @@ EOD;
 			$method = 'pfsense.exec_php';
 			$params = array( XML_RPC_encode($password), XML_RPC_encode($payload) );
 
-			log_error("[snort] Snort XMLRPC sync sending IPREP files to {$url}:{$port}.");
+			syslog(LOG_NOTICE, "[snort] Snort XMLRPC sync sending IPREP files to {$url}:{$port}.");
 			$msg = new XML_RPC_Message($method, $params);
 			$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 			$cli->setCredentials($username, $password);
@@ -4313,17 +4313,17 @@ EOD;
 			$error = "";
 			if (!$resp) {
 				$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
-				log_error($error);
+				syslog(LOG_ERR, $error);
 				file_notice("sync_settings", $error, "Snort Settings Sync", "");
 			} elseif ($resp->faultCode()) {
 				$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
-				log_error($error);
+				syslog(LOG_ERR, $error);
 				file_notice("sync_settings", $error, "Snort Settings Sync", "");
 			}
 		}
 
 		if (!empty($iprep_files) && $error == "") {
-			log_error("[snort] XMLRPC sync IPREP files success with {$url}:{$port} (pfsense.exec_php).");
+			syslog(LOG_ERR, "[snort] XMLRPC sync IPREP files success with {$url}:{$port} (pfsense.exec_php).");
 		}
 
 		/* assemble xmlrpc payload */
@@ -4332,7 +4332,7 @@ EOD;
 			XML_RPC_encode($xml)
 		);
 
-		log_error("[snort] Beginning package configuration XMLRPC sync to {$url}:{$port}.");
+		syslog(LOG_NOTICE, "[snort] Beginning package configuration XMLRPC sync to {$url}:{$port}.");
 		$method = 'pfsense.merge_installedpackages_section_xmlrpc';
 		$msg = new XML_RPC_Message($method, $params);
 		$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
@@ -4342,14 +4342,14 @@ EOD;
 		$resp = $cli->send($msg, $synctimeout);
 		if (!$resp) {
 			$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port}.";
-			log_error($error);
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Snort Settings Sync", "");
 		} elseif ($resp->faultCode()) {
 			$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-			log_error($error);
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Snort Settings Sync", "");
 		} else {
-			log_error("[snort] Package configuration XMLRPC sync successfully completed with {$url}:{$port}.");
+			syslog(LOG_NOTICE, "[snort] Package configuration XMLRPC sync successfully completed with {$url}:{$port}.");
 		}
 
 		/* assemble xmlrpc payload */
@@ -4359,40 +4359,40 @@ EOD;
 			XML_RPC_encode($execcmd)
 		);
 
-		log_error("[snort] XMLRPC sync sending reload configuration cmd set as a file to {$url}:{$port}.");
+		syslog(LOG_NOTICE, "[snort] XMLRPC sync sending reload configuration cmd set as a file to {$url}:{$port}.");
 		$msg = new XML_RPC_Message($method, $params);
 		$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 		$cli->setCredentials($username, $password);
 		$resp = $cli->send($msg, $synctimeout);
 		if (!$resp) {
 			$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
-			log_error($error);
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Snort Settings Sync", "");
 		} elseif ($resp->faultCode()) {
 			$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-			log_error($error);
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Snort Settings Sync", "");
 		} else {
-			log_error("[snort] XMLRPC sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
+			syslog(LOG_NOTICE, "[snort] XMLRPC sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
 		}
 
 		$params2 = array(
 			XML_RPC_encode($password),
 			XML_RPC_encode($execcmd2)
 		);
-		log_error("[snort] XMLRPC sync sending {$url}:{$port} cmd to execute configuration reload.");
+		syslog(LOG_NOTICE, "[snort] XMLRPC sync sending {$url}:{$port} cmd to execute configuration reload.");
 		$msg2 = new XML_RPC_Message($method, $params2);
 		$resp = $cli->send($msg2, $synctimeout);
 		if (!$resp) {
 			$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
-			log_error($error);
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Snort Settings Sync", "");
 		} elseif ($resp->faultCode()) {
 			$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-			log_error($error);
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Snort Settings Sync", "");
 		} else {
-			log_error("[snort] XMLRPC sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
+			syslog(LOG_NOTICE, "[snort] XMLRPC sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
 		}
 	}
 }

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_cron_misc.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_cron_misc.inc
@@ -44,11 +44,11 @@ function snort_check_dir_size_limit($snortloglimitsize) {
 	$snortloglimitsizeKB = round($snortloglimitsize * 1024);
 	$snortlogdirsizeKB = snort_Getdirsize(SNORTLOGDIR);
 	if ($snortlogdirsizeKB > 0 && $snortlogdirsizeKB > $snortloglimitsizeKB) {
-		log_error(gettext("[Snort] Log directory size exceeds configured limit of " . number_format($snortloglimitsize) . " MB set on Global Settings tab. All Snort log files will be truncated."));
+		syslog(LOG_NOTICE, gettext("[Snort] Log directory size exceeds configured limit of " . number_format($snortloglimitsize) . " MB set on Global Settings tab. All Snort log files will be truncated."));
 
 		// Truncate the Rules Update Log file if it exists
 		if (file_exists(SNORT_RULES_UPD_LOGFILE)) {
-			log_error(gettext("[Snort] Truncating the Rules Update Log file..."));
+			syslog(LOG_NOTICE, gettext("[Snort] Truncating the Rules Update Log file..."));
 			@file_put_contents(SNORT_RULES_UPD_LOGFILE, "");
 		}
 
@@ -57,7 +57,7 @@ function snort_check_dir_size_limit($snortloglimitsize) {
 			$if_real = get_real_interface($value['interface']);
 			$snort_uuid = $value['uuid'];
 			$snort_log_dir = SNORTLOGDIR . "/snort_{$if_real}{$snort_uuid}";
-			log_error(gettext("[Snort] Truncating logs for {$value['descr']} ({$if_real})..."));
+			syslog(LOG_NOTICE, gettext("[Snort] Truncating logs for {$value['descr']} ({$if_real})..."));
 			snort_post_delete_logs($snort_uuid);
 
 			// Truncate the alert log file if it exists
@@ -65,7 +65,7 @@ function snort_check_dir_size_limit($snortloglimitsize) {
 				try {
 					fclose(fopen("{$snort_log_dir}/alert", 'w'));
 				} catch (Exception $e) {
-					log_error(gettext("[Snort] ERROR: Failed to truncate file '{$snort_log_dir}/alert' -- error was {$e->getMessage()}"));
+					syslog(LOG_ERR, gettext("[Snort] ERROR: Failed to truncate file '{$snort_log_dir}/alert' -- error was {$e->getMessage()}"));
 				}
 			}
 
@@ -89,11 +89,11 @@ function snort_check_dir_size_limit($snortloglimitsize) {
 
 			// Soft-restart Snort process to resync logging
 			if (file_exists("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid")) {
-				log_error(gettext("[Snort] Restarting logging on {$value['descr']} ({$if_real})..."));
+				syslog(LOG_NOTICE, gettext("[Snort] Restarting logging on {$value['descr']} ({$if_real})..."));
 				mwexec("/bin/pkill -HUP -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid -a");
 			}
 		}
-		log_error(gettext("[Snort] Automatic clean-up of Snort logs completed."));
+		syslog(LOG_NOTICE, gettext("[Snort] Automatic clean-up of Snort logs completed."));
 	}
 }
 
@@ -127,7 +127,7 @@ function snort_check_rotate_log($log_file, $log_limit, $retention) {
 			rename($log_file, $newfile);
 			touch($log_file);
 		} catch (Exception $e) {
-			log_error("[Snort] Failed to rotate file '{$log_file}' -- error was {$e->getMessage()}");
+			syslog(LOG_ERR, "[Snort] Failed to rotate file '{$log_file}' -- error was {$e->getMessage()}");
 		}
 	}
 
@@ -194,7 +194,7 @@ if ($config['installedpackages']['snortglobal']['enable_log_mgmt'] == 'on') {
 			}
 			unset($rotated_files);
 			if ($prune_count > 0)
-				log_error(gettext("[Snort] Alert pcap file cleanup job removed {$prune_count} pcap file(s) from {$snort_log_dir}/..."));
+				syslog(LOG_NOTICE, gettext("[Snort] Alert pcap file cleanup job removed {$prune_count} pcap file(s) from {$snort_log_dir}/..."));
 		}
 
 		// Prune any aged-out Barnyard2 archived logs if any exist
@@ -210,7 +210,7 @@ if ($config['installedpackages']['snortglobal']['enable_log_mgmt'] == 'on') {
 			}
 			unset($files);
 			if ($prune_count > 0)
-				log_error(gettext("[Snort] Barnyard2 archived logs cleanup job removed {$prune_count} file(s) from {$snort_log_dir}/barnyard2/archive/..."));
+				syslog(LOG_NOTICE, gettext("[Snort] Barnyard2 archived logs cleanup job removed {$prune_count} file(s) from {$snort_log_dir}/barnyard2/archive/..."));
 		}
 
 		// Prune aged-out perfmon stats logs if any exist
@@ -231,7 +231,7 @@ if ($config['installedpackages']['snortglobal']['enable_log_mgmt'] == 'on') {
 			}
 			unset($list, $files);
 			if ($prune_count > 0)
-				log_error(gettext("[Snort] perfmon stats logs cleanup job removed {$prune_count} file(s) from {$snort_log_dir}/..."));
+				syslog(LOG_NOTICE, gettext("[Snort] perfmon stats logs cleanup job removed {$prune_count} file(s) from {$snort_log_dir}/..."));
 		}
 
 		// Prune any aged-out AppID stats logs if any exist
@@ -247,7 +247,7 @@ if ($config['installedpackages']['snortglobal']['enable_log_mgmt'] == 'on') {
 			}
 			unset($files);
 			if ($prune_count > 0)
-				log_error(gettext("[Snort] AppID stats logs cleanup job removed {$prune_count} file(s) from {$snort_log_dir}/..."));
+				syslog(LOG_NOTICE, gettext("[Snort] AppID stats logs cleanup job removed {$prune_count} file(s) from {$snort_log_dir}/..."));
 		}
 	}
 }

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_cron_misc.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_cron_misc.inc
@@ -3,9 +3,9 @@
  * snort_check_cron_misc.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -62,7 +62,11 @@ function snort_check_dir_size_limit($snortloglimitsize) {
 
 			// Truncate the alert log file if it exists
 			if (file_exists("{$snort_log_dir}/alert")) {
-				@file_put_contents("{$snort_log_dir}/alert", "");
+				try {
+					fclose(fopen("{$snort_log_dir}/alert", 'w'));
+				} catch (Exception $e) {
+					log_error(gettext("[Snort] ERROR: Failed to truncate file '{$snort_log_dir}/alert' -- error was {$e->getMessage()}"));
+				}
 			}
 
 			// Cleanup any perfmon stats logs
@@ -120,8 +124,8 @@ function snort_check_rotate_log($log_file, $log_limit, $retention) {
 	if (($log_limit > 0) && (filesize($log_file) >= $log_limit)) {
 		$newfile = $log_file . "." . strval(time());
 		try {
-			copy($log_file, $newfile);
-			file_put_contents($log_file, "");
+			rename($log_file, $newfile);
+			touch($log_file);
 		} catch (Exception $e) {
 			log_error("[Snort] Failed to rotate file '{$log_file}' -- error was {$e->getMessage()}");
 		}

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -222,8 +222,8 @@ function snort_download_file_url($url, $file_out) {
 			$rc = curl_exec($ch);
 			if ($rc === true)
 				break;
-			log_error(gettext("[Snort] Rules download error: " . curl_error($ch)));
-			log_error(gettext("[Snort] Will retry in 15 seconds..."));
+			syslog(LOG_ERR, gettext("[Snort] Rules download error: " . curl_error($ch)));
+			syslog(LOG_ERR, gettext("[Snort] Will retry in 15 seconds..."));
 			sleep(15);
 		}
 		if ($rc === false)
@@ -236,12 +236,12 @@ function snort_download_file_url($url, $file_out) {
 
 		// If we had to try more than once, log it
 		if ($counter > 1)
-			log_error(gettext("File '" . basename($file_out) . "' download attempts: {$counter} ..."));
+			syslog(LOG_NOTICE, gettext("File '" . basename($file_out) . "' download attempts: {$counter} ..."));
 		return ($http_code == 200) ? true : $http_code;
 	}
 	else {
 		$last_curl_error = gettext("Failed to create file " . $file_out);
-		log_error(gettext("[Snort] Failed to create file {$file_out} ..."));
+		syslog(LOG_ERR, gettext("[Snort] Failed to create file {$file_out} ..."));
 		return false;
 	}
 }
@@ -286,7 +286,7 @@ function snort_check_rule_md5($file_url, $file_dst, $desc = "") {
 			snort_update_status(gettext(" done.") . "\n");
 			if ($md5_check_new == $md5_check_old) {
 				snort_update_status(gettext("{$desc} are current. No update required.") . "\n");
-				log_error(gettext("[Snort] {$desc} are up to date..."));
+				syslog(LOG_NOTICE, gettext("[Snort] {$desc} are up to date..."));
 				error_log(gettext("\t{$desc} are up to date.\n"), 3, SNORT_RULES_UPD_LOGFILE);
 				return false;
 			}
@@ -303,8 +303,8 @@ function snort_check_rule_md5($file_url, $file_dst, $desc = "") {
 		snort_update_status(gettext(" FAILED!") . "\n");
 		snort_update_status(gettext("{$desc} md5 error ... Server returned error code {$rc} ...") . "\n");
 		snort_update_status(gettext("{$desc} will not be updated.\n{$snort_err_msg}") . "\n");
-		log_error(gettext("[Snort] {$desc} md5 download failed..."));
-		log_error(gettext("[Snort] Server returned error code {$rc}..."));
+		syslog(LOG_ERR, gettext("[Snort] {$desc} md5 download failed..."));
+		syslog(LOG_ERR, gettext("[Snort] Server returned error code {$rc}..."));
 		error_log(gettext("\t{$snort_err_msg}\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		error_log(gettext("\tServer error message was: {$last_curl_error}\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		error_log(gettext("\t{$desc} will not be updated.\n"), 3, SNORT_RULES_UPD_LOGFILE);
@@ -338,7 +338,7 @@ function snort_fetch_new_rules($file_url, $file_dst, $file_md5, $desc = "") {
 	$filename = basename($file_dst);
 
 	snort_update_status(gettext("There is a new set of {$desc} posted.\nDownloading {$filename}..."));
-	log_error(gettext("[Snort] There is a new set of {$desc} posted. Downloading {$filename}..."));
+	syslog(LOG_NOTICE, gettext("[Snort] There is a new set of {$desc} posted. Downloading {$filename}..."));
 	error_log(gettext("\tThere is a new set of {$desc} posted.\n"), 3, SNORT_RULES_UPD_LOGFILE);
 	error_log(gettext("\tDownloading file '{$filename}'...\n"), 3, SNORT_RULES_UPD_LOGFILE);
        	$rc = snort_download_file_url($file_url, $file_dst);
@@ -346,15 +346,15 @@ function snort_fetch_new_rules($file_url, $file_dst, $file_md5, $desc = "") {
 	// See if the download from the URL was successful
 	if ($rc === true) {
 		snort_update_status(gettext(" done.") . "\n");
-		log_error("[Snort] {$desc} file update downloaded successfully");
+		syslog(LOG_NOTICE, "[Snort] {$desc} file update downloaded successfully");
 		error_log(gettext("\tDone downloading rules file.\n"),3, SNORT_RULES_UPD_LOGFILE);
 	
 		// Test integrity of the rules file.  Turn off update if file has wrong md5 hash
 		if ($file_md5 != trim(md5_file($file_dst))){
 			snort_update_status(gettext("{$desc} file MD5 checksum failed...") . "\n");
-			log_error(gettext("[Snort] {$desc} file download failed.  Bad MD5 checksum..."));
-        	        log_error(gettext("[Snort] Downloaded File MD5: " . md5_file($file_dst)));
-			log_error(gettext("[Snort] Expected File MD5: {$file_md5}"));
+			syslog(LOG_ERR, gettext("[Snort] {$desc} file download failed.  Bad MD5 checksum..."));
+        	        syslog(LOG_ERR, gettext("[Snort] Downloaded File MD5: " . md5_file($file_dst)));
+			syslog(LOG_ERR, gettext("[Snort] Expected File MD5: {$file_md5}"));
 			error_log(gettext("\t{$desc} file download failed.  Bad MD5 checksum.\n"), 3, SNORT_RULES_UPD_LOGFILE);
 			error_log(gettext("\tDownloaded {$desc} file MD5: " . md5_file($file_dst) . "\n"), 3, SNORT_RULES_UPD_LOGFILE);
 			error_log(gettext("\tExpected {$desc} file MD5: {$file_md5}\n"), 3, SNORT_RULES_UPD_LOGFILE);
@@ -367,7 +367,7 @@ function snort_fetch_new_rules($file_url, $file_dst, $file_md5, $desc = "") {
 	else {
 		snort_update_status(gettext(" FAILED!") . "\n");
 		snort_update_status(gettext("{$desc} file download failed... server returned error '{$rc}'.") . "\n");
-		log_error(gettext("[Snort] {$desc} file download failed... server returned error '{$rc}'..."));
+		syslog(LOG_ERR, gettext("[Snort] {$desc} file download failed... server returned error '{$rc}'..."));
 		error_log(gettext("\t{$desc} file download failed.  Server returned error {$rc}.\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		error_log(gettext("\tThe error text was: {$last_curl_error}\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		error_log(gettext("\t{$desc} will not be updated.\n"), 3, SNORT_RULES_UPD_LOGFILE);
@@ -668,7 +668,7 @@ if ($emergingthreats == 'on') {
 
 // If removing deprecated rules categories, then do it
 if ($config['installedpackages']['snortglobal']['hide_deprecated_rules'] == "on") {
-	log_error(gettext("[Snort] Hide Deprecated Rules is enabled.  Removing obsoleted rules categories."));
+	syslog(LOG_NOTICE, gettext("[Snort] Hide Deprecated Rules is enabled.  Removing obsoleted rules categories."));
 	snort_remove_dead_rules();
 }
 
@@ -787,7 +787,7 @@ if ($snortdownload == 'on' || $emergingthreats == 'on' || $snortcommunityrules =
 		sleep(3);
 		unlink_if_exists("{$g['varrun_path']}/snort_pkg_starting.lck");
 		snort_update_status(gettext(" done.") . "\n");
-       		log_error(gettext("[Snort] Snort has restarted with your new set of rules..."));
+       		syslog(LOG_NOTICE, gettext("[Snort] Snort has restarted with your new set of rules..."));
 		error_log(gettext("\tSnort has restarted with your new set of rules.\n"), 3, SNORT_RULES_UPD_LOGFILE);
 	}
 }
@@ -804,7 +804,7 @@ elseif ($openappid_detectors == 'on') {
 		sleep(2);
 		unlink_if_exists("{$g['varrun_path']}/snort_pkg_starting.lck");
 		snort_update_status(gettext(" done.") . "\n");
-       		log_error(gettext("[Snort] Snort has restarted with your new set of OpenAppID detectors..."));
+       		syslog(LOG_NOTICE, gettext("[Snort] Snort has restarted with your new set of OpenAppID detectors..."));
 		error_log(gettext("\tSnort has restarted with your new set of OpenAppID detectors.\n"), 3, SNORT_RULES_UPD_LOGFILE);
 	}
 }
@@ -817,7 +817,7 @@ if (is_dir("{$tmpfname}")) {
 }
 
 snort_update_status(gettext("The Rules update has finished.") . "\n");
-log_error(gettext("[Snort] The Rules update has finished."));
+syslog(LOG_NOTICE, gettext("[Snort] The Rules update has finished."));
 error_log(gettext("The Rules update has finished.  Time: " . date("Y-m-d H:i:s"). "\n\n"), 3, SNORT_RULES_UPD_LOGFILE);
 
 /* Save this update status to the configuration file */

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -387,7 +387,6 @@ if (is_dir("{$tmpfname}"))
 
 /*  Make sure required snortdirs exsist */
 safe_mkdir("{$snortdir}/rules");
-safe_mkdir("{$snortdir}/signatures");
 safe_mkdir("{$snortdir}/preproc_rules");
 safe_mkdir("{$tmpfname}");
 safe_mkdir("{$snortlibdir}/snort_dynamicrules");

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
@@ -190,7 +190,7 @@ foreach ($snort_ports as $alias => $avalue) {
 			$snort_ports[$alias] = trim(filter_expand_alias($snortcfg["def_{$alias}"]));
 		}
 		else {
-			log_error("[snort] WARNING: unable to resolve Alias specified for PORTS variable " . strtoupper($alias) . " ... using default value '{$avalue}' instead.");
+			syslog(LOG_WARN, "[snort] WARNING: unable to resolve Alias specified for PORTS variable " . strtoupper($alias) . " ... using default value '{$avalue}' instead.");
 		}
 	}
 	$snort_ports[$alias] = preg_replace('/\s+/', ',', trim($snort_ports[$alias]));
@@ -331,12 +331,12 @@ foreach ($snortcfg['ftp_client_engine']['item'] as $f => $v) {
 			$buffer .= "{$tmp} \\\n";
 		}
 		else {
-			log_error("[snort] ERROR: unable to resolve IP Address Alias '{$v['bind_to']}' for FTP client '{$v['name']}' ... skipping entry.");
+			syslog(LOG_ERR, "[snort] ERROR: unable to resolve IP Address Alias '{$v['bind_to']}' for FTP client '{$v['name']}' ... skipping entry.");
 			continue;
 		}
 	}
 	else {
-			log_error("[snort] ERROR: unable to resolve IP Address Alias '{$v['bind_to']}' for FTP client '{$v['name']}' ... skipping entry.");
+			syslog(LOG_ERR, "[snort] ERROR: unable to resolve IP Address Alias '{$v['bind_to']}' for FTP client '{$v['name']}' ... skipping entry.");
 			continue;
 	}
 
@@ -366,9 +366,9 @@ foreach ($snortcfg['ftp_client_engine']['item'] as $f => $v) {
 				// One or both of the BOUNCE_TO alias values is not right,
 				// so figure out which and log an appropriate error.
 				if (empty($net) || !snort_is_single_addr_alias($v['bounce_to_net']))
-					log_error("[snort] ERROR: illegal value for bounce_to Address Alias [{$v['bounce_to_net']}] for FTP client engine [{$v['name']}] ... omitting 'bounce_to' option for this client engine.");
+					syslog(LOG_ERR, "[snort] ERROR: illegal value for bounce_to Address Alias [{$v['bounce_to_net']}] for FTP client engine [{$v['name']}] ... omitting 'bounce_to' option for this client engine.");
 				if (empty($port) || !(is_port($port) || is_portrange($port)))
-					log_error("[snort] ERROR: illegal value for bounce_to Port Alias [{$v['bounce_to_port']}] for FTP client engine [{$v['name']}] ... omitting 'bounce_to' option for this client engine.");
+					syslog(LOG_ERR, "[snort] ERROR: illegal value for bounce_to Port Alias [{$v['bounce_to_port']}] for FTP client engine [{$v['name']}] ... omitting 'bounce_to' option for this client engine.");
 				$buffer .= "\tbounce yes\n";
 			}
 		}
@@ -411,12 +411,12 @@ foreach ($snortcfg['ftp_server_engine']['item'] as $f => $v) {
 			$buffer .= "{$tmp} \\\n";
 		}
 		else {
-			log_error("[snort] ERROR: unable to resolve IP Address Alias '{$v['bind_to']}' for FTP server '{$v['name']}' ... skipping entry.");
+			syslog(LOG_ERR, "[snort] ERROR: unable to resolve IP Address Alias '{$v['bind_to']}' for FTP server '{$v['name']}' ... skipping entry.");
 			continue;
 		}
 	}
 	else {
-			log_error("[snort] ERROR: unable to resolve IP Address Alias '{$v['bind_to']}' for FTP server '{$v['name']}' ... skipping entry.");
+			syslog(LOG_ERR, "[snort] ERROR: unable to resolve IP Address Alias '{$v['bind_to']}' for FTP server '{$v['name']}' ... skipping entry.");
 			continue;
 	}
 
@@ -435,7 +435,7 @@ foreach ($snortcfg['ftp_server_engine']['item'] as $f => $v) {
 			$buffer .= "\tports { {$tmp} } \\\n";
 		}
 		else {
-			log_error("[snort] ERROR: unable to resolve Port Alias '{$v['ports']}' for FTP server '{$v['name']}' ... reverting to defaults.");
+			syslog(LOG_ERR, "[snort] ERROR: unable to resolve Port Alias '{$v['ports']}' for FTP server '{$v['name']}' ... reverting to defaults.");
 			$buffer .= "\tports { {$ftp_ports} } \\\n";
 		}
 	}
@@ -651,7 +651,7 @@ if (!empty($snortcfg['pscan_ignore_scanners'])) {
 			$sf_pscan_ignore_scanners = preg_replace('/\s+/', ',', trim($sf_pscan_ignore_scanners));
 		}
 		else {
-			log_error("[snort] WARNING: unable to resolve Alias {$snortcfg['pscan_ignore_scanners']} for PSCAN_IGNORE_SCANNERS ... reverting to default value of HOME_NET.");
+			syslog(LOG_WARN, "[snort] WARNING: unable to resolve Alias {$snortcfg['pscan_ignore_scanners']} for PSCAN_IGNORE_SCANNERS ... reverting to default value of HOME_NET.");
 		}
 	} else {
         	$sf_pscan_ignore_scanners = $snortcfg['pscan_ignore_scanners'];
@@ -665,7 +665,7 @@ if (!empty($snortcfg['pscan_ignore_scanned'])) {
 			$sf_pscan_ignore_scanned = preg_replace('/\s+/', ',', trim($sf_pscan_ignore_scanned));
 		}
 		else {
-			log_error("[snort] WARNING: unable to resolve Alias {$snortcfg['pscan_ignore_scanned']} for PSCAN_IGNORE_SCANNED ... reverting to default value of null.");
+			syslog(LOG_WARN, "[snort] WARNING: unable to resolve Alias {$snortcfg['pscan_ignore_scanned']} for PSCAN_IGNORE_SCANNED ... reverting to default value of null.");
 		}
 	} else {
           	$sf_pscan_ignore_scanned = $snortcfg['pscan_ignore_scanned'];
@@ -706,7 +706,7 @@ if (isset($snortcfg['ssh_preproc_ports'])) {
 			$ssh_ports = preg_replace('/\s+/', ',', trim($ssh_ports));
 		}
 		else {
-			log_error("[snort] WARNING: unable to resolve Alias {$snortcfg['ssh_preproc_ports']} for SSH Preprocessor Ports parameter ... reverting to default value of 22.");
+			syslog(LOG_WARN, "[snort] WARNING: unable to resolve Alias {$snortcfg['ssh_preproc_ports']} for SSH Preprocessor Ports parameter ... reverting to default value of 22.");
 			$ssh_ports = "22";
 		}
 	} else {
@@ -1026,7 +1026,7 @@ foreach ($snort_servers as $alias => $avalue) {
 			$avalue = preg_replace('/\s+/', ',', trim($avalue));
 		}
 		else {
-			log_error("[snort] WARNING: unable to resolve Alias specified for SERVERS variable " . strtoupper($alias) . " ... using default value '{$avalue}' instead.");
+			syslog(LOG_WARN, "[snort] WARNING: unable to resolve Alias specified for SERVERS variable " . strtoupper($alias) . " ... using default value '{$avalue}' instead.");
 		}
 	}
 	$ipvardef .= "ipvar " . strtoupper($alias) . " [{$avalue}]\n";
@@ -1077,7 +1077,7 @@ foreach ($snort_preproc as $preproc) {
 					$snort_preprocessors .= $$preproc;
 					$snort_preprocessors .= "\n";
 				} else
-					log_error("Could not find the {$preproclib} library file in '{$snortlibdir}/snort_dynamicpreprocessor/'. Snort might fail to start!");
+					syslog(LOG_WARN, "Could not find the {$preproclib} library file in '{$snortlibdir}/snort_dynamicpreprocessor/'. Snort might fail to start!");
 			} else {
 				$snort_preprocessors .= $$preproc;
 				$snort_preprocessors .= "\n";
@@ -1112,7 +1112,7 @@ if (file_exists("{$snortcfgdir}/classification.config"))
 	$snort_misc_include_rules .= "include {$snortcfgdir}/classification.config\n";
 if (!file_exists("{$snortcfgdir}/preproc_rules/decoder.rules") || !file_exists("{$snortcfgdir}/preproc_rules/preprocessor.rules")) {
 	$snort_misc_include_rules .= "config autogenerate_preprocessor_decoder_rules\n";
-	log_error("[Snort] Seems preprocessor and/or decoder rules are missing, enabling autogeneration of them in conf file.");
+	syslog(LOG_ALERT, "[Snort] Seems preprocessor and/or decoder rules are missing, enabling autogeneration of them in conf file.");
 }
 
 /* generate rule sections to load */
@@ -1181,7 +1181,7 @@ if ($snortcfg['frag3_detection'] == "on") {
 					$frag3_engine .= " \\\n\tbind_to {$tmp}";
 			}
 			else
-				log_error("[snort] WARNING: unable to resolve IP List Alias '{$v['bind_to']}' for Frag3 engine '{$v['name']}' ... using 0.0.0.0 failsafe.");
+				syslog(LOG_WARN, "[snort] WARNING: unable to resolve IP List Alias '{$v['bind_to']}' for Frag3 engine '{$v['name']}' ... using 0.0.0.0 failsafe.");
 		}
 		$frag3_engine .= " \\\n\ttimeout {$v['timeout']}";
 		$frag3_engine .= " \\\n\tmin_ttl {$v['min_ttl']}";
@@ -1280,7 +1280,7 @@ if ($snortcfg['stream5_reassembly'] == "on") {
 					$buffer .= " \\\n\tbind_to {$tmp},";
 			}
 			else {
-				log_error("[snort] WARNING: unable to resolve IP Address Alias [{$v['bind_to']}] for Stream5 TCP engine '{$v['name']}' ... skipping this engine.");
+				syslog(LOG_WARN, "[snort] WARNING: unable to resolve IP Address Alias [{$v['bind_to']}] for Stream5 TCP engine '{$v['name']}' ... skipping this engine.");
 				continue;
 			}
 		}
@@ -1314,7 +1314,7 @@ if ($snortcfg['stream5_reassembly'] == "on") {
 					$stream5_tcp_engine .= " " . trim(preg_replace('/\s+/', ' ', $tmp));
 				else {
 					$stream5_tcp_engine .= " {$stream5_ports_client}";
-					log_error("[snort] WARNING: unable to resolve Ports Client Alias [{$v['ports_client']}] for Stream5 TCP engine '{$v['name']}' ... using default value.");
+					syslog(LOG_WARN, "[snort] WARNING: unable to resolve Ports Client Alias [{$v['ports_client']}] for Stream5 TCP engine '{$v['name']}' ... using default value.");
 				}
 			}
 		}
@@ -1330,7 +1330,7 @@ if ($snortcfg['stream5_reassembly'] == "on") {
 					$stream5_tcp_engine .= " " . trim(preg_replace('/\s+/', ' ', $tmp));
 				else {
 					$stream5_tcp_engine .= " {$stream5_ports_both}";
-					log_error("[snort] WARNING: unable to resolve Ports Both Alias [{$v['ports_both']}] for Stream5 TCP engine '{$v['name']}' ... using default value.");
+					syslog(LOG_WARN, "[snort] WARNING: unable to resolve Ports Both Alias [{$v['ports_both']}] for Stream5 TCP engine '{$v['name']}' ... using default value.");
 				}
 			}
 		}
@@ -1346,7 +1346,7 @@ if ($snortcfg['stream5_reassembly'] == "on") {
 					$stream5_tcp_engine .= " " . trim(preg_replace('/\s+/', ' ', $tmp));
 				}
 				else
-					log_error("[snort] WARNING: unable to resolve Ports Server Alias [{$v['ports_server']}] for Stream5 TCP engine '{$v['name']}' ... defaulting to none.");
+					syslog(LOG_WARN, "[snort] WARNING: unable to resolve Ports Server Alias [{$v['ports_server']}] for Stream5 TCP engine '{$v['name']}' ... defaulting to none.");
 			}
 		}
 
@@ -1447,12 +1447,12 @@ if ($snortcfg['http_inspect'] <> "off") {
 					$buffer .= "\tserver { {$tmp} } \\\n";
 			}
 			else {
-				log_error("[snort] WARNING: unable to resolve IP Address Alias [{$v['bind_to']}] for HTTP_INSPECT server '{$v['name']}' ... skipping this server engine.");
+				syslog(LOG_WARN, "[snort] WARNING: unable to resolve IP Address Alias [{$v['bind_to']}] for HTTP_INSPECT server '{$v['name']}' ... skipping this server engine.");
 				continue;
 			}
 		}
 		else {
-				log_error("[snort] WARNING: unable to resolve IP Address Alias [{$v['bind_to']}] for HTTP_INSPECT server '{$v['name']}' ... skipping this server engine.");
+				syslog(LOG_WARN, "[snort] WARNING: unable to resolve IP Address Alias [{$v['bind_to']}] for HTTP_INSPECT server '{$v['name']}' ... skipping this server engine.");
 				continue;
 		}
 		$http_inspect_servers .= $buffer;
@@ -1471,12 +1471,12 @@ if ($snortcfg['http_inspect'] <> "off") {
 				$http_inspect_servers .= "\tports { {$tmp} } \\\n";
 			}
 			else {
-				log_error("[snort] WARNING: unable to resolve Ports Alias [{$v['ports']}] for HTTP_INSPECT server '{$v['name']}' ... using safe default instead.");
+				syslog(LOG_WARN, "[snort] WARNING: unable to resolve Ports Alias [{$v['ports']}] for HTTP_INSPECT server '{$v['name']}' ... using safe default instead.");
 				$http_inspect_servers .= "\tports { {$http_ports} } \\\n";
 			}
 		}
 		else {
-				log_error("[snort] WARNING: unable to resolve Ports Alias [{$v['ports']}] for HTTP_INSPECT server '{$v['name']}' ... using safe default instead.");
+				syslog(LOG_WARN, "[snort] WARNING: unable to resolve Ports Alias [{$v['ports']}] for HTTP_INSPECT server '{$v['name']}' ... using safe default instead.");
 				$http_inspect_servers .= "\tports { {$http_ports} } \\\n";
 		}
 

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
@@ -56,7 +56,7 @@ $rule = &$config['installedpackages']['snortglobal']['rule'];
 /****************************************************************************/
 
 $updated_cfg = false;
-log_error("[Snort] Checking configuration settings version...");
+syslog(LOG_NOTICE, "[Snort] Checking configuration settings version...");
 
 // Check the configuration version to see if XMLRPC Sync should
 // auto-disabled as part of the upgrade due to config format changes.
@@ -64,7 +64,7 @@ if (empty($config['installedpackages']['snortglobal']['snort_config_ver']) &&
     ($config['installedpackages']['snortsync']['config']['varsynconchanges'] == 'auto' ||
      $config['installedpackages']['snortsync']['config']['varsynconchanges'] == 'manual')) {
 	$config['installedpackages']['snortsync']['config']['varsynconchanges']	= "disabled";
-	log_error("[Snort] Turning off Snort Sync on this host due to configuration format changes in this update.  Upgrade all Snort Sync targets to this same Snort package version before re-enabling Snort Sync.");
+	syslog(LOG_NOTICE, "[Snort] Turning off Snort Sync on this host due to configuration format changes in this update.  Upgrade all Snort Sync targets to this same Snort package version before re-enabling Snort Sync.");
 	$updated_cfg = true;
 }
 
@@ -229,7 +229,7 @@ foreach ($rule as &$r) {
 	// Create a default "frag3_engine" if none are configured
 	if (empty($pconfig['frag3_engine']['item'])) {
 		$updated_cfg = true;
-		log_error("[Snort] Migrating Frag3 Engine configuration for interface {$pconfig['descr']}...");
+		syslog(LOG_NOTICE, "[Snort] Migrating Frag3 Engine configuration for interface {$pconfig['descr']}...");
 		$default = array( "name" => "default", "bind_to" => "all", "policy" => "bsd", 
 				"timeout" => 60, "min_ttl" => 1, "detect_anomalies" => "on", 
 				"overlap_limit" => 0, "min_frag_len" => 0 );
@@ -263,7 +263,7 @@ foreach ($rule as &$r) {
 	// Create a default Stream5 engine array if none are configured
 	if (empty($pconfig['stream5_tcp_engine']['item'])) {
 		$updated_cfg = true;
-		log_error("[Snort] Migrating Stream5 Engine configuration for interface {$pconfig['descr']}...");
+		syslog(LOG_NOTICE, "[Snort] Migrating Stream5 Engine configuration for interface {$pconfig['descr']}...");
 		$default = array( "name" => "default", "bind_to" => "all", "policy" => "bsd", "timeout" => 30, 
 				"max_queued_bytes" => 1048576, "detect_anomalies" => "off", "overlap_limit" => 0, 
 				"max_queued_segs" => 2621, "require_3whs" => "off", "startup_3whs_timeout" => 0, 
@@ -330,7 +330,7 @@ foreach ($rule as &$r) {
 	// Create a default HTTP_INSPECT engine if none are configured
 	if (empty($pconfig['http_inspect_engine']['item'])) {
 		$updated_cfg = true;
-		log_error("[Snort] Migrating HTTP_Inspect Engine configuration for interface {$pconfig['descr']}...");
+		syslog(LOG_NOTICE, "[Snort] Migrating HTTP_Inspect Engine configuration for interface {$pconfig['descr']}...");
 		$default = array( "name" => "default", "bind_to" => "all", "server_profile" => "all", "enable_xff" => "off", 
 				"log_uri" => "off", "log_hostname" => "off", "server_flow_depth" => 65535, "enable_cookie" => "on", 
 				"client_flow_depth" => 1460, "extended_response_inspection" => "on", "no_alerts" => "off", 
@@ -380,7 +380,7 @@ foreach ($rule as &$r) {
 	// Create a default FTP_CLIENT engine if none are configured
 	if (empty($pconfig['ftp_client_engine']['item'])) {
 		$updated_cfg = true;
-		log_error("[Snort] Migrating FTP Client Engine configuration for interface {$pconfig['descr']}...");
+		syslog(LOG_NOTICE, "[Snort] Migrating FTP Client Engine configuration for interface {$pconfig['descr']}...");
 		$default = array( "name" => "default", "bind_to" => "all", "max_resp_len" => 256, 
 				  "telnet_cmds" => "no", "ignore_telnet_erase_cmds" => "yes", 
 				  "bounce" => "yes", "bounce_to_net" => "", "bounce_to_port" => "" );
@@ -407,7 +407,7 @@ foreach ($rule as &$r) {
 	// Create a default FTP_SERVER engine if none are configured
 	if (empty($pconfig['ftp_server_engine']['item'])) {
 		$updated_cfg = true;
-		log_error("[Snort] Migrating FTP Server Engine configuration for interface {$pconfig['descr']}...");
+		syslog(LOG_NOTICE, "[Snort] Migrating FTP Server Engine configuration for interface {$pconfig['descr']}...");
 		$default = array( "name" => "default", "bind_to" => "all", "ports" => "default", 
 				  "telnet_cmds" => "no", "ignore_telnet_erase_cmds" => "yes", 
 				  "ignore_data_chan" => "no", "def_max_param_len" => 100 );
@@ -704,10 +704,10 @@ unset($r);
 
 // Log a message if we changed anything
 if ($updated_cfg) {
-	log_error("[Snort] Settings successfully migrated to new configuration format...");
+	syslog(LOG_NOTICE, "[Snort] Settings successfully migrated to new configuration format...");
 }
 else {
-	log_error("[Snort] Configuration version is current...");
+	syslog(LOG_NOTICE, "[Snort] Configuration version is current...");
 }
 
 ?>

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
@@ -93,7 +93,7 @@ safe_mkdir(SNORT_APPID_ODP_PATH);
 /* by removing it as a separately installed package.                 */
 $pkgid = get_package_id("Dashboard Widget: Snort");
 if ($pkgid >= 0) {
-	log_error(gettext("[Snort] Removing legacy 'Dashboard Widget: Snort' package because the widget is now part of the Snort package."));
+	syslog(LOG_NOTICE, gettext("[Snort] Removing legacy 'Dashboard Widget: Snort' package because the widget is now part of the Snort package."));
 	unset($config['installedpackages']['package'][$pkgid]);
 	unlink_if_exists("/usr/local/pkg/widget-snort.xml");
 }
@@ -116,7 +116,7 @@ while (snort_cron_job_exists("snort2c", FALSE)) {
 	$cron_count++;
 }
 if ($cron_count > 0)
-	log_error(gettext("[Snort] Removed {$cron_count} duplicate 'remove_blocked_hosts' cron task(s)."));
+	syslog(LOG_NOTICE, gettext("[Snort] Removed {$cron_count} duplicate 'remove_blocked_hosts' cron task(s)."));
 
 /*********************************************************/
 /* END OF BUG FIX CODE                                   */
@@ -124,7 +124,7 @@ if ($cron_count > 0)
 
 /* remake saved settings */
 if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
-	log_error(gettext("[Snort] Saved settings detected... rebuilding installation with saved settings."));
+	syslog(LOG_NOTICE, gettext("[Snort] Saved settings detected... rebuilding installation with saved settings."));
 	update_status(gettext("Saved settings detected.") . "\n");
 
 	/****************************************************************/
@@ -152,7 +152,7 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 					@rename("{$snortlogdir}snort_{$if_real}{$old_uuid}/", "{$snortlogdir}snort_{$if_real}{$new_uuid}/");
 				$snortcfg['uuid'] = $new_uuid;
 				$uuids[$new_uuid] = $if_real;
-				log_error(gettext("[Snort] updated UUID for interface " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . " from {$old_uuid} to {$new_uuid}."));
+				syslog(LOG_NOTICE, gettext("[Snort] updated UUID for interface " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . " from {$old_uuid} to {$new_uuid}."));
 				$fixed_duplicate = TRUE;
 			}
 		}
@@ -166,7 +166,7 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 	update_status(gettext("Migrating settings to new configuration..."));
 	include('/usr/local/pkg/snort/snort_migrate_config.php');
 	update_status(gettext(" done.") . "\n");
-	log_error(gettext("[Snort] Downloading and updating configured rule sets."));
+	syslog(LOG_NOTICE, gettext("[Snort] Downloading and updating configured rule sets."));
 	include('/usr/local/pkg/snort/snort_check_for_rule_updates.php');
 	update_status(gettext("Generating snort.conf configuration file from saved settings.") . "\n");
 	$rebuild_rules = true;
@@ -230,7 +230,7 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 
 	$rebuild_rules = false;
 	update_status(gettext("Finished rebuilding Snort configuration files.") . "\n");
-	log_error(gettext("[Snort] Finished rebuilding installation from saved settings."));
+	syslog(LOG_NOTICE, gettext("[Snort] Finished rebuilding installation from saved settings."));
 }
 
 /* If an existing Snort Dashboard Widget container is not found, */
@@ -244,7 +244,7 @@ write_config("Snort pkg v{$config['installedpackages']['package'][get_package_id
 
 /* Done with post-install, so clear flag */
 unset($g['snort_postinstall']);
-log_error(gettext("[Snort] Package post-installation tasks completed..."));
+syslog(LOG_NOTICE, gettext("[Snort] Package post-installation tasks completed..."));
 return true;
 
 ?>

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
@@ -64,12 +64,17 @@ unlink_if_exists("{$g['varrun_path']}/snort_pkg_starting.lck");
 /* Set flag for post-install in progress */
 $g['snort_postinstall'] = true;
 
+/*****************************************************************/
 /* In the event this is a reinstall (or update), then recreate   */
-/* critical map files from the package sample templates.         */
-$map_files = array("unicode.map", "gen-msg.map", "classification.config", "reference.config", "attribute_table.dtd");
+/* critical map, config and preprocessor rules files from the    */
+/* package sample templates.                                     */
+/*****************************************************************/
+$map_files = array("/unicode.map", "/gen-msg.map", "/classification.config", "/reference.config", 
+		   "/attribute_table.dtd", "/preproc_rules/preprocessor.rules", 
+		   "/preproc_rules/decoder.rules" , "/preproc_rules/sensitive-data.rules" );
 foreach ($map_files as $f) {
-	if (file_exists(SNORTDIR . "/" . $f . "-sample") && !file_exists(SNORTDIR . "/" . $f)) {
-		copy(SNORTDIR . "/" . $f . "-sample", SNORTDIR . "/" . $f);
+	if (file_exists(SNORTDIR .  $f . "-sample") && !file_exists(SNORTDIR . $f)) {
+		copy(SNORTDIR .  $f . "-sample", SNORTDIR . $f);
 	}
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -3,9 +3,9 @@
  * snort_uninstall.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2016 Bill Meeks
+ * Copyright (c) 2013-2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -160,6 +160,17 @@ if (is_array($config['installedpackages']['snortglobal']['rule']) && count($conf
 }
 
 /**********************************************************/
+/* Clear IP addresses we placed in <snort2c> pf table if  */
+/* that option is enabled on GLOBAL SETTINGS tab or if    */
+/* the package and its configuration are being removed.   */
+/**********************************************************/
+if (($config['installedpackages']['snortglobal']['clearblocks'] == 'on') ||
+    ($config['installedpackages']['snortglobal']['forcekeepsettings'] != 'on')) {
+	log_error(gettext("[Snort] Flushing <snort2c> firewall table to remove addresses blocked by Snort..."));
+	mwexec("/sbin/pfctl -t snort2c -T flush");
+}
+
+/**********************************************************/
 /* Keep this as a last step because it is the total       */
 /* removal of the configuration settings when the user    */
 /* has elected to not retain the package configuration.   */
@@ -169,8 +180,6 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] != 'on') {
 	unset($config['installedpackages']['snortglobal']);
 	unset($config['installedpackages']['snortsync']);
 	unlink_if_exists("{$snort_rules_upd_log}");
-	log_error(gettext("[Snort] Flushing <snort2c> firewall table to remove addresses blocked by Snort..."));
-	mwexec("/sbin/pfctl -t snort2c -T flush");
 	rmdir_recursive("{$snortlogdir}");
 	rmdir_recursive("{$g['vardb_path']}/snort");
 	write_config("Removing Snort configuration");

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -141,6 +141,7 @@ unlink_if_exists(SNORTDIR . "/*.md5");
 unlink_if_exists(SNORTDIR . "/rules/*.txt");
 unlink_if_exists(SNORTDIR . "/classification.config");
 unlink_if_exists(SNORTDIR . "/reference.config");
+unlink_if_exists(SNORTDIR . "/unicode.map");
 unlink_if_exists(SNORTDIR . "/preproc_rules/*.rules");
 unlink_if_exists(SNORTDIR . "/rules/" . VRT_FILE_PREFIX . "*.rules");
 unlink_if_exists(SNORTDIR . "/rules/" . ET_OPEN_FILE_PREFIX . "*.rules");

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -134,8 +134,11 @@ if (is_dir(SNORT_APPID_ODP_PATH)) {
 if (is_dir("/usr/local/lib/snort_dynamicrules")) {
 	rmdir_recursive("/usr/local/lib/snort_dynamicrules");
 }
+if (is_dir(SNORTDIR . "/signatures")) {
+	rmdir_recursive(SNORTDIR . "/signatures");
+}
 unlink_if_exists(SNORTDIR . "/*.md5");
-unlink_if_exists(SNORTDIR . "/*.txt");
+unlink_if_exists(SNORTDIR . "/rules/*.txt");
 unlink_if_exists(SNORTDIR . "/classification.config");
 unlink_if_exists(SNORTDIR . "/reference.config");
 unlink_if_exists(SNORTDIR . "/preproc_rules/*.rules");
@@ -143,6 +146,7 @@ unlink_if_exists(SNORTDIR . "/rules/" . VRT_FILE_PREFIX . "*.rules");
 unlink_if_exists(SNORTDIR . "/rules/" . ET_OPEN_FILE_PREFIX . "*.rules");
 unlink_if_exists(SNORTDIR . "/rules/" . ET_PRO_FILE_PREFIX . "*.rules");
 unlink_if_exists(SNORTDIR . "/rules/" . GPL_FILE_PREFIX . "*.rules");
+unlink_if_exists(SNORTDIR . "/rules/" . "appid.rules");
 unlink_if_exists(SNORT_APPID_RULES_PATH . OPENAPPID_FILE_PREFIX . "*.rules");
 
 if (is_array($config['installedpackages']['snortglobal']['rule']) && count($config['installedpackages']['snortglobal']['rule']) > 0) {

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -164,7 +164,7 @@ if (is_array($config['installedpackages']['snortglobal']['rule']) && count($conf
 /* that option is enabled on GLOBAL SETTINGS tab or if    */
 /* the package and its configuration are being removed.   */
 /**********************************************************/
-if (($config['installedpackages']['snortglobal']['clearblocks'] == 'on') ||
+if (($config['installedpackages']['snortglobal']['clearblocks'] != 'on') ||
     ($config['installedpackages']['snortglobal']['forcekeepsettings'] != 'on')) {
 	syslog(LOG_NOTICE, gettext("[Snort] Flushing <snort2c> firewall table to remove addresses blocked by Snort..."));
 	mwexec("/sbin/pfctl -t snort2c -T flush");

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -127,27 +127,23 @@ if ($config['installedpackages']['snortglobal']['clearlogs'] == 'on') {
 /* Remove files and directories that pkg will not because */
 /* we changed or created them post-install.               */
 /**********************************************************/
-log_error(gettext("[Snort] Removing package files..."));
-if (is_dir("{$snortdir}/appid")) {
-	rmdir_recursive("{$snortdir}/appid");
-}
-if (is_dir("{$snortdir}/rules")) {
-	rmdir_recursive("{$snortdir}/rules");
-}
-if (is_dir("{$snortdir}/signatures")) {
-	rmdir_recursive("{$snortdir}/signatures");
-}
-if (is_dir("{$snortdir}/preproc_rules")) {
-	rmdir_recursive("{$snortdir}/preproc_rules");
+log_error(gettext("[Snort] Removing GUI package-modified files..."));
+if (is_dir(SNORT_APPID_ODP_PATH)) {
+	rmdir_recursive(SNORT_APPID_ODP_PATH);
 }
 if (is_dir("/usr/local/lib/snort_dynamicrules")) {
 	rmdir_recursive("/usr/local/lib/snort_dynamicrules");
 }
-unlink_if_exists("{$snortdir}/*.md5");
-unlink_if_exists("{$snortdir}/*.conf");
-unlink_if_exists("{$snortdir}/*.map");
-unlink_if_exists("{$snortdir}/*.config");
-unlink_if_exists("{$snortdir}/attribute_table.dtd");
+unlink_if_exists(SNORTDIR . "/*.md5");
+unlink_if_exists(SNORTDIR . "/*.txt");
+unlink_if_exists(SNORTDIR . "/classification.config");
+unlink_if_exists(SNORTDIR . "/reference.config");
+unlink_if_exists(SNORTDIR . "/preproc_rules/*.rules");
+unlink_if_exists(SNORTDIR . "/rules/" . VRT_FILE_PREFIX . "*.rules");
+unlink_if_exists(SNORTDIR . "/rules/" . ET_OPEN_FILE_PREFIX . "*.rules");
+unlink_if_exists(SNORTDIR . "/rules/" . ET_PRO_FILE_PREFIX . "*.rules");
+unlink_if_exists(SNORTDIR . "/rules/" . GPL_FILE_PREFIX . "*.rules");
+unlink_if_exists(SNORT_APPID_RULES_PATH . OPENAPPID_FILE_PREFIX . "*.rules");
 
 if (is_array($config['installedpackages']['snortglobal']['rule']) && count($config['installedpackages']['snortglobal']['rule']) > 0) {
 	foreach ($config['installedpackages']['snortglobal']['rule'] as $snortcfg) {

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -42,7 +42,7 @@ $snortlogdir = SNORTLOGDIR;
 $rcdir = RCFILEPREFIX;
 $snort_rules_upd_log = SNORT_RULES_UPD_LOGFILE;
 
-log_error(gettext("[Snort] Snort package uninstall in progress..."));
+syslog(LOG_NOTICE, gettext("[Snort] Snort package uninstall in progress..."));
 
 // Remove our rc.d startup shell script
 unlink_if_exists("{$rcdir}snort.sh");
@@ -50,7 +50,7 @@ unlink_if_exists("{$rcdir}snort.sh");
 // Make sure all active Snort processes are terminated
 // Log a message only if a running process is detected
 if (is_process_running("snort")) {
-	log_error(gettext("[Snort] Snort STOP on all interfaces..."));
+	syslog(LOG_NOTICE, gettext("[Snort] Snort STOP on all interfaces..."));
 	snort_stop_all_interfaces();
 }
 sleep(2);
@@ -65,7 +65,7 @@ unlink_if_exists("{$g['varrun_path']}/snort_*.pid");
 // Make sure all active Barnyard2 processes are terminated
 // Log a message only if a running process is detected
 if (is_process_running("barnyard2")) {
-	log_error(gettext("[Snort] Barnyard2 STOP on all interfaces..."));
+	syslog(LOG_NOTICE, gettext("[Snort] Barnyard2 STOP on all interfaces..."));
 }
 mwexec('/usr/bin/killall -z barnyard2', true);
 sleep(2);
@@ -112,13 +112,13 @@ if (!empty($widgets)) {
 
 // See if we are to clear blocked hosts on uninstall
 if ($config['installedpackages']['snortglobal']['clearblocks'] == 'on') {
-	log_error(gettext("[Snort] Removing all blocked hosts from <snort2c> table..."));
+	syslog(LOG_NOTICE, gettext("[Snort] Removing all blocked hosts from <snort2c> table..."));
 	mwexec("/sbin/pfctl -t snort2c -T flush");
 }
 
 // See if we are to clear Snort log files on uninstall
 if ($config['installedpackages']['snortglobal']['clearlogs'] == 'on') {
-	log_error(gettext("[Snort] Clearing all Snort-related log files..."));
+	syslog(LOG_NOTICE, gettext("[Snort] Clearing all Snort-related log files..."));
 	unlink_if_exists("{$snort_rules_upd_log}");
 	rmdir_recursive($snortlogdir);
 }
@@ -127,7 +127,7 @@ if ($config['installedpackages']['snortglobal']['clearlogs'] == 'on') {
 /* Remove files and directories that pkg will not because */
 /* we changed or created them post-install.               */
 /**********************************************************/
-log_error(gettext("[Snort] Removing GUI package-modified files..."));
+syslog(LOG_NOTICE, gettext("[Snort] Removing GUI package-modified files..."));
 if (is_dir(SNORT_APPID_ODP_PATH)) {
 	rmdir_recursive(SNORT_APPID_ODP_PATH);
 }
@@ -162,7 +162,7 @@ if (is_array($config['installedpackages']['snortglobal']['rule']) && count($conf
 /**********************************************************/
 if (($config['installedpackages']['snortglobal']['clearblocks'] == 'on') ||
     ($config['installedpackages']['snortglobal']['forcekeepsettings'] != 'on')) {
-	log_error(gettext("[Snort] Flushing <snort2c> firewall table to remove addresses blocked by Snort..."));
+	syslog(LOG_NOTICE, gettext("[Snort] Flushing <snort2c> firewall table to remove addresses blocked by Snort..."));
 	mwexec("/sbin/pfctl -t snort2c -T flush");
 }
 
@@ -172,17 +172,17 @@ if (($config['installedpackages']['snortglobal']['clearblocks'] == 'on') ||
 /* has elected to not retain the package configuration.   */
 /**********************************************************/
 if ($config['installedpackages']['snortglobal']['forcekeepsettings'] != 'on') {
-	log_error(gettext("[Snort] Not saving settings... all Snort configuration info and logs will be deleted..."));
+	syslog(LOG_NOTICE, gettext("[Snort] Not saving settings... all Snort configuration info and logs will be deleted..."));
 	unset($config['installedpackages']['snortglobal']);
 	unset($config['installedpackages']['snortsync']);
 	unlink_if_exists("{$snort_rules_upd_log}");
 	rmdir_recursive("{$snortlogdir}");
 	rmdir_recursive("{$g['vardb_path']}/snort");
 	write_config("Removing Snort configuration");
-	log_error(gettext("[Snort] The package has been completely removed from this system."));
+	syslog(LOG_NOTICE, gettext("[Snort] The package and its configuration has been completely removed from this system."));
 }
 else {
-	log_error(gettext("[Snort] Package files removed but all Snort configuration info has been retained."));
+	syslog(LOG_NOTICE, gettext("[Snort] Package files removed but all Snort configuration info has been retained."));
 }
 
 return true;

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -164,7 +164,7 @@ if (is_array($config['installedpackages']['snortglobal']['rule']) && count($conf
 /* that option is enabled on GLOBAL SETTINGS tab or if    */
 /* the package and its configuration are being removed.   */
 /**********************************************************/
-if (($config['installedpackages']['snortglobal']['clearblocks'] != 'on') ||
+if (($config['installedpackages']['snortglobal']['clearblocks'] != 'off') ||
     ($config['installedpackages']['snortglobal']['forcekeepsettings'] != 'on')) {
 	syslog(LOG_NOTICE, gettext("[Snort] Flushing <snort2c> firewall table to remove addresses blocked by Snort..."));
 	mwexec("/sbin/pfctl -t snort2c -T flush");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces.php
@@ -363,21 +363,21 @@ if ($savemsg)
 							<?php if (snort_is_running($if_real)) : ?>
 								<i id="snort_<?=$if_real;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('snort is running on this interface');?>"></i>
 								&nbsp;
-								<i id="snort_<?=$if_real;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle('start', '<?=$i?>');" title="<?=gettext('Restart snort on this interface');?>"></i>
-								<i id="snort_<?=$if_real;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle('start', '<?=$i?>');" title="<?=gettext('Start snort on this interface');?>"></i>
-								<i id="snort_<?=$if_real;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle('stop', '<?=$i?>');" title="<?=gettext('Stop snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Restart snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Start snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle($(this), 'stop', '<?=$i?>');" title="<?=gettext('Stop snort on this interface');?>"></i>
 							<?php elseif ($snort_starting[$i] == 'TRUE' || file_exists("{$g['varrun_path']}/snort_pkg_starting.lck")) : ?>
 								<i id="snort_<?=$if_real;?>" class="fa fa-cog fa-spin text-info icon-primary" title="<?=gettext('snort is starting on this interface');?>"></i>
 								&nbsp;
-								<i id="snort_<?=$if_real;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle('start', '<?=$i?>');" title="<?=gettext('Restart snort on this interface');?>"></i>
-								<i id="snort_<?=$if_real;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle('start', '<?=$i?>');" title="<?=gettext('Start snort on this interface');?>"></i>
-								<i id="snort_<?=$if_real?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle('stop', '<?=$i?>');" title="<?=gettext('Stop snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Restart snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Start snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle($(this), 'stop', '<?=$i?>');" title="<?=gettext('Stop snort on this interface');?>"></i>
 							<?php else: ?>
-								<i class="fa fa-times-circle text-danger icon-primary" title="<?=gettext('snort is stopped on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>" class="fa fa-times-circle text-danger icon-primary" title="<?=gettext('snort is stopped on this interface');?>"></i>
 								&nbsp;
-								<i id="snort_<?=$if_real;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle('start', '<?=$i?>');" title="<?=gettext('Restart snort on this interface');?>"></i>
-								<i id="snort_<?=$if_real;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle('start', '<?=$i?>');" title="<?=gettext('Start snort on this interface');?>"></i>
-								<i id="snort_<?=$if_real;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle('stop', '<?=$i?>');" title="<?=gettext('Stop snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Restart snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Start snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle($(this), 'stop', '<?=$i?>');" title="<?=gettext('Stop snort on this interface');?>"></i>
 							<?php endif; ?>
 						<?php else : ?>
 							<?=gettext('DISABLED');?>&nbsp;
@@ -404,21 +404,21 @@ if ($savemsg)
 							<?php if (snort_is_running($if_real, 'barnyard2')) : ?>
 								<i id="barnyard2_<?=$if_real;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('barnyard2 is running on this interface');?>"></i>
 								&nbsp;
-								<i id="barnyard2_<?=$if_real;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$i?>');" title="<?=gettext('Restart barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$i?>');" title="<?=gettext('Start barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('stop', '<?=$i?>');" title="<?=gettext('Stop barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Restart barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Start barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle($(this), 'stop', '<?=$i?>');" title="<?=gettext('Stop barnyard2 on this interface');?>"></i>
 							<?php elseif ($by2_starting[$i] == 'TRUE' || file_exists("{$g['varrun_path']}/snort_pkg_starting.lck")) : ?>
 								<i id="barnyard2_<?=$if_real;?>" class="fa fa-cog fa-spin text-info icon-primary" title="<?=gettext('barnyard2 is starting on this interface');?>"></i>
 								&nbsp;
-								<i id="barnyard2_<?=$if_real;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$i?>');" title="<?=gettext('Restart barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$i?>');" title="<?=gettext('Start barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('stop', '<?=$i?>');" title="<?=gettext('Stop barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Restart barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Start barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle($(this), 'stop', '<?=$i?>');" title="<?=gettext('Stop barnyard2 on this interface');?>"></i>
 							<?php else: ?>
-								<i class="fa fa-times-circle text-danger icon-primary" title="<?=gettext('barnyard2 is stopped on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real;?>" class="fa fa-times-circle text-danger icon-primary" title="<?=gettext('barnyard2 is stopped on this interface');?>"></i>
 								&nbsp;
-								<i id="barnyard2_<?=$if_real;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('start', '<?=$i?>');" title="<?=gettext('Restart barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle('start', '<?=$i?>');" title="<?=gettext('Start barnyard2 on this interface');?>"></i>
-								<i id="barnyard2_<?=$if_real;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle('stop', '<?=$i?>');" title="<?=gettext('Stop barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real;?>_restart" class="fa fa-repeat icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Restart barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real;?>_start" class="fa fa-play-circle icon-pointer text-info icon-primary" onclick="javascript:by2_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Start barnyard2 on this interface');?>"></i>
+								<i id="barnyard2_<?=$if_real;?>_stop" class="fa fa-stop-circle-o icon-pointer text-info icon-primary hidden" onclick="javascript:by2_iface_toggle($(this), 'stop', '<?=$i?>');" title="<?=gettext('Stop barnyard2 on this interface');?>"></i>
 							<?php endif; ?>
 						<?php else : ?>
 							<?=gettext('DISABLED');?>&nbsp;
@@ -563,13 +563,39 @@ if ($savemsg)
 		}
 	}	
 
-	function snort_iface_toggle(action, id) {
+	function snort_iface_toggle(elem, action, id) {
+		// Peel off the first part of the control name
+		// to identify the STATUS icon.
+		var fldName = $(elem).attr('id');
+		fldName = fldName.substring(0, fldName.lastIndexOf('_'));
+		var service_name = fldName.substring(0, fldName.indexOf('_'));
+
+		// If stopping the service, change STATUS to a spinning gear cog.
+		if (action == 'stop') {
+			$('#' + fldName.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).removeClass('fa-check-circle fa-times-circle text-success text-danger');
+			$('#' + fldName.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).addClass('fa-cog fa-spin text-info');
+			$('#' + fldName.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).prop('title', service_name + ' is stopping on this interface');
+			$('#' + fldName.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_restart').addClass('hidden');
+		}
 		$('#toggle').val(action);
 		$('#id').val(id);
 		$('#iform').submit();
 	}
 
-	function by2_iface_toggle(action, id) {
+	function by2_iface_toggle(elem, action, id) {
+		// Peel off the first part of the control name
+		// to identify the STATUS icon.
+		var fldName = $(elem).attr('id');
+		fldName = fldName.substring(0, fldName.lastIndexOf('_'));
+		var service_name = fldName.substring(0, fldName.indexOf('_'));
+
+		// If stopping the service, change STATUS to a spinning gear cog.
+		if (action == 'stop') {
+			$('#' + fldName.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).removeClass('fa-check-circle fa-times-circle text-success text-danger');
+			$('#' + fldName.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).addClass('fa-cog fa-spin text-info');
+			$('#' + fldName.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).prop('title', service_name + ' is stopping on this interface');
+			$('#' + fldName.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_restart').addClass('hidden');
+		}
 		$('#by2toggle').val(action);
 		$('#id').val(id);
 		$('#iform').submit();

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces.php
@@ -99,14 +99,14 @@ if (isset($_POST['del_x'])) {
 			$if_real = get_real_interface($a_nat[$rulei]['interface']);
 			$if_friendly = convert_friendly_interface_to_friendly_descr($snortcfg['interface']);
 			$snort_uuid = $a_nat[$rulei]['uuid'];
-			log_error("Stopping Snort on {$if_friendly}({$if_real}) due to interface deletion...");
+			syslog(LOG_NOTICE, "Stopping Snort on {$if_friendly}({$if_real}) due to interface deletion...");
 			snort_stop($a_nat[$rulei], $if_real);
 			rmdir_recursive("{$snortlogdir}/snort_{$if_real}{$snort_uuid}");
 			rmdir_recursive("{$snortdir}/snort_{$snort_uuid}_{$if_real}");
 
 			// Finally delete the interface's config entry entirely
 			unset($a_nat[$rulei]);
-			log_error("Deleted Snort instance on {$if_friendly}({$if_real}) per user request...");
+			syslog(LOG_NOTICE, "Deleted Snort instance on {$if_friendly}({$if_real}) per user request...");
 		}
 	  
 		/* If all the Snort interfaces are removed, then unset the interfaces config array. */
@@ -137,14 +137,14 @@ else {
 		$if_real = get_real_interface($a_nat[$delbtn_list]['interface']);
 		$if_friendly = convert_friendly_interface_to_friendly_descr($snortcfg['interface']);
 		$snort_uuid = $a_nat[$delbtn_list]['uuid'];
-		log_error("Stopping Snort on {$if_friendly}({$if_real}) due to interface deletion...");
+		syslog(LOG_NOTICE, "Stopping Snort on {$if_friendly}({$if_real}) due to interface deletion...");
 		snort_stop($a_nat[$delbtn_list], $if_real);
 		rmdir_recursive("{$snortlogdir}/snort_{$if_real}{$snort_uuid}");
 		rmdir_recursive("{$snortdir}/snort_{$snort_uuid}_{$if_real}");
 
 		// Finally delete the interface's config entry entirely
 		unset($a_nat[$delbtn_list]);
-		log_error("Deleted Snort instance on {$if_friendly}({$if_real}) per user request...");
+		syslog(LOG_NOTICE, "Deleted Snort instance on {$if_friendly}({$if_real}) per user request...");
 
 		// Save updated configuration
 		write_config("Snort pkg: deleted one or more Snort interfaces.");
@@ -175,19 +175,19 @@ if ($_POST['by2toggle'] && is_numericint($_POST['id'])) {
 			sync_snort_package_config();
 			$rebuild_rules = false;
 			if (snort_is_running($if_real, 'barnyard2')) {
-				log_error("Restarting Barnyard2 on {$if_friendly}({$if_real}) per user request...");
+				syslog(LOG_NOTICE, "Restarting Barnyard2 on {$if_friendly}({$if_real}) per user request...");
 				snort_barnyard_stop($snortcfg, $if_real);
 				snort_barnyard_start($snortcfg, $if_real);
 			}
 			else {
-				log_error("Starting Barnyard2 on {$if_friendly}({$if_real}) per user request...");
+				syslog(LOG_NOTICE, "Starting Barnyard2 on {$if_friendly}({$if_real}) per user request...");
 				snort_barnyard_start($snortcfg, $if_real);
 			}
 			$by2_starting[$id] = 'TRUE';
 			break;
 		case 'stop':
 			if (snort_is_running($if_real, 'barnyard2')) {
-				log_error("Stopping Barnyard2 on {$if_friendly}({$if_real}) per user request...");
+				syslog(LOG_NOTICE, "Stopping Barnyard2 on {$if_friendly}({$if_real}) per user request...");
 				snort_barnyard_stop($snortcfg, $if_real);
 			}
 			unset($by2_starting[$id]);
@@ -233,12 +233,12 @@ EOD;
 		case 'start':
 			file_put_contents("{$g['tmp_path']}/snort_{$if_real}_startcmd.php", $snort_start_cmd);
 			if (snort_is_running($if_real)) {
-				log_error("Restarting Snort on {$if_friendly}({$if_real}) per user request...");
+				syslog(LOG_NOTICE, "Restarting Snort on {$if_friendly}({$if_real}) per user request...");
 				snort_stop($snortcfg, $if_real);
 				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/snort_{$if_real}_startcmd.php");
 			}
 			else {
-				log_error("Starting Snort on {$if_friendly}({$if_real}) per user request...");
+				syslog(LOG_NOTICE, "Starting Snort on {$if_friendly}({$if_real}) per user request...");
 				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/snort_{$if_real}_startcmd.php");
 			}
 			$snort_starting[$id] = 'TRUE';
@@ -248,7 +248,7 @@ EOD;
 			break;
 		case 'stop':
 			if (snort_is_running($if_real)) {
-				log_error("Stopping Snort on {$if_friendly}({$if_real}) per user request...");
+				syslog(LOG_NOTICE, "Stopping Snort on {$if_friendly}({$if_real}) per user request...");
 				snort_stop($snortcfg, $if_real);
 			}
 			unset($snort_starting[$id]);

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
@@ -57,6 +57,8 @@ if (!isset($pconfig['rule_update_starttime']))
 	$pconfig['rule_update_starttime'] = '00:05';
 if (!isset($config['installedpackages']['snortglobal']['forcekeepsettings']))
 	$pconfig['forcekeepsettings'] = 'on';
+if (!isset($config['installedpackages']['snortglobal']['clearblocks']))
+	$pconfig['clearblocks'] = 'on';
 if (!isset($config['installedpackages']['snortglobal']['curl_no_verify_ssl_peer']))
 	$pconfig['curl_no_verify_ssl_peer'] = 'off';
 
@@ -339,7 +341,7 @@ $section->addInput(new Form_Select(
 $section->addInput(new Form_Checkbox(
 	'clearblocks',
 	'Remove Blocked Hosts After Deinstall',
-	'Click to clear all blocked hosts added by Snort when removing the package.',
+	'Click to clear all blocked hosts added by Snort when removing the package.  Default is checked.',
 	$pconfig['clearblocks'] == 'on' ? true:false,
 	'on'
 ));

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
@@ -135,7 +135,7 @@ if (!$input_errors) {
 
 		// If deprecated rules should be removed, then do it
 		if ($config['installedpackages']['snortglobal']['hide_deprecated_rules'] == "on") {
-			log_error(gettext("[Snort] Hide Deprecated Rules is enabled.  Removing obsoleted rules categories."));
+			syslog(LOG_NOTICE, gettext("[Snort] Hide Deprecated Rules is enabled.  Removing obsoleted rules categories."));
 			snort_remove_dead_rules();
 		}
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ip_reputation.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ip_reputation.php
@@ -141,7 +141,7 @@ if ($_POST['apply']) {
 
 	// If Snort is already running, must restart to change IP REP preprocessor configuration.
 	if (snort_is_running($if_real)) {
-		log_error(gettext("Snort: restarting on interface " . convert_real_interface_to_friendly_descr($if_real) . " due to IP REP preprocessor configuration change."));
+		syslog(LOG_NOTICE, gettext("Snort: restarting on interface " . convert_real_interface_to_friendly_descr($if_real) . " due to IP REP preprocessor configuration change."));
 		snort_stop($a_nat[$id], $if_real);
 		snort_start($a_nat[$id], $if_real, TRUE);
 	}
@@ -184,7 +184,7 @@ if ($_POST['save']) {
 
 		// If Snort is already running, must restart to change IP REP preprocessor configuration.
 		if (snort_is_running($if_real)) {
-			log_error(gettext("Snort: restarting on interface " . convert_real_interface_to_friendly_descr($if_real) . " due to IP REP preprocessor configuration change."));
+			syslog(LOG_NOTICE, gettext("Snort: restarting on interface " . convert_real_interface_to_friendly_descr($if_real) . " due to IP REP preprocessor configuration change."));
 			snort_stop($a_nat[$id], $if_real);
 			snort_start($a_nat[$id], $if_real, TRUE);
 			$savemsg = gettext("Snort has been restarted on interface " . convert_real_interface_to_friendly_descr($if_real) . " because IP Reputation preprocessor changes require a restart.");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
@@ -727,7 +727,7 @@ if ($_POST['save']) {
 		/* changes.                                     */
 		$if_real = get_real_interface($a_nat[$id]['interface']);
 		if (snort_is_running($if_real)) {
-			log_error(gettext("Snort: restarting on interface " . convert_real_interface_to_friendly_descr($if_real) . " due to Preprocessor configuration change."));
+			syslog(LOG_NOTICE, gettext("Snort: restarting on interface " . convert_real_interface_to_friendly_descr($if_real) . " due to Preprocessor configuration change."));
 			snort_stop($a_nat[$id], $if_real);
 			snort_start($a_nat[$id], $if_real, TRUE);
 			$savemsg = gettext("Snort has been restarted on interface " . convert_real_interface_to_friendly_descr($if_real) . " because Preprocessor changes require a restart.");


### PR DESCRIPTION
### pfSense-pkg-snort-4.0_2
This update for the Snort GUI package enhances logging by providing PRIORITY tagging for messages and also corrects six bugs.

**New Features:**
1. Log messages are now tagged with a PRIORITY flag to facilitate parsing by third-party log analysis programs.  The PHP _syslog()_ function is now used for system logging and an appropriate PRIORITY tag is included with each logged message.

**Bug Fixes:**
1. Fix issues with updating the dynamic STATUS icons for Snort and Barnyard2 on the INTERFACES tab when starting/stopping Snort and Barnyard2 on an interface.

2. Change log rotation code to use _rename()_ to just move the existing log file to a new name and then _touch()_ to create the new empty one instead of a copy-then-empty string write sequence.  The former is much more efficient.

3. Ensure that binary-installed files and rules such as preprocessor and decoder rules are not deleted by GUI code during package upgrade or removal.

4. Make "Clear Blocked Hosts on Package Removal" the default on the GLOBAL SETTINGS tab.  This will help ensure any blocks inserted by Snort are removed along with the package.

5. Check for the "Remove Blocked Hosts After De-Install" setting preference and act accordingly when upgrading or uninstalling the package.  Formerly this check only happened when removing the package and electing to "not save" settings.

6. Recreate any critical config or preprocessor rules files from the "_*-sample_" versions if missing on upgrade or package reinstall to prevent Snort startup warnings or failures.