### PR TITLE
pfSense-pkg-snort-4.0_8 -- Fix typo in snort.sh shell script creation code

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.0
-PORTREVISION=	7
+PORTREVISION=	8
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -3249,7 +3249,7 @@ function snort_create_rc() {
 		// Skip disabled Snort instances or
 		// intances whose pfSense physical
 		// interface has been removed.
-		if (($value['enable'] <> 'on') || ($if_real = ""))
+		if (($value['enable'] <> 'on') || ($if_real == ""))
 			continue;
 		$snort_uuid = $value['uuid'];
 


### PR DESCRIPTION
### pfSense-pkg-snort-4.0_8
This update corrects a typo in the _snort_create_rc()_ function in the _snort.inc_ source file that results in an invalid path being passed to the snort binary as part of its startup arguments.

**New Features:**
None

**Bug Fixes:**
1. Fix typo within if() conditional in _snort_create_rc()_ function so the string operation is a comparision instead of an assignment.