### PR TITLE
pfSense-pkg-snort 3.2.9.9_1 -- Fix display of last rules update status info

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	3.2.9.9
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -831,10 +831,13 @@ error_log(gettext("The Rules update has finished.  Time: " . date("Y-m-d H:i:s")
 if ($mounted_rw == TRUE)
 	conf_mount_ro();
 
-/* Save this update status to the configuration file */
-if ($update_errors)
-	$config['installedpackages']['snortglobal']['last_rule_upd_status'] = gettext("failed");
-else
-	$config['installedpackages']['snortglobal']['last_rule_upd_status'] = gettext("success");
-$config['installedpackages']['snortglobal']['last_rule_upd_time'] = time();
+/* Save this update status to the rulesupd_status file */
+$status = time() . '|';
+if ($update_errors) {
+	$status .= gettext("failed");
+}
+else {
+	$status .= gettext("success");
+}
+@file_put_contents(SNORTDIR . "/rulesupd_status", $status);
 ?>

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
@@ -157,6 +157,20 @@ if (empty($config['installedpackages']['snortglobal']['sid_list_migration']) && 
 }
 
 /**********************************************************/
+/* Remove the two deprecated Rules Update Status fields   */
+/* from the package configuration. The status is now      */
+/* stored in a local file.                                */
+/**********************************************************/
+if (isset($config['installedpackages']['snortglobal']['last_rule_upd_status'])) {
+	unset($config['installedpackages']['snortglobal']['last_rule_upd_status']);
+	$updated_cfg = true;
+}
+if (isset($config['installedpackages']['snortglobal']['last_rule_upd_time'])) {
+	unset($config['installedpackages']['snortglobal']['last_rule_upd_time']);
+	$updated_cfg = true;
+}
+
+/**********************************************************/
 /* Migrate per interface settings if required.            */
 /**********************************************************/
 foreach ($config['installedpackages']['snortglobal']['rule'] as &$r) {

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -3,9 +3,9 @@
  * snort_uninstall.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2016 Bill Meeks
+ * Copyright (c) 2013-2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -158,6 +158,7 @@ unlink_if_exists("{$snortdir}/*.conf");
 unlink_if_exists("{$snortdir}/*.map");
 unlink_if_exists("{$snortdir}/*.config");
 unlink_if_exists("{$snortdir}/attribute_table.dtd");
+unlink_if_exists("{$snortdir}/rulesupd_status");
 
 if (is_array($config['installedpackages']['snortglobal']['rule']) && count($config['installedpackages']['snortglobal']['rule']) > 0) {
 	foreach ($config['installedpackages']['snortglobal']['rule'] as $snortcfg) {

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
@@ -3,8 +3,8 @@
  * snort_download_updates.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2004-2016 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2004-2019 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,14 +47,15 @@ $openappid_detectors = $config['installedpackages']['snortglobal']['openappid_de
 $openappid_rules_detectors = $config['installedpackages']['snortglobal']['openappid_rules_detectors'];
 
 /* Get last update information if available */
-if (!empty($config['installedpackages']['snortglobal']['last_rule_upd_time']))
-	$last_rule_upd_time = date('M-d Y H:i', $config['installedpackages']['snortglobal']['last_rule_upd_time']);
-else
+if (file_exists(SNORTDIR . "/rulesupd_status")) {
+	$status = explode("|", file_get_contents(SNORTDIR . "/rulesupd_status"));
+	$last_rule_upd_time = date('M-d Y H:i', $status[0]);
+	$last_rule_upd_status = gettext($status[1]);
+}
+else {
 	$last_rule_upd_time = gettext("Unknown");
-if (!empty($config['installedpackages']['snortglobal']['last_rule_upd_status']))
-	$last_rule_upd_status = htmlspecialchars($config['installedpackages']['snortglobal']['last_rule_upd_status']);
-else
 	$last_rule_upd_status = gettext("Unknown");
+}
 
 if ($etpro == "on") {
 	$emergingthreats_filename = SNORT_ETPRO_DNLD_FILENAME;


### PR DESCRIPTION
### pfSense-pkg-snort-3.2.9.9_1
This update corrects a cosmetic issue with the display of the last rules update execution time and status information. Formerly this info was stored in the _config.xml_ file, but that resulted in unnecessary backups of _config.xml_ with each rules update job run. A previous package update removed the call to _write_config()_ that was generating the unnecessary backup, but that prevented the recording of rules update time and status. The rules update execution time and status are now recorded locally in a small file on the firewall.

**New Features:**
None

**Bug Fixes:**
1. Rules update task info (execution time and status) is displaying as either "unknown" or the last package installation date and time.