### PR TITLE
dns/pfSense-pkg-bind: freeze dynamic zones

### DIFF
--- a/dns/pfSense-pkg-bind/Makefile
+++ b/dns/pfSense-pkg-bind/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-bind
 PORTVERSION=	9.14
-PORTREVISION=   1
+PORTREVISION=	1
 CATEGORIES=	dns net ipv6
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/dns/pfSense-pkg-bind/Makefile
+++ b/dns/pfSense-pkg-bind/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-bind
 PORTVERSION=	9.14
+PORTREVISION=   1
 CATEGORIES=	dns net ipv6
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/dns/pfSense-pkg-bind/files/usr/local/pkg/bind.inc
+++ b/dns/pfSense-pkg-bind/files/usr/local/pkg/bind.inc
@@ -586,11 +586,11 @@ EOD;
 						}
 
 						// Freeze dynamic zones to prevent journal corruption
-						$zone_is_dynamic = $zone['enable_updatepolicy'] == "on" || $zoneallowupdate != "none";
+						$zone_is_dynamic = (($zone['enable_updatepolicy'] == "on") || ($zoneallowupdate != "none"));
 						$rndc_conf_path = BIND_LOCALBASE . "/etc/rndc.conf";
-						$rndc = "/usr/local/sbin/rndc -q -c $rndc_conf_path";
+						$rndc = "/usr/local/sbin/rndc -q -c {$rndc_conf_path}";
 						if ($zone_is_dynamic) {
-							exec("$rndc freeze " . escapeshellarg($zonename) . " IN " . escapeshellarg($zoneview));
+							exec("{$rndc} freeze " . escapeshellarg($zonename) . " IN " . escapeshellarg($zoneview));
 							// TODO: diff frozen zone DB with pfSense's stored DB file
 							//       and (optionally?) add dynamic records to customzonerecords
 						}
@@ -600,7 +600,7 @@ EOD;
 
 						// Thaw frozen dynamic zone
 						if ($zone_is_dynamic) {
-							exec("$rndc thaw " . escapeshellarg($zonename) . " IN " . escapeshellarg($zoneview));
+							exec("{$rndc} thaw " . escapeshellarg($zonename) . " IN " . escapeshellarg($zoneview));
 						}
 
 						$config['installedpackages']['bindzone']['config'][$x]['resultconfig'] = base64_encode($zone_conf);

--- a/dns/pfSense-pkg-bind/files/usr/local/pkg/bind.inc
+++ b/dns/pfSense-pkg-bind/files/usr/local/pkg/bind.inc
@@ -590,7 +590,7 @@ EOD;
 						$rndc_conf_path = BIND_LOCALBASE . "/etc/rndc.conf";
 						$rndc = "/usr/local/sbin/rndc -q -c $rndc_conf_path";
 						if ($zone_is_dynamic) {
-							exec("$rndc freeze $zonename IN $zoneview");
+							exec("$rndc freeze " . escapeshellarg($zonename) . " IN " . escapeshellarg($zoneview));
 							// TODO: diff frozen zone DB with pfSense's stored DB file
 							//       and (optionally?) add dynamic records to customzonerecords
 						}
@@ -600,7 +600,7 @@ EOD;
 
 						// Thaw frozen dynamic zone
 						if ($zone_is_dynamic) {
-							exec("$rndc thaw $zonename IN $zoneview");
+							exec("$rndc thaw " . escapeshellarg($zonename) . " IN " . escapeshellarg($zoneview));
 						}
 
 						$config['installedpackages']['bindzone']['config'][$x]['resultconfig'] = base64_encode($zone_conf);

--- a/dns/pfSense-pkg-bind/files/usr/local/pkg/bind.inc
+++ b/dns/pfSense-pkg-bind/files/usr/local/pkg/bind.inc
@@ -585,8 +585,23 @@ EOD;
 							$zone_conf .= "\n\n;\n;custom zone records\n;\n".base64_decode($zone['customzonerecords'])."\n";
 						}
 
+						// Freeze dynamic zones to prevent journal corruption
+						$zone_is_dynamic = $zone['enable_updatepolicy'] == "on" || $zoneallowupdate != "none";
+						$rndc_conf_path = BIND_LOCALBASE . "/etc/rndc.conf";
+						$rndc = "/usr/local/sbin/rndc -q -c $rndc_conf_path";
+						if ($zone_is_dynamic) {
+							exec("$rndc freeze $zonename IN $zoneview");
+							// TODO: diff frozen zone DB with pfSense's stored DB file
+							//       and (optionally?) add dynamic records to customzonerecords
+						}
+
 						// Save zone configuration DB file
 						file_put_contents(CHROOT_LOCALBASE."/etc/namedb/{$zonetype}/{$zoneview}/{$zonename}.DB", $zone_conf);
+
+						// Thaw frozen dynamic zone
+						if ($zone_is_dynamic) {
+							exec("$rndc thaw $zonename IN $zoneview");
+						}
 
 						$config['installedpackages']['bindzone']['config'][$x]['resultconfig'] = base64_encode($zone_conf);
 						$write_config++;


### PR DESCRIPTION
Fixes [Bug #8258](https://redmine.pfsense.org/issues/8258)

DDNS-enabled zones are corrupted by any changes made
to their DB files during `bind_sync()`, because it causes
them to conflict with the .jnl files BIND maintains
for DDNS updates. The corruption causes BIND to refuse
to load the zone until the .jnl file is manually deleted.

This patch causes pfSense to run rndc freeze/thaw
before/after changing the zone files so that the
zones are no longer considered corrupt by BIND.

This patch quickly resolves the issue of pfSense causing
BIND to refuse to load the zones, but it does have the
effect that all DDNS changes to the zone are overwritten
with pfSense's saved XML zone configuration every time
`bind_sync()` runs.

This overwriting behavior is still an improvement on the
current situation in which the user must manually discard
all dynamic changes by deleting the .jnl file, so this
maintains the status quo behavior of dynamic zones and
fixes a bug.

A future improvement, but much more complex to implement,
will be to persist the dynamic changes to the zone either
by adding them to pfSense's custom zone records or
temporarily caching them while bind_sync() rewrites the
DB file and adding them back to the DB before thaw. Either
approach will require parsing the DB file with PHP
and diff-ing it with what pfSense expects it to be. Another
possibility would be to add use of the
[$INCLUDE directive](http://www.zytrax.com/books/dns/ch8/include.html)
to pfSense's zone generation if a zone is dynamic so that
BIND puts dynamic updates in one DB file and pfSense maintains
a separate DB file that corresponds to the XML configuration.