### PR TITLE
filterdns - always wake action thread from hostname thread

### DIFF
--- a/net/filterdns/files/filterdns.c
+++ b/net/filterdns/files/filterdns.c
@@ -575,16 +575,14 @@ check_hostname(void *arg)
 			}
 		}
 
-		if (update > 0) {
-			if (debug >= 4)
-				syslog(LOG_WARNING,
-				    "Change detected on host: %s",
-				    thr->hostname);
-			TAILQ_FOREACH(act, &thr->actions, next_actions) {
-				pthread_mutex_lock(&act->mtx);
-				pthread_cond_signal(&act->cond);
-				pthread_mutex_unlock(&act->mtx);
-			}
+		if (debug >= 4)
+			syslog(LOG_WARNING,
+			    "Change detected on host: %s",
+			    thr->hostname);
+		TAILQ_FOREACH(act, &thr->actions, next_actions) {
+			pthread_mutex_lock(&act->mtx);
+			pthread_cond_signal(&act->cond);
+			pthread_mutex_unlock(&act->mtx);
 		}
 
 		pthread_rwlock_unlock(&main_lock);


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/9296

This change to filterdns.c causes the action thread to always be woken from the hostname thread, regardless of whether the resolved address has changed or not. 

This change is necessary for when a new alias is added with the same hostname in a previous alias, and the hostname thread never wakes the new action thread to populate the table since the resolved address hasn't changed.