### PR TITLE
pfSense-pkg-snort v4.0_4 -- Include two files left out of previous 4.0_3 update

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.0
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -825,5 +825,4 @@ if ($update_errors)
 else
 	$config['installedpackages']['snortglobal']['last_rule_upd_status'] = gettext("success");
 $config['installedpackages']['snortglobal']['last_rule_upd_time'] = time();
-write_config("Snort pkg: updated status for updated rules package(s) check.", FALSE);
 ?>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interface_logs.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interface_logs.php
@@ -3,11 +3,11 @@
  * snort_interface_logs.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2014-2018 Bill Meeks
+ * Copyright (c) 2014-2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,8 +43,8 @@ $if_real = get_real_interface($a_instance[$id]['interface']);
 // Construct a pointer to the instance's logging subdirectory
 $snortlogdir = SNORTLOGDIR . "/snort_{$if_real}{$snort_uuid}/";
 
-// Construct a pointer to the PBI_BIN directory
-$snortbindir = SNORT_PBI_BINDIR;
+// Construct a pointer to the Snort BIN directory
+$snortbindir = SNORT_BINDIR;
 
 // Limit all file access to just the currently selected interface's logging subdirectory
 $logfile = htmlspecialchars($snortlogdir . basename($_POST['file']));

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
@@ -35,13 +35,13 @@ if ($_POST['save'])
 	$pconfig = $_POST;
 else {
 	$pconfig['snortdownload'] = $config['installedpackages']['snortglobal']['snortdownload'] == "on" ? 'on' : 'off';
-	$pconfig['oinkmastercode'] = $config['installedpackages']['snortglobal']['oinkmastercode'];
-	$pconfig['etpro_code'] = $config['installedpackages']['snortglobal']['etpro_code'];
+	$pconfig['oinkmastercode'] = htmlentities($config['installedpackages']['snortglobal']['oinkmastercode']);
+	$pconfig['etpro_code'] = htmlentities($config['installedpackages']['snortglobal']['etpro_code']);
 	$pconfig['emergingthreats'] = $config['installedpackages']['snortglobal']['emergingthreats'] == "on" ? 'on' : 'off';
 	$pconfig['emergingthreats_pro'] = $config['installedpackages']['snortglobal']['emergingthreats_pro'] == "on" ? 'on' : 'off';
 	$pconfig['rm_blocked'] = $config['installedpackages']['snortglobal']['rm_blocked'];
 	$pconfig['autorulesupdate7'] = $config['installedpackages']['snortglobal']['autorulesupdate7'];
-	$pconfig['rule_update_starttime'] = $config['installedpackages']['snortglobal']['rule_update_starttime'];
+	$pconfig['rule_update_starttime'] = htmlentities($config['installedpackages']['snortglobal']['rule_update_starttime']);
 	$pconfig['forcekeepsettings'] = $config['installedpackages']['snortglobal']['forcekeepsettings'] == "on" ? 'on' : 'off';
 	$pconfig['snortcommunityrules'] = $config['installedpackages']['snortglobal']['snortcommunityrules'] == "on" ? 'on' : 'off';
 	$pconfig['clearblocks'] = $config['installedpackages']['snortglobal']['clearblocks'] == "on" ? 'on' : 'off';
@@ -141,8 +141,8 @@ if (!$input_errors) {
 			snort_remove_dead_rules();
 		}
 
-		$config['installedpackages']['snortglobal']['oinkmastercode'] = $_POST['oinkmastercode'];
-		$config['installedpackages']['snortglobal']['etpro_code'] = $_POST['etpro_code'];
+		$config['installedpackages']['snortglobal']['oinkmastercode'] = trim(html_entity_decode($_POST['oinkmastercode']));
+		$config['installedpackages']['snortglobal']['etpro_code'] = trim(html_entity_decode($_POST['etpro_code']));
 
 		$config['installedpackages']['snortglobal']['rm_blocked'] = $_POST['rm_blocked'];
 		$config['installedpackages']['snortglobal']['autorulesupdate7'] = $_POST['autorulesupdate7'];
@@ -154,7 +154,7 @@ if (!$input_errors) {
 				$tmp = str_pad($_POST['rule_update_starttime'], 4, "0", STR_PAD_LEFT);
 				$_POST['rule_update_starttime'] = substr($tmp, 0, 2) . ":" . substr($tmp, -2);
 			}
-			$config['installedpackages']['snortglobal']['rule_update_starttime'] = str_pad($_POST['rule_update_starttime'], 4, "0", STR_PAD_LEFT);
+			$config['installedpackages']['snortglobal']['rule_update_starttime'] = str_pad(html_entity_decode($_POST['rule_update_starttime']), 4, "0", STR_PAD_LEFT);
 		}
 
 		$config['installedpackages']['snortglobal']['forcekeepsettings'] = $_POST['forcekeepsettings'] ? 'on' : 'off';

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
@@ -27,7 +27,7 @@ require_once("/usr/local/pkg/snort/snort.inc");
 global $g, $rebuild_rules;
 
 $snortdir = SNORTDIR;
-$snortbindir = SNORT_PBI_BINDIR;
+$snortbindir = SNORT_BINDIR;
 $rules_map = array();
 $categories = array();
 $pconfig = array();


### PR DESCRIPTION
### pfSense-pkg-snort 4.0_4
This update for the Snort GUI package contains only bug fixes.  No new features are introduced.

**New Features:**
None

**Bug Fixes:**
1. Two changed files were inadvertently left out of the previous Snort 4.0_3 update package.  The files were part of the change set where the constant SNORT_PBI_BINDIR was changed to SNORT_BINDIR.

2. Remove any leading or trailing spaces put there by mistake when saving the Oinkmaster and ETpro subscription codes on GLOBAL SETTINGS tab.

3. Wrap user input on GLOBAL SETTINGS tab with HTML-encode/decode functions for added security against code injection.

4. Clean-up unnecessary _write_config()_ call to prevent spamming of ACB service when downloading rules updates.