### PR TITLE
Check allow-transfer in custom option when the zone is slave

### DIFF
--- a/dns/pfSense-pkg-bind/files/usr/local/pkg/bind.inc
+++ b/dns/pfSense-pkg-bind/files/usr/local/pkg/bind.inc
@@ -450,7 +450,10 @@ EOD;
 					case 'slave':
 						$bind_conf .= "\t\tmasters { $zoneipslave; };\n";
 						$bind_conf .= "\t\tallow-query { $zoneallowquery; };\n";
-						$bind_conf .= "\t\tallow-transfer { $zoneallowtransfer; };\n";
+						//$bind_conf .= "\t\tallow-transfer { $zoneallowtransfer; };\n";
+							if ($zonecustom != '' and !preg_match('/allow-transfer/', $zonecustom)) {
+								$bind_conf .= "\t\tallow-transfer { $zoneallowtransfer; };\n";
+							}
 						break;
 					case 'forward':
 						$bind_conf .= "\t\tforward only;\n";

--- a/dns/pfSense-pkg-bind/files/usr/local/pkg/bind.inc
+++ b/dns/pfSense-pkg-bind/files/usr/local/pkg/bind.inc
@@ -451,7 +451,7 @@ EOD;
 						$bind_conf .= "\t\tmasters { $zoneipslave; };\n";
 						$bind_conf .= "\t\tallow-query { $zoneallowquery; };\n";
 						//$bind_conf .= "\t\tallow-transfer { $zoneallowtransfer; };\n";
-							if ($zonecustom != '' and !preg_match('/allow-transfer/', $zonecustom)) {
+							if ( $zonecustom == '' or ($zonecustom != '' and !preg_match('/allow-transfer/', $zonecustom))) {
 								$bind_conf .= "\t\tallow-transfer { $zoneallowtransfer; };\n";
 							}
 						break;


### PR DESCRIPTION
If i add custom option (allow-transfer) to my slave zone, bind exit with error, because say already defined this option.
Created this modification and the zone finally good for zone transfer (if you want to enable zone tranfer for your slave zone).
Please accept this modification or enable allow-transfer acl selection in the GUI.

https://redmine.pfsense.org/issues/9916