### PR TITLE
Status_Monitoring: packets graphs scale fix

### DIFF
--- a/sysutils/pfSense-Status_Monitoring/Makefile
+++ b/sysutils/pfSense-Status_Monitoring/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-Status_Monitoring
 PORTVERSION=	1.7.11
+PORTREVISION=	1
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/rrd_fetch_json.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/rrd_fetch_json.php
@@ -227,28 +227,36 @@ foreach ($side as $settings) {
 				$ignore = true;
 				break;
 			case "inpass":
+				if ($settings['category'] === "traffic") {
+					$multiplier = 8;
+				}
 				$ninetyfifth = true;
-				$multiplier = 8;
 				$format = "s";
 				break;
 			case "max":
 				$format = "s";
 				break;
 			case "inpass6":
+				if ($settings['category'] === "traffic") {
+					$multiplier = 8;
+				}
 				$ninetyfifth = true;
-				$multiplier = 8;
 				$format = "s";
 				break;
 			case "outpass":
+				if ($settings['category'] === "traffic") {
+					$multiplier = 8;
+				}
 				$invert = $invert_graph;
 				$ninetyfifth = true;
-				$multiplier = 8;
 				$format = "s";
 				break;
 			case "outpass6":
+				if ($settings['category'] === "traffic") {
+					$multiplier = 8;
+				}
 				$invert = $invert_graph;
 				$ninetyfifth = true;
-				$multiplier = 8;
 				$format = "s";
 				break;
 			case "rate":

--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/rrd_fetch_json.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/rrd_fetch_json.php
@@ -227,9 +227,6 @@ foreach ($side as $settings) {
 				$ignore = true;
 				break;
 			case "inpass":
-				if ($settings['category'] === "traffic") {
-					$multiplier = 8;
-				}
 				$ninetyfifth = true;
 				$format = "s";
 				break;
@@ -237,24 +234,15 @@ foreach ($side as $settings) {
 				$format = "s";
 				break;
 			case "inpass6":
-				if ($settings['category'] === "traffic") {
-					$multiplier = 8;
-				}
 				$ninetyfifth = true;
 				$format = "s";
 				break;
 			case "outpass":
-				if ($settings['category'] === "traffic") {
-					$multiplier = 8;
-				}
 				$invert = $invert_graph;
 				$ninetyfifth = true;
 				$format = "s";
 				break;
 			case "outpass6":
-				if ($settings['category'] === "traffic") {
-					$multiplier = 8;
-				}
 				$invert = $invert_graph;
 				$ninetyfifth = true;
 				$format = "s";
@@ -281,6 +269,10 @@ foreach ($side as $settings) {
 			case "freq":
 				$unit_acronym = "";
 				break;
+		}
+
+		if ($settings['category'] === "traffic") {
+			$multiplier = 8;
 		}
 
 		if (!$ignore) {


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/9807
Ready for review

It looks like the data used for the packets logging is being incorrectly multiplied by 8 as though it is assuming a Bytes value that shouldn't be be applied to PPS.
