### PR TITLE
pf-Sense-pkg-snort-4.0_3 -- Bug Fix Update

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.0
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -1687,7 +1687,7 @@ function snort_resolve_flowbits($rules, $active_rules) {
 
 	/* Check $rules array to be sure it is filled.    */
 	if (empty($rules)) {
-		syslog(LOG_WARN, gettext("[Snort] WARNING: Flowbit resolution not done - no rules in {$snortdir}/rules/ ..."));
+		syslog(LOG_WARNING, gettext("[Snort] WARNING: Flowbit resolution not done - no rules in {$snortdir}/rules/ ..."));
 		return array();
 	}
 
@@ -3892,7 +3892,7 @@ function snort_filter_preproc_rules($snortcfg, &$active_rules, $persist_log = fa
 	/* than optimal with the preprocessors disabled.   */
 	/***************************************************/
 	if ($disabled_count > 0) {
-		syslog(LOG_WARN, gettext("[Snort] Warning: auto-disabled {$disabled_count} rules due to disabled preprocessor dependencies."));
+		syslog(LOG_WARNING, gettext("[Snort] Warning: auto-disabled {$disabled_count} rules due to disabled preprocessor dependencies."));
 		natcasesort($log_msg);
 		if ($fp) {
 			/* Only write the header when not persisting the log */

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -553,7 +553,7 @@ function snort_barnyard_start($snortcfg, $if_real, $background=FALSE) {
 	$snortdir = SNORTDIR;
 	$snortlogdir = SNORTLOGDIR;
 	$snort_uuid = $snortcfg['uuid'];
-	$snortbindir = SNORT_PBI_BINDIR;
+	$snortbindir = SNORT_BINDIR;
 
 	if ($snortcfg['barnyard_enable'] == 'on' && !isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}.pid")) {
 		syslog(LOG_NOTICE, "[Snort] Barnyard2 START for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
@@ -570,7 +570,7 @@ function snort_start($snortcfg, $if_real, $background=FALSE) {
 	$snortdir = SNORTDIR;
 	$snortlogdir = SNORTLOGDIR;
 	$snort_uuid = $snortcfg['uuid'];
-	$snortbindir = SNORT_PBI_BINDIR;
+	$snortbindir = SNORT_BINDIR;
 
 	if ($config['installedpackages']['snortglobal']['verbose_logging'] == "on")
 		$quiet = "";
@@ -3215,7 +3215,7 @@ function snort_create_rc() {
 
 	$snortdir = SNORTDIR;
 	$snortlogdir = SNORTLOGDIR;
-	$snortbindir = SNORT_PBI_BINDIR;
+	$snortbindir = SNORT_BINDIR;
 	$rcdir = RCFILEPREFIX;	
 
 	$snortconf = $config['installedpackages']['snortglobal']['rule'];
@@ -3939,7 +3939,7 @@ function snort_generate_conf($snortcfg) {
 		return;
 
 	$snortdir = SNORTDIR;
-	$snortlibdir = SNORT_PBI_BASEDIR . "lib";
+	$snortlibdir = SNORT_BASEDIR . "lib";
 	$snortlogdir = SNORTLOGDIR;
 	$flowbit_rules_file = FLOWBITS_FILENAME;
 	$snort_enforcing_rules_file = SNORT_ENFORCING_RULES_FILENAME;

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -29,10 +29,10 @@ require("/usr/local/pkg/snort/snort_defs.inc");
 global $g, $config, $rebuild_rules;
 
 $snortdir = SNORTDIR;
-$snortlibdir = SNORT_PBI_BASEDIR . "lib";
+$snortlibdir = SNORT_BASEDIR . "lib";
 $snortlogdir = SNORTLOGDIR;
 $snortiprepdir = SNORT_IPREP_PATH;
-$snortbindir = SNORT_PBI_BINDIR;
+$snortbindir = SNORT_BINDIR;
 
 /* define checks */
 $oinkid = $config['installedpackages']['snortglobal']['oinkmastercode'];

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -24,20 +24,20 @@
 global $g, $config;
 
 /* Define some useful constants for Snort */
-if (!defined("SNORT_PBI_BASEDIR")) {
-	define("SNORT_PBI_BASEDIR", "/usr/local/");
+if (!defined("SNORT_BASEDIR")) {
+	define("SNORT_BASEDIR", "/usr/local/");
 }
-if (!defined("SNORT_PBI_BINDIR"))
-	define("SNORT_PBI_BINDIR", SNORT_PBI_BASEDIR . "bin/");
+if (!defined("SNORT_BINDIR"))
+	define("SNORT_BINDIR", SNORT_BASEDIR . "bin/");
 if (!defined("SNORTDIR"))
-	define("SNORTDIR", SNORT_PBI_BASEDIR . "etc/snort");
+	define("SNORTDIR", SNORT_BASEDIR . "etc/snort");
 if (!defined("SNORTLOGDIR"))
 	define("SNORTLOGDIR", "{$g['varlog_path']}/snort");
 if (!defined("SNORT_BIN_VERSION")) {
 	// Grab the Snort binary version programmatically by
 	// running the binary with the command-line argument
 	// to display the version information.
-	$snortbindir = SNORT_PBI_BINDIR;
+	$snortbindir = SNORT_BINDIR;
 	$snortver = exec_command("{$snortbindir}/snort -V 2>&1 |/usr/bin/grep Version | /usr/bin/cut -c20-31");
 
 	// Extract just the numbers and decimal point

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
@@ -190,7 +190,7 @@ foreach ($snort_ports as $alias => $avalue) {
 			$snort_ports[$alias] = trim(filter_expand_alias($snortcfg["def_{$alias}"]));
 		}
 		else {
-			syslog(LOG_WARN, "[snort] WARNING: unable to resolve Alias specified for PORTS variable " . strtoupper($alias) . " ... using default value '{$avalue}' instead.");
+			syslog(LOG_WARNING, "[snort] WARNING: unable to resolve Alias specified for PORTS variable " . strtoupper($alias) . " ... using default value '{$avalue}' instead.");
 		}
 	}
 	$snort_ports[$alias] = preg_replace('/\s+/', ',', trim($snort_ports[$alias]));
@@ -651,7 +651,7 @@ if (!empty($snortcfg['pscan_ignore_scanners'])) {
 			$sf_pscan_ignore_scanners = preg_replace('/\s+/', ',', trim($sf_pscan_ignore_scanners));
 		}
 		else {
-			syslog(LOG_WARN, "[snort] WARNING: unable to resolve Alias {$snortcfg['pscan_ignore_scanners']} for PSCAN_IGNORE_SCANNERS ... reverting to default value of HOME_NET.");
+			syslog(LOG_WARNING, "[snort] WARNING: unable to resolve Alias {$snortcfg['pscan_ignore_scanners']} for PSCAN_IGNORE_SCANNERS ... reverting to default value of HOME_NET.");
 		}
 	} else {
         	$sf_pscan_ignore_scanners = $snortcfg['pscan_ignore_scanners'];
@@ -665,7 +665,7 @@ if (!empty($snortcfg['pscan_ignore_scanned'])) {
 			$sf_pscan_ignore_scanned = preg_replace('/\s+/', ',', trim($sf_pscan_ignore_scanned));
 		}
 		else {
-			syslog(LOG_WARN, "[snort] WARNING: unable to resolve Alias {$snortcfg['pscan_ignore_scanned']} for PSCAN_IGNORE_SCANNED ... reverting to default value of null.");
+			syslog(LOG_WARNING, "[snort] WARNING: unable to resolve Alias {$snortcfg['pscan_ignore_scanned']} for PSCAN_IGNORE_SCANNED ... reverting to default value of null.");
 		}
 	} else {
           	$sf_pscan_ignore_scanned = $snortcfg['pscan_ignore_scanned'];
@@ -706,7 +706,7 @@ if (isset($snortcfg['ssh_preproc_ports'])) {
 			$ssh_ports = preg_replace('/\s+/', ',', trim($ssh_ports));
 		}
 		else {
-			syslog(LOG_WARN, "[snort] WARNING: unable to resolve Alias {$snortcfg['ssh_preproc_ports']} for SSH Preprocessor Ports parameter ... reverting to default value of 22.");
+			syslog(LOG_WARNING, "[snort] WARNING: unable to resolve Alias {$snortcfg['ssh_preproc_ports']} for SSH Preprocessor Ports parameter ... reverting to default value of 22.");
 			$ssh_ports = "22";
 		}
 	} else {
@@ -1026,7 +1026,7 @@ foreach ($snort_servers as $alias => $avalue) {
 			$avalue = preg_replace('/\s+/', ',', trim($avalue));
 		}
 		else {
-			syslog(LOG_WARN, "[snort] WARNING: unable to resolve Alias specified for SERVERS variable " . strtoupper($alias) . " ... using default value '{$avalue}' instead.");
+			syslog(LOG_WARNING, "[snort] WARNING: unable to resolve Alias specified for SERVERS variable " . strtoupper($alias) . " ... using default value '{$avalue}' instead.");
 		}
 	}
 	$ipvardef .= "ipvar " . strtoupper($alias) . " [{$avalue}]\n";
@@ -1077,7 +1077,7 @@ foreach ($snort_preproc as $preproc) {
 					$snort_preprocessors .= $$preproc;
 					$snort_preprocessors .= "\n";
 				} else
-					syslog(LOG_WARN, "Could not find the {$preproclib} library file in '{$snortlibdir}/snort_dynamicpreprocessor/'. Snort might fail to start!");
+					syslog(LOG_WARNING, "Could not find the {$preproclib} library file in '{$snortlibdir}/snort_dynamicpreprocessor/'. Snort might fail to start!");
 			} else {
 				$snort_preprocessors .= $$preproc;
 				$snort_preprocessors .= "\n";
@@ -1181,7 +1181,7 @@ if ($snortcfg['frag3_detection'] == "on") {
 					$frag3_engine .= " \\\n\tbind_to {$tmp}";
 			}
 			else
-				syslog(LOG_WARN, "[snort] WARNING: unable to resolve IP List Alias '{$v['bind_to']}' for Frag3 engine '{$v['name']}' ... using 0.0.0.0 failsafe.");
+				syslog(LOG_WARNING, "[snort] WARNING: unable to resolve IP List Alias '{$v['bind_to']}' for Frag3 engine '{$v['name']}' ... using 0.0.0.0 failsafe.");
 		}
 		$frag3_engine .= " \\\n\ttimeout {$v['timeout']}";
 		$frag3_engine .= " \\\n\tmin_ttl {$v['min_ttl']}";
@@ -1280,7 +1280,7 @@ if ($snortcfg['stream5_reassembly'] == "on") {
 					$buffer .= " \\\n\tbind_to {$tmp},";
 			}
 			else {
-				syslog(LOG_WARN, "[snort] WARNING: unable to resolve IP Address Alias [{$v['bind_to']}] for Stream5 TCP engine '{$v['name']}' ... skipping this engine.");
+				syslog(LOG_WARNING, "[snort] WARNING: unable to resolve IP Address Alias [{$v['bind_to']}] for Stream5 TCP engine '{$v['name']}' ... skipping this engine.");
 				continue;
 			}
 		}
@@ -1314,7 +1314,7 @@ if ($snortcfg['stream5_reassembly'] == "on") {
 					$stream5_tcp_engine .= " " . trim(preg_replace('/\s+/', ' ', $tmp));
 				else {
 					$stream5_tcp_engine .= " {$stream5_ports_client}";
-					syslog(LOG_WARN, "[snort] WARNING: unable to resolve Ports Client Alias [{$v['ports_client']}] for Stream5 TCP engine '{$v['name']}' ... using default value.");
+					syslog(LOG_WARNING, "[snort] WARNING: unable to resolve Ports Client Alias [{$v['ports_client']}] for Stream5 TCP engine '{$v['name']}' ... using default value.");
 				}
 			}
 		}
@@ -1330,7 +1330,7 @@ if ($snortcfg['stream5_reassembly'] == "on") {
 					$stream5_tcp_engine .= " " . trim(preg_replace('/\s+/', ' ', $tmp));
 				else {
 					$stream5_tcp_engine .= " {$stream5_ports_both}";
-					syslog(LOG_WARN, "[snort] WARNING: unable to resolve Ports Both Alias [{$v['ports_both']}] for Stream5 TCP engine '{$v['name']}' ... using default value.");
+					syslog(LOG_WARNING, "[snort] WARNING: unable to resolve Ports Both Alias [{$v['ports_both']}] for Stream5 TCP engine '{$v['name']}' ... using default value.");
 				}
 			}
 		}
@@ -1346,7 +1346,7 @@ if ($snortcfg['stream5_reassembly'] == "on") {
 					$stream5_tcp_engine .= " " . trim(preg_replace('/\s+/', ' ', $tmp));
 				}
 				else
-					syslog(LOG_WARN, "[snort] WARNING: unable to resolve Ports Server Alias [{$v['ports_server']}] for Stream5 TCP engine '{$v['name']}' ... defaulting to none.");
+					syslog(LOG_WARNING, "[snort] WARNING: unable to resolve Ports Server Alias [{$v['ports_server']}] for Stream5 TCP engine '{$v['name']}' ... defaulting to none.");
 			}
 		}
 
@@ -1447,12 +1447,12 @@ if ($snortcfg['http_inspect'] <> "off") {
 					$buffer .= "\tserver { {$tmp} } \\\n";
 			}
 			else {
-				syslog(LOG_WARN, "[snort] WARNING: unable to resolve IP Address Alias [{$v['bind_to']}] for HTTP_INSPECT server '{$v['name']}' ... skipping this server engine.");
+				syslog(LOG_WARNING, "[snort] WARNING: unable to resolve IP Address Alias [{$v['bind_to']}] for HTTP_INSPECT server '{$v['name']}' ... skipping this server engine.");
 				continue;
 			}
 		}
 		else {
-				syslog(LOG_WARN, "[snort] WARNING: unable to resolve IP Address Alias [{$v['bind_to']}] for HTTP_INSPECT server '{$v['name']}' ... skipping this server engine.");
+				syslog(LOG_WARNING, "[snort] WARNING: unable to resolve IP Address Alias [{$v['bind_to']}] for HTTP_INSPECT server '{$v['name']}' ... skipping this server engine.");
 				continue;
 		}
 		$http_inspect_servers .= $buffer;
@@ -1471,12 +1471,12 @@ if ($snortcfg['http_inspect'] <> "off") {
 				$http_inspect_servers .= "\tports { {$tmp} } \\\n";
 			}
 			else {
-				syslog(LOG_WARN, "[snort] WARNING: unable to resolve Ports Alias [{$v['ports']}] for HTTP_INSPECT server '{$v['name']}' ... using safe default instead.");
+				syslog(LOG_WARNING, "[snort] WARNING: unable to resolve Ports Alias [{$v['ports']}] for HTTP_INSPECT server '{$v['name']}' ... using safe default instead.");
 				$http_inspect_servers .= "\tports { {$http_ports} } \\\n";
 			}
 		}
 		else {
-				syslog(LOG_WARN, "[snort] WARNING: unable to resolve Ports Alias [{$v['ports']}] for HTTP_INSPECT server '{$v['name']}' ... using safe default instead.");
+				syslog(LOG_WARNING, "[snort] WARNING: unable to resolve Ports Alias [{$v['ports']}] for HTTP_INSPECT server '{$v['name']}' ... using safe default instead.");
 				$http_inspect_servers .= "\tports { {$http_ports} } \\\n";
 		}
 

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -37,7 +37,7 @@ require("/usr/local/pkg/snort/snort_defs.inc");
 global $config, $g;
 
 $snortdir = SNORTDIR;
-$snortlibdir = SNORT_PBI_BASEDIR . "lib";
+$snortlibdir = SNORT_BASEDIR . "lib";
 $snortlogdir = SNORTLOGDIR;
 $rcdir = RCFILEPREFIX;
 $snort_rules_upd_log = SNORT_RULES_UPD_LOGFILE;


### PR DESCRIPTION
### pfSense-pkg-snort-4.0_3
This update corrects the erroneous use of LOG_WARN instead of LOG_WARNING as a PRIORITY flag for _syslog()_ messages.

**New Features:**
None

**Bug Fixes:**
1.  The PRIORITY flag for warning messages printed via _syslog()_ uses LOG_WARN instead of the correct LOG_WARNING constant.
