### PR TITLE
pfSense-pkg-snort-3.2.9.9 -- Add support for snort-2.9.14.1 and other updates

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-snort
-PORTVERSION=	3.2.9.8
-PORTREVISION=	6
+PORTVERSION=	3.2.9.9
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +12,7 @@ COMMENT=	pfSense package snort
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	snort>=2.9.12:security/snort \
+RUN_DEPENDS=	snort>=2.9.14.1:security/snort \
 		barnyard2>=0:security/barnyard2
 
 NO_BUILD=	yes

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -3,9 +3,9 @@
  * snort_check_for_rule_updates.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009 Robert Zelaya
- * Copyright (c) 2013-2018 Bill Meeks
+ * Copyright (c) 2013-2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -837,5 +837,4 @@ if ($update_errors)
 else
 	$config['installedpackages']['snortglobal']['last_rule_upd_status'] = gettext("success");
 $config['installedpackages']['snortglobal']['last_rule_upd_time'] = time();
-write_config("Snort pkg: updated status for updated rules package(s) check.", FALSE);
 ?>

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -3,9 +3,9 @@
  * snort_defs.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2018 Bill Meeks
+ * Copyright (c) 2013-2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,7 +47,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 		define("SNORT_BIN_VERSION", $matches[0]);
 	}
 	else {
-		define("SNORT_BIN_VERSION", "2.9.12");
+		define("SNORT_BIN_VERSION", "2.9.14.1");
 	}
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
@@ -3,8 +3,8 @@
  * snort_migrate_config.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2018 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2013-2018 Bill Meeks
+ * Copyright (c) 2019 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2013-2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,8 +47,6 @@ if (!is_array($config['installedpackages']['snortglobal']['rule'])) {
 // Just exit if this is a clean install with no saved settings
 if (empty($config['installedpackages']['snortglobal']['rule']))
 	return;
-
-$rule = &$config['installedpackages']['snortglobal']['rule'];
 
 /****************************************************************************/
 /* Loop through all the <rule> elements in the Snort configuration and      */
@@ -161,7 +159,7 @@ if (empty($config['installedpackages']['snortglobal']['sid_list_migration']) && 
 /**********************************************************/
 /* Migrate per interface settings if required.            */
 /**********************************************************/
-foreach ($rule as &$r) {
+foreach ($config['installedpackages']['snortglobal']['rule'] as &$r) {
 	// Initialize arrays for supported preprocessors if necessary
 	if (!is_array($r['frag3_engine'])) {
 		$r['frag3_engine'] = array();

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
@@ -3,9 +3,9 @@
  * snort_post_install.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2016 Bill Meeks
+ * Copyright (c) 2013-2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -143,8 +143,7 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 	if (count($config['installedpackages']['snortglobal']['rule']) > 0) {
 		$uuids = array();
 		$fixed_duplicate = FALSE;
-		$snortconf = &$config['installedpackages']['snortglobal']['rule'];
-		foreach ($snortconf as &$snortcfg) {
+		foreach ($config['installedpackages']['snortglobal']['rule'] as &$snortcfg) {
 			// Check for and fix a duplicate UUID
 			$if_real = get_real_interface($snortcfg['interface']);
 			if (!isset($uuids[$snortcfg['uuid']])) {
@@ -164,7 +163,8 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 				$fixed_duplicate = TRUE;
 			}
 		}
-		unset($uuids);
+		// Release config array reference and $uuids array memory
+		unset($snortcfg, $uuids);
 	}
 	/****************************************************************/
 	/* End of duplicate UUID bug fix.                               */

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -3,10 +3,10 @@
  * snort_alerts.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
  * All rights reserved.
  *
@@ -403,7 +403,7 @@ $supplist = snort_load_suppress_sigs($a_instance[$instanceid], true);
 // Load up an array with the configured Snort interfaces
 $interfaces = array();
 foreach ($a_instance as $id => $instance) {
-	$interfaces[$id] = convert_friendly_interface_to_friendly_descr($instance['interface']);
+	$interfaces[$id] = convert_friendly_interface_to_friendly_descr($instance['interface']) . " (" . get_real_interface($instance['interface']) . ")";
 }
 
 $pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Alerts"));

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces.php
@@ -3,8 +3,8 @@
  * snort_interfaces.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2011-2018 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2011-2019 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -344,7 +344,7 @@ if ($savemsg)
 					/* convert fake interfaces to real and check if iface is up */
 					/* There has to be a smarter way to do this */
 					$if_real = get_real_interface($natent['interface']);
-					$natend_friendly = convert_friendly_interface_to_friendly_descr($natent['interface']);
+					$natend_friendly = convert_friendly_interface_to_friendly_descr($natent['interface']) . " ({$if_real})";
 					$snort_uuid = $natent['uuid'];
 
 					/* See if interface has any rules defined and set boolean flag */

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
@@ -3,9 +3,9 @@
  * snort_interfaces_edit.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2011-2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2011-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (C) 2008-2009 Robert Zelaya
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,6 +110,11 @@ $snort_uuid = $pconfig['uuid'];
 // Get the physical configured interfaces on the firewall
 $interfaces = get_configured_interface_with_descr();
 
+// Footnote real interface associated with each configured interface
+foreach ($interfaces as $if => $desc) {
+		$interfaces[$if] = $interfaces[$if] . " (" . get_real_interface($if) . ")";
+}
+
 // See if interface is already configured, and use its values
 if (isset($id) && $a_rule[$id]) {
 	/* old options */
@@ -128,7 +133,20 @@ elseif (isset($id) && !isset($a_rule[$id])) {
 	foreach ($ifaces as $i) {
 		if (!in_array($i, $ifrules)) {
 			$pconfig['interface'] = $i;
-			$pconfig['descr'] = convert_friendly_interface_to_friendly_descr($i);
+
+			// If the interface is a VLAN, use the VLAN description
+			// if set, otherwise default to the friendly description.
+			if ($vlan = interface_is_vlan(get_real_interface($i))) {
+				if (strlen($vlan['descr']) > 0) {
+					$pconfig['descr'] = $vlan['descr'];
+				}
+				else {
+					$pconfig['descr'] = convert_friendly_interface_to_friendly_descr($i);
+				}
+			}
+			else {
+				$pconfig['descr'] = convert_friendly_interface_to_friendly_descr($i);
+			}
 			$pconfig['enable'] = 'on';
 			break;
 		}
@@ -166,7 +184,20 @@ if (strcasecmp($action, 'dup') == 0) {
 		if (!in_array($i, $ifrules)) {
 			$pconfig['interface'] = $i;
 			$pconfig['enable'] = 'on';
-			$pconfig['descr'] = convert_friendly_interface_to_friendly_descr($i);
+
+			// If the interface is a VLAN, use the VLAN description
+			// if set, otherwise default to the friendly description.
+			if ($vlan = interface_is_vlan(get_real_interface($i))) {
+				if (strlen($vlan['descr']) > 0) {
+					$pconfig['descr'] = $vlan['descr'];
+				}
+				else {
+					$pconfig['descr'] = convert_friendly_interface_to_friendly_descr($i);
+				}
+			}
+			else {
+				$pconfig['descr'] = convert_friendly_interface_to_friendly_descr($i);
+			}
 			break;
 		}
 	}


### PR DESCRIPTION
### pfSense-pkg-snort-3.2.9.9
This update for the Snort package on pfSense-2.4.4 adds support for the latest 2.9.14.1 snort binary.  It also adds one new feature and corrects two issues.

**New Features:**
1. The physical real interface is now shown in parentheses along with the friendly interface name when displaying interfaces on the INTERFACES tab and within drop-down selectors on the INTERFACE SETTINGS and ALERTS tabs.

2. Add support for the latest snort-2.9.14.1 binary from upstream.

**Bug Fixes:**
1. Remove an unnecessary _write_config()_ call when performing the scheduled cron task to update rules to prevent spamming the ACB (Auto Config Backup) service.

2. Release the config array reference pointer used to iterate the Snort _config.xml_ entries during saved settings migration steps when finished using the reference pointer.