### PR TITLE
nrpe: allow ipv6 nagios servers addresses

### DIFF
--- a/net-mgmt/pfSense-pkg-nrpe/Makefile
+++ b/net-mgmt/pfSense-pkg-nrpe/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-nrpe
 PORTVERSION=	3.1
+PORTREVISION=	1
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-nrpe/files/usr/local/pkg/nrpe.inc
+++ b/net-mgmt/pfSense-pkg-nrpe/files/usr/local/pkg/nrpe.inc
@@ -247,7 +247,7 @@ function nrpe_custom_php_validation_command($post, &$input_errors) {
 		}
 	}
 	foreach (explode(",", $post['allowed_hosts']) as $host) {
-		if (!empty($host) && !is_ipaddr($host)) {
+		if (!empty($host) && !is_ipaddr($host) && !is_ipaddrv6($host)) {
 			$input_errors[] = gettext("'Nagios Server(s)' entry '{$host}' is not a valid IP address.");
 		}
 	}


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/9973
Ready for review

Nagios NRPE package lacks IPv6 capabilities.
1. binding IP: I can only give one IP. For Dual Stack I need to be able to give more than one IP - need additional changes, xinetd
2. binding IP: I can only give IPv4 addresses, IPv6 address not accepted - it works
3. nagios Servers: IPv6 addresses not accepted - **fixed by this PR**