### PR TITLE
pfSense-pkg-snort-4.0_5 -- Snort GUI Package Update

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.0
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package snort
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	snort>=2.9.13_1:security/snort \
+RUN_DEPENDS=	snort>=2.9.14.1:security/snort \
 		barnyard2>=0:security/barnyard2
 
 NO_BUILD=	yes

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -47,7 +47,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 		define("SNORT_BIN_VERSION", $matches[0]);
 	}
 	else {
-		define("SNORT_BIN_VERSION", "2.9.13");
+		define("SNORT_BIN_VERSION", "2.9.14.1");
 	}
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
@@ -48,8 +48,6 @@ if (!is_array($config['installedpackages']['snortglobal']['rule'])) {
 if (empty($config['installedpackages']['snortglobal']['rule']))
 	return;
 
-$rule = &$config['installedpackages']['snortglobal']['rule'];
-
 /****************************************************************************/
 /* Loop through all the <rule> elements in the Snort configuration and      */
 /* migrate the relevant preprocessor parameters to the new format.          */
@@ -190,80 +188,77 @@ elseif ($config['installedpackages']['snortglobal']['sid_list_migration'] < "2")
 /**********************************************************/
 /* Migrate per interface settings if required.            */
 /**********************************************************/
-foreach ($rule as &$r) {
+foreach ($config['installedpackages']['snortglobal']['rule'] as &$rule) {
 	// Initialize arrays for supported preprocessors if necessary
-	if (!is_array($r['frag3_engine'])) {
-		$r['frag3_engine'] = array();
+	if (!is_array($rule['frag3_engine'])) {
+		$rule['frag3_engine'] = array();
 	}
-	if (!is_array($r['frag3_engine']['item'])) {
-		$r['frag3_engine']['item'] = array();
+	if (!is_array($rule['frag3_engine']['item'])) {
+		$rule['frag3_engine']['item'] = array();
 	}
-	if (!is_array($r['stream5_tcp_engine'])) {
-		$r['stream5_tcp_engine'] = array();
+	if (!is_array($rule['stream5_tcp_engine'])) {
+		$rule['stream5_tcp_engine'] = array();
 	}
-	if (!is_array($r['stream5_tcp_engine']['item'])) {
-		$r['stream5_tcp_engine']['item'] = array();
+	if (!is_array($rule['stream5_tcp_engine']['item'])) {
+		$rule['stream5_tcp_engine']['item'] = array();
 	}
-	if (!is_array($r['http_inspect_engine'])) {
-		$r['http_inspect_engine'] = array();
+	if (!is_array($rule['http_inspect_engine'])) {
+		$rule['http_inspect_engine'] = array();
 	}
-	if (!is_array($r['http_inspect_engine']['item'])) {
-		$r['http_inspect_engine']['item'] = array();
+	if (!is_array($rule['http_inspect_engine']['item'])) {
+		$rule['http_inspect_engine']['item'] = array();
 	}
-	if (!is_array($r['ftp_client_engine'])) {
-		$r['ftp_client_engine'] = array();
+	if (!is_array($rule['ftp_client_engine'])) {
+		$rule['ftp_client_engine'] = array();
 	}
-	if (!is_array($r['ftp_client_engine']['item'])) {
-		$r['ftp_client_engine']['item'] = array();
+	if (!is_array($rule['ftp_client_engine']['item'])) {
+		$rule['ftp_client_engine']['item'] = array();
 	}
-	if (!is_array($r['ftp_server_engine'])) {
-		$r['ftp_server_engine'] = array();
+	if (!is_array($rule['ftp_server_engine'])) {
+		$rule['ftp_server_engine'] = array();
 	}
-	if (!is_array($r['ftp_server_engine']['item'])) {
-		$r['ftp_server_engine']['item'] = array();
+	if (!is_array($rule['ftp_server_engine']['item'])) {
+		$rule['ftp_server_engine']['item'] = array();
 	}
-
-	$pconfig = array();
-	$pconfig = $r;
 
 	// Create a default "frag3_engine" if none are configured
-	if (empty($pconfig['frag3_engine']['item'])) {
+	if (empty($rule['frag3_engine']['item'])) {
 		$updated_cfg = true;
-		syslog(LOG_NOTICE, "[Snort] Migrating Frag3 Engine configuration for interface {$pconfig['descr']}...");
+		syslog(LOG_NOTICE, "[Snort] Migrating Frag3 Engine configuration for interface {$rule['descr']}...");
 		$default = array( "name" => "default", "bind_to" => "all", "policy" => "bsd", 
 				"timeout" => 60, "min_ttl" => 1, "detect_anomalies" => "on", 
 				"overlap_limit" => 0, "min_frag_len" => 0 );
 
 		// Ensure sensible default values exist for global Frag3 parameters
-		if (empty($pconfig['frag3_max_frags']))
-			$pconfig['frag3_max_frags'] = '8192';
-		if (empty($pconfig['frag3_memcap']))
-			$pconfig['frag3_memcap'] = '4194304';
-		if (empty($pconfig['frag3_detection']))
-			$pconfig['frag3_detection'] = 'on';
+		if (empty($rule['frag3_max_frags']))
+			$rule['frag3_max_frags'] = '8192';
+		if (empty($rule['frag3_memcap']))
+			$rule['frag3_memcap'] = '4194304';
+		if (empty($rule['frag3_detection']))
+			$rule['frag3_detection'] = 'on';
 
 		// Put any old values in new default engine and remove old value
-		if (isset($pconfig['frag3_policy']))
-			$default['policy'] = $pconfig['frag3_policy'];
-		unset($pconfig['frag3_policy']);
-		if (isset($pconfig['frag3_timeout']) && is_numeric($pconfig['frag3_timeout']))
-			$default['timeout'] = $pconfig['frag3_timeout'];
-		unset($pconfig['frag3_timeout']);
-		if (isset($pconfig['frag3_overlap_limit']) && is_numeric($pconfig['frag3_overlap_limit']))
-			$default['overlap_limit'] = $pconfig['frag3_overlap_limit'];
-		unset($pconfig['frag3_overlap_limit']);
-		if (isset($pconfig['frag3_min_frag_len']) && is_numeric($pconfig['frag3_min_frag_len']))
-			$default['min_frag_len'] = $pconfig['frag3_min_frag_len'];
-		unset($pconfig['frag3_min_frag_len']);
+		if (isset($rule['frag3_policy']))
+			$default['policy'] = $rule['frag3_policy'];
+		unset($rule['frag3_policy']);
+		if (isset($rule['frag3_timeout']) && is_numeric($rule['frag3_timeout']))
+			$default['timeout'] = $rule['frag3_timeout'];
+		unset($rule['frag3_timeout']);
+		if (isset($rule['frag3_overlap_limit']) && is_numeric($rule['frag3_overlap_limit']))
+			$default['overlap_limit'] = $rule['frag3_overlap_limit'];
+		unset($rule['frag3_overlap_limit']);
+		if (isset($rule['frag3_min_frag_len']) && is_numeric($rule['frag3_min_frag_len']))
+			$default['min_frag_len'] = $rule['frag3_min_frag_len'];
+		unset($rule['frag3_min_frag_len']);
 
-		$pconfig['frag3_engine']['item'] = array();
-		$pconfig['frag3_engine']['item'][] = $default;
+		$rule['frag3_engine']['item'] = array();
+		$rule['frag3_engine']['item'][] = $default;
 	}
 
 	// Create a default Stream5 engine array if none are configured
-	if (empty($pconfig['stream5_tcp_engine']['item'])) {
+	if (empty($rule['stream5_tcp_engine']['item'])) {
 		$updated_cfg = true;
-		syslog(LOG_NOTICE, "[Snort] Migrating Stream5 Engine configuration for interface {$pconfig['descr']}...");
+		syslog(LOG_NOTICE, "[Snort] Migrating Stream5 Engine configuration for interface {$rule['descr']}...");
 		$default = array( "name" => "default", "bind_to" => "all", "policy" => "bsd", "timeout" => 30, 
 				"max_queued_bytes" => 1048576, "detect_anomalies" => "off", "overlap_limit" => 0, 
 				"max_queued_segs" => 2621, "require_3whs" => "off", "startup_3whs_timeout" => 0, 
@@ -272,65 +267,65 @@ foreach ($rule as &$r) {
 				"ports_both" => "default", "ports_server" => "none" );
 
 		// Ensure sensible defaults exist for Stream5 global parameters
-		if (empty($pconfig['stream5_reassembly']))
-			$pconfig['stream5_reassembly'] = 'on';
-		if (empty($pconfig['stream5_flush_on_alert']))
-			$pconfig['stream5_flush_on_alert'] = 'off';
-		if (empty($pconfig['stream5_prune_log_max']))
-			$pconfig['stream5_prune_log_max'] = '1048576';
-		if (empty($pconfig['stream5_track_tcp']))
-			$pconfig['stream5_track_tcp'] = 'on';
-		if (empty($pconfig['stream5_max_tcp']))
-			$pconfig['stream5_max_tcp'] = '262144';
-		if (empty($pconfig['stream5_track_udp']))
-			$pconfig['stream5_track_udp'] = 'on';
-		if (empty($pconfig['stream5_max_udp']))
-			$pconfig['stream5_max_udp'] = '131072';
-		if (empty($pconfig['stream5_udp_timeout']))
-			$pconfig['stream5_udp_timeout'] = '30';
-		if (empty($pconfig['stream5_track_icmp']))
-			$pconfig['stream5_track_icmp'] = 'off';
-		if (empty($pconfig['stream5_max_icmp']))
-			$pconfig['stream5_max_icmp'] = '65536';
-		if (empty($pconfig['stream5_icmp_timeout']))
-			$pconfig['stream5_icmp_timeout'] = '30';
-		if (empty($pconfig['stream5_mem_cap']))
-			$pconfig['stream5_mem_cap']= '8388608';
+		if (empty($rule['stream5_reassembly']))
+			$rule['stream5_reassembly'] = 'on';
+		if (empty($rule['stream5_flush_on_alert']))
+			$rule['stream5_flush_on_alert'] = 'off';
+		if (empty($rule['stream5_prune_log_max']))
+			$rule['stream5_prune_log_max'] = '1048576';
+		if (empty($rule['stream5_track_tcp']))
+			$rule['stream5_track_tcp'] = 'on';
+		if (empty($rule['stream5_max_tcp']))
+			$rule['stream5_max_tcp'] = '262144';
+		if (empty($rule['stream5_track_udp']))
+			$rule['stream5_track_udp'] = 'on';
+		if (empty($rule['stream5_max_udp']))
+			$rule['stream5_max_udp'] = '131072';
+		if (empty($rule['stream5_udp_timeout']))
+			$rule['stream5_udp_timeout'] = '30';
+		if (empty($rule['stream5_track_icmp']))
+			$rule['stream5_track_icmp'] = 'off';
+		if (empty($rule['stream5_max_icmp']))
+			$rule['stream5_max_icmp'] = '65536';
+		if (empty($rule['stream5_icmp_timeout']))
+			$rule['stream5_icmp_timeout'] = '30';
+		if (empty($rule['stream5_mem_cap']))
+			$rule['stream5_mem_cap']= '8388608';
 
 		// Put any old values in new default engine and remove old value
-		if (isset($pconfig['stream5_policy']))
-			$default['policy'] = $pconfig['stream5_policy'];
-		unset($pconfig['stream5_policy']);
-		if (isset($pconfig['stream5_tcp_timeout']) && is_numeric($pconfig['stream5_tcp_timeout']))
-			$default['timeout'] = $pconfig['stream5_tcp_timeout'];
-		unset($pconfig['stream5_tcp_timeout']);
-		if (isset($pconfig['stream5_overlap_limit']) && is_numeric($pconfig['stream5_overlap_limit']))
-			$default['overlap_limit'] = $pconfig['stream5_overlap_limit'];
-		unset($pconfig['stream5_overlap_limit']);
-		if (isset($pconfig['stream5_require_3whs']))
-			$default['require_3whs'] = $pconfig['stream5_require_3whs'];
-		unset($pconfig['stream5_require_3whs']);
-		if (isset($pconfig['stream5_no_reassemble_async']))
-			$default['no_reassemble_async'] = $pconfig['stream5_no_reassemble_async'];
-		unset($pconfig['stream5_no_reassemble_async']);
-		if (isset($pconfig['stream5_dont_store_lg_pkts']))
-			$default['dont_store_lg_pkts'] = $pconfig['stream5_dont_store_lg_pkts'];
-		unset($pconfig['stream5_dont_store_lg_pkts']);
-		if (isset($pconfig['max_queued_bytes']) && is_numeric($pconfig['max_queued_bytes']))
-			$default['max_queued_bytes'] = $pconfig['max_queued_bytes'];
-		unset($pconfig['max_queued_bytes']);
-		if (isset($pconfig['max_queued_segs']) && is_numeric($pconfig['max_queued_segs']))
-			$default['max_queued_segs'] = $pconfig['max_queued_segs'];
-		unset($pconfig['max_queued_segs']);
+		if (isset($rule['stream5_policy']))
+			$default['policy'] = $rule['stream5_policy'];
+		unset($rule['stream5_policy']);
+		if (isset($rule['stream5_tcp_timeout']) && is_numeric($rule['stream5_tcp_timeout']))
+			$default['timeout'] = $rule['stream5_tcp_timeout'];
+		unset($rule['stream5_tcp_timeout']);
+		if (isset($rule['stream5_overlap_limit']) && is_numeric($rule['stream5_overlap_limit']))
+			$default['overlap_limit'] = $rule['stream5_overlap_limit'];
+		unset($rule['stream5_overlap_limit']);
+		if (isset($rule['stream5_require_3whs']))
+			$default['require_3whs'] = $rule['stream5_require_3whs'];
+		unset($rule['stream5_require_3whs']);
+		if (isset($rule['stream5_no_reassemble_async']))
+			$default['no_reassemble_async'] = $rule['stream5_no_reassemble_async'];
+		unset($rule['stream5_no_reassemble_async']);
+		if (isset($rule['stream5_dont_store_lg_pkts']))
+			$default['dont_store_lg_pkts'] = $rule['stream5_dont_store_lg_pkts'];
+		unset($rule['stream5_dont_store_lg_pkts']);
+		if (isset($rule['max_queued_bytes']) && is_numeric($rule['max_queued_bytes']))
+			$default['max_queued_bytes'] = $rule['max_queued_bytes'];
+		unset($rule['max_queued_bytes']);
+		if (isset($rule['max_queued_segs']) && is_numeric($rule['max_queued_segs']))
+			$default['max_queued_segs'] = $rule['max_queued_segs'];
+		unset($rule['max_queued_segs']);
 
-		$pconfig['stream5_tcp_engine']['item'] = array();
-		$pconfig['stream5_tcp_engine']['item'][] = $default;
+		$rule['stream5_tcp_engine']['item'] = array();
+		$rule['stream5_tcp_engine']['item'][] = $default;
 	}
 
 	// Create a default HTTP_INSPECT engine if none are configured
-	if (empty($pconfig['http_inspect_engine']['item'])) {
+	if (empty($rule['http_inspect_engine']['item'])) {
 		$updated_cfg = true;
-		syslog(LOG_NOTICE, "[Snort] Migrating HTTP_Inspect Engine configuration for interface {$pconfig['descr']}...");
+		syslog(LOG_NOTICE, "[Snort] Migrating HTTP_Inspect Engine configuration for interface {$rule['descr']}...");
 		$default = array( "name" => "default", "bind_to" => "all", "server_profile" => "all", "enable_xff" => "off", 
 				"log_uri" => "off", "log_hostname" => "off", "server_flow_depth" => 65535, "enable_cookie" => "on", 
 				"client_flow_depth" => 1460, "extended_response_inspection" => "on", "no_alerts" => "off", 
@@ -341,97 +336,97 @@ foreach ($rule as &$r) {
 				"decompress_swf" => "off", "decompress_pdf" => "off" );
 
 		// Ensure sensible default values exist for global HTTP_INSPECT parameters
-		if (empty($pconfig['http_inspect']))
-			$pconfig['http_inspect'] = "on";
-		if (empty($pconfig['http_inspect_proxy_alert']))
-			$pconfig['http_inspect_proxy_alert'] = "off";
-		if (empty($pconfig['http_inspect_memcap']))
-			$pconfig['http_inspect_memcap'] = "150994944";
-		if (empty($pconfig['http_inspect_max_gzip_mem']))
-			$pconfig['http_inspect_max_gzip_mem'] = "838860";
+		if (empty($rule['http_inspect']))
+			$rule['http_inspect'] = "on";
+		if (empty($rule['http_inspect_proxy_alert']))
+			$rule['http_inspect_proxy_alert'] = "off";
+		if (empty($rule['http_inspect_memcap']))
+			$rule['http_inspect_memcap'] = "150994944";
+		if (empty($rule['http_inspect_max_gzip_mem']))
+			$rule['http_inspect_max_gzip_mem'] = "838860";
 
 		// Put any old values in new default engine and remove old value
-		if (isset($pconfig['server_flow_depth']) && is_numeric($pconfig['server_flow_depth']))
-			$default['server_flow_depth'] = $pconfig['server_flow_depth'];
-		unset($pconfig['server_flow_depth']);
-		if (isset($pconfig['client_flow_depth']) & is_numeric($pconfig['client_flow_depth']))
-			$default['client_flow_depth'] = $pconfig['client_flow_depth'];
-		unset($pconfig['client_flow_depth']);
-		if (isset($pconfig['http_server_profile']))
-			$default['server_profile'] = $pconfig['http_server_profile'];
-		unset($pconfig['http_server_profile']);
-		if (isset($pconfig['http_inspect_enable_xff']))
-			$default['enable_xff'] = $pconfig['http_inspect_enable_xff'];
-		unset($pconfig['http_inspect_enable_xff']);
-		if (isset($pconfig['http_inspect_log_uri']))
-			$default['log_uri'] = $pconfig['http_inspect_log_uri'];
-		unset($pconfig['http_inspect_log_uri']);
-		if (isset($pconfig['http_inspect_log_hostname']))
-			$default['log_hostname'] = $pconfig['http_inspect_log_hostname'];
-		unset($pconfig['http_inspect_log_hostname']);
-		if (isset($pconfig['noalert_http_inspect']))
-			$default['no_alerts'] = $pconfig['noalert_http_inspect'];
-		unset($pconfig['noalert_http_inspect']);
+		if (isset($rule['server_flow_depth']) && is_numeric($rule['server_flow_depth']))
+			$default['server_flow_depth'] = $rule['server_flow_depth'];
+		unset($rule['server_flow_depth']);
+		if (isset($rule['client_flow_depth']) & is_numeric($rule['client_flow_depth']))
+			$default['client_flow_depth'] = $rule['client_flow_depth'];
+		unset($rule['client_flow_depth']);
+		if (isset($rule['http_server_profile']))
+			$default['server_profile'] = $rule['http_server_profile'];
+		unset($rule['http_server_profile']);
+		if (isset($rule['http_inspect_enable_xff']))
+			$default['enable_xff'] = $rule['http_inspect_enable_xff'];
+		unset($rule['http_inspect_enable_xff']);
+		if (isset($rule['http_inspect_log_uri']))
+			$default['log_uri'] = $rule['http_inspect_log_uri'];
+		unset($rule['http_inspect_log_uri']);
+		if (isset($rule['http_inspect_log_hostname']))
+			$default['log_hostname'] = $rule['http_inspect_log_hostname'];
+		unset($rule['http_inspect_log_hostname']);
+		if (isset($rule['noalert_http_inspect']))
+			$default['no_alerts'] = $rule['noalert_http_inspect'];
+		unset($rule['noalert_http_inspect']);
 
-		$pconfig['http_inspect_engine']['item'] = array();
-		$pconfig['http_inspect_engine']['item'][] = $default;
+		$rule['http_inspect_engine']['item'] = array();
+		$rule['http_inspect_engine']['item'][] = $default;
 	}
 
 	// Create a default FTP_CLIENT engine if none are configured
-	if (empty($pconfig['ftp_client_engine']['item'])) {
+	if (empty($rule['ftp_client_engine']['item'])) {
 		$updated_cfg = true;
-		syslog(LOG_NOTICE, "[Snort] Migrating FTP Client Engine configuration for interface {$pconfig['descr']}...");
+		syslog(LOG_NOTICE, "[Snort] Migrating FTP Client Engine configuration for interface {$rule['descr']}...");
 		$default = array( "name" => "default", "bind_to" => "all", "max_resp_len" => 256, 
 				  "telnet_cmds" => "no", "ignore_telnet_erase_cmds" => "yes", 
 				  "bounce" => "yes", "bounce_to_net" => "", "bounce_to_port" => "" );
 
 		// Set defaults for new FTP_Telnet preprocessor configurable parameters
-		if (empty($pconfig['ftp_telnet_inspection_type']))
-			$pconfig['ftp_telnet_inspection_type'] = 'stateful';
-		if (empty($pconfig['ftp_telnet_alert_encrypted']))
-			$pconfig['ftp_telnet_alert_encrypted'] = 'off';
-		if (empty($pconfig['ftp_telnet_check_encrypted']))
-			$pconfig['ftp_telnet_check_encrypted'] = 'on';
-		if (empty($pconfig['ftp_telnet_normalize']))
-			$pconfig['ftp_telnet_normalize'] = 'on';
-		if (empty($pconfig['ftp_telnet_detect_anomalies']))
-			$pconfig['ftp_telnet_detect_anomalies'] = 'on';
-		if (empty($pconfig['ftp_telnet_ayt_attack_threshold']))
-			$pconfig['ftp_telnet_ayt_attack_threshold'] = '20';
+		if (empty($rule['ftp_telnet_inspection_type']))
+			$rule['ftp_telnet_inspection_type'] = 'stateful';
+		if (empty($rule['ftp_telnet_alert_encrypted']))
+			$rule['ftp_telnet_alert_encrypted'] = 'off';
+		if (empty($rule['ftp_telnet_check_encrypted']))
+			$rule['ftp_telnet_check_encrypted'] = 'on';
+		if (empty($rule['ftp_telnet_normalize']))
+			$rule['ftp_telnet_normalize'] = 'on';
+		if (empty($rule['ftp_telnet_detect_anomalies']))
+			$rule['ftp_telnet_detect_anomalies'] = 'on';
+		if (empty($rule['ftp_telnet_ayt_attack_threshold']))
+			$rule['ftp_telnet_ayt_attack_threshold'] = '20';
 
 		// Add new FTP_Telnet Client default engine
-		$pconfig['ftp_client_engine']['item'] = array();
-		$pconfig['ftp_client_engine']['item'][] = $default;
+		$rule['ftp_client_engine']['item'] = array();
+		$rule['ftp_client_engine']['item'][] = $default;
 	}
 
 	// Create a default FTP_SERVER engine if none are configured
-	if (empty($pconfig['ftp_server_engine']['item'])) {
+	if (empty($rule['ftp_server_engine']['item'])) {
 		$updated_cfg = true;
-		syslog(LOG_NOTICE, "[Snort] Migrating FTP Server Engine configuration for interface {$pconfig['descr']}...");
+		syslog(LOG_NOTICE, "[Snort] Migrating FTP Server Engine configuration for interface {$rule['descr']}...");
 		$default = array( "name" => "default", "bind_to" => "all", "ports" => "default", 
 				  "telnet_cmds" => "no", "ignore_telnet_erase_cmds" => "yes", 
 				  "ignore_data_chan" => "no", "def_max_param_len" => 100 );
 
 		// Add new FTP_Telnet Server default engine
-		$pconfig['ftp_server_engine']['item'] = array();
-		$pconfig['ftp_server_engine']['item'][] = $default;
+		$rule['ftp_server_engine']['item'] = array();
+		$rule['ftp_server_engine']['item'][] = $default;
 	}
 
 	// Set sensible defaults for new SDF options if SDF is enabled
-	if ($pconfig['sensitive_data'] == 'on') {
-		if (empty($pconfig['sdf_alert_threshold'])) {
-			$pconfig['sdf_alert_threshold'] = 25;
+	if ($rule['sensitive_data'] == 'on') {
+		if (empty($rule['sdf_alert_threshold'])) {
+			$rule['sdf_alert_threshold'] = 25;
 			$updated_cfg = true;
 		}
-		if (empty($pconfig['sdf_alert_data_type'])) {
-			$pconfig['sdf_alert_data_type'] = "Credit Card,Email Addresses,U.S. Phone Numbers,U.S. Social Security Numbers";
+		if (empty($rule['sdf_alert_data_type'])) {
+			$rule['sdf_alert_data_type'] = "Credit Card,Email Addresses,U.S. Phone Numbers,U.S. Social Security Numbers";
 			$updated_cfg = true;
 		}
 	}
 
 	// Change any ENABLE_SID settings to new format of GID:SID
-	if (!empty($pconfig['rule_sid_on'])) {
-		$tmp = explode("||", $pconfig['rule_sid_on']);
+	if (!empty($rule['rule_sid_on'])) {
+		$tmp = explode("||", $rule['rule_sid_on']);
 		$new_tmp = "";
 		foreach ($tmp as $v) {
 			if (strpos($v, ":") === false) {
@@ -441,14 +436,14 @@ foreach ($rule as &$r) {
 		}
 		$new_tmp = rtrim($new_tmp, " ||");
 		if (!empty($new_tmp)) {
-			$pconfig['rule_sid_on'] = $new_tmp;
+			$rule['rule_sid_on'] = $new_tmp;
 			$updated_cfg = true;
 		}
 	}
 
 	// Change any DISABLE_SID settings to new format of GID:SID
-	if (!empty($pconfig['rule_sid_off'])) {
-		$tmp = explode("||", $pconfig['rule_sid_off']);
+	if (!empty($rule['rule_sid_off'])) {
+		$tmp = explode("||", $rule['rule_sid_off']);
 		$new_tmp = "";
 		foreach ($tmp as $v) {
 			if (strpos($v, ":") === false) {
@@ -458,7 +453,7 @@ foreach ($rule as &$r) {
 		}
 		$new_tmp = rtrim($new_tmp, " ||");
 		if (!empty($new_tmp)) {
-			$pconfig['rule_sid_off'] = $new_tmp;
+			$rule['rule_sid_off'] = $new_tmp;
 			$updated_cfg = true;
 		}
 	}
@@ -467,178 +462,178 @@ foreach ($rule as &$r) {
 	// Parse the old DB connect string and find the "host", "user",
 	// "dbname" and "password" values and save them in the new
 	// MySQL field names in the config file.
-	if (!empty($pconfig['barnyard_mysql'])) {
-		if (preg_match_all('/(dbname|host|user|password)\s*\=\s*([^\s]*)/i', $pconfig['barnyard_mysql'], $matches)) {
+	if (!empty($rule['barnyard_mysql'])) {
+		if (preg_match_all('/(dbname|host|user|password)\s*\=\s*([^\s]*)/i', $rule['barnyard_mysql'], $matches)) {
 			foreach ($matches[1] as $k => $p) {
 				if (strcasecmp($p, 'dbname') == 0)
-					$pconfig['barnyard_dbname'] = $matches[2][$k];
+					$rule['barnyard_dbname'] = $matches[2][$k];
 				elseif (strcasecmp($p, 'host') == 0)
-					$pconfig['barnyard_dbhost'] = $matches[2][$k];
+					$rule['barnyard_dbhost'] = $matches[2][$k];
 				elseif (strcasecmp($p, 'user') == 0)
-					$pconfig['barnyard_dbuser'] = $matches[2][$k];
+					$rule['barnyard_dbuser'] = $matches[2][$k];
 				elseif (strcasecmp($p, 'password') == 0)
-					$pconfig['barnyard_dbpwd'] = base64_encode($matches[2][$k]);
+					$rule['barnyard_dbpwd'] = base64_encode($matches[2][$k]);
 			}
-			$pconfig['barnyard_mysql_enable'] = 'on';
-			unset($pconfig['barnyard_mysql']);
+			$rule['barnyard_mysql_enable'] = 'on';
+			unset($rule['barnyard_mysql']);
 		}
 		// Since Barnyard2 was enabled, configure the new archived log settings
-		$pconfig['u2_archived_log_retention'] = '168';
-		$pconfig['barnyard_archive_enable'] = 'on';
-		$pconfig['unified2_log_limit'] = '32M';
+		$rule['u2_archived_log_retention'] = '168';
+		$rule['barnyard_archive_enable'] = 'on';
+		$rule['unified2_log_limit'] = '32M';
 		$updated_cfg = true;
 	}
 
 	// This setting is deprecated and replaced
 	// by 'barnyard_enable' since any Barnyard2
 	// chaining requires unified2 logging.
-	if (isset($pconfig['snortunifiedlog'])) {
-		unset($pconfig['snortunifiedlog']);
-		$pconfig['barnyard_enable'] = 'on';
+	if (isset($rule['snortunifiedlog'])) {
+		unset($rule['snortunifiedlog']);
+		$rule['barnyard_enable'] = 'on';
 		$updated_cfg = true;
 	}
 
 	// Migrate new POP3 preprocessor parameter settings
-	if (empty($pconfig['pop_memcap'])) {
-		$pconfig['pop_memcap'] = "838860";
+	if (empty($rule['pop_memcap'])) {
+		$rule['pop_memcap'] = "838860";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['pop_b64_decode_depth']) && $pconfig['pop_b64_decode_depth'] != '0') {
-		$pconfig['pop_b64_decode_depth'] = "0";
+	if (empty($rule['pop_b64_decode_depth']) && $rule['pop_b64_decode_depth'] != '0') {
+		$rule['pop_b64_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['pop_qp_decode_depth']) && $pconfig['pop_qp_decode_depth'] != '0') {
-		$pconfig['pop_qp_decode_depth'] = "0";
+	if (empty($rule['pop_qp_decode_depth']) && $rule['pop_qp_decode_depth'] != '0') {
+		$rule['pop_qp_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['pop_bitenc_decode_depth']) && $pconfig['pop_bitenc_decode_depth'] != '0') {
-		$pconfig['pop_bitenc_decode_depth'] = "0";
+	if (empty($rule['pop_bitenc_decode_depth']) && $rule['pop_bitenc_decode_depth'] != '0') {
+		$rule['pop_bitenc_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['pop_uu_decode_depth']) && $pconfig['pop_uu_decode_depth'] != '0') {
-		$pconfig['pop_uu_decode_depth'] = "0";
+	if (empty($rule['pop_uu_decode_depth']) && $rule['pop_uu_decode_depth'] != '0') {
+		$rule['pop_uu_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
 
 	// Migrate new IMAP preprocessor parameter settings
-	if (empty($pconfig['imap_memcap'])) {
-		$pconfig['imap_memcap'] = "838860";
+	if (empty($rule['imap_memcap'])) {
+		$rule['imap_memcap'] = "838860";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['imap_b64_decode_depth']) && $pconfig['imap_b64_decode_depth'] != '0') {
-		$pconfig['imap_b64_decode_depth'] = "0";
+	if (empty($rule['imap_b64_decode_depth']) && $rule['imap_b64_decode_depth'] != '0') {
+		$rule['imap_b64_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['imap_qp_decode_depth']) && $pconfig['imap_qp_decode_depth'] != '0') {
-		$pconfig['imap_qp_decode_depth'] = "0";
+	if (empty($rule['imap_qp_decode_depth']) && $rule['imap_qp_decode_depth'] != '0') {
+		$rule['imap_qp_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['imap_bitenc_decode_depth']) && $pconfig['imap_bitenc_decode_depth'] != '0') {
-		$pconfig['imap_bitenc_decode_depth'] = "0";
+	if (empty($rule['imap_bitenc_decode_depth']) && $rule['imap_bitenc_decode_depth'] != '0') {
+		$rule['imap_bitenc_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['imap_uu_decode_depth']) && $pconfig['imap_uu_decode_depth'] != '0') {
-		$pconfig['imap_uu_decode_depth'] = "0";
+	if (empty($rule['imap_uu_decode_depth']) && $rule['imap_uu_decode_depth'] != '0') {
+		$rule['imap_uu_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
 
 	// Migrate new SMTP preprocessor parameter settings
-	if (empty($pconfig['smtp_memcap'])) {
-		$pconfig['smtp_memcap'] = "838860";
+	if (empty($rule['smtp_memcap'])) {
+		$rule['smtp_memcap'] = "838860";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_max_mime_mem'])) {
-		$pconfig['smtp_max_mime_mem'] = "838860";
+	if (empty($rule['smtp_max_mime_mem'])) {
+		$rule['smtp_max_mime_mem'] = "838860";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_b64_decode_depth']) && $pconfig['smtp_b64_decode_depth'] != "0") {
-		$pconfig['smtp_b64_decode_depth'] = "0";
+	if (empty($rule['smtp_b64_decode_depth']) && $rule['smtp_b64_decode_depth'] != "0") {
+		$rule['smtp_b64_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_qp_decode_depth']) && $pconfig['smtp_qp_decode_depth'] != "0") {
-		$pconfig['smtp_qp_decode_depth'] = "0";
+	if (empty($rule['smtp_qp_decode_depth']) && $rule['smtp_qp_decode_depth'] != "0") {
+		$rule['smtp_qp_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_bitenc_decode_depth']) && $pconfig['smtp_bitenc_decode_depth'] != "0") {
-		$pconfig['smtp_bitenc_decode_depth'] = "0";
+	if (empty($rule['smtp_bitenc_decode_depth']) && $rule['smtp_bitenc_decode_depth'] != "0") {
+		$rule['smtp_bitenc_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_uu_decode_depth']) && $pconfig['smtp_uu_decode_depth'] != "0") {
-		$pconfig['smtp_uu_decode_depth'] = "0";
+	if (empty($rule['smtp_uu_decode_depth']) && $rule['smtp_uu_decode_depth'] != "0") {
+		$rule['smtp_uu_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_email_hdrs_log_depth'])) {
-		$pconfig['smtp_email_hdrs_log_depth'] = "1464";
+	if (empty($rule['smtp_email_hdrs_log_depth'])) {
+		$rule['smtp_email_hdrs_log_depth'] = "1464";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_ignore_tls_data'])) {
-		$pconfig['smtp_ignore_tls_data'] = 'on';
+	if (empty($rule['smtp_ignore_tls_data'])) {
+		$rule['smtp_ignore_tls_data'] = 'on';
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_log_mail_from'])) {
-		$pconfig['smtp_log_mail_from'] = 'on';
+	if (empty($rule['smtp_log_mail_from'])) {
+		$rule['smtp_log_mail_from'] = 'on';
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_log_rcpt_to'])) {
-		$pconfig['smtp_log_rcpt_to'] = 'on';
+	if (empty($rule['smtp_log_rcpt_to'])) {
+		$rule['smtp_log_rcpt_to'] = 'on';
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_log_filename'])) {
-		$pconfig['smtp_log_filename'] = 'on';
+	if (empty($rule['smtp_log_filename'])) {
+		$rule['smtp_log_filename'] = 'on';
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_log_email_hdrs'])) {
-		$pconfig['smtp_log_email_hdrs'] = 'on';
+	if (empty($rule['smtp_log_email_hdrs'])) {
+		$rule['smtp_log_email_hdrs'] = 'on';
 		$updated_cfg = true;
 	}
 
 	// Migrate any BY2 limit for unified2 logs to new format
-	if (!empty($pconfig['unified2_log_limit']) && 
-	    !preg_match('/^\d+[g|k|m|G|K|M]/', $pconfig['unified2_log_limit'])) {
-		$pconfig['unified2_log_limit'] .= "M";
+	if (!empty($rule['unified2_log_limit']) && 
+	    !preg_match('/^\d+[g|k|m|G|K|M]/', $rule['unified2_log_limit'])) {
+		$rule['unified2_log_limit'] .= "M";
 		$updated_cfg = true;
 	}
 
 	// Set new BY2 syslog parameter to default if it is empty
 	// and Barnyard2 is enabled.
-	if ($pconfig['barnyard_enable'] == 'on' && empty($pconfig['barnyard_syslog_payload_encoding'])) {
-		$pconfig['barnyard_syslog_payload_encoding'] = 'hex';
+	if ($rule['barnyard_enable'] == 'on' && empty($rule['barnyard_syslog_payload_encoding'])) {
+		$rule['barnyard_syslog_payload_encoding'] = 'hex';
 		$updated_cfg = true;
 	}
 
 	// Default any unconfigured AppID preprocessor settings
-	if (empty($pconfig['appid_preproc'])) {
-		$pconfig['appid_preproc'] = 'off';
+	if (empty($rule['appid_preproc'])) {
+		$rule['appid_preproc'] = 'off';
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['sf_appid_mem_cap'])) {
-		$pconfig['sf_appid_mem_cap'] = '256';
+	if (empty($rule['sf_appid_mem_cap'])) {
+		$rule['sf_appid_mem_cap'] = '256';
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['sf_appid_statslog'])) {
-		$pconfig['sf_appid_statslog'] = 'on';
+	if (empty($rule['sf_appid_statslog'])) {
+		$rule['sf_appid_statslog'] = 'on';
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['sf_appid_stats_period'])) {
-		$pconfig['sf_appid_stats_period'] = '300';
+	if (empty($rule['sf_appid_stats_period'])) {
+		$rule['sf_appid_stats_period'] = '300';
 		$updated_cfg = true;
 	}
 
 	// Check for and fix an incorrect value for <blockoffendersip>.
 	// The value should be a string and not the index of the string.
 	// This corrects for the impact of a Bootstrap conversion bug.
-	if ($pconfig['blockoffendersip'] == '0' || $pconfig['blockoffendersip'] == '1' || $pconfig['blockoffendersip'] == '2') {
-		switch ($pconfig['blockoffendersip']) {
+	if ($rule['blockoffendersip'] == '0' || $rule['blockoffendersip'] == '1' || $rule['blockoffendersip'] == '2') {
+		switch ($rule['blockoffendersip']) {
 			case '0':
-				$pconfig['blockoffendersip'] = 'src';
+				$rule['blockoffendersip'] = 'src';
 				break;
 
 			case '1':
-				$pconfig['blockoffendersip'] = 'dst';
+				$rule['blockoffendersip'] = 'dst';
 				break;
 
 			case '2':
-				$pconfig['blockoffendersip'] = 'both';
+				$rule['blockoffendersip'] = 'both';
 				break;
 
 			default:
@@ -648,42 +643,42 @@ foreach ($rule as &$r) {
 	}
 
 	// Configure a default interface snaplen if not previously configured
-	if (!isset($pconfig['snaplen'])) {
-		$pconfig['snaplen'] = '1518';
+	if (!isset($rule['snaplen'])) {
+		$rule['snaplen'] = '1518';
 		$updated_cfg = true;
 	}
 
 	// Configure new SSH preprocessor parameter defaults if not already set
-	if (!isset($pconfig['ssh_preproc_ports'])) {
-		$pconfig['ssh_preproc_ports'] = '22';
+	if (!isset($rule['ssh_preproc_ports'])) {
+		$rule['ssh_preproc_ports'] = '22';
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['ssh_preproc_max_encrypted_packets'])) {
-		$pconfig['ssh_preproc_max_encrypted_packets'] = 20;
+	if (!isset($rule['ssh_preproc_max_encrypted_packets'])) {
+		$rule['ssh_preproc_max_encrypted_packets'] = 20;
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['ssh_preproc_max_client_bytes'])) {
-		$pconfig['ssh_preproc_max_client_bytes'] = 19600;
+	if (!isset($rule['ssh_preproc_max_client_bytes'])) {
+		$rule['ssh_preproc_max_client_bytes'] = 19600;
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['ssh_preproc_max_server_version_len'])) {
-		$pconfig['ssh_preproc_max_server_version_len'] = 100;
+	if (!isset($rule['ssh_preproc_max_server_version_len'])) {
+		$rule['ssh_preproc_max_server_version_len'] = 100;
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['ssh_preproc_enable_respoverflow'])) {
-		$pconfig['ssh_preproc_enable_respoverflow'] = 'on';
+	if (!isset($rule['ssh_preproc_enable_respoverflow'])) {
+		$rule['ssh_preproc_enable_respoverflow'] = 'on';
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['ssh_preproc_enable_srvoverflow'])) {
-		$pconfig['ssh_preproc_enable_srvoverflow'] = 'on';
+	if (!isset($rule['ssh_preproc_enable_srvoverflow'])) {
+		$rule['ssh_preproc_enable_srvoverflow'] = 'on';
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['ssh_preproc_enable_ssh1crc32'])) {
-		$pconfig['ssh_preproc_enable_ssh1crc32'] = 'on';
+	if (!isset($rule['ssh_preproc_enable_ssh1crc32'])) {
+		$rule['ssh_preproc_enable_ssh1crc32'] = 'on';
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['ssh_preproc_enable_protomismatch'])) {
-		$pconfig['ssh_preproc_enable_protomismatch'] = 'on';
+	if (!isset($rule['ssh_preproc_enable_protomismatch'])) {
+		$rule['ssh_preproc_enable_protomismatch'] = 'on';
 		$updated_cfg = true;
 	}
 	// End new SSH parameters
@@ -691,16 +686,13 @@ foreach ($rule as &$r) {
 	/**********************************************************/
 	/* Create new interface IPS mode setting if not set       */
 	/**********************************************************/
-	if (empty($pconfig['ips_mode'])) {
-		$pconfig['ips_mode'] = 'ips_mode_legacy';
+	if (empty($rule['ips_mode'])) {
+		$rule['ips_mode'] = 'ips_mode_legacy';
 		$updated_cfg = true;
 	}
-
-	// Save the new configuration data into the $config array pointer
-	$r = $pconfig;
 }
-// Release reference to final array element
-unset($r);
+// Release reference to config array
+unset($rule);
 
 // Log a message if we changed anything
 if ($updated_cfg) {

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
@@ -135,8 +135,7 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 	if (count($config['installedpackages']['snortglobal']['rule']) > 0) {
 		$uuids = array();
 		$fixed_duplicate = FALSE;
-		$snortconf = &$config['installedpackages']['snortglobal']['rule'];
-		foreach ($snortconf as &$snortcfg) {
+		foreach ($config['installedpackages']['snortglobal']['rule'] as &$snortcfg) {
 			// Check for and fix a duplicate UUID
 			$if_real = get_real_interface($snortcfg['interface']);
 			if (!isset($uuids[$snortcfg['uuid']])) {
@@ -156,7 +155,8 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 				$fixed_duplicate = TRUE;
 			}
 		}
-		unset($uuids);
+		// Release config array reference and $uuids array
+		unset($snortcfg, $uuids);
 	}
 	/****************************************************************/
 	/* End of duplicate UUID bug fix.                               */
@@ -172,8 +172,7 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 	$rebuild_rules = true;
 
 	/* Create the snort.conf files for each enabled interface */
-	$snortconf = $config['installedpackages']['snortglobal']['rule'];
-	foreach ($snortconf as $snortcfg) {
+	foreach ($config['installedpackages']['snortglobal']['rule'] as $snortcfg) {
 		$if_real = get_real_interface($snortcfg['interface']);
 		$snort_uuid = $snortcfg['uuid'];
 		$snortcfgdir = "{$snortdir}/snort_{$snort_uuid}_{$if_real}";

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -108,6 +108,9 @@ function snort_add_supplist_entry($suppress) {
 		}
 	}
 
+	// Release config array reference
+	unset($a_suppress);
+
 	/* If we created a new list or updated an existing one, save the change, */
 	/* tell Snort to load it, and return true; otherwise return false.       */
 	if ($found_list) {
@@ -245,7 +248,7 @@ if ($_POST['save']) {
 	$config['installedpackages']['snortglobal']['alertsblocks']['alertnumber'] = $_POST['alertnumber'];
 
 	write_config("Snort pkg: updated ALERTS tab settings.");
-
+	unset($a_instance);
 	header("Location: /snort/snort_alerts.php?instance={$instanceid}");
 	exit;
 }
@@ -513,6 +516,7 @@ if ($_POST['clear']) {
 	mwexec("/bin/chmod 660 {$snortlogdir}/*", true);
 	if (file_exists("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid"))
 		mwexec("/bin/pkill -HUP -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid -a");
+	unset($a_instance);
 	header("Location: /snort/snort_alerts.php?instance={$instanceid}");
 	exit;
 }
@@ -1078,6 +1082,7 @@ if (file_exists("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/alert")) {
 		</div>
 	</div>
 <?php endif; ?>
+<?php unset($a_instance); ?>
 
 <script type="text/javascript">
 //<![CDATA[

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -550,7 +550,7 @@ $supplist = snort_load_suppress_sigs($a_instance[$instanceid], true);
 // Load up an array with the configured Snort interfaces
 $interfaces = array();
 foreach ($a_instance as $id => $instance) {
-	$interfaces[$id] = convert_friendly_interface_to_friendly_descr($instance['interface']);
+	$interfaces[$id] = convert_friendly_interface_to_friendly_descr($instance['interface']) . " (" . get_real_interface($instance['interface']) . ")";
 }
 
 $pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Alerts"));

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_define_servers.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_define_servers.php
@@ -3,10 +3,10 @@
  * snort_define_servers.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2008-2009 Robert Zelaya.
- * Copyright (c) 2014-2018 Bill Meeks
+ * Copyright (c) 2014-2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -139,6 +139,9 @@ if ($_POST['save']) {
 		/* Sync to configured CARP slaves if any are enabled */
 		snort_sync_on_changes();
 
+		/* Release config array reference */
+		unset($a_nat);
+
 		/* after click go to this page */
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
@@ -163,6 +166,9 @@ if ($input_errors)
 	print_input_errors($input_errors); // TODO: add checks
 if ($savemsg)
 	print_info_box($savemsg);
+
+// Finished with config array reference, so release it
+unset($a_nat);
 
 $tab_array = array();
 $tab_array[] = array(gettext("Snort Interfaces"), true, "/snort/snort_interfaces.php");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces.php
@@ -365,7 +365,7 @@ if ($savemsg)
 					/* convert fake interfaces to real and check if iface is up */
 					/* There has to be a smarter way to do this */
 					$if_real = get_real_interface($natent['interface']);
-					$natend_friendly = convert_friendly_interface_to_friendly_descr($natent['interface']);
+					$natend_friendly = convert_friendly_interface_to_friendly_descr($natent['interface']) . " ({$if_real})";
 					$snort_uuid = $natent['uuid'];
 					$start_lck_file = "{$g['varrun_path']}/snort_{$if_real}_starting.lck";
 					$stop_lck_file = "{$g['varrun_path']}/snort_{$if_real}_stopping.lck";

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces.php
@@ -144,6 +144,7 @@ if (isset($_POST['del_x'])) {
 		write_config("Snort pkg: deleted one or more Snort interfaces.");
 		sleep(2);
 		sync_snort_package_config();
+		unset($a_nat);
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
 		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
@@ -177,6 +178,7 @@ else {
 		write_config("Snort pkg: deleted one or more Snort interfaces.");
 		sleep(2);
 		sync_snort_package_config();
+		unset($a_nat);
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
 		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
@@ -674,6 +676,9 @@ if ($savemsg)
 </script>
 
 <?php
+// Finished with config array reference, so release it
+unset($a_nat);
+
 include("foot.inc");
 ?>
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
@@ -110,6 +110,11 @@ $snort_uuid = $pconfig['uuid'];
 // Get the physical configured interfaces on the firewall
 $interfaces = get_configured_interface_with_descr();
 
+// Footnote real interface associated with each configured interface
+foreach ($interfaces as $if => $desc) {
+		$interfaces[$if] = $interfaces[$if] . " (" . get_real_interface($if) . ")";
+}
+
 // See if interface is already configured, and use its values
 if (isset($id) && $a_rule[$id]) {
 	/* old options */
@@ -128,7 +133,20 @@ elseif (isset($id) && !isset($a_rule[$id])) {
 	foreach ($ifaces as $i) {
 		if (!in_array($i, $ifrules)) {
 			$pconfig['interface'] = $i;
-			$pconfig['descr'] = convert_friendly_interface_to_friendly_descr($i);
+
+			// If the interface is a VLAN, use the VLAN description
+			// if set, otherwise default to the friendly description.
+			if ($vlan = interface_is_vlan(get_real_interface($i))) {
+				if (strlen($vlan['descr']) > 0) {
+					$pconfig['descr'] = $vlan['descr'];
+				}
+				else {
+					$pconfig['descr'] = convert_friendly_interface_to_friendly_descr($i);
+				}
+			}
+			else {
+				$pconfig['descr'] = convert_friendly_interface_to_friendly_descr($i);
+			}
 			$pconfig['enable'] = 'on';
 			break;
 		}
@@ -168,7 +186,20 @@ if (strcasecmp($action, 'dup') == 0) {
 		if (!in_array($i, $ifrules)) {
 			$pconfig['interface'] = $i;
 			$pconfig['enable'] = 'on';
-			$pconfig['descr'] = convert_friendly_interface_to_friendly_descr($i);
+
+			// If the interface is a VLAN, use the VLAN description
+			// if set, otherwise default to the friendly description.
+			if ($vlan = interface_is_vlan(get_real_interface($i))) {
+				if (strlen($vlan['descr']) > 0) {
+					$pconfig['descr'] = $vlan['descr'];
+				}
+				else {
+					$pconfig['descr'] = convert_friendly_interface_to_friendly_descr($i);
+				}
+			}
+			else {
+				$pconfig['descr'] = convert_friendly_interface_to_friendly_descr($i);
+			}
 			break;
 		}
 	}

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
@@ -40,6 +40,7 @@ elseif (isset($_GET['id']) && is_numericint($_GET['id']))
 	$id = htmlspecialchars($_GET['id']);
 
 if (is_null($id)) {
+	unset($a_rule);
         header("Location: /snort/snort_interfaces.php");
         exit;
 }
@@ -51,13 +52,13 @@ if ($_REQUEST['ajax']) {
 	$type = $_REQUEST['type'];
 
 	if (isset($id) && isset($wlist)) {
-		$a_rule = $config['installedpackages']['snortglobal']['rule'][$id];
+		$rule = $config['installedpackages']['snortglobal']['rule'][$id];
 		if ($type == "homenet") {
-			$list = snort_build_list($a_rule, empty($wlist) ? 'default' : $wlist);
+			$list = snort_build_list($rule, empty($wlist) ? 'default' : $wlist);
 			$contents = implode("\n", $list);
 		}
 		elseif ($type == "passlist") {
-			$list = snort_build_list($a_rule, $wlist, true);
+			$list = snort_build_list($rule, $wlist, true);
 			$contents = implode("\n", $list);
 		}
 		elseif ($type == "suppress") {
@@ -66,14 +67,14 @@ if ($_REQUEST['ajax']) {
 		}
 		elseif ($type == "externalnet") {
 			if (empty($wlist) || $wlist == "default") {
-				$list = snort_build_list($a_rule, $a_rule['homelistname']);
+				$list = snort_build_list($rule, $rule['homelistname']);
 				$contents = "";
 				foreach ($list as $ip)
 					$contents .= "!{$ip}\n";
 				$contents = trim($contents, "\n");
 			}
 			else {
-				$list = snort_build_list($a_rule, $wlist, false, true);
+				$list = snort_build_list($rule, $wlist, false, true);
 				$contents = implode("\n", $list);
 			}
 		}
@@ -240,6 +241,7 @@ if ($_POST['save'] && !$input_errors) {
 		write_config("Snort pkg: modified interface configuration for {$a_rule[$id]['interface']}.");
 		$rebuild_rules = false;
 		sync_snort_package_config();
+		unset($a_rule);
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
 		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
@@ -477,6 +479,7 @@ if ($_POST['save'] && !$input_errors) {
 		if ($snort_reload == true)
 			snort_reload_config($natent, "SIGHUP");
 
+		unset($a_rule);
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
 		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
@@ -507,6 +510,10 @@ $if_friendly = convert_friendly_interface_to_friendly_descr($a_rule[$id]['interf
 if (empty($if_friendly)) {
 	$if_friendly = "None";
 }
+
+// Finished with config array reference, so release it
+unset($a_rule);
+
 $pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Edit Interface"), gettext("{$if_friendly}"));
 include("head.inc");
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
@@ -441,6 +441,15 @@ if ($_POST['save'] && !$input_errors) {
 			$natent['sf_appid_statslog'] = "on";
 			$natent['sf_appid_stats_period'] = "300";
 
+			$natent['ssh_preproc_ports'] = '22';
+			$natent['ssh_preproc_max_encrypted_packets'] = 20;
+			$natent['ssh_preproc_max_client_bytes'] = 19600;
+			$natent['ssh_preproc_max_server_version_len'] = 100;
+			$natent['ssh_preproc_enable_respoverflow'] = 'on';
+			$natent['ssh_preproc_enable_srvoverflow'] = 'on';
+			$natent['ssh_preproc_enable_ssh1crc32'] = 'on';
+			$natent['ssh_preproc_enable_protomismatch'] = 'on';
+
 			$a_rule[] = $natent;
 		}
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress.php
@@ -3,9 +3,9 @@
  * snort_interfaces_suppress.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2004-2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2004-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya.
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * originially part of m0n0wall (http://m0n0.ch/wall)
@@ -77,6 +77,7 @@ if (isset($_POST['del_btn'])) {
 		if ($need_save) {
 			write_config("Snort pkg: deleted SUPPRESSION LIST.");
 			sync_snort_package_config();
+			unset($a_suppress);
 			header("Location: /snort/snort_interfaces_suppress.php");
 			return;
 		}
@@ -99,6 +100,7 @@ else {
 			unset($a_suppress[$delbtn_list]);
 			write_config("Snort pkg: deleted SUPPRESSION LIST.");
 			sync_snort_package_config();
+			unset($a_suppress);
 			header("Location: /snort/snort_interfaces_suppress.php");
 			return;
 		}
@@ -184,6 +186,8 @@ display_top_tabs($tab_array, true);
 		</div>
 	</div>
 </div>
+
+<?php unset($a_suppress); ?>
 
 <script type="text/javascript">
 //<![CDATA[

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress_edit.php
@@ -3,9 +3,9 @@
  * snort_interfaces_suppress_edit.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2004-2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2004-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya.
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * originially part of m0n0wall (http://m0n0.ch/wall)
@@ -43,6 +43,7 @@ elseif (isset($_GET['id']) && is_numericint($_GET['id']))
 
 /* Should never be called without identifying list index, so bail */
 if (is_null($id)) {
+	unset($a_suppress);
 	header("Location: /snort/snort_interfaces_suppress.php");
 	exit;
 }
@@ -59,6 +60,7 @@ function is_validwhitelistname($name) {
 }
 
 if ($_POST['cancel']) {
+	unset($a_suppress);
 	header("Location: /snort/snort_interfaces_suppress.php");
 	exit;
 }
@@ -124,11 +126,14 @@ if ($_POST['save']) {
 
 		write_config("Snort pkg: modified Suppress List {$s_list['name']}.");
 		sync_snort_package_config();
-
+		unset($a_suppress);
 		header("Location: /snort/snort_interfaces_suppress.php");
 		exit;
 	}
 }
+
+// Finished with config array reference, so release it
+unset($a_suppress);
 
 $pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Suppression List Edit"));
 include_once("head.inc");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ip_reputation.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ip_reputation.php
@@ -218,6 +218,9 @@ if ($input_errors)
 if ($savemsg)
 	print_info_box($savemsg);
 
+// Finished with config array reference, so release it
+unset($a_nat);
+
 $tab_array = array();
 $tab_array[] = array(gettext("Snort Interfaces"), true, "/snort/snort_interfaces.php");
 $tab_array[] = array(gettext("Global Settings"), false, "/snort/snort_interfaces_global.php");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist.php
@@ -3,9 +3,9 @@
  * snort_passlist.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2004-2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2004-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * originially part of m0n0wall (http://m0n0.ch/wall)
@@ -80,6 +80,7 @@ if (isset($_POST['del_btn'])) {
 			}
 		}
 		if ($need_save) {
+			unset($a_passlist);
 			write_config("Snort pkg: deleted PASS LIST.");
 			sync_snort_package_config();
 			header("Location: /snort/snort_passlist.php");
@@ -102,6 +103,7 @@ else {
 		}
 		else {
 			unset($a_passlist[$delbtn_list]);
+			unset($a_passlist);
 			write_config("Snort pkg: deleted PASS LIST.");
 			sync_snort_package_config();
 			header("Location: /snort/snort_passlist.php");
@@ -217,5 +219,6 @@ events.push(function() {
 
 //]]>
 </script>
+<?php unset($a_passlist); ?>
 <?php include("foot.inc"); ?>
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist_edit.php
@@ -3,9 +3,9 @@
  * snort_passlist_edit.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2004-2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2004-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * originially part of m0n0wall (http://m0n0.ch/wall)
@@ -49,6 +49,7 @@ elseif (isset($_GET['id']) && is_numericint($_GET['id'])) {
 
 /* Should never be called without identifying list index, so bail */
 if (is_null($id)) {
+	unset($a_passlist);
 	header("Location: /snort/snort_passlist.php");
 	exit;
 }
@@ -167,7 +168,7 @@ if ($_POST['save']) {
 
 		/* create pass list and homenet file, then sync files */
 		sync_snort_package_config();
-
+		unset($a_passlist);
 		header("Location: /snort/snort_passlist.php");
 		exit;
 	}
@@ -289,6 +290,7 @@ if (isset($id)) {
 }
 
 print($form);
+unset($a_passlist);
 ?>
 
 <script type="text/javascript">

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
@@ -367,6 +367,8 @@ if ($_POST['arp_spoof_save']) {
 			$a_nat[$id]['arp_spoof_engine']['item'][] = $engine;
 		}
 
+		unset($a_nat);
+
 		// Save the updates to the Snort configuration
 		write_config("Snort pkg: Updated ARP Spoofing engine address pairs for {$a_nat[$id]['interface']}.");
 		header("Location: snort_preprocessors.php?id=$id#preproc_arp_spoof_row");
@@ -384,6 +386,7 @@ if ($_POST['del_http_inspect']) {
 	if (isset($_POST['eng_id']) && isset($id) && isset($a_nat[$id])) {
 		unset($a_nat[$id]['http_inspect_engine']['item'][$_POST['eng_id']]);
 		write_config("Snort pkg: deleted http_inspect engine for {$a_nat[$id]['interface']}.");
+		unset($a_nat);
 		header("Location: snort_preprocessors.php?id=$id#httpinspect_row");
 		exit;
 	}
@@ -392,6 +395,7 @@ elseif ($_POST['del_frag3']) {
 	if (isset($_POST['eng_id']) && isset($id) && isset($a_nat[$id])) {
 		unset($a_nat[$id]['frag3_engine']['item'][$_POST['eng_id']]);
 		write_config("Snort pkg: deleted frag3 engine for {$a_nat[$id]['interface']}.");
+		unset($a_nat);
 		header("Location: snort_preprocessors.php?id=$id#frag3_row");
 		exit;
 	}
@@ -400,6 +404,7 @@ elseif ($_POST['del_stream5_tcp']) {
 	if (isset($_POST['eng_id']) && isset($id) && isset($a_nat[$id])) {
 		unset($a_nat[$id]['stream5_tcp_engine']['item'][$_POST['eng_id']]);
 		write_config("Snort pkg: deleted stream5 engine for {$a_nat[$id]['interface']}.");
+		unset($a_nat);
 		header("Location: snort_preprocessors.php?id=$id#stream5_row");
 		exit;
 	}
@@ -408,6 +413,7 @@ elseif ($_POST['del_ftp_client']) {
 	if (isset($_POST['eng_id']) && isset($id) && isset($a_nat[$id])) {
 		unset($a_nat[$id]['ftp_client_engine']['item'][$_POST['eng_id']]);
 		write_config("Snort pkg: deleted ftp_client engine for {$a_nat[$id]['interface']}.");
+		unset($a_nat);
 		header("Location: snort_preprocessors.php?id=$id#ftp_telnet_row");
 		exit;
 	}
@@ -416,6 +422,7 @@ elseif ($_POST['del_ftp_server']) {
 	if (isset($_POST['eng_id']) && isset($id) && isset($a_nat[$id])) {
 		unset($a_nat[$id]['ftp_server_engine']['item'][$_POST['eng_id']]);
 		write_config("Snort pkg: deleted ftp_server engine for {$a_nat[$id]['interface']}.");
+		unset($a_nat);
 		header("Location: snort_preprocessors.php?id=$id#ftp_telnet_row");
 		exit;
 	}
@@ -424,6 +431,7 @@ elseif ($_POST['del_arp_spoof_engine']) {
 	if (isset($_POST['eng_id']) && isset($id) && isset($a_nat[$id])) {
 		unset($a_nat[$id]['arp_spoof_engine']['item'][$_POST['eng_id']]);
 		write_config("Snort pkg: deleted ARP spoof host address pair for {$a_nat[$id]['interface']}.");
+		unset($a_nat);
 		header("Location: snort_preprocessors.php?id=$id#preproc_arp_spoof_row");
 		exit;
 	}
@@ -733,6 +741,8 @@ if ($_POST['save']) {
 			$savemsg = gettext("Snort has been restarted on interface " . convert_real_interface_to_friendly_descr($if_real) . " because Preprocessor changes require a restart.");
 		}
 
+		unset($a_nat);
+
 		/* Sync to configured CARP slaves if any are enabled */
 		snort_sync_on_changes();
 
@@ -765,6 +775,7 @@ if ($_POST['btn_import']) {
 				$a_nat[$id]['max_attribute_services_per_host'] = $pconfig['max_attribute_services_per_host'];
 				write_config("Snort pkg: imported Host Attribute Table data for {$a_nat[$id]['interface']}.");
 			}
+			unset($a_nat);
 			header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 			header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
 			header( 'Cache-Control: no-store, no-cache, must-revalidate' );
@@ -786,6 +797,7 @@ if ($_POST['btn_edit_hat']) {
 		$a_nat[$id]['max_attribute_hosts'] = $pconfig['max_attribute_hosts'];
 		$a_nat[$id]['max_attribute_services_per_host'] = $pconfig['max_attribute_services_per_host'];
 		write_config("Snort pkg: modified Host Attribute Table data for {$a_nat[$id]['interface']}.");
+		unset($a_nat);
 		header("Location: snort_edit_hat_data.php?id=$id");
 		exit;
 	}
@@ -2226,6 +2238,7 @@ print($modal);
 print_callout('<p>' . gettext("Remember to save your changes before you exit this page.  Preprocessor changes will rebuild the rules file.  This ") . 
 		gettext("may take several seconds to complete.  Snort must also be restarted on the interface to activate any changes made on this screen.") . '</p>', 
 		'info', 'NOTE:');
+unset($a_nat);
 ?>
 
 <script type="text/javascript">

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
@@ -54,8 +54,9 @@ if (is_null($id)) {
 		$_POST['openruleset'] = $response[1];
 	}
 	else {
-	header("Location: /snort/snort_interfaces.php");
-	exit;
+		unset($a_rule);
+		header("Location: /snort/snort_interfaces.php");
+		exit;
 	}
 }
 
@@ -1678,6 +1679,7 @@ $modal->addInput(new Form_Textarea (
 ))->removeClass('form-control')->addClass('row-fluid col-sm-10')->setAttribute('rows', '10')->setAttribute('wrap', 'soft');
 $form->add($modal);
 print($form);
+unset($a_rule);
 ?>
 
 <script type="text/javascript">

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
@@ -272,6 +272,9 @@ if ($savemsg) {
 	print_info_box($savemsg);
 }
 
+// Finished with config array reference, so release it
+unset($a_nat);
+
 $tab_array = array();
 	$tab_array[] = array(gettext("Snort Interfaces"), true, "/snort/snort_interfaces.php");
 	$tab_array[] = array(gettext("Global Settings"), false, "/snort/snort_interfaces_global.php");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
@@ -680,6 +680,9 @@ print($section);
 				gettext("The Enable SID File, Disable SID File, Modify SID File, Drop SID File and Reject SID File drop-down controls specify which rule modification lists are run automatically for the interface.  Setting a list control to 'None' disables that modification. " . 
 					"Setting all list controls for an interface to 'None' disables automatic SID state management for the interface.") .
 			'</p>', 'info', false);
+
+		// Finished with config array reference, so release it
+		unset($a_nat);
 	?>
 	</div>
 </div>


### PR DESCRIPTION
### pfSense-pkg-snort-4.0_5
This update for the Snort GUI package adds two new features and corrects two bugs. Support is added for the latest Snort-2.9.14.1 binary.

**New Features:**
1. The FreeBSD real interface name is now shown in parentheses beside the friendly interface name on the INTERFACES tab and in the interface selection drop-downs on the INTERFACE SETTINGS and ALERTS tabs.

2. Support is added for the latest Snort v2.9.14.1 binary from upstream.

**Bug Fixes:**
1. New SSH preprocessor parameters default value values were not being set when adding a new interface on the INTERFACES tab.

2. An error in the Snort GUI code could allow the most recently added interface configuration to be overwritten by the values of the interface immediately before it in the _config.xml_ file.