### PR TITLE
stunnel: chmod 0600 pem file

### DIFF
--- a/security/pfSense-pkg-stunnel/Makefile
+++ b/security/pfSense-pkg-stunnel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-stunnel
 PORTVERSION=	5.50
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.inc
+++ b/security/pfSense-pkg-stunnel/files/usr/local/pkg/stunnel.inc
@@ -57,6 +57,7 @@ function stunnel_save() {
 					trim(base64_decode($cert['crt'])) . "\n" .
 					ca_chain($cert));
 				fwrite($fout, "cert = " . STUNNEL_ETCDIR . "/{$pkgconfig['certificate']}.pem\n");
+				chmod(STUNNEL_ETCDIR . "/{$pkgconfig['certificate']}.pem", 0600);
 				$in_use_certs[] = "{$pkgconfig['certificate']}.pem";
 			}
 		} else {


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/9219
Ready for review

After defining a new tunnel with a non-default certificate the resulting .pem file is readable by any user 

It should be chmod'ed to 0600