### PR TITLE
pfSense-pkg-suricata-4.1.5_1 -- Bug Fix (Redmine Issue #9789)

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.1.5
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -54,6 +54,12 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 		// Clean-up the rotated logs for each configured Suricata instance
 		foreach ($config['installedpackages']['suricata']['rule'] as $value) {
 			$if_real = get_real_interface($value['interface']);
+
+			// Skip instances where pfSense physical interface
+			// has been removed.
+			if ($if_real == "") {
+				continue;
+			}
 			$suricata_uuid = $value['uuid'];
 			$suricata_log_dir = SURICATALOGDIR . "suricata_{$if_real}{$suricata_uuid}";
 			syslog(LOG_NOTICE, gettext("[Suricata] Cleaning logs for {$value['descr']} ({$if_real})..."));
@@ -94,6 +100,12 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 		// Clean-up active logs for each configured Suricata instance
 		foreach ($config['installedpackages']['suricata']['rule'] as $value) {
 			$if_real = get_real_interface($value['interface']);
+
+			// Skip instances where pfSense physical interface
+			// has been removed.
+			if ($if_real == "") {
+				continue;
+			}
 			$suricata_uuid = $value['uuid'];
 			$suricata_log_dir = SURICATALOGDIR . "suricata_{$if_real}{$suricata_uuid}";
 			if (suricata_Getdirsize(SURICATALOGDIR) < $suricataloglimitsizeKB) {
@@ -224,6 +236,12 @@ $logs['tls.log']['retention'] = $config['installedpackages']['suricata']['config
 if ($config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 'on') {
 	foreach ($config['installedpackages']['suricata']['rule'] as $value) {
 		$if_real = get_real_interface($value['interface']);
+
+		// Skip instances where pfSense physical interface
+		// has been removed.
+		if ($if_real == "") {
+			continue;
+		}
 		$suricata_log_dir = SURICATALOGDIR . "suricata_{$if_real}{$value['uuid']}";
 		foreach ($logs as $k => $p) {
 			suricata_check_rotate_log("{$suricata_log_dir}/{$k}", $p['limit']*1024, $p['retention']);

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_post_install.php
@@ -219,6 +219,11 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 	// Create the suricata.yaml files for each enabled interface
 	foreach ($config['installedpackages']['suricata']['rule'] as $suricatacfg) {
 		$if_real = get_real_interface($suricatacfg['interface']);
+
+		/* Skip instance if its real interface is missing in pfSense */
+		if ($if_real == "") {
+			continue;
+		}
 		$suricata_uuid = $suricatacfg['uuid'];
 		$suricatacfgdir = "{$suricatadir}suricata_{$suricata_uuid}_{$if_real}";
 		update_status(gettext("Generating YAML configuration file for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . "..."));

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -68,6 +68,14 @@ $suricata_uuid = $pconfig['uuid'];
 // Get the physical configured interfaces on the firewall
 $interfaces = get_configured_interface_with_descr();
 
+// Footnote real interface associated with each configured interface
+foreach ($interfaces as $if => $desc) {
+	$interfaces[$if] = $interfaces[$if] . " (" . get_real_interface($if) . ")";
+}
+
+// Add a special "Unassigned" interface selection at end of list
+$interfaces["Unassigned"] = gettext("Unassigned");
+
 // See if interface is already configured, and use its values
 if (isset($id) && isset($a_rule[$id])) {
 	/* old options */
@@ -76,6 +84,10 @@ if (isset($id) && isset($a_rule[$id])) {
 		$pconfig['configpassthru'] = base64_decode($pconfig['configpassthru']);
 	if (empty($pconfig['uuid']))
 		$pconfig['uuid'] = $suricata_uuid;
+	if (get_real_interface($pconfig['interface']) == "") {
+		$pconfig['interface'] = gettext("Unassigned");
+		$pconfig['enable'] = "off";
+	}
 }
 
 // Must be a new interface, so try to pick next available physical interface to use

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -102,7 +102,7 @@ function suricata_barnyard_start($suricatacfg, $if_real) {
 	$suricatalogdir = SURICATALOGDIR . "suricata_{$if_real}{$suricata_uuid}";
 	$suricatabindir = SURICATA_PBI_BINDIR;
 
-	if ($suricatacfg['barnyard_enable'] == 'on') {
+	if ($suricatacfg['barnyard_enable'] == 'on' && $if_real <> "") {
 		syslog(LOG_NOTICE, "[Suricata] Barnyard2 START for {$suricatacfg['descr']}({$if_real})...");
 		mwexec_bg("{$suricatabindir}barnyard2 -r {$suricata_uuid} -f unified2.alert --pid-path {$g['varrun_path']} --nolock-pidfile -c {$suricatadir}/barnyard2.conf -d {$suricatalogdir} -D -q");
 	}
@@ -116,7 +116,7 @@ function suricata_start($suricatacfg, $if_real) {
 	$suricatalogdir = SURICATALOGDIR . "suricata_{$if_real}{$suricata_uuid}";
 	$suricatabindir = SURICATA_PBI_BINDIR;
 
-	if ($suricatacfg['enable'] == 'on') {
+	if ($suricatacfg['enable'] == 'on' && $if_real <> "") {
 		// Truncate suricata.log file for this interface.
 		file_put_contents("{$suricatalogdir}/suricata.log", '');
 		$run_mode = $suricatacfg['ips_mode'] == 'ips_mode_inline' && $suricatacfg['blockoffenders'] == 'on' ? '--netmap' : '-i ' . $if_real;
@@ -145,7 +145,7 @@ function suricata_start_all_interfaces($background=FALSE) {
 	}
 
 	foreach ($config['installedpackages']['suricata']['rule'] as $suricatacfg) {
-		if ($suricatacfg['enable'] != 'on') {
+		if ($suricatacfg['enable'] != 'on' || get_real_interface($suricatacfg['interface']) == "") {
 			continue;
 		}
 		suricata_start($suricatacfg, get_real_interface($suricatacfg['interface']));
@@ -206,6 +206,14 @@ function suricata_reload_config($suricatacfg, $signal="USR2") {
 	$suricatadir = SURICATADIR;
 	$suricata_uuid = $suricatacfg['uuid'];
 	$if_real = get_real_interface($suricatacfg['interface']);
+
+	/******************************************************/
+	/* Skip disabled Suricata instances or instances      */
+	/* whose pfSense physical interface has been removed. */
+	/******************************************************/
+	if (($suricatacfg['enable'] != 'on') || ($if_real == "")) {
+		return;
+	}
 
 	/******************************************************/
 	/* Only send the SIGUSR2 if Suricata is running and   */
@@ -881,8 +889,10 @@ function sync_suricata_package_config() {
 
 	$suricataconf = $config['installedpackages']['suricata']['rule'];
 	foreach ($suricataconf as $value) {
-		/* Skip configuration of any disabled interface */
-		if ($value['enable'] != 'on') {
+		/* Skip configuration of any disabled instance or */
+		/* an instance whose assigned physical interface  */
+		/* has been removed.                              */
+		if (($value['enable'] != 'on') || (get_real_interface($value['interface']) == "")) {
 			continue;
 		}
 
@@ -3603,12 +3613,18 @@ function suricata_create_rc() {
 	// Loop thru each configured interface and build
 	// the shell script.
 	foreach ($suricataconf as $value) {
-		// Skip disabled Suricata interfaces
-		if ($value['enable'] != 'on') {
+
+		// Attempt to grab physical interface
+		// for this Suricata instance.
+		$if_real = get_real_interface($value['interface']);
+
+		// Skip disabled Suricata instances
+		// or instances whose pfSense physical
+		// interface has been removed.
+		if (($value['enable'] != 'on') || ($if_real == "")) {
 			continue;
 		}
 		$suricata_uuid = $value['uuid'];
-		$if_real = get_real_interface($value['interface']);
 		$run_mode = $value['ips_mode'] == 'ips_mode_inline' && $value['blockoffenders'] == 'on' ? '--netmap' : '-i ' . $if_real;
 
 		$start_barnyard = <<<EOE

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -54,6 +54,12 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 		// Clean-up the rotated logs for each configured Suricata instance
 		foreach ($config['installedpackages']['suricata']['rule'] as $value) {
 			$if_real = get_real_interface($value['interface']);
+
+			// Skip instances where pfSense physical interface
+			// has been removed.
+			if ($if_real == "") {
+				continue;
+			}
 			$suricata_uuid = $value['uuid'];
 			$suricata_log_dir = SURICATALOGDIR . "suricata_{$if_real}{$suricata_uuid}";
 			syslog(LOG_NOTICE, gettext("[Suricata] Cleaning logs for {$value['descr']} ({$if_real})..."));
@@ -94,6 +100,12 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 		// Clean-up active logs for each configured Suricata instance
 		foreach ($config['installedpackages']['suricata']['rule'] as $value) {
 			$if_real = get_real_interface($value['interface']);
+
+			// Skip instances where pfSense physical interface
+			// has been removed.
+			if ($if_real == "") {
+				continue;
+			}
 			$suricata_uuid = $value['uuid'];
 			$suricata_log_dir = SURICATALOGDIR . "suricata_{$if_real}{$suricata_uuid}";
 			if (suricata_Getdirsize(SURICATALOGDIR) < $suricataloglimitsizeKB) {
@@ -222,6 +234,12 @@ $logs['tls.log']['retention'] = $config['installedpackages']['suricata']['config
 if ($config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 'on') {
 	foreach ($config['installedpackages']['suricata']['rule'] as $value) {
 		$if_real = get_real_interface($value['interface']);
+
+		// Skip instances where pfSense physical interface
+		// has been removed.
+		if ($if_real == "") {
+			continue;
+		}
 		$suricata_log_dir = SURICATALOGDIR . "suricata_{$if_real}{$value['uuid']}";
 		foreach ($logs as $k => $p) {
 			suricata_check_rotate_log("{$suricata_log_dir}/{$k}", $p['limit']*1024, $p['retention']);

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -647,6 +647,13 @@ if ($snortdownload == 'on' || $emergingthreats == 'on' || $snortcommunityrules =
 		/* Create configuration for each active Suricata interface */
 		foreach ($config['installedpackages']['suricata']['rule'] as $value) {
 			$if_real = get_real_interface($value['interface']);
+
+			/* Skip processing for instances whose underlying physical       */
+			/* interface has been removed in pfSense.                        */
+			if ($if_real == "") {
+				continue;
+			}
+
 			// Make sure the interface subdirectory exists.  We need to re-create
 			// it during a pkg reinstall on the intial rules set download.
 			if (!is_dir("{$suricatadir}suricata_{$value['uuid']}_{$if_real}"))

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -209,6 +209,11 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 	// Create the suricata.yaml files for each enabled interface
 	foreach ($config['installedpackages']['suricata']['rule'] as $suricatacfg) {
 		$if_real = get_real_interface($suricatacfg['interface']);
+
+		/* Skip instance if its real interface is missing in pfSense */
+		if ($if_real == "") {
+			continue;
+		}
 		$suricata_uuid = $suricatacfg['uuid'];
 		$suricatacfgdir = "{$suricatadir}suricata_{$suricata_uuid}_{$if_real}";
 		update_status(gettext("Generating YAML configuration file for " . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . "..."));

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
@@ -558,6 +558,12 @@ if ($savemsg) {
 				</thead>
 				<tbody>
 			   <?php foreach ($a_nat as $k => $natent): ?>
+				<?php
+					// Skip displaying any instance where the physical pfSense interface is missing
+					if (get_real_interface($natent['interface']) == "") {
+						continue;
+					}
+				?>
 				<tr>
 					<td class="text-center">
 						<input type="checkbox" name="torestart[]" id="torestart[]" value="<?=$k;?>" title="<?=gettext("Apply new configuration and rebuild rules for this interface when saving");?>" />


### PR DESCRIPTION
### pfSense-pkg-suricata-4.1.5_1

This update to the Suricata GUI package corrects an issue present in Suricata that was also identified and fixed recently in the Snort GUI package. See [Redmine Issue #9789](https://redmine.pfsense.org/issues/9789) for details.

**New Features:**
None

**Bug Fixes:**
1. The Suriata GUI does not account for the underlying physical interface for a configured Suricata instance being removed in pfSense prior to the Suricata instance being removed. This can lead to anomalous behavior. See [Redmine issue #9789](https://redmine.pfsense.org/issues/9789) created for Snort.