### PR TITLE
pfSense-pkg-suricata-4.1.4_8 -- Fix display of rules update status info & dangling array reference iterator

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.1.4
-PORTREVISION=	6
+PORTREVISION=	7
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.1.4
-PORTREVISION=	7
+PORTREVISION=	8
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.1.4
-PORTREVISION=	5
+PORTREVISION=	6
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -41,8 +41,6 @@ if (!is_array($config['installedpackages']['suricata']['rule']))
 if (empty($config['installedpackages']['suricata']['rule']))
 	return;
 
-$rule = &$config['installedpackages']['suricata']['rule'];
-
 /****************************************************************************/
 /* Loop through all the <rule> elements in the Suricata configuration and   */
 /* migrate relevant parameters to the new format.                           */
@@ -229,7 +227,7 @@ if (!isset($config['installedpackages']['suricata']['config'][0]['u2_archive_log
 }
 
 // Now process the interface-specific settings
-foreach ($rule as &$r) {
+foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 
 	// Initialize arrays for supported preprocessors if necessary
 	if (!is_array($r['libhtp_policy']))

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -125,6 +125,20 @@ if (empty($config['installedpackages']['suricata']['config'][0]['hide_deprecated
 }
 
 /**********************************************************/
+/* Remove the two deprecated Rules Update Status fields   */
+/* from the package configuration. The status is now      */
+/* stored in a local file.                                */
+/**********************************************************/
+if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status'])) {
+	unset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status'];
+	$updated_cfg = true;
+}
+if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_time'])) {
+	unset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_time']);
+	$updated_cfg = true;
+}
+
+/**********************************************************/
 /* Set default log size and retention limits if not set   */
 /**********************************************************/
 if (!isset($config['installedpackages']['suricata']['config'][0]['alert_log_retention']) && $config['installedpackages']['suricata']['config'][0]['alert_log_retention'] != '0') {

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -130,7 +130,7 @@ if (empty($config['installedpackages']['suricata']['config'][0]['hide_deprecated
 /* stored in a local file.                                */
 /**********************************************************/
 if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status'])) {
-	unset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status'];
+	unset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status']);
 	$updated_cfg = true;
 }
 if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_time'])) {

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_post_install.php
@@ -160,8 +160,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 		$builtin_rules = array( "app-layer-events.rules", "decoder-events.rules", "dnp3-events.rules", "dns-events.rules", "files.rules", "http-events.rules",  
 					"modbus-events.rules", "smtp-events.rules", "stream-events.rules", "tls-events.rules" );
 		$rust_required_rules = array( "ipsec-events.rules", "kerberos-events.rules", "nfs-events.rules", "ntp-events.rules", "smb-events.rules" );
-		$suriconf = &$config['installedpackages']['suricata']['rule'];
-		foreach ($suriconf as &$suricatacfg) {
+		foreach ($config['installedpackages']['suricata']['rule']as &$suricatacfg) {
 			$rulesets = explode("||", $suricatacfg['rulesets']);
 			foreach ($builtin_rules as $name) {
 				if (in_array($name, $rulesets)) {
@@ -184,7 +183,8 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 			// and write result back to interface config location.
 			$suricatacfg['rulesets'] = implode("||", array_keys(array_flip($rulesets)));
 		}
-		unset($builtin_rules, $rulesets, $rust_required_rules);
+		// Release our config array reference and other memory
+		unset($suricatacfg, $builtin_rules, $rulesets, $rust_required_rules);
 	}
 	/****************************************************************/
 	/* End of built-in events rules fix.                            */
@@ -217,9 +217,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 	}
 
 	// Create the suricata.yaml files for each enabled interface
-	$suriconf = $config['installedpackages']['suricata']['rule'];
-
-	foreach ($suriconf as $suricatacfg) {
+	foreach ($config['installedpackages']['suricata']['rule'] as $suricatacfg) {
 		$if_real = get_real_interface($suricatacfg['interface']);
 		$suricata_uuid = $suricatacfg['uuid'];
 		$suricatacfgdir = "{$suricatadir}suricata_{$suricata_uuid}_{$if_real}";

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -709,11 +709,14 @@ suricata_update_status(gettext("The Rules update has finished.") . "\n");
 syslog(LOG_NOTICE, gettext("[Suricata] The Rules update has finished."));
 error_log(gettext("The Rules update has finished.  Time: " . date("Y-m-d H:i:s"). "\n\n"), 3, SURICATA_RULES_UPD_LOGFILE);
 
-/* Save this update status to the configuration file */
-if ($update_errors)
-	$config['installedpackages']['suricata']['config'][0]['last_rule_upd_status'] = gettext("failed");
-else
-	$config['installedpackages']['suricata']['config'][0]['last_rule_upd_status'] = gettext("success");
-$config['installedpackages']['suricata']['config'][0]['last_rule_upd_time'] = time();
+/* Save this update status to the rulesupd_status file */
+$status = time() . '|';
+if ($update_errors) {
+	$status .= gettext("failed");
+}
+else {
+	$status .= gettext("success");
+}
+@file_put_contents(SURICATADIR . "rulesupd_status", $status);
 
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
@@ -126,7 +126,7 @@ if ($rc === true) {
 			break;
 
 		default:
-			syslog(LOG_WARN, "[Suricata] WARNING: Received an unexpected HTTP response code " . $response . " during GeoLite2-Country database update check.");
+			syslog(LOG_WARNING, "[Suricata] WARNING: Received an unexpected HTTP response code " . $response . " during GeoLite2-Country database update check.");
 	}
 } else {
 	syslog(LOG_ERR, "[Suricata] ERROR: GeoLite2-Country IP database download failed.  The HTTP Response Code was " . $response . ".");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -41,8 +41,6 @@ if (!is_array($config['installedpackages']['suricata']['rule']))
 if (empty($config['installedpackages']['suricata']['rule']))
 	return;
 
-$rule = &$config['installedpackages']['suricata']['rule'];
-
 /****************************************************************************/
 /* Loop through all the <rule> elements in the Suricata configuration and   */
 /* migrate relevant parameters to the new format.                           */
@@ -220,7 +218,7 @@ if (!isset($config['installedpackages']['suricata']['config'][0]['u2_archive_log
 }
 
 // Now process the interface-specific settings
-foreach ($rule as &$r) {
+foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 
 	// Initialize arrays for supported preprocessors if necessary
 	if (!is_array($r['libhtp_policy']))

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -125,6 +125,20 @@ if (empty($config['installedpackages']['suricata']['config'][0]['hide_deprecated
 }
 
 /**********************************************************/
+/* Remove the two deprecated Rules Update Status fields   */
+/* from the package configuration. The status is now      */
+/* stored in a local file.                                */
+/**********************************************************/
+if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status'])) {
+	unset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status'];
+	$updated_cfg = true;
+}
+if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_time'])) {
+	unset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_time']);
+	$updated_cfg = true;
+}
+
+/**********************************************************/
 /* Set default log size and retention limits if not set   */
 /**********************************************************/
 if (!isset($config['installedpackages']['suricata']['config'][0]['alert_log_retention']) && $config['installedpackages']['suricata']['config'][0]['alert_log_retention'] != '0') {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -130,7 +130,7 @@ if (empty($config['installedpackages']['suricata']['config'][0]['hide_deprecated
 /* stored in a local file.                                */
 /**********************************************************/
 if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status'])) {
-	unset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status'];
+	unset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status']);
 	$updated_cfg = true;
 }
 if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_time'])) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -159,8 +159,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 		$builtin_rules = array( "app-layer-events.rules", "decoder-events.rules", "dnp3-events.rules", "dns-events.rules", "files.rules", "http-events.rules", "ipsec-events.rules", "kerberos-events.rules", 
 					"modbus-events.rules", "nfs-events.rules", "ntp-events.rules", "smb-events.rules", "smtp-events.rules", "stream-events.rules", "tls-events.rules" );
 
-		$suriconf = &$config['installedpackages']['suricata']['rule'];
-		foreach ($suriconf as &$suricatacfg) {
+		foreach ($config['installedpackages']['suricata']['rule'] as &$suricatacfg) {
 			$rulesets = explode("||", $suricatacfg['rulesets']);
 			foreach ($builtin_rules as $name) {
 				if (in_array($name, $rulesets)) {
@@ -173,7 +172,9 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 			// Remove any duplicate ruleset names from earlier bug
 			$suricatacfg['rulesets'] = implode("||", array_keys(array_flip($rulesets)));
 		}
-		unset($builtin_rules, $rulesets);
+
+		// Release our config array iterator and other memory
+		unset($suricatacfg, $builtin_rules, $rulesets);
 	}
 	/****************************************************************/
 	/* End of built-in events rules fix.                            */
@@ -206,9 +207,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 	}
 
 	// Create the suricata.yaml files for each enabled interface
-	$suriconf = $config['installedpackages']['suricata']['rule'];
-
-	foreach ($suriconf as $suricatacfg) {
+	foreach ($config['installedpackages']['suricata']['rule'] as $suricatacfg) {
 		$if_real = get_real_interface($suricatacfg['interface']);
 		$suricata_uuid = $suricatacfg['uuid'];
 		$suricatacfgdir = "{$suricatadir}suricata_{$suricata_uuid}_{$if_real}";

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
@@ -80,6 +80,7 @@ unlink_if_exists("{$suricatadir}*.gz.md5");
 unlink_if_exists("{$suricatadir}gen-msg.map");
 unlink_if_exists("{$suricatadir}classification.config");
 unlink_if_exists("{$suricatadir}reference.config");
+unlink_if_exists("{$suricatadir}rulesupd_status");
 unlink_if_exists(SURICATA_RULES_DIR . "*.txt");
 unlink_if_exists(SURICATA_RULES_DIR . VRT_FILE_PREFIX . "*.rules");
 unlink_if_exists(SURICATA_RULES_DIR . ET_OPEN_FILE_PREFIX . "*.rules");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
@@ -3,11 +3,11 @@
  * suricata_download_updates.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,14 +37,15 @@ $etpro = $config['installedpackages']['suricata']['config'][0]['enable_etpro_rul
 $snortcommunityrules = $config['installedpackages']['suricata']['config'][0]['snortcommunityrules'];
 
 /* Get last update information if available */
-if (!empty($config['installedpackages']['suricata']['config'][0]['last_rule_upd_time']))
-	$last_rule_upd_time = date('M-d Y H:i', $config['installedpackages']['suricata']['config'][0]['last_rule_upd_time']);
-else
+if (file_exists(SURICATADIR . "rulesupd_status")) {
+	$status = explode("|", file_get_contents(SURICATADIR . "rulesupd_status"));
+	$last_rule_upd_time = date('M-d Y H:i', $status[0]);
+	$last_rule_upd_status = gettext($status[1]);
+}
+else {
 	$last_rule_upd_time = gettext("Unknown");
-if (!empty($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status']))
-	$last_rule_upd_status = htmlspecialchars($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status']);
-else
 	$last_rule_upd_status = gettext("Unknown");
+}
 
 // Check for any custom URLs and extract custom filenames
 // if present, else use package default values.


### PR DESCRIPTION
### pfSense-pkg-suricata-4.1.4_7
This update fixes an issue with displaying the last rules update job status and corrects the spelling of a _syslog()_ PRIORITY constant in the GeoIP2 database update cron task script.

Formerly the rules update status info was stored in the _config.xml_ file, but that resulted in unnecessary backups of _config.xml_ with each rules update job run. A previous package update removed the call to _write_config()_ that was generating the unnecessary backup, but that prevented the recording of rules update time and status. The rules update execution time and status are now recorded locally in a small file on the firewall.

**New Features:**
None

**Bug Fixes:**
1. A PHP warning message is generated in the crash log due to use of an unknown constant in a call to the _syslog()_ function in the GeoIP2 database update cron task.

2. Rules update task info (execution time and status) is displaying as either "unknown" or the last package installation date and time.