### PR TITLE
pfSense-pkg-suricata-4.1.4_8 -- Fix dangling config array iterator bug.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.1.4
-PORTREVISION=	7
+PORTREVISION=	8
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -41,8 +41,6 @@ if (!is_array($config['installedpackages']['suricata']['rule']))
 if (empty($config['installedpackages']['suricata']['rule']))
 	return;
 
-$rule = &$config['installedpackages']['suricata']['rule'];
-
 /****************************************************************************/
 /* Loop through all the <rule> elements in the Suricata configuration and   */
 /* migrate relevant parameters to the new format.                           */
@@ -229,7 +227,7 @@ if (!isset($config['installedpackages']['suricata']['config'][0]['u2_archive_log
 }
 
 // Now process the interface-specific settings
-foreach ($rule as &$r) {
+foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 
 	// Initialize arrays for supported preprocessors if necessary
 	if (!is_array($r['libhtp_policy']))

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_post_install.php
@@ -160,8 +160,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 		$builtin_rules = array( "app-layer-events.rules", "decoder-events.rules", "dnp3-events.rules", "dns-events.rules", "files.rules", "http-events.rules",  
 					"modbus-events.rules", "smtp-events.rules", "stream-events.rules", "tls-events.rules" );
 		$rust_required_rules = array( "ipsec-events.rules", "kerberos-events.rules", "nfs-events.rules", "ntp-events.rules", "smb-events.rules" );
-		$suriconf = &$config['installedpackages']['suricata']['rule'];
-		foreach ($suriconf as &$suricatacfg) {
+		foreach ($config['installedpackages']['suricata']['rule']as &$suricatacfg) {
 			$rulesets = explode("||", $suricatacfg['rulesets']);
 			foreach ($builtin_rules as $name) {
 				if (in_array($name, $rulesets)) {
@@ -184,7 +183,8 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 			// and write result back to interface config location.
 			$suricatacfg['rulesets'] = implode("||", array_keys(array_flip($rulesets)));
 		}
-		unset($builtin_rules, $rulesets, $rust_required_rules);
+		// Release our config array reference and other memory
+		unset($suricatacfg, $builtin_rules, $rulesets, $rust_required_rules);
 	}
 	/****************************************************************/
 	/* End of built-in events rules fix.                            */
@@ -217,9 +217,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 	}
 
 	// Create the suricata.yaml files for each enabled interface
-	$suriconf = $config['installedpackages']['suricata']['rule'];
-
-	foreach ($suriconf as $suricatacfg) {
+	foreach ($config['installedpackages']['suricata']['rule'] as $suricatacfg) {
 		$if_real = get_real_interface($suricatacfg['interface']);
 		$suricata_uuid = $suricatacfg['uuid'];
 		$suricatacfgdir = "{$suricatadir}suricata_{$suricata_uuid}_{$if_real}";

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -41,8 +41,6 @@ if (!is_array($config['installedpackages']['suricata']['rule']))
 if (empty($config['installedpackages']['suricata']['rule']))
 	return;
 
-$rule = &$config['installedpackages']['suricata']['rule'];
-
 /****************************************************************************/
 /* Loop through all the <rule> elements in the Suricata configuration and   */
 /* migrate relevant parameters to the new format.                           */
@@ -220,7 +218,7 @@ if (!isset($config['installedpackages']['suricata']['config'][0]['u2_archive_log
 }
 
 // Now process the interface-specific settings
-foreach ($rule as &$r) {
+foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 
 	// Initialize arrays for supported preprocessors if necessary
 	if (!is_array($r['libhtp_policy']))

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -159,8 +159,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 		$builtin_rules = array( "app-layer-events.rules", "decoder-events.rules", "dnp3-events.rules", "dns-events.rules", "files.rules", "http-events.rules", "ipsec-events.rules", "kerberos-events.rules", 
 					"modbus-events.rules", "nfs-events.rules", "ntp-events.rules", "smb-events.rules", "smtp-events.rules", "stream-events.rules", "tls-events.rules" );
 
-		$suriconf = &$config['installedpackages']['suricata']['rule'];
-		foreach ($suriconf as &$suricatacfg) {
+		foreach ($config['installedpackages']['suricata']['rule'] as &$suricatacfg) {
 			$rulesets = explode("||", $suricatacfg['rulesets']);
 			foreach ($builtin_rules as $name) {
 				if (in_array($name, $rulesets)) {
@@ -173,7 +172,9 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 			// Remove any duplicate ruleset names from earlier bug
 			$suricatacfg['rulesets'] = implode("||", array_keys(array_flip($rulesets)));
 		}
-		unset($builtin_rules, $rulesets);
+
+		// Release our config array iterator and other memory
+		unset($suricatacfg, $builtin_rules, $rulesets);
 	}
 	/****************************************************************/
 	/* End of built-in events rules fix.                            */
@@ -206,9 +207,7 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 	}
 
 	// Create the suricata.yaml files for each enabled interface
-	$suriconf = $config['installedpackages']['suricata']['rule'];
-
-	foreach ($suriconf as $suricatacfg) {
+	foreach ($config['installedpackages']['suricata']['rule'] as $suricatacfg) {
 		$if_real = get_real_interface($suricatacfg['interface']);
 		$suricata_uuid = $suricatacfg['uuid'];
 		$suricatacfgdir = "{$suricatadir}suricata_{$suricata_uuid}_{$if_real}";


### PR DESCRIPTION
### pfSense-pkg-suricata-4.1.4_8
This update corrects a bug caused by a dangling (un-released) config array iterator variable. During the package installation process, when an existing Suricata configuration is present and being migrated to the new package version, it is possible for the last configured Suricata interface to be overwritten by the first configured interface.

**New Features:**
None

**Bug Fixes:**
1. During package installation when a user has two or more configured Suricata interfaces, the most recently added interface can be overwritten by the data from the first configured interface.