### PR TITLE
pfSense-pkg-snort-4.0_9 -- Update to support 2.9.15 binary

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.0
-PORTREVISION=	8
+PORTREVISION=	9
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package snort
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	snort>=2.9.14.1:security/snort \
+RUN_DEPENDS=	snort>=2.9.15:security/snort \
 		barnyard2>=0:security/barnyard2
 
 NO_BUILD=	yes

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -47,7 +47,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 		define("SNORT_BIN_VERSION", $matches[0]);
 	}
 	else {
-		define("SNORT_BIN_VERSION", "2.9.14.1");
+		define("SNORT_BIN_VERSION", "2.9.15");
 	}
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress.php
@@ -67,8 +67,8 @@ if (isset($_POST['del_btn'])) {
 	if (is_array($_POST['del']) && count($_POST['del'])) {
 		foreach ($_POST['del'] as $itemi) {
 			/* make sure list is not being referenced by any interface */
-			if (snort_suppresslist_used($a_suppress[$_POST['list_id']]['name'])) {
-				$input_errors[] = gettext("Suppression List '{$a_suppress[$itemi]['name']}' is currently assigned to a Snort interface and cannot be deleted.  Unassign it from all Snort interfaces first.");
+			if (snort_suppresslist_used($a_suppress[$itemi]['name'])) {
+				$input_errors[] = gettext("Suppression List '{$a_suppress[$itemi]['name']}' is currently assigned to one or more Snort interfaces and cannot be deleted. Unassign it from all Snort interfaces first.");
 			} else {
 				unset($a_suppress[$itemi]);
 				$need_save = true;
@@ -93,8 +93,8 @@ else {
 		}
 	}
 	if (is_numeric($delbtn_list) && $a_suppress[$delbtn_list]) {
-		if (snort_suppresslist_used($a_suppress[$_POST['list_id']]['name'])) {
-			$input_errors[] = gettext("This Suppression List '{$$a_suppress[$delbtn_list]['name']}' is currently assigned to a Snort interface and cannot be deleted.  Unassign it from all Snort interfaces first.");
+		if (snort_suppresslist_used($a_suppress[$delbtn_list]['name'])) {
+			$input_errors[] = gettext("This Suppression List '{$$a_suppress[$delbtn_list]['name']}' is currently assigned to one or more Snort interfaces and cannot be deleted. Unassign it from all Snort interfaces first.");
 		}
 		else {
 			unset($a_suppress[$delbtn_list]);

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
@@ -1176,7 +1176,7 @@ print($section);
 
 			<?php if ($currentruleset != 'decoder.rules' && $currentruleset != 'preprocessor.rules'): ?>
 
-					<table style="table-layout: fixed; width: 100%;" class="table table-striped table-hover table-condensed">
+					<table style="table-layout: fixed; width: 100%;" class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>
 						<colgroup>
 							<col width="5%">
 							<col width="5%">
@@ -1191,16 +1191,16 @@ print($section);
 						</colgroup>
 						<thead>
 						   <tr class="sortableHeaderRowIdentifier">
-							<th class="sorttable_nosort"><?=gettext("State");?></th>
-							<th><?=gettext("Action");?></th>
-							<th><?=gettext("GID"); ?></th>
-							<th><?=gettext("SID"); ?></th>
-							<th><?=gettext("Proto"); ?></th>
-							<th><?=gettext("Source"); ?></th>
-							<th><?=gettext("SPort"); ?></th>
-							<th><?=gettext("Destination"); ?></th>
-							<th><?=gettext("DPort"); ?></th>
-							<th><?=gettext("Message"); ?></th>
+							<th data-sortable="false"><?=gettext("State");?></th>
+							<th data-sortable="false"><?=gettext("Action");?></th>
+							<th data-sortable="true" data-sortable-type="numeric"><?=gettext("GID"); ?></th>
+							<th data-sortable="true" data-sortable-type="numeric"><?=gettext("SID"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Proto"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Source"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("SPort"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Destination"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("DPort"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Message"); ?></th>
 						   </tr>
 						</thead>
 						<tbody>
@@ -1380,7 +1380,7 @@ print($section);
 
 			<?php else: ?>
 
-					<table style="table-layout: fixed; width: 100%;" class="table table-striped table-hover table-condensed">
+					<table style="table-layout: fixed; width: 100%;" class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>
 						<colgroup>
 							<col width="5%">
 							<col width="5%">
@@ -1392,13 +1392,13 @@ print($section);
 						</colgroup>
 						<thead>
 						   <tr class="sortableHeaderRowIdentifier">
-							<th sorttable_nosort><?=gettext("State"); ?></th>
-							<th><?=gettext("Action");?></th>
-							<th><?=gettext("GID"); ?></th>
-							<th><?=gettext("SID"); ?></th>
-							<th><?=gettext("Classification"); ?></th>
-							<th><?=gettext("IPS Policy"); ?></th>
-							<th><?=gettext("Message"); ?></th>
+							<th data-sortable="false"><?=gettext("State"); ?></th>
+							<th data-sortable="false"><?=gettext("Action");?></th>
+							<th data-sortable="true" data-sortable-type="numeric"><?=gettext("GID"); ?></th>
+							<th data-sortable="true" data-sortable-type="numeric"><?=gettext("SID"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Classification"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("IPS Policy"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Message"); ?></th>
 						   </tr>
 						</thead>
 						<tbody>


### PR DESCRIPTION
### pfSense-pkg-snort v4.0_9
This update provides support for the 2.9.15 snort binary and adds one new feature as requested in Redmine Issue #9871 and fixes one bug.

**New Features:**
1. Several columns are now sortable on the RULES tab (duplicating the functionality present on the ALERTS tab).

**Bug Fixes:**
1. The SUPPRESS tab allows deletion of an assigned Suppress List when it should instead issue a warning and not delete assigned lists.