### PR TITLE
stunnel: check ECDSA certs curves

### DIFF
--- a/security/pfSense-pkg-stunnel/Makefile
+++ b/security/pfSense-pkg-stunnel/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-stunnel
 PORTVERSION=	5.50
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.inc
+++ b/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.inc
@@ -143,4 +143,16 @@ function stunnel_deinstall() {
 	rmdir_recursive("/var/tmp/stunnel");
 	rmdir_recursive(STUNNEL_ETCDIR);
 }
+
+/* This change cannot be pulled back to RELENG_2_4_4 since it would break there.
+ * see https://redmine.pfsense.org/issues/9897
+ */
+function stunnel_get_certs() {
+	$c_arr = array();
+	$ecdsagood = cert_build_list('cert', 'IPsec');
+	foreach ($ecdsagood as $refid => $descr) {
+		$c_arr[] = array('refid' => $refid, 'descr' => $descr);
+	}
+	return $c_arr;
+}
 ?>

--- a/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.xml
+++ b/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.xml
@@ -108,7 +108,7 @@
 			<fieldname>certificate</fieldname>
 			<description>Select server certificate to use for this tunnel.</description>
 			<type>select_source</type>
-			<source><![CDATA[$config['cert']]]></source>
+			<source><![CDATA[stunnel_get_certs()]]></source>
 			<source_name>descr</source_name>
 			<source_value>refid</source_value>
 			<show_disable_value>default</show_disable_value>


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/9919
Ready for review

stunnel client can use cert with any ECDSA curve,
but if stunnel server use incorrect (not prime256v1, secp384r1, secp521r1) curve, an error occurs:
`SSL_connect: /build/ce-crossbuild-master/pfSense/tmp/FreeBSD-src/crypto/openssl/ssl/record/rec_layer_s3.c:1528: error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure`

same func as https://github.com/pfsense/FreeBSD-ports/pull/710
maybe we can create system-wide pkg_get_ca_or_certs($type) function?