### PR TITLE
pfSense-pkg-snort-3.2.9.10 -- Support 2.9.15 binary and bug fixes

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-snort
-PORTVERSION=	3.2.9.9
-PORTREVISION=	1
+PORTVERSION=	3.2.9.10
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +12,7 @@ COMMENT=	pfSense package snort
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	snort>=2.9.14.1:security/snort \
+RUN_DEPENDS=	snort>=2.9.15:security/snort \
 		barnyard2>=0:security/barnyard2
 
 NO_BUILD=	yes

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -47,7 +47,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 		define("SNORT_BIN_VERSION", $matches[0]);
 	}
 	else {
-		define("SNORT_BIN_VERSION", "2.9.14.1");
+		define("SNORT_BIN_VERSION", "2.9.15");
 	}
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
@@ -3,9 +3,9 @@
  * snort_generate_conf.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2006-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2006-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2018 Bill Meeks
+ * Copyright (c) 2013-2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1052,10 +1052,6 @@ $default_disabled_preprocs = array(
 /* Begin preprocessor lib file copies  */
 /***************************************/
 
-// Start by removing all existing preproc libraries in the
-// snort_dynamicpreprocessors directory for the interface.
-mwexec("/bin/rm -rf {$snort_dirs['dynamicpreprocessor']}/*.so");
-
 // Build the string variable we use to actually populate the snort.conf
 // file's preprocessors config section by walking the list of enabled
 // preprocessors and copying the required library files from the master
@@ -1064,28 +1060,42 @@ $snort_preprocessors = "";
 foreach ($snort_preproc as $preproc) {
 	if ($snortcfg[$preproc] == 'on' || empty($snortcfg[$preproc]) ) {
 
-		/* If preprocessor is not explicitly "on" or "off", then default to "off" if in our default disabled list */
+		/* If preprocessor is not explicitly "on" or "off", then default to "off" if it  */
+		/* is in our default disabled list by skipping the library file copy.            */
 		if (empty($snortcfg[$preproc]) && in_array($preproc, $default_disabled_preprocs))
 			continue;
 
 		/* NOTE: The $$ is not a bug. It is an advanced feature of php */
 		if (!empty($snort_preproc_libs[$preproc])) {
 			$preproclib = "libsf_" . $snort_preproc_libs[$preproc] . ".so";
-			if (!file_exists($snort_dirs['dynamicpreprocessor'] . "{$preproclib}")) {
+			if (!file_exists($snort_dirs['dynamicpreprocessor'] . "/{$preproclib}")) {
 				if (file_exists("{$snortlibdir}/snort_dynamicpreprocessor/{$preproclib}")) {
-					@copy("{$snortlibdir}/snort_dynamicpreprocessor/{$preproclib}", "{$snort_dirs['dynamicpreprocessor']}/{$preproclib}");
+					// Use '/bin/cp -p' to preserve file timestamps because a changed
+					// timestamp will cause SIGHUP (live reload) to give a false error
+					// about a changed dynamic preprocessor configuration.
+					mwexec("/bin/cp -p {$snortlibdir}/snort_dynamicpreprocessor/{$preproclib} {$snort_dirs['dynamicpreprocessor']}/{$preproclib}");
 					$snort_preprocessors .= $$preproc;
 					$snort_preprocessors .= "\n";
 				} else
-					log_error("Could not find the {$preproclib} file. Snort might error out!");
+					syslog(LOG_WARNING, "Could not find the {$preproclib} library file in '{$snortlibdir}/snort_dynamicpreprocessor/'. Snort might fail to start!");
 			} else {
 				$snort_preprocessors .= $$preproc;
 				$snort_preprocessors .= "\n";
 			}
 		} else {
+			// Some preprocessors don't have a library, so just add
+			// their configuration settings to the master string.
 			$snort_preprocessors .= $$preproc;
 			$snort_preprocessors .= "\n";
 		}
+	}
+	elseif ($snortcfg[$preproc] == 'off' && !empty($snort_preproc_libs[$preproc])) {
+
+		// Remove the associated *.so library file from our local
+		// snort_dynamicpreprocessor directory for any disabled
+		// dynamic preprocessor.
+		$preproclib = "libsf_" . $snort_preproc_libs[$preproc] . ".so";
+		mwexec("rm -f {$snort_dirs['dynamicpreprocessor']}/{$preproclib}");
 	}
 }
 // Remove final trailing newline

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress.php
@@ -3,9 +3,9 @@
  * snort_interfaces_suppress.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2004-2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2004-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya.
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * originially part of m0n0wall (http://m0n0.ch/wall)
@@ -67,8 +67,8 @@ if (isset($_POST['del_btn'])) {
 	if (is_array($_POST['del']) && count($_POST['del'])) {
 		foreach ($_POST['del'] as $itemi) {
 			/* make sure list is not being referenced by any interface */
-			if (snort_suppresslist_used($a_suppress[$_POST['list_id']]['name'])) {
-				$input_errors[] = gettext("Suppression List '{$a_suppress[$itemi]['name']}' is currently assigned to a Snort interface and cannot be deleted.  Unassign it from all Snort interfaces first.");
+			if (snort_suppresslist_used($a_suppress[$itemi]['name'])) {
+				$input_errors[] = gettext("Suppression List '{$a_suppress[$itemi]['name']}' is currently assigned to one or more Snort interfaces and cannot be deleted.  Unassign it from all Snort interfaces first.");
 			} else {
 				unset($a_suppress[$itemi]);
 				$need_save = true;
@@ -94,8 +94,8 @@ else {
 		}
 	}
 	if (is_numeric($delbtn_list) && $a_suppress[$delbtn_list]) {
-		if (snort_suppresslist_used($a_suppress[$_POST['list_id']]['name'])) {
-			$input_errors[] = gettext("This Suppression List '{$$a_suppress[$delbtn_list]['name']}' is currently assigned to a Snort interface and cannot be deleted.  Unassign it from all Snort interfaces first.");
+		if (snort_suppresslist_used($a_suppress[$delbtn_list]['name'])) {
+			$input_errors[] = gettext("This Suppression List '{$a_suppress[$delbtn_list]['name']}' is currently assigned to one or more Snort interfaces and cannot be deleted.  Unassign it from all Snort interfaces first.");
 		}
 		else {
 			unset($a_suppress[$delbtn_list]);

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
@@ -3,9 +3,9 @@
  * snort_rules.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2004-2018 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2004-2019 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2008-2009 Robert Zelaya
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -927,7 +927,7 @@ print($section);
 
 			<?php if ($currentruleset != 'decoder.rules' && $currentruleset != 'preprocessor.rules'): ?>
 
-					<table style="table-layout: fixed; width: 100%;" class="table table-striped table-hover table-condensed">
+					<table style="table-layout: fixed; width: 100%;" class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>
 						<colgroup>
 							<col width="3%">
 							<col width="4%">
@@ -941,15 +941,15 @@ print($section);
 						</colgroup>
 						<thead>
 						   <tr class="sortableHeaderRowIdentifier">
-							<th class="sorttable_nosort">&nbsp;</th>
-							<th><?=gettext("GID"); ?></th>
-							<th><?=gettext("SID"); ?></th>
-							<th><?=gettext("Proto"); ?></th>
-							<th><?=gettext("Source"); ?></th>
-							<th><?=gettext("SPort"); ?></th>
-							<th><?=gettext("Destination"); ?></th>
-							<th><?=gettext("DPort"); ?></th>
-							<th><?=gettext("Message"); ?></th>
+							<th data-sortable="false">&nbsp;</th>
+							<th data-sortable="true" data-sortable-type="numeric"><?=gettext("GID"); ?></th>
+							<th data-sortable="true" data-sortable-type="numeric"><?=gettext("SID"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Proto"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Source"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("SPort"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Destination"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("DPort"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Message"); ?></th>
 						   </tr>
 						</thead>
 						<tbody>
@@ -1089,7 +1089,7 @@ print($section);
 
 			<?php else: ?>
 
-					<table style="table-layout: fixed; width: 100%;" class="table table-striped table-hover table-condensed">
+					<table style="table-layout: fixed; width: 100%;" class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>
 						<colgroup>
 							<col width="4%">
 							<col width="5%">
@@ -1100,12 +1100,12 @@ print($section);
 						</colgroup>
 						<thead>
 						   <tr class="sortableHeaderRowIdentifier">
-							<th sorttable_nosort>&nbsp;</th>
-							<th><?=gettext("GID"); ?></th>
-							<th><?=gettext("SID"); ?></th>
-							<th><?=gettext("Classification"); ?></th>
-							<th><?=gettext("IPS Policy"); ?></th>
-							<th><?=gettext("Message"); ?></th>
+							<th data-sortable="false">&nbsp;</th>
+							<th data-sortable="true" data-sortable-type="numeric"><?=gettext("GID"); ?></th>
+							<th data-sortable="true" data-sortable-type="numeric"><?=gettext("SID"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Classification"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("IPS Policy"); ?></th>
+							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Message"); ?></th>
 						   </tr>
 						</thead>
 						<tbody>


### PR DESCRIPTION
### pfSense-pkg-snort-3.2.9.10
This update adds support for the latest 2.9.15 version of the snort binary, fixes two bugs and adds one new feature.

**New Features:**
1. Added sortable columns on the RULES tab to duplicate similar functionality available on the ALERTS tab.

**Bug Fixes:**
1. When adding a SID to a Suppress List or disabilng a rule on the ALERTS tab, Snort is stopped if running and logs a "_Snort Reload: Any change to the dynamic preprocessor configuration requires a restart._" message to the system log.

2. The SUPPRESS tab allows deletion of an assigned Suppress List when it should instead issue a warning and not delete lists currently assigned to an interface.