### PR TITLE
Patch Barnyard2 for SG-3100 ARMv6/7

### DIFF
--- a/security/barnyard2/files/patch-configure.in
+++ b/security/barnyard2/files/patch-configure.in
@@ -1,0 +1,28 @@
+--- configure.in.orig	2013-05-27 04:04:34 UTC
++++ configure.in
+@@ -428,6 +428,16 @@ AC_DEFUN([FAIL_MESSAGE],[
+    exit 1
+ ])
+ 
++# any arm platform has to disable optimization
++AC_MSG_CHECKING(for arm avoid bus error)
++if eval "echo $host_cpu|grep -i 'armv[[6|7]]' >/dev/null"; then
++    AC_MSG_RESULT(yes)
++    NO_OPTIMIZE="yes"
++    CFLAGS="$CFLAGS -mno-unaligned-access "
++else
++    AC_MSG_RESULT(no)
++fi
++
+ # any sparc platform has to have this one defined.
+ AC_MSG_CHECKING(for sparc)
+ if eval "echo $host_cpu|grep -i sparc >/dev/null"; then
+@@ -1095,7 +1105,7 @@ fi
+ 
+ # Set to no optimization regardless of what user or autostuff set
+ if test "x$NO_OPTIMIZE" = "xyes"; then
+-    CFLAGS=`echo $CFLAGS | sed -e "s/-O./-O0/"`
++    CFLAGS=`echo $CFLAGS | sed -e "s/-O./-O0 /"`
+ 
+     # in case user override doesn't include -O
+     if echo $CFLAGS | grep -qve -O0 ; then

--- a/security/barnyard2/files/patch-schemas_create__mysql
+++ b/security/barnyard2/files/patch-schemas_create__mysql
@@ -1,0 +1,19 @@
+--- schemas/create_mysql.orig	2019-08-07 17:47:42 UTC
++++ schemas/create_mysql
+@@ -51,13 +51,13 @@ CREATE TABLE sig_reference (sig_id  INT 
+                             PRIMARY KEY(sig_id, ref_seq));
+ 
+ CREATE TABLE reference (  ref_id        INT         UNSIGNED NOT NULL AUTO_INCREMENT,
+-                          ref_system_id INT         UNSIGNED NOT NULL,
++                          `ref_system_id` INT         UNSIGNED NOT NULL,
+                           ref_tag       TEXT NOT NULL,
+                           PRIMARY KEY (ref_id));
+ 
+-CREATE TABLE reference_system ( ref_system_id   INT         UNSIGNED NOT NULL AUTO_INCREMENT,
++CREATE TABLE reference_system ( `ref_system_id`   INT         UNSIGNED NOT NULL AUTO_INCREMENT,
+                                 ref_system_name VARCHAR(20),
+-                                PRIMARY KEY (ref_system_id));
++                                PRIMARY KEY (`ref_system_id`));
+ 
+ CREATE TABLE sig_class ( sig_class_id        INT    UNSIGNED NOT NULL AUTO_INCREMENT,
+                          sig_class_name      VARCHAR(60) NOT NULL,

--- a/security/barnyard2/files/patch-src_output-plugins_spo__database__cache.h
+++ b/security/barnyard2/files/patch-src_output-plugins_spo__database__cache.h
@@ -1,0 +1,39 @@
+--- src/output-plugins/spo_database_cache.h.orig	2019-08-07 13:48:17 UTC
++++ src/output-plugins/spo_database_cache.h
+@@ -96,9 +96,9 @@
+ ** Ref: http://www.postgresql.org/docs/9.1/static/datatype-binary.html
+ 
+ #define PGSQL_SQL_INSERT_SPECIFIC_REFERENCE_SYSTEM "INSERT INTO reference_system (ref_system_name) VALUES (E'%s');"
+-#define PGSQL_SQL_SELECT_SPECIFIC_REFERENCE_SYSTEM "SELECT ref_system_id FROM reference_system WHERE ref_system_name = E'%s';"
+-#define PGSQL_SQL_INSERT_SPECIFIC_REF  "INSERT INTO reference (ref_system_id,ref_tag) VALUES ('%u',E'%s');"
+-#define PGSQL_SQL_SELECT_SPECIFIC_REF  "SELECT ref_id FROM reference WHERE ref_system_id = '%u' AND ref_tag = E'%s';"
++#define PGSQL_SQL_SELECT_SPECIFIC_REFERENCE_SYSTEM "SELECT `ref_system_id` FROM reference_system WHERE ref_system_name = E'%s';"
++#define PGSQL_SQL_INSERT_SPECIFIC_REF  "INSERT INTO reference (`ref_system_id`,ref_tag) VALUES ('%u',E'%s');"
++#define PGSQL_SQL_SELECT_SPECIFIC_REF  "SELECT ref_id FROM reference WHERE `ref_system_id` = '%u' AND ref_tag = E'%s';"
+ #define PGSQL_SQL_INSERT_CLASSIFICATION "INSERT INTO sig_class (sig_class_name) VALUES (E'%s');"
+ #define PGSQL_SQL_SELECT_SPECIFIC_CLASSIFICATION "SELECT sig_class_id FROM sig_class WHERE sig_class_name = E'%s';"
+ #define PGSQL_SQL_INSERT_SIGNATURE "INSERT INTO signature (sig_sid, sig_gid, sig_rev, sig_class_id, sig_priority, sig_name) VALUES ('%u','%u','%u','%u','%u',E'%s');"
+@@ -117,9 +117,9 @@
+ 
+ 
+ #define SQL_INSERT_SPECIFIC_REFERENCE_SYSTEM "INSERT INTO reference_system (ref_system_name) VALUES ('%s');"
+-#define SQL_SELECT_SPECIFIC_REFERENCE_SYSTEM "SELECT ref_system_id FROM reference_system WHERE ref_system_name = '%s';"
+-#define SQL_INSERT_SPECIFIC_REF  "INSERT INTO reference (ref_system_id,ref_tag) VALUES ('%u','%s');"
+-#define SQL_SELECT_SPECIFIC_REF  "SELECT ref_id FROM reference WHERE ref_system_id = '%u' AND ref_tag = '%s';"
++#define SQL_SELECT_SPECIFIC_REFERENCE_SYSTEM "SELECT `ref_system_id` FROM reference_system WHERE ref_system_name = '%s';"
++#define SQL_INSERT_SPECIFIC_REF  "INSERT INTO reference (`ref_system_id`,ref_tag) VALUES ('%u','%s');"
++#define SQL_SELECT_SPECIFIC_REF  "SELECT ref_id FROM reference WHERE `ref_system_id` = '%u' AND ref_tag = '%s';"
+ #define SQL_INSERT_CLASSIFICATION "INSERT INTO sig_class (sig_class_name) VALUES ('%s');"
+ #define SQL_SELECT_SPECIFIC_CLASSIFICATION "SELECT sig_class_id FROM sig_class WHERE sig_class_name = '%s';"
+ #define SQL_INSERT_SIGNATURE "INSERT INTO signature (sig_sid, sig_gid, sig_rev, sig_class_id, sig_priority, sig_name) VALUES ('%u','%u','%u','%u','%u','%s');"
+@@ -145,8 +145,8 @@
+ #define SQL_SELECT_ALL_SIGREF "SELECT ref_id, sig_id, ref_seq FROM sig_reference ORDER BY sig_id,ref_seq;"
+ #define SQL_INSERT_SIGREF "INSERT INTO sig_reference (ref_id,sig_id,ref_seq) VALUES ('%u','%u','%u');"
+ #define SQL_SELECT_SPECIFIC_SIGREF "SELECT ref_id FROM sig_reference WHERE (ref_id = '%u') AND (sig_id = '%u') AND (ref_seq='%u');"
+-#define SQL_SELECT_ALL_REFERENCE_SYSTEM  "SELECT ref_system_id, ref_system_name FROM reference_system;"
+-#define SQL_SELECT_ALL_REF "SELECT ref_id, ref_system_id, ref_tag FROM reference; "
++#define SQL_SELECT_ALL_REFERENCE_SYSTEM  "SELECT `ref_system_id`, ref_system_name FROM reference_system;"
++#define SQL_SELECT_ALL_REF "SELECT ref_id, `ref_system_id`, ref_tag FROM reference; "
+ #define SQL_SELECT_ALL_CLASSIFICATION "SELECT sig_class_id, sig_class_name FROM sig_class ORDER BY sig_class_id ASC; "
+ #define SQL_SELECT_ALL_SIGNATURE "SELECT sig_id, sig_sid, sig_gid,sig_rev, sig_class_id, sig_priority, sig_name FROM signature;"
+ #define SQL_UPDATE_SPECIFIC_SIGNATURE "UPDATE signature SET "		\


### PR DESCRIPTION
The Barnyard2 from 2.4.4.p3 is broken in my recent purchased SG-3100. There are two road blocks:

- Outdated syntax in SQL query.
- Use optimization `-O` CFLAGS that cause unaligned memory access in pointer casting. Barnyard2 crashed with bus error.

I have tested my patched Barnyard2 under SG-3100 in 2.4.4.p3 for days. The database is MariaDB 10.3.9. I haven't seen the crash any more.

See discussion details in [pfSense forum](https://forum.netgate.com/topic/143538/barnyard2-and-mariadb/6)