### PR TITLE
pfSense-pkg-suricata 4.1.4_5 -- Bug Fix Update

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.1.4
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -119,7 +119,7 @@ function suricata_start($suricatacfg, $if_real) {
 	if ($suricatacfg['enable'] == 'on') {
 		// Truncate suricata.log file for this interface.
 		file_put_contents("{$suricatalogdir}/suricata.log", '');
-		$run_mode = $suricatacfg['ips_mode'] == 'ips_mode_inline' ? '--netmap' : '-i ' . $if_real;
+		$run_mode = $suricatacfg['ips_mode'] == 'ips_mode_inline' && $suricatacfg['blockoffenders'] == 'on' ? '--netmap' : '-i ' . $if_real;
 		syslog(LOG_NOTICE, "[Suricata] Suricata START for {$suricatacfg['descr']}({$if_real})...");
 		mwexec_bg("{$suricatabindir}suricata {$run_mode} -D -c {$suricatadir}suricata_{$suricata_uuid}_{$if_real}/suricata.yaml --pidfile {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid");
 	} else {
@@ -304,7 +304,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 		// and allow all traffic to pass!  We do include
 		// locally-attached networks, VPNs, VIPs and the WAN IP
 		// when building only the HOME_NET variable.
-		if ($suricatacfg['ips_mode'] == 'ips_mode_inline' && $passlist == TRUE) {
+		if ($suricatacfg['ips_mode'] == 'ips_mode_inline' && $suricatacfg['blockoffenders'] == 'on' && $passlist == TRUE) {
 			$localnet = 'no';
 			$wanip = 'no';
 			$vpns = 'no';
@@ -3609,7 +3609,7 @@ function suricata_create_rc() {
 		}
 		$suricata_uuid = $value['uuid'];
 		$if_real = get_real_interface($value['interface']);
-		$run_mode = $value['ips_mode'] == 'ips_mode_inline' ? '--netmap' : '-i ' . $if_real;
+		$run_mode = $value['ips_mode'] == 'ips_mode_inline' && $value['blockoffenders'] == 'on' ? '--netmap' : '-i ' . $if_real;
 
 		$start_barnyard = <<<EOE
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -715,6 +715,5 @@ if ($update_errors)
 else
 	$config['installedpackages']['suricata']['config'][0]['last_rule_upd_status'] = gettext("success");
 $config['installedpackages']['suricata']['config'][0]['last_rule_upd_time'] = time();
-write_config("Suricata pkg: updated status for updated rules package(s) check.", FALSE);
 
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -3,11 +3,11 @@
  * suricata_alerts.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -176,6 +176,9 @@ if ($a_instance[$instanceid]['blockoffenders'] == 'on' && ($a_instance[$instance
 	// REJECT forcing is only applicable to Inline IPS Mode
 	if ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' ) {
 		$rejectsid = suricata_load_sid_mods($a_instance[$instanceid]['rule_sid_force_reject']);
+	}
+	else {
+		$rejectsid = array();
 	}
 }
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -152,8 +152,8 @@ if (!$input_errors) {
 		}
 
 		$config['installedpackages']['suricata']['config'][0]['snort_rules_file'] = html_entity_decode($_POST['snort_rules_file']);
-		$config['installedpackages']['suricata']['config'][0]['oinkcode'] = html_entity_decode($_POST['oinkcode']);
-		$config['installedpackages']['suricata']['config'][0]['etprocode'] = html_entity_decode($_POST['etprocode']);
+		$config['installedpackages']['suricata']['config'][0]['oinkcode'] = trim(html_entity_decode($_POST['oinkcode']));
+		$config['installedpackages']['suricata']['config'][0]['etprocode'] = trim(html_entity_decode($_POST['etprocode']));
 		$config['installedpackages']['suricata']['config'][0]['rm_blocked'] = $_POST['rm_blocked'];
 		$config['installedpackages']['suricata']['config'][0]['autoruleupdate'] = $_POST['autoruleupdate'];
 		$config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url'] = trim(html_entity_decode($_POST['etopen_custom_rule_url']));

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -147,7 +147,7 @@ if (!$input_errors) {
 
 		// If deprecated rules should be removed, then do it
 		if ($config['installedpackages']['suricata']['config'][0]['hide_deprecated_rules'] == "on") {
-			syslog(gettext(LOG_NOTICE, "[Suricata] Hide Deprecated Rules is enabled.  Removing obsoleted rules categories."));
+			syslog(LOG_NOTICE, gettext("[Suricata] Hide Deprecated Rules is enabled.  Removing obsoleted rules categories."));
 			suricata_remove_dead_rules();
 		}
 


### PR DESCRIPTION
### pfSense-pkg-suricata-4.1.4_5
This Suricata GUI package update corrects five bug reports.  No new features are added in this release.

**New Features:**
None

**Bug Fixes:**
1. Syntax error typo in _syslog()_ function call on GLOBAL SETTINGS tab causes PHP warning.

2. When using Legacy Mode blocking the array of SIDs modified for REJECT action is not properly initialized as an empty array before an iteration attempt is made later in the code.

3. Code logic bug allows attempted operation with netmap without specifying an interface when 'Block Offenders' is not checked.

4. Remove any inadvertent leading or trailing spaces from Oinkcode and ETPro code when saving on GLOBAL SETTINGS tab.

5. Clean-up unnecessary _write_config()_ call to prevent spamming of ACB service when downloading rules updates.