### PR TITLE
pfSense-pkg-snort-4.0_7 -- Bug fix update

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.0
-PORTREVISION=	6
+PORTREVISION=	7
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -555,7 +555,7 @@ function snort_barnyard_start($snortcfg, $if_real, $background=FALSE) {
 	$snort_uuid = $snortcfg['uuid'];
 	$snortbindir = SNORT_BINDIR;
 
-	if ($snortcfg['barnyard_enable'] == 'on' && !isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}.pid")) {
+	if ($snortcfg['barnyard_enable'] == 'on' && $if_real <> "" && !isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}.pid")) {
 		syslog(LOG_NOTICE, "[Snort] Barnyard2 START for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
 		if ($background)
 			mwexec_bg("{$snortbindir}barnyard2 -f \"snort_{$snort_uuid}_{$if_real}.u2\" --pid-path {$g['varrun_path']} --nolock-pidfile -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/barnyard2.conf -d {$snortlogdir}/snort_{$if_real}{$snort_uuid} -D -q");
@@ -577,7 +577,7 @@ function snort_start($snortcfg, $if_real, $background=FALSE) {
 	else
 		$quiet = "-q --suppress-config-log";
 
-	if ($snortcfg['enable'] == 'on' && !isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid")) {
+	if ($snortcfg['enable'] == 'on' && $if_real <> "" && !isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid")) {
 
 		// Adjust the interface specification and DAQ type according to operating mode
 		if ($snortcfg['ips_mode'] == "ips_mode_inline" && $snortcfg['blockoffenders7'] == "on") {
@@ -612,7 +612,7 @@ function snort_start_all_interfaces($background=FALSE) {
 		return;
 
 	foreach ($config['installedpackages']['snortglobal']['rule'] as $snortcfg) {
-		if ($snortcfg['enable'] != 'on')
+		if ($snortcfg['enable'] != 'on' || get_real_interface($snortcfg['interface']) == "")
 			continue;
 		snort_start($snortcfg, get_real_interface($snortcfg['interface']), $background);
 	}
@@ -1020,7 +1020,7 @@ function snort_rules_up_install_cron($should_install) {
 	}
 }
 
-/* Only run when all ifaces needed to sync. Expects filesystem rw */
+/* Only run when all ifaces needed to sync */
 function sync_snort_package_config() {
 	global $config, $g;
 	global $rebuild_rules;
@@ -1041,8 +1041,10 @@ function sync_snort_package_config() {
 
 	$snortconf = $config['installedpackages']['snortglobal']['rule'];
 	foreach ($snortconf as $value) {
-		/* Skip configuration of any disabled interface */
-		if ($value['enable'] != 'on')
+		/* Skip configuration of any disabled instance or */
+		/* an instance whose assigned physical interface  */
+		/* has been removed.                              */
+		if (($value['enable'] != 'on') || (get_real_interface($value['interface']) == ""))
 			continue;
 
 		/* create a snort.conf file for interface */
@@ -3239,11 +3241,17 @@ function snort_create_rc() {
 	// Loop thru each configured interface and build
 	// the shell script.
 	foreach ($snortconf as $value) {
-		// Skip disabled Snort interfaces
-		if ($value['enable'] <> 'on')
+
+		// Attempt to grab physical interface
+		// for this Snort instance.
+		$if_real = get_real_interface($value['interface']);
+
+		// Skip disabled Snort instances or
+		// intances whose pfSense physical
+		// interface has been removed.
+		if (($value['enable'] <> 'on') || ($if_real = ""))
 			continue;
 		$snort_uuid = $value['uuid'];
-		$if_real = get_real_interface($value['interface']);
 
 		// Adjust the interface specification and DAQ type according to operating mode
 		if ($value['ips_mode'] == "ips_mode_inline" && $value['blockoffenders7'] == "on") {

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -742,6 +742,13 @@ if ($snortdownload == 'on' || $emergingthreats == 'on' || $snortcommunityrules =
 		/* Create configuration for each active Snort interface */
 		foreach ($config['installedpackages']['snortglobal']['rule'] as $id => $value) {
 			$if_real = get_real_interface($value['interface']);
+
+			/* Skip processing for instances whose underlying physical        */
+			/* interface has been removed in pfSense.                         */
+			if ($if_real == "") {
+				continue;
+			}
+
 			$tmp = "Updating rules configuration for: " . convert_friendly_interface_to_friendly_descr($value['interface']) . " ...";
 			snort_update_status(gettext($tmp));
 

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
@@ -174,6 +174,11 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 	/* Create the snort.conf files for each enabled interface */
 	foreach ($config['installedpackages']['snortglobal']['rule'] as $snortcfg) {
 		$if_real = get_real_interface($snortcfg['interface']);
+
+		/* Skip instance if its real interface is missing in pfSense */
+		if ($if_real == "") {
+			continue;
+		}
 		$snort_uuid = $snortcfg['uuid'];
 		$snortcfgdir = "{$snortdir}/snort_{$snort_uuid}_{$if_real}";
 		update_status(gettext("Generating configuration for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . "..."));

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
@@ -664,7 +664,7 @@ $section->addInput(new Form_Checkbox(
 	'Split ANY-ANY',
 	'Enable splitting of ANY-ANY port group.  Default is Not Checked.',
 	$pconfig['fpm_split_any_any'] == 'on' ? true:false,
-	'yes'
+	'on'
 ));
 $section->addInput(new Form_Checkbox(
 	'fpm_search_optimize',

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
@@ -113,8 +113,11 @@ $interfaces = get_configured_interface_with_descr();
 
 // Footnote real interface associated with each configured interface
 foreach ($interfaces as $if => $desc) {
-		$interfaces[$if] = $interfaces[$if] . " (" . get_real_interface($if) . ")";
+	$interfaces[$if] = $interfaces[$if] . " (" . get_real_interface($if) . ")";
 }
+
+// Add a special "Unassigned" interface selection at end of list
+$interfaces["Unassigned"] = gettext("Unassigned");
 
 // See if interface is already configured, and use its values
 if (isset($id) && $a_rule[$id]) {
@@ -124,6 +127,10 @@ if (isset($id) && $a_rule[$id]) {
 		$pconfig['configpassthru'] = base64_decode($pconfig['configpassthru']);
 	if (empty($pconfig['uuid']))
 		$pconfig['uuid'] = $snort_uuid;
+	if (get_real_interface($pconfig['interface']) == "") {
+		$pconfig['interface'] = gettext("Unassigned");
+		$pconfig['enable'] = "off";
+	}
 }
 // Must be a new interface, so try to pick next available physical interface to use
 elseif (isset($id) && !isset($a_rule[$id])) {

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
@@ -549,6 +549,12 @@ print($section);
 				</thead>
 				<tbody>
 			   <?php foreach ($a_nat as $k => $natent): ?>
+				<?php
+					// Skip displaying any instance where the physical pfSense interface is missing
+					if (get_real_interface($natent['interface']) == "") {
+						continue;
+					}
+				?>
 				<tr>
 					<td class="text-center">
 						<input type="checkbox" name="torestart[]" id="torestart[]" value="<?=$k;?>" title="<?=gettext("Apply new configuration and rebuild rules for this interface when saving");?>" />


### PR DESCRIPTION
### pfSense-pkg-snort-4.0_7
This update for the Snort GUI package addresses two identified Redmine Issues.

**New Features:**
None

**Bug Fixes:**
1. The WebGUI ignores _Split ANY-ANY_ option on INTERFACE SETTINGS tab. Redmine issue #9772.

2. The Snort GUI does not account for the underlying physical interface for a configured Snort instance being removed in pfSense prior to the Snort instance being removed. This can lead to anomalous behavior. Redmine issue #9789.