### PR TITLE
Telegraf additional conf fix 

### DIFF
--- a/net-mgmt/pfSense-pkg-Telegraf/Makefile
+++ b/net-mgmt/pfSense-pkg-Telegraf/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-Telegraf
 PORTVERSION=	0.9
+PORTREVISION=	1
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.inc
+++ b/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.inc
@@ -186,9 +186,8 @@ EOD;
 
 	/* Raw additional configuration options */
  	if ($telegraf_conf["telegraf_raw_config"]) {
-		#$telegraf_conf["telegraf_raw_config"] = $_POST["telegraf_raw_config"];
 		$cfg .= "\n# Additional Raw Options\n";
-		$cfg .= $_POST["telegraf_raw_config"];
+		$cfg .= base64_decode($telegraf_conf["telegraf_raw_config"]);
 		$cfg .= "\n";
 	}
 


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/9322
Ready for review

"after reboot, the "Additional configuration for Telegraf" appending configurations will be lost, but the content on the GUI still there, will have to click "save" again, thank you ."