### PR TITLE
Update Suricata GUI package to v4.1.5 and import fixes from DEVEL branch

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	4.1.4
-PORTREVISION=	8
+PORTVERSION=	4.1.5
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +12,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=4.1.4:security/suricata \
+RUN_DEPENDS=	suricata>=4.1.5:security/suricata \
 		barnyard2:security/barnyard2
 
 NO_BUILD=	yes

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -413,6 +413,7 @@ if (($suricatacfg['eve_log_alerts'] == 'on')) {
 	$eve_out_types .= "\n            packet: ".($suricatacfg['eve_log_alerts_packet'] == 'on'?'yes':'no ')."               # enable dumping of packet (without stream segments)";
 	$eve_out_types .= "\n            http-body: ".($suricatacfg['eve_log_alerts_payload'] == 'on'?'yes':'no ' || $suricatacfg['eve_log_alerts_payload'] == 'only-base64' ?'yes':'no ')."            # enable dumping of http body in Base64";
 	$eve_out_types .= "\n            http-body-printable: ".($suricatacfg['eve_log_alerts_payload'] == 'on' || $suricatacfg['eve_log_alerts_payload'] == 'only-printable' ?'yes':'no ')."  # enable dumping of http body in printable format";
+	$eve_out_types .= "\n            metadata: ".($suricatacfg['eve_log_alerts_metadata'] == 'on'?'yes':'no ')."             # enable inclusion of app layer metadata with alert";
 	$eve_out_types .= "\n            tagged-packets: yes       # enable logging of tagged packets for rules using the 'tag' keyword";
 }
 
@@ -737,6 +738,7 @@ else {
 				$engine .= "]\n";
 				$engine .= "         personality: {$v['personality']}\n         request-body-limit: {$v['request-body-limit']}\n";
 				$engine .= "         response-body-limit: {$v['response-body-limit']}\n";
+				$engine .= "         meta-field-limit: " . (isset($v['meta-field-limit']) ? $v['meta-field-limit'] : "18432") . "\n";
 				$engine .= "         double-decode-path: {$v['double-decode-path']}\n";
 				$engine .= "         double-decode-query: {$v['double-decode-query']}\n";
 				$engine .= "         uri-include-all: {$v['uri-include-all']}\n";
@@ -750,6 +752,7 @@ else {
 		else {
 			$http_hosts_default_policy = "     personality: {$v['personality']}\n     request-body-limit: {$v['request-body-limit']}\n";
 			$http_hosts_default_policy .= "     response-body-limit: {$v['response-body-limit']}\n";
+			$http_hosts_default_policy .= "     meta-field-limit: " . (isset($v['meta-field-limit']) ? $v['meta-field-limit'] : "18432") . "\n";
 			$http_hosts_default_policy .= "     double-decode-path: {$v['double-decode-path']}\n";
 			$http_hosts_default_policy .= "     double-decode-query: {$v['double-decode-query']}\n";
 			$http_hosts_default_policy .= "     uri-include-all: {$v['uri-include-all']}\n";

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -265,6 +265,9 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 		}
 	}
 
+	// Release config array references used immediately above
+	unset($http_serv, $policy);
+
 	/***********************************************************/
 	/* Add the new 'dns-events.rules' file to the rulesets.    */
 	/***********************************************************/
@@ -330,6 +333,10 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 	}
 	if (!isset($pconfig['eve_log_alerts'])) {
 		$pconfig['eve_log_alerts'] = "on";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_alerts_metadata'])) {
+		$pconfig['eve_log_alerts_metadata'] = "on";
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_http'])) {

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_app_parsers.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_app_parsers.php
@@ -65,7 +65,7 @@ if (isset($id) && $a_nat[$id]) {
 		$default = array( "name" => "default", "bind_to" => "all", "personality" => "IDS",
 				  "request-body-limit" => 4096, "response-body-limit" => 4096,
 				  "double-decode-path" => "no", "double-decode-query" => "no",
-				  "uri-include-all" => "no" );
+				  "uri-include-all" => "no", "meta-field-limit" => 18432 );
 		$pconfig['libhtp_policy']['item'] = array();
 		$pconfig['libhtp_policy']['item'][] = $default;
 		if (!is_array($a_nat[$id]['libhtp_policy']['item']))
@@ -99,6 +99,7 @@ elseif ($_POST['select_alias']) {
 	$eng_personality = $_POST['personality'];
 	$eng_req_body_limit = $_POST['req_body_limit'];
 	$eng_resp_body_limit = $_POST['resp_body_limit'];
+	$eng_meta_field_limit = $_POST['meta_field_limit'];
 	$eng_enable_double_decode_path = $_POST['enable_double_decode_path'];
 	$eng_enable_double_decode_query = $_POST['enable_double_decode_query'];
 	$eng_enable_uri_include_all = $_POST['enable_uri_include_all'];
@@ -140,6 +141,11 @@ if ($_POST['save_libhtp_policy']) {
 			$engine['response-body-limit'] = $_POST['resp_body_limit'];
 		else
 			$input_errors[] = gettext("The value for 'Response Body Limit' must be all numbers and greater than or equal to zero.");
+
+		if (is_numeric($_POST['meta_field_limit']) && $_POST['meta_field_limit'] >= 0)
+			$engine['meta-field-limit'] = $_POST['meta_field_limit'];
+		else
+			$input_errors[] = gettext("The value for 'Meta-Field Limit' must be all numbers and greater than or equal to zero.");
 
 		if ($_POST['enable_double_decode_path']) { $engine['double-decode-path'] = 'yes'; }else{ $engine['double-decode-path'] = 'no'; }
 		if ($_POST['enable_double_decode_query']) { $engine['double-decode-query'] = 'yes'; }else{ $engine['double-decode-query'] = 'no'; }
@@ -198,7 +204,7 @@ if ($_POST['save_libhtp_policy']) {
 elseif ($_POST['add_libhtp_policy']) {
 	$add_edit_libhtp_policy = true;
 	$pengcfg = array( "name" => "engine_{$libhtp_engine_next_id}", "bind_to" => "", "personality" => "IDS",
-			  "request-body-limit" => "4096", "response-body-limit" => "4096",
+			  "request-body-limit" => "4096", "response-body-limit" => "4096", "meta-field-limit" => 18432, 
 			  "double-decode-path" => "no", "double-decode-query" => "no", "uri-include-all" => "no" );
 	$eng_id = $libhtp_engine_next_id;
 }
@@ -278,6 +284,7 @@ elseif ($_POST['save_import_alias']) {
 		$pengcfg['personality'] = $_POST['eng_personality'];
 		$pengcfg['request-body-limit'] = $_POST['eng_req_body_limit'];
 		$pengcfg['response-body-limit'] = $_POST['eng_resp_body_limit'];
+		$pengcfg['meta-field-limit'] = $_POST['eng_meta_field_limit'];
 		$pengcfg['double-decode-path'] = $_POST['eng_enable_double_decode_path'];
 		$pengcfg['double-decode-query'] = $_POST['eng_enable_double_decode_query'];
 		$pengcfg['uri-include-all'] = $_POST['eng_enable_uri_include_all'];
@@ -299,6 +306,7 @@ elseif ($_POST['save_import_alias']) {
 			$eng_personality = $_POST['eng_personality'];
 			$eng_req_body_limit = $_POST['eng_req_body_limit'];
 			$eng_resp_body_limit = $_POST['eng_resp_body_limit'];
+			$eng_meta_field_limit = $_POST['eng_meta_field_limit'];
 			$eng_enable_double_decode_path = $_POST['eng_enable_double_decode_path'];
 			$eng_enable_double_decode_query = $_POST['eng_enable_double_decode_query'];
 			$eng_enable_uri_include_all = $_POST['eng_enable_uri_include_all'];
@@ -306,7 +314,7 @@ elseif ($_POST['save_import_alias']) {
 	}
 	else {
 		$engine = array( "name" => "", "bind_to" => "", "personality" => "IDS",
-				 "request-body-limit" => "4096", "response-body-limit" => "4096",
+				 "request-body-limit" => "4096", "response-body-limit" => "4096", "meta-field-limit" => 18432, 
 				 "double-decode-path" => "no", "double-decode-query" => "no", "uri-include-all" => "no" );
 
 		// See if anything was checked to import
@@ -374,6 +382,7 @@ elseif ($_POST['cancel_import_alias']) {
 		$pengcfg['personality'] = $_POST['eng_personality'];
 		$pengcfg['request-body-limit'] = $_POST['eng_req_body_limit'];
 		$pengcfg['response-body-limit'] = $_POST['eng_resp_body_limit'];
+		$pengcfg['meta-field-limit'] = $_POST['eng_meta_field_limit'];
 		$pengcfg['double-decode-path'] = $_POST['eng_enable_double_decode_path'];
 		$pengcfg['double-decode-query'] = $_POST['eng_enable_double_decode_query'];
 		$pengcfg['uri-include-all'] = $_POST['eng_enable_uri_include_all'];
@@ -523,6 +532,7 @@ if ($importalias) {
 		print('<input type="hidden" name="eng_personality" value="' . $eng_personality . '"/>');
 		print('<input type="hidden" name="eng_req_body_limit" value="' . $eng_req_body_limit . '"/>');
 		print('<input type="hidden" name="eng_resp_body_limit" value="' . $eng_resp_body_limit . '"/>');
+		print('<input type="hidden" name="eng_meta_field_limit" value="' . $eng_meta_field_limit . '"/>');
 		print('<input type="hidden" name="eng_enable_double_decode_path" value="' . $eng_enable_double_decode_path . '"/>');
 		print('<input type="hidden" name="eng_enable_double_decode_query" value="' . $eng_enable_double_decode_query . '"/>');
 		print('<input type="hidden" name="eng_enable_uri_include_all" value="' . $eng_enable_uri_include_all . '"/>');

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -153,6 +153,8 @@ if (empty($pconfig['eve_log_alerts_payload']))
 	$pconfig['eve_log_alerts_payload'] = "on";
 if (empty($pconfig['eve_log_alerts_packet']))
 	$pconfig['eve_log_alerts_packet'] = "on";
+if (empty($pconfig['eve_log_alerts_metadata']))
+	$pconfig['eve_log_alerts_metadata'] = "on";
 if (empty($pconfig['eve_log_alerts_http']))
 	$pconfig['eve_log_alerts_http'] = "on";
 if (empty($pconfig['eve_log_alerts_xff']))
@@ -372,6 +374,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['eve_log_alerts'] == "on") { $natent['eve_log_alerts'] = 'on'; }else{ $natent['eve_log_alerts'] = 'off'; }
 		if ($_POST['eve_log_alerts_payload']) { $natent['eve_log_alerts_payload'] = $_POST['eve_log_alerts_payload']; }else{ $natent['eve_log_alerts_payload'] = 'off'; }
 		if ($_POST['eve_log_alerts_packet'] == "on") { $natent['eve_log_alerts_packet'] = 'on'; }else{ $natent['eve_log_alerts_packet'] = 'off'; }
+		if ($_POST['eve_log_alerts_metadata'] == "on") { $natent['eve_log_alerts_metadata'] = 'on'; }else{ $natent['eve_log_alerts_metadata'] = 'off'; }
 		if ($_POST['eve_log_alerts_http'] == "on") { $natent['eve_log_alerts_http'] = 'on'; }else{ $natent['eve_log_alerts_http'] = 'off'; }
 		if ($_POST['eve_log_alerts_xff'] == "on") { $natent['eve_log_alerts_xff'] = 'on'; }else{ $natent['eve_log_alerts_xff'] = 'off'; }
 		if ($_POST['eve_log_alerts_xff_mode']) { $natent['eve_log_alerts_xff_mode'] = $_POST['eve_log_alerts_xff_mode']; }else{ $natent['eve_log_alert_xff_mode'] = 'extra-data'; }
@@ -531,7 +534,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$default = array( "name" => "default", "bind_to" => "all", "personality" => "IDS",
 					  "request-body-limit" => 4096, "response-body-limit" => 4096,
 					  "double-decode-path" => "no", "double-decode-query" => "no",
-					  "uri-include-all" => "no" );
+					  "uri-include-all" => "no", "meta-field-limit" => 18432 );
 			if (!is_array($natent['libhtp_policy']))
 				$natent['libhtp_policy'] = array();
 			if (!is_array($natent['libhtp_policy']['item']))
@@ -951,6 +954,14 @@ $group->add(new Form_Checkbox(
 	'Alert Payloads',
 	'Log additional HTTP data.',
 	$pconfig['eve_log_alerts_http'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_alerts_metadata',
+	'App Layer Metadata',
+	'Include App Layer metadata.',
+	$pconfig['eve_log_alerts_metadata'] == 'on' ? true:false,
 	'on'
 ));
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -403,6 +403,7 @@ if (($suricatacfg['eve_log_alerts'] == 'on')) {
 	$eve_out_types .= "\n            packet: ".($suricatacfg['eve_log_alerts_packet'] == 'on'?'yes':'no ')."               # enable dumping of packet (without stream segments)";
 	$eve_out_types .= "\n            http-body: ".($suricatacfg['eve_log_alerts_payload'] == 'on'?'yes':'no ' || $suricatacfg['eve_log_alerts_payload'] == 'only-base64' ?'yes':'no ')."            # enable dumping of http body in Base64";
 	$eve_out_types .= "\n            http-body-printable: ".($suricatacfg['eve_log_alerts_payload'] == 'on' || $suricatacfg['eve_log_alerts_payload'] == 'only-printable' ?'yes':'no ')."  # enable dumping of http body in printable format";
+	$eve_out_types .= "\n            metadata: ".($suricatacfg['eve_log_alerts_metadata'] == 'on'?'yes':'no ')."             # enable inclusion of app layer metadata with alert";
 	$eve_out_types .= "\n            tagged-packets: yes       # enable logging of tagged packets for rules using the 'tag' keyword";
 }
 
@@ -755,6 +756,7 @@ else {
 				$engine .= "]\n";
 				$engine .= "         personality: {$v['personality']}\n         request-body-limit: {$v['request-body-limit']}\n";
 				$engine .= "         response-body-limit: {$v['response-body-limit']}\n";
+				$engine .= "         meta-field-limit: " . (isset($v['meta-field-limit']) ? $v['meta-field-limit'] : "18432") . "\n";
 				$engine .= "         double-decode-path: {$v['double-decode-path']}\n";
 				$engine .= "         double-decode-query: {$v['double-decode-query']}\n";
 				$engine .= "         uri-include-all: {$v['uri-include-all']}\n";
@@ -768,6 +770,7 @@ else {
 		else {
 			$http_hosts_default_policy = "     personality: {$v['personality']}\n     request-body-limit: {$v['request-body-limit']}\n";
 			$http_hosts_default_policy .= "     response-body-limit: {$v['response-body-limit']}\n";
+			$http_hosts_default_policy .= "     meta-field-limit: " . (isset($v['meta-field-limit']) ? $v['meta-field-limit'] : "18432") . "\n";
 			$http_hosts_default_policy .= "     double-decode-path: {$v['double-decode-path']}\n";
 			$http_hosts_default_policy .= "     double-decode-query: {$v['double-decode-query']}\n";
 			$http_hosts_default_policy .= "     uri-include-all: {$v['uri-include-all']}\n";

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -256,6 +256,9 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 		}
 	}
 
+	// Release config array references used immediately above
+	unset($http_serv, $policy);
+
 	/***********************************************************/
 	/* Add the new 'dns-events.rules' file to the rulesets.    */
 	/***********************************************************/
@@ -321,6 +324,10 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 	}
 	if (!isset($pconfig['eve_log_alerts'])) {
 		$pconfig['eve_log_alerts'] = "on";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_alerts_metadata'])) {
+		$pconfig['eve_log_alerts_metadata'] = "on";
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_http'])) {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
@@ -65,7 +65,7 @@ if (isset($id) && $a_nat[$id]) {
 		$default = array( "name" => "default", "bind_to" => "all", "personality" => "IDS",
 				  "request-body-limit" => 4096, "response-body-limit" => 4096,
 				  "double-decode-path" => "no", "double-decode-query" => "no",
-				  "uri-include-all" => "no" );
+				  "uri-include-all" => "no", "meta-field-limit" => 18432 );
 		$pconfig['libhtp_policy']['item'] = array();
 		$pconfig['libhtp_policy']['item'][] = $default;
 		if (!is_array($a_nat[$id]['libhtp_policy']['item']))
@@ -99,6 +99,7 @@ elseif ($_POST['select_alias']) {
 	$eng_personality = $_POST['personality'];
 	$eng_req_body_limit = $_POST['req_body_limit'];
 	$eng_resp_body_limit = $_POST['resp_body_limit'];
+	$eng_meta_field_limit = $_POST['meta_field_limit'];
 	$eng_enable_double_decode_path = $_POST['enable_double_decode_path'];
 	$eng_enable_double_decode_query = $_POST['enable_double_decode_query'];
 	$eng_enable_uri_include_all = $_POST['enable_uri_include_all'];
@@ -140,6 +141,11 @@ if ($_POST['save_libhtp_policy']) {
 			$engine['response-body-limit'] = $_POST['resp_body_limit'];
 		else
 			$input_errors[] = gettext("The value for 'Response Body Limit' must be all numbers and greater than or equal to zero.");
+
+		if (is_numeric($_POST['meta_field_limit']) && $_POST['meta_field_limit'] >= 0)
+			$engine['meta-field-limit'] = $_POST['meta_field_limit'];
+		else
+			$input_errors[] = gettext("The value for 'Meta-Field Limit' must be all numbers and greater than or equal to zero.");
 
 		if ($_POST['enable_double_decode_path']) { $engine['double-decode-path'] = 'yes'; }else{ $engine['double-decode-path'] = 'no'; }
 		if ($_POST['enable_double_decode_query']) { $engine['double-decode-query'] = 'yes'; }else{ $engine['double-decode-query'] = 'no'; }
@@ -198,7 +204,7 @@ if ($_POST['save_libhtp_policy']) {
 elseif ($_POST['add_libhtp_policy']) {
 	$add_edit_libhtp_policy = true;
 	$pengcfg = array( "name" => "engine_{$libhtp_engine_next_id}", "bind_to" => "", "personality" => "IDS",
-			  "request-body-limit" => "4096", "response-body-limit" => "4096",
+			  "request-body-limit" => "4096", "response-body-limit" => "4096", "meta-field-limit" => 18432, 
 			  "double-decode-path" => "no", "double-decode-query" => "no", "uri-include-all" => "no" );
 	$eng_id = $libhtp_engine_next_id;
 }
@@ -284,6 +290,7 @@ elseif ($_POST['save_import_alias']) {
 		$pengcfg['personality'] = $_POST['eng_personality'];
 		$pengcfg['request-body-limit'] = $_POST['eng_req_body_limit'];
 		$pengcfg['response-body-limit'] = $_POST['eng_resp_body_limit'];
+		$pengcfg['meta-field-limit'] = $_POST['eng_meta_field_limit'];
 		$pengcfg['double-decode-path'] = $_POST['eng_enable_double_decode_path'];
 		$pengcfg['double-decode-query'] = $_POST['eng_enable_double_decode_query'];
 		$pengcfg['uri-include-all'] = $_POST['eng_enable_uri_include_all'];
@@ -305,6 +312,7 @@ elseif ($_POST['save_import_alias']) {
 			$eng_personality = $_POST['eng_personality'];
 			$eng_req_body_limit = $_POST['eng_req_body_limit'];
 			$eng_resp_body_limit = $_POST['eng_resp_body_limit'];
+			$eng_meta_field_limit = $_POST['eng_meta_field_limit'];
 			$eng_enable_double_decode_path = $_POST['eng_enable_double_decode_path'];
 			$eng_enable_double_decode_query = $_POST['eng_enable_double_decode_query'];
 			$eng_enable_uri_include_all = $_POST['eng_enable_uri_include_all'];
@@ -312,7 +320,7 @@ elseif ($_POST['save_import_alias']) {
 	}
 	else {
 		$engine = array( "name" => "", "bind_to" => "", "personality" => "IDS",
-				 "request-body-limit" => "4096", "response-body-limit" => "4096",
+				 "request-body-limit" => "4096", "response-body-limit" => "4096", "meta-field-limit" => 18432, 
 				 "double-decode-path" => "no", "double-decode-query" => "no", "uri-include-all" => "no" );
 
 		// See if anything was checked to import
@@ -380,6 +388,7 @@ elseif ($_POST['cancel_import_alias']) {
 		$pengcfg['personality'] = $_POST['eng_personality'];
 		$pengcfg['request-body-limit'] = $_POST['eng_req_body_limit'];
 		$pengcfg['response-body-limit'] = $_POST['eng_resp_body_limit'];
+		$pengcfg['meta-field-limit'] = $_POST['eng_meta_field_limit'];
 		$pengcfg['double-decode-path'] = $_POST['eng_enable_double_decode_path'];
 		$pengcfg['double-decode-query'] = $_POST['eng_enable_double_decode_query'];
 		$pengcfg['uri-include-all'] = $_POST['eng_enable_uri_include_all'];
@@ -535,6 +544,7 @@ if ($importalias) {
 		print('<input type="hidden" name="eng_personality" value="' . $eng_personality . '"/>');
 		print('<input type="hidden" name="eng_req_body_limit" value="' . $eng_req_body_limit . '"/>');
 		print('<input type="hidden" name="eng_resp_body_limit" value="' . $eng_resp_body_limit . '"/>');
+		print('<input type="hidden" name="eng_meta_field_limit" value="' . $eng_meta_field_limit . '"/>');
 		print('<input type="hidden" name="eng_enable_double_decode_path" value="' . $eng_enable_double_decode_path . '"/>');
 		print('<input type="hidden" name="eng_enable_double_decode_query" value="' . $eng_enable_double_decode_query . '"/>');
 		print('<input type="hidden" name="eng_enable_uri_include_all" value="' . $eng_enable_uri_include_all . '"/>');

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -153,6 +153,8 @@ if (empty($pconfig['eve_log_alerts_packet']))
 	$pconfig['eve_log_alerts_packet'] = "on";
 if (empty($pconfig['eve_log_alerts_http']))
 	$pconfig['eve_log_alerts_http'] = "on";
+if (empty($pconfig['eve_log_alerts_metadata']))
+	$pconfig['eve_log_alerts_metadata'] = "on";
 if (empty($pconfig['eve_log_alerts_xff']))
 	$pconfig['eve_log_alerts_xff'] = "off";
 if (empty($pconfig['eve_log_alerts_xff_mode']))
@@ -382,6 +384,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['eve_log_alerts'] == "on") { $natent['eve_log_alerts'] = 'on'; }else{ $natent['eve_log_alerts'] = 'off'; }
 		if ($_POST['eve_log_alerts_payload']) { $natent['eve_log_alerts_payload'] = $_POST['eve_log_alerts_payload']; }else{ $natent['eve_log_alerts_payload'] = 'off'; }
 		if ($_POST['eve_log_alerts_packet'] == "on") { $natent['eve_log_alerts_packet'] = 'on'; }else{ $natent['eve_log_alerts_packet'] = 'off'; }
+		if ($_POST['eve_log_alerts_metadata'] == "on") { $natent['eve_log_alerts_metadata'] = 'on'; }else{ $natent['eve_log_alerts_metadata'] = 'off'; }
 		if ($_POST['eve_log_alerts_http'] == "on") { $natent['eve_log_alerts_http'] = 'on'; }else{ $natent['eve_log_alerts_http'] = 'off'; }
 		if ($_POST['eve_log_alerts_xff'] == "on") { $natent['eve_log_alerts_xff'] = 'on'; }else{ $natent['eve_log_alerts_xff'] = 'off'; }
 		if ($_POST['eve_log_alerts_xff_mode']) { $natent['eve_log_alerts_xff_mode'] = $_POST['eve_log_alerts_xff_mode']; }else{ $natent['eve_log_alert_xff_mode'] = 'extra-data'; }
@@ -554,7 +557,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$default = array( "name" => "default", "bind_to" => "all", "personality" => "IDS",
 					  "request-body-limit" => 4096, "response-body-limit" => 4096,
 					  "double-decode-path" => "no", "double-decode-query" => "no",
-					  "uri-include-all" => "no" );
+					  "uri-include-all" => "no", "meta-field-limit" => 18432 );
 			if (!is_array($natent['libhtp_policy']))
 				$natent['libhtp_policy'] = array();
 			if (!is_array($natent['libhtp_policy']['item']))
@@ -958,6 +961,14 @@ $group->add(new Form_Checkbox(
 	'Alert Payloads',
 	'Log additional HTTP data.',
 	$pconfig['eve_log_alerts_http'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_alerts_metadata',
+	'App Layer Metadata',
+	'Include App Layer metadata.',
+	$pconfig['eve_log_alerts_metadata'] == 'on' ? true:false,
 	'on'
 ));
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_libhtp_policy_engine.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_libhtp_policy_engine.php
@@ -3,11 +3,11 @@
  * suricata_libhtp_policy_engine.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,6 +43,7 @@
 	select_alias --> Submit button for select alias operation
 	req_body_limit --> Request Body Limit size
 	resp_body_limit --> Response Body Limit size
+	meta_field_limit --> Meta-Field Limit size
 	enable_double_decode_path --> double-decode path part of URI
 	enable_double_decode_query --> double-decode query string part of URI
 	enable_uri_include_all --> inspect all of URI
@@ -126,6 +127,12 @@ $section->addInput(new Form_Input(
 	'text',
 	$pengcfg['response-body-limit']
 ))->setHelp('Maximum number of HTTP response body bytes to inspect. Default is 4,096 bytes. HTTP response bodies are often big, so they take a lot of time to process which has a significant impact on performance. This sets the limit (in bytes) of the server-body that will be inspected. Setting this parameter to 0 will inspect all of the server-body.');
+$section->addInput(new Form_Input(
+	'meta_field_limit',
+	'Meta-Field Limit',
+	'text',
+	$pengcfg['meta-field-limit']
+))->setHelp('Hard size limit for request and response size limits. Applies to request line and headers, response line and headers. Does not apply to request or response bodies. Default is 18k (18432) bytes. If this limit is reached an event is raised.');
 $form->add($section);
 
 $section = new Form_Section('Decode Settings');


### PR DESCRIPTION
### pfSense-pkg-suricata v4.1.5
This update for the Suricata GUI package adds two new configurable parameters to interface configurations and sets the minimum Suricata binary version requirement to 4.1.5 or greater.

**New Features:**
1. Added new meta-field-limit parameter for an HTTP App Layer Parser server config. Redmine issue #6785. This parameter is now available on the libhtp engine configuration when editing a HTP Policy Engine on the APP PARSERS tab.

2. The EVE Alert Log metadata setting is now configurable. Turning off this App Layer metadata logging when sending EVE alert data to a syslog server can help prevent truncating of long lines by syslog. This new parameter is located on the INTERFACE SETTINGS tab.

**Bug Fixes:**
None