### PR TITLE
pfSense-pkg-snort-4.0_6 -- Fix display of last rules update status info

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.0
-PORTREVISION=	5
+PORTREVISION=	6
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -819,10 +819,13 @@ snort_update_status(gettext("The Rules update has finished.") . "\n");
 syslog(LOG_NOTICE, gettext("[Snort] The Rules update has finished."));
 error_log(gettext("The Rules update has finished.  Time: " . date("Y-m-d H:i:s"). "\n\n"), 3, SNORT_RULES_UPD_LOGFILE);
 
-/* Save this update status to the configuration file */
-if ($update_errors)
-	$config['installedpackages']['snortglobal']['last_rule_upd_status'] = gettext("failed");
-else
-	$config['installedpackages']['snortglobal']['last_rule_upd_status'] = gettext("success");
-$config['installedpackages']['snortglobal']['last_rule_upd_time'] = time();
+/* Save this update status to the rulesupd_status file */
+$status = time() . '|';
+if ($update_errors) {
+	$status .= gettext("failed");
+}
+else {
+	$status .= gettext("success");
+}
+@file_put_contents(SNORTDIR . "/rulesupd_status", $status);
 ?>

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
@@ -186,6 +186,20 @@ elseif ($config['installedpackages']['snortglobal']['sid_list_migration'] < "2")
 }
 
 /**********************************************************/
+/* Remove the two deprecated Rules Update Status fields   */
+/* from the package configuration. The status is now      */
+/* stored in a local file.                                */
+/**********************************************************/
+if (isset($config['installedpackages']['snortglobal']['last_rule_upd_status'])) {
+	unset($config['installedpackages']['snortglobal']['last_rule_upd_status']);
+	$updated_cfg = true;
+}
+if (isset($config['installedpackages']['snortglobal']['last_rule_upd_time'])) {
+	unset($config['installedpackages']['snortglobal']['last_rule_upd_time']);
+	$updated_cfg = true;
+}
+
+/**********************************************************/
 /* Migrate per interface settings if required.            */
 /**********************************************************/
 foreach ($config['installedpackages']['snortglobal']['rule'] as &$rule) {

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -142,6 +142,7 @@ unlink_if_exists(SNORTDIR . "/rules/*.txt");
 unlink_if_exists(SNORTDIR . "/classification.config");
 unlink_if_exists(SNORTDIR . "/reference.config");
 unlink_if_exists(SNORTDIR . "/unicode.map");
+unlink_if_exists(SNORTDIR . "/rulesupd_status");
 unlink_if_exists(SNORTDIR . "/preproc_rules/*.rules");
 unlink_if_exists(SNORTDIR . "/rules/" . VRT_FILE_PREFIX . "*.rules");
 unlink_if_exists(SNORTDIR . "/rules/" . ET_OPEN_FILE_PREFIX . "*.rules");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
@@ -3,8 +3,8 @@
  * snort_download_updates.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2004-2016 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2004-2019 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,14 +47,15 @@ $openappid_detectors = $config['installedpackages']['snortglobal']['openappid_de
 $openappid_rules_detectors = $config['installedpackages']['snortglobal']['openappid_rules_detectors'];
 
 /* Get last update information if available */
-if (!empty($config['installedpackages']['snortglobal']['last_rule_upd_time']))
-	$last_rule_upd_time = date('M-d Y H:i', $config['installedpackages']['snortglobal']['last_rule_upd_time']);
-else
+if (file_exists(SNORTDIR . "/rulesupd_status")) {
+	$status = explode("|", file_get_contents(SNORTDIR . "/rulesupd_status"));
+	$last_rule_upd_time = date('M-d Y H:i', $status[0]);
+	$last_rule_upd_status = gettext($status[1]);
+}
+else {
 	$last_rule_upd_time = gettext("Unknown");
-if (!empty($config['installedpackages']['snortglobal']['last_rule_upd_status']))
-	$last_rule_upd_status = htmlspecialchars($config['installedpackages']['snortglobal']['last_rule_upd_status']);
-else
 	$last_rule_upd_status = gettext("Unknown");
+}
 
 if ($etpro == "on") {
 	$emergingthreats_filename = SNORT_ETPRO_DNLD_FILENAME;

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
@@ -656,6 +656,7 @@ print($section);
 			</table>
 		</div>
 	</div>
+</div>
 	<div>
 		<button type="submit" id="save_auto_sid_conf" name="save_auto_sid_conf" class="btn btn-primary" value="<?=gettext("Save");?>" title="<?=gettext("Save SID Management configuration");?>" >
 			<i class="fa fa-save icon-embed-btn"></i>
@@ -685,7 +686,6 @@ print($section);
 		unset($a_nat);
 	?>
 	</div>
-</div>
 
 <script type="text/javascript">
 //<![CDATA[


### PR DESCRIPTION
### pfSense-pkg-snort-4.0_6
This update corrects a cosmetic issue with the display of the last rules update execution time and status information. Formerly this info was stored in the _config.xml_ file, but that resulted in unnecessary backups of _config.xml_ with each rules update job run. A previous package update removed the call to _write_config()_ that was generating the unnecessary backup, but that prevented the recording of rules update time and status. The rules update execution time and status are now recorded locally in a small file on the firewall.

**New Features:**
None

**Bug Fixes:**
1. Rules update task info (execution time and status) is displaying as either "unknown" or the last package installation date and time.

2. The **Save** button is hidden on SID MGMT tab whenever the **Enable** checkbox is cleared, thus the user is unable to save the SID MGMT disabled state.