### PR TITLE
ovpn-export: cryptoapicert full subj

### DIFF
--- a/security/pfSense-pkg-openvpn-client-export/Makefile
+++ b/security/pfSense-pkg-openvpn-client-export/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-openvpn-client-export
 PORTVERSION=	1.4.19
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
+++ b/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
@@ -308,7 +308,9 @@ EOF;
 			$conf .= "pkcs11-id '{$pkcs11id}'{$nl}";
 		} elseif ($usetoken) {
 			$conf .= "ca {$cafile}{$nl}";
-			$conf .= "cryptoapicert \"SUBJ:{$user['name']}\"{$nl}";
+			$crt = openssl_x509_parse(base64_decode($cert['crt']));
+			$subj = implode(', ', $crt['subject']);
+			$conf .= "cryptoapicert \"SUBJ:{$subj}\"{$nl}";
 		} elseif (substr($expformat, 0, 6) != "inline") {
 			$conf .= "pkcs12 {$prefix}.p12{$nl}";
 		}


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/6339
Ready for review

Use full 'subject' line in openvpn exported configs.
See details on redmine and https://community.openvpn.net/openvpn/ticket/386