### PR TITLE
patching logging with fix

### DIFF
--- a/sysutils/pfSense-pkg-System_Patches/Makefile
+++ b/sysutils/pfSense-pkg-System_Patches/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-System_Patches
 PORTVERSION=	1.2
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches.inc
+++ b/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches.inc
@@ -184,7 +184,9 @@ function bootup_apply_patches() {
 		   only attempt to apply if it can be applied;
 		   and	if it can be reverted it is presumably already applied, so skip it. */
 		if (isset($patch['autoapply']) && patch_test_apply($patch) && !patch_test_revert($patch)) {
-			patch_apply($patch);
+			$descr = patch_descr($patch);
+			$savemsg = patch_apply($patch) ? gettext("Patch autoapplied succesfully") : gettext("Patch could NOT be autoapplied");
+	                patchlog($savemsg . $descr);
 		}
 	}
 }
@@ -225,6 +227,21 @@ function patch_remove_shellcmd() {
 	if ($removed > 0) {
 		write_config("System Patches package removed {$removed} existing early shellcmd(s): apply patches");
 	}
+}
+
+function patchlog($msg) {
+        syslog(LOG_WARNING, gettext("System Patches: {$msg}"));
+}
+
+function patch_descr($id) {
+	global $config;
+	$a_patches = &$config['installedpackages']['patches']['item'];
+	$descr = " (" . gettext("ID") . ": {$a_patches[$id]['uniqid']}");
+	if (isset($a_patches[$id]['descr'])) {
+		$descr .= ", " . gettext("DESCR") . ": {$a_patches[$id]['descr']}";
+	}
+	$descr .= ")";
+	return $descr;
 }
 
 ?>

--- a/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches.inc
+++ b/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches.inc
@@ -236,7 +236,7 @@ function patchlog($msg) {
 function patch_descr($id) {
 	global $config;
 	$a_patches = &$config['installedpackages']['patches']['item'];
-	$descr = " (" . gettext("ID") . ": {$a_patches[$id]['uniqid']}");
+	$descr = " (" . gettext("ID") . ": {$a_patches[$id]['uniqid']}";
 	if (isset($a_patches[$id]['descr'])) {
 		$descr .= ", " . gettext("DESCR") . ": {$a_patches[$id]['descr']}";
 	}

--- a/sysutils/pfSense-pkg-System_Patches/files/usr/local/www/system_patches.php
+++ b/sysutils/pfSense-pkg-System_Patches/files/usr/local/www/system_patches.php
@@ -48,28 +48,38 @@ if ($_POST) {
 	}
 }
 
-if (($_POST['act'] == "fetch") && ($a_patches[$_POST['id']])) {
-	$savemsg = patch_fetch($a_patches[$_POST['id']]) ? gettext("Patch Fetched Successfully") : gettext("Patch Fetch Failed");
-}
-if (($_POST['act'] == "test") && ($a_patches[$_POST['id']])) {
-	$savemsg = patch_test_apply($a_patches[$_POST['id']]) ? gettext("Patch can be applied cleanly") : gettext("Patch can NOT be applied cleanly");
-	$savemsg .= " (<a href=\"system_patches.php?id={$_POST['id']}&amp;fulltest=apply\" usepost>" . gettext("detail") . "</a>)";
-	$savemsg .= empty($savemsg) ? "" : "<br/>";
-	$savemsg .= patch_test_revert($a_patches[$_POST['id']]) ? gettext("Patch can be reverted cleanly") : gettext("Patch can NOT be reverted cleanly");
-	$savemsg .= " (<a href=\"system_patches.php?id={$_POST['id']}&amp;fulltest=revert\" usepost>" . gettext("detail") . "</a>)";
-}
-if (($_POST['fulltest']) && ($a_patches[$_POST['id']])) {
-	if ($_POST['fulltest'] == "apply") {
-		$fulldetail = patch_test_apply($a_patches[$_POST['id']], true);
-	} elseif ($_POST['fulltest'] == "revert") {
-		$fulldetail = patch_test_revert($a_patches[$_POST['id']], true);
+if ($a_patches[$_POST['id']]) {
+	$savemsg = gettext("Patch ");
+	$descr = patch_descr($_POST['id']);
+	switch ($_POST['act']) {
+		case 'fetch':
+			$savemsg .= patch_fetch($a_patches[$_POST['id']]) ? gettext("fetched succesfully") : gettext("fetch failed");
+			patchlog($savemsg . $descr);
+			break;
+		case 'test':
+			$savemsg .= patch_test_apply($a_patches[$_POST['id']]) ? gettext("can be applied cleanly") : gettext("can NOT be applied cleanly");
+			$savemsg .= " (<a href=\"system_patches.php?id={$_POST['id']}&amp;fulltest=apply\" usepost>" . gettext("detail") . "</a>)";
+			$savemsg .= empty($savemsg) ? "" : "<br/>";
+			$savemsg .= patch_test_revert($a_patches[$_POST['id']]) ? gettext("Patch can be reverted cleanly") : gettext("Patch can NOT be reverted cleanly");
+			$savemsg .= " (<a href=\"system_patches.php?id={$_POST['id']}&amp;fulltest=revert\" usepost>" . gettext("detail") . "</a>)";
+			break;
+		case 'apply':
+			$savemsg .= patch_apply($a_patches[$_POST['id']]) ? gettext("applied succesfully") : gettext("could NOT be applied");
+			patchlog($savemsg . $descr);
+			break;
+		case 'revert':
+			$savemsg .= patch_revert($a_patches[$_POST['id']]) ? gettext("reverted successfully") : gettext("could NOT be reverted!");
+			patchlog($savemsg . $descr);
+			break;
+		default:
 	}
-}
-if (($_POST['act'] == "apply") && ($a_patches[$_POST['id']])) {
-	$savemsg = patch_apply($a_patches[$_POST['id']]) ? gettext("Patch applied successfully") : gettext("Patch could NOT be applied!");
-}
-if (($_POST['act'] == "revert") && ($a_patches[$_POST['id']])) {
-	$savemsg = patch_revert($a_patches[$_POST['id']]) ? gettext("Patch reverted successfully") : gettext("Patch could NOT be reverted!");
+	if ($_POST['fulltest']) {
+		if ($_POST['fulltest'] == "apply") {
+			$fulldetail = patch_test_apply($a_patches[$_POST['id']], true);
+		} elseif ($_POST['fulltest'] == "revert") {
+			$fulldetail = patch_test_revert($a_patches[$_POST['id']], true);
+		}
+	}
 }
 
 $need_save = false;


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/9742
Ready for review

Adds ability to log patch id to system log
fixes for https://github.com/pfsense/FreeBSD-ports/pull/685:

"PHP Parse error: syntax error, unexpected ')' in /usr/local/pkg/patches.inc on line 241"
"Parse error: syntax error, unexpected ')' in /usr/local/pkg/patches.inc on line 239"