### PR TITLE
syslog-ng TLS support

### DIFF
--- a/sysutils/pfSense-pkg-syslog-ng/Makefile
+++ b/sysutils/pfSense-pkg-syslog-ng/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-syslog-ng
 PORTVERSION=	1.15
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
@@ -30,6 +30,7 @@ require_once('util.inc');
 if (!function_exists("filter_configure")) {
 	require_once("filter.inc");
 }
+
 define("SYSLOGNG_BASEDIR", "/usr/local/");
 define('SYSLOGNG_DIR', "/var/etc/syslog-ng/");
 
@@ -127,6 +128,7 @@ function syslogng_build_default_objects($settings) {
 	$default_port = $settings['default_port'];
 	$default_logdir = $settings['default_logdir'];
 	$default_logfile = $settings['default_logfile'];
+
 	$default_objects[0] = array("objecttype"=>"source", "objectname"=>"_DEFAULT", "objectparameters"=>"{ internal(); syslog(transport($default_protocol) port($default_port)");
 
 	if ($settings['default_protocol'] == 'tls') {

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
@@ -30,7 +30,6 @@ require_once('util.inc');
 if (!function_exists("filter_configure")) {
 	require_once("filter.inc");
 }
-	
 define("SYSLOGNG_BASEDIR", "/usr/local/");
 define('SYSLOGNG_DIR', "/var/etc/syslog-ng/");
 
@@ -128,7 +127,6 @@ function syslogng_build_default_objects($settings) {
 	$default_port = $settings['default_port'];
 	$default_logdir = $settings['default_logdir'];
 	$default_logfile = $settings['default_logfile'];
-	
 	$default_objects[0] = array("objecttype"=>"source", "objectname"=>"_DEFAULT", "objectparameters"=>"{ internal(); syslog(transport($default_protocol) port($default_port)");
 
 	if ($settings['default_protocol'] == 'tls') {

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
@@ -418,13 +418,13 @@ function syslogng_get_ca_or_certs($type, $consumer = 'IPsec') {
 		if (is_array($list_arr)) {
 			foreach ($config[$type] as $c) {
 				if (in_array($c['refid'],array_column($list_arr, 'refid')) &&
-				 (!empty($c['prv']))) {
+				 (!empty($c['prv']) || $type == 'ca')) {
 					$c_arr[] = $c;
 				}
 			}
 		} else {
 			foreach ($config[$type] as $c) {
-				if (!empty($c['prv'])) {
+				if (!empty($c['prv']) || $type == 'ca') {
 					$c_arr[] = $c;
 				}
 			}

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
@@ -30,8 +30,9 @@ require_once('util.inc');
 if (!function_exists("filter_configure")) {
 	require_once("filter.inc");
 }
-
+	
 define("SYSLOGNG_BASEDIR", "/usr/local/");
+define('SYSLOGNG_DIR', "/var/etc/syslog-ng/");
 
 function syslogng_get_real_interface_address($interface) {
 	$interface = convert_friendly_interface_to_real_interface_name($interface);
@@ -127,8 +128,21 @@ function syslogng_build_default_objects($settings) {
 	$default_port = $settings['default_port'];
 	$default_logdir = $settings['default_logdir'];
 	$default_logfile = $settings['default_logfile'];
-
+	
 	$default_objects[0] = array("objecttype"=>"source", "objectname"=>"_DEFAULT", "objectparameters"=>"{ internal(); syslog(transport($default_protocol) port($default_port)");
+
+	if ($settings['default_protocol'] == 'tls') {
+		safe_mkdir(SYSLOGNG_DIR);
+		safe_mkdir(SYSLOGNG_DIR . "/ca.d");
+		syslogng_build_cert();
+		$default_objects[0]['objectparameters'] .= " tls(
+		    key-file('/var/etc/syslog-ng/syslog-ng.key')
+		    cert-file('/var/etc/syslog-ng/syslog-ng.cert')
+		    ca-dir('/var/etc/syslog-ng/ca.d'))";
+	} else {
+		rmdir_recursive(SYSLOGNG_DIR);
+	}
+
 	foreach (explode(",", $interfaces) as $interface) {
 		$interface_address = syslogng_get_real_interface_address($interface);
 		if ($interface_address[0]) {
@@ -392,5 +406,48 @@ fi
 
 EOD;
 	write_rcfile($rc);
+}
+
+function syslogng_get_ca_or_certs($type, $consumer = 'IPsec') {
+	global $config;
+	$c_arr = array();
+	if (function_exists('cert_build_list')) {
+		$list_arr = cert_build_list($type, $consumer, true, false);
+	}
+	if (isset($config[$type]) && is_array($config[$type])) {
+		if (is_array($list_arr)) {
+			foreach ($config[$type] as $c) {
+				if (in_array($c['refid'],array_column($list_arr, 'refid')) &&
+				 (!empty($c['prv']))) {
+					$c_arr[] = $c;
+				}
+			}
+		} else {
+			foreach ($config[$type] as $c) {
+				if (!empty($c['prv'])) {
+					$c_arr[] = $c;
+				}
+			}
+		}
+	}
+	return $c_arr;
+}
+
+function syslogng_build_cert() {
+	global $config;
+
+	$settings = $config['installedpackages']['syslogng']['config'][0];
+	$ca = lookup_ca($settings['dca']);
+	$cert = lookup_cert($settings['certificate']);
+
+	if ($cert != false) {
+		file_put_contents(SYSLOGNG_DIR . "/syslog-ng.cert", base64_decode($cert['crt']));
+		file_put_contents(SYSLOGNG_DIR . "/syslog-ng.key", base64_decode($cert['prv']));
+		chmod(SYSLOGNG_DIR . "/syslog-ng.key", 0600);
+	}
+
+	if ($ca != false) {
+		file_put_contents(SYSLOGNG_DIR . "/ca.d/cacert.pem", base64_decode($ca['crt']));
+	}
 }
 ?>

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.xml
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.xml
@@ -87,7 +87,12 @@
 		<field>
                         <fielddescr>CA</fielddescr>
                         <fieldname>dca</fieldname>
-                        <description>Select Certificate Authority to use for TLS protocol.</description>
+			<description>
+				<![CDATA[
+				Select Certificate Authority for TLS protocol.<br />
+				You can use it in your object definition as ca-dir('/var/etc/syslog-ng/ca.d') option of tls( ).
+				]]>
+			</description>
                         <type>select_source</type>
                         <source><![CDATA[syslogng_get_ca_or_certs('ca')]]></source>
                         <source_name>descr</source_name>
@@ -96,7 +101,12 @@
 		<field>
                         <fielddescr>Certificate</fielddescr>
                         <fieldname>certificate</fieldname>
-                        <description>Select server certificate for TLS protocol.</description>
+			<description>
+				<![CDATA[
+				Select server certificate for TLS protocol.<br />
+			       	You can use it in your object definition as key-file('/var/etc/syslog-ng/syslog-ng.key') and cert-file('/var/etc/syslog-ng/syslog-ng.cert') options of tls( ).
+				]]>
+			</description>
                         <type>select_source</type>
                         <source><![CDATA[syslogng_get_ca_or_certs('cert')]]></source>
                         <source_name>descr</source_name>

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.xml
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.xml
@@ -80,9 +80,28 @@
 			<options>
 				<option><name>UDP</name><value>udp</value></option>
 				<option><name>TCP</name><value>tcp</value></option>
+				<option><name>TLS</name><value>tls</value></option>
 			</options>
 			<required/>
 		</field>
+		<field>
+                        <fielddescr>CA</fielddescr>
+                        <fieldname>dca</fieldname>
+                        <description>Select Certificate Authority to use for TLS protocol.</description>
+                        <type>select_source</type>
+                        <source><![CDATA[syslogng_get_ca_or_certs('ca')]]></source>
+                        <source_name>descr</source_name>
+                        <source_value>refid</source_value>
+                </field>
+		<field>
+                        <fielddescr>Certificate</fielddescr>
+                        <fieldname>certificate</fieldname>
+                        <description>Select server certificate for TLS protocol.</description>
+                        <type>select_source</type>
+                        <source><![CDATA[syslogng_get_ca_or_certs('cert')]]></source>
+                        <source_name>descr</source_name>
+                        <source_value>refid</source_value>
+                </field>
 		<field>
 			<fielddescr>Default Port</fielddescr>
 			<fieldname>default_port</fieldname>


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/9563
Ready for review

Adds TLS to default protocols list,
creates cert, key and ca files,
and changes syslog-ng.conf by adding to _DEFAULT object:
```php
tls(
            key-file('/var/etc/syslog-ng/syslog-ng.key')
	    cert-file('/var/etc/syslog-ng/syslog-ng.cert')
	    ca-dir('/var/etc/syslog-ng/ca.d')
        )
```

see https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.16/administration-guide/56

It also check cert/ca with cert_build_list()  for correct ECDSA cert with private key