### PR TITLE
Redmine #9752: Write certificate files before executing actions.

### DIFF
--- a/security/pfSense-pkg-acme/Makefile
+++ b/security/pfSense-pkg-acme/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-acme
-PORTVERSION=	0.6.2
+PORTVERSION=	0.6.3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_command.sh
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_command.sh
@@ -45,6 +45,7 @@ if ($command == "importcert") {
 	$changedesc .= "Storing signed certificate: " . $certificatename;
 	write_config($changedesc);
 
+	acme_write_all_certificates();
 	if (is_array($certificate['a_actionlist']['item'])) {
 		foreach($certificate['a_actionlist']['item'] as $action) {
 			if ($action['status'] == "disable") {
@@ -77,7 +78,6 @@ if ($command == "importcert") {
 			}
 		}
 	}
-	acme_write_all_certificates();
 	return;
 }
 


### PR DESCRIPTION
Execute actions only after the additional certificate files have been written.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/9752
- [x] Ready for review