### PR TITLE
Update arpwatch to 3.0, pfSense-pkg-arpwatch to support the new zero pad flags (-Z/-C).

### DIFF
--- a/net-mgmt/pfSense-pkg-arpwatch/Makefile
+++ b/net-mgmt/pfSense-pkg-arpwatch/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-arpwatch
-PORTVERSION=	0.1.2
+PORTVERSION=	0.2.0
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -12,7 +12,7 @@ COMMENT=	Arpwatch package for pfSense
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	arpwatch>=0:net-mgmt/arpwatch
+RUN_DEPENDS=	arpwatch>=3.0:net-mgmt/arpwatch
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.inc
+++ b/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.inc
@@ -19,7 +19,7 @@
  */
 
 define('ARPWATCH_LOCAL_DIR', '/usr/local/arpwatch');
-define('ARPWATCH_ETHERCODES_URL', 'http://linuxnet.ca/ieee/oui/ethercodes.dat');
+define('ARPWATCH_ETHERCODES_URL', 'http://standards-oui.ieee.org/oui/oui.csv');
 define('ARPWATCH_SENDMAIL_PATH', '/usr/sbin/sendmail');
 define('ARPWATCH_SENDMAIL_PROXY', '/usr/local/arpwatch/sendmail_proxy.php');
 
@@ -32,6 +32,7 @@ function arpwatch_install_command() {
 	$arpwatch_config = $config['installedpackages']['arpwatch']['config'][0];
 	$active_interfaces = $arpwatch_config['active_interfaces'];
 	$notifications_recipient = $arpwatch_config['notifications_recipient'];
+	$enable_zeropad = ($arpwatch_config['zeropad'] == 'on') ? '-Z' : '-C';
 	$disable_carp = ($arpwatch_config['disable_carp'] == 'on') ? '-v' : '';
 	$disable_bogons = ($arpwatch_config['disable_bogons'] == 'on') ? '-N' : '';
 	$disable_zero = ($arpwatch_config['disable_zero'] == 'on') ? '-z' : '';
@@ -39,7 +40,7 @@ function arpwatch_install_command() {
 	$clear_database = ($arpwatch_config['clear_database'] == 'on');
 
 	if ($update_vendors) {
-		arpwatch_update_vendors();
+		arpwatch_update_vendors($enable_zeropad);
 	}
 
 	if ($clear_database) {
@@ -61,7 +62,15 @@ function arpwatch_install_command() {
 
 			touch($arp_file);
 
-			$rc['start'] .= "/usr/local/sbin/arpwatch $disable_carp $disable_bogons $disable_zero -f $arp_file -i $ifname -m $notifications_recipient"."\n";
+			$rc['start'] .= '/usr/local/sbin/arpwatch'
+			    .' '.$disable_carp
+			    .' '.$disable_bogons
+			    .' '.$disable_zero
+			    .' '.$enable_zeropad
+			    .' -f '.escapeshellarg($arp_file)
+			    .' -i '.escapeshellarg($ifname)
+			    .' -w '.escapeshellarg($notifications_recipient)
+			    ."\n";
 		}
 	}
 
@@ -109,11 +118,13 @@ function arpwatch_resync_config_command() {
 }
 
 function arpwatch_get_arp_file($ifname) {
-	return ARPWATCH_LOCAL_DIR."/arp_$ifname.dat";
+	return ARPWATCH_LOCAL_DIR."/arp_{$ifname}.dat";
 }
 
-function arpwatch_update_vendors() {
-	download_file(ARPWATCH_ETHERCODES_URL, ARPWATCH_LOCAL_DIR."/ethercodes.dat");
+function arpwatch_update_vendors($args) {
+	exec('/usr/bin/fetch -qo - '.ARPWATCH_ETHERCODES_URL.'|'
+	    .ARPWATCH_LOCAL_DIR.'/massagevendor '.$args.' >'
+	    .ARPWATCH_LOCAL_DIR.'/ethercodes.dat');
 }
 
 function arpwatch_clear_database() {

--- a/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.xml
+++ b/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.xml
@@ -81,6 +81,13 @@
 			<required/>
 		</field>
 		<field>
+			<fielddescr>Zero padded ethernet addresses</fielddescr>
+			<fieldname>zeropad</fieldname>
+			<type>checkbox</type>
+			<description>Use zero padded ethernet addresses in *.dat files</description>
+			<default_value>on</default_value>
+		</field>
+		<field>
 			<fielddescr>Disable CARP/VRRP</fielddescr>
 			<fieldname>disable_carp</fieldname>
 			<type>checkbox</type>
@@ -102,7 +109,7 @@
 			<fielddescr>Update vendors</fielddescr>
 			<fieldname>update_vendors</fieldname>
 			<type>checkbox</type>
-			<description>Updates the ethernet vendor database, downloaded from http://linuxnet.ca/ieee/oui/.</description>
+			<description>Updates the ethernet vendor database, downloaded from http://standards-oui.ieee.org/oui/oui.csv.</description>
 		</field>
 		<field>
 			<fielddescr>Clear database</fielddescr>


### PR DESCRIPTION
Update net-mgmt/arpwatch to 3.0 from -current, update net-mgmt/pfSense-pkg-arpwatch to use arpwatch >= 3.0 and add support for the new zero pad flags (-Z/-C). Fix the "update vendors" option to actually ethercodes.dat.