### PR TITLE
pfSense-pkg-suricata-4.1.4_7 -- Fix missing parenthesis

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.1.4
-PORTREVISION=	6
+PORTREVISION=	7
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -130,7 +130,7 @@ if (empty($config['installedpackages']['suricata']['config'][0]['hide_deprecated
 /* stored in a local file.                                */
 /**********************************************************/
 if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status'])) {
-	unset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status'];
+	unset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status']);
 	$updated_cfg = true;
 }
 if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_time'])) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -130,7 +130,7 @@ if (empty($config['installedpackages']['suricata']['config'][0]['hide_deprecated
 /* stored in a local file.                                */
 /**********************************************************/
 if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status'])) {
-	unset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status'];
+	unset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status']);
 	$updated_cfg = true;
 }
 if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_time'])) {


### PR DESCRIPTION
### pfSense-pkg-suricata-4.1.4_7
This corrects a typo (missing parenthesis) on line 133 in the file _suricata_migrate_config.php_.

**New Features:**
None

**Bug Fixes:**
1. Line 133 of _suricata_migrate_config.php_ generates a syntax error.