### PR TITLE
Change redir domain(s) to use regex

### DIFF
--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid_reverse.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid_reverse.inc
@@ -244,7 +244,7 @@ function squid_resync_reverse() {
 
 				if (is_array($rdr['row'])) {
 					foreach ($rdr['row'] as $uri) {
-						$conf_rdr .= "acl rdr_dst_{$rdr['name']} dstdomain {$uri['uri']}\n";
+ 						$conf_rdr .= "acl rdr_dst_{$rdr['name']} dstdom_regex -i {$uri['uri']}\n";
 					}
 				}
 

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid_reverse_redir.xml
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid_reverse_redir.xml
@@ -127,13 +127,14 @@
 			<type>info</type>
 			<description>
 				<![CDATA[
-				Use Redirect Domains row(s) below to match domains to redirect for (one per row).
+				Use Redirect Domains row(s) containing <strong>regular expressions</strong> below to match domains to redirect for (one per row).
 				<div class="infoblock">
 					Do <strong>NOT</strong> enter http:// or https:// - only the hostname is required.<br/><br/>
 					<span class="text-info">Examples:</span><br/>
 					example.com<br/>
-					sub.example.com<br/>
 					www.example.com<br/>
+					^this.example.com/.*$<br/>
+					^(?!butnotthis\.)(.*\.)?example\.com$
 					</span>
 				</div>
 				]]>
@@ -151,7 +152,7 @@
 					<required/>
 					<fielddescr>
 						<![CDATA[
-						Enter the domains to match here.
+						Enter <strong>regular expression(s)</strong> for the domain(s) to match here.
 						<span class="text-info">Click Info above for examples.</span>
 						]]>
 					</fielddescr>
@@ -164,7 +165,7 @@
 			<description>
 				<![CDATA[
 				Enter the path regex to match here.
-				<span class="text-info">Hint: Enter ^/$ to match the domain only.</span>
+				<span class="text-info">Hint: Enter ^/$ to match the domain(s) only.</span>
 				]]>
 			</description>
 			<type>input</type>

--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid_reverse_redir.xml
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid_reverse_redir.xml
@@ -134,7 +134,7 @@
 					example.com<br/>
 					www.example.com<br/>
 					^this.example.com/.*$<br/>
-					^(?!butnotthis\.)(.*\.)?example\.com$
+					^(?!butnotthis\.)(.+\.)?example\.com$
 					</span>
 				</div>
 				]]>


### PR DESCRIPTION
This makes the redirects much more flexible in general.
Also makes it possible to redirect a subdomain to a different mapping than the domain itself.
This is a more consistent approach as mappings and redirects are handled in a similar manner.

Redmine: https://redmine.pfsense.org/issues/9762
Ready for review