### PR TITLE
suricata4 - Update to v4.1.6 for non-AMD64 architectures.

### DIFF
--- a/security/suricata4/Makefile
+++ b/security/suricata4/Makefile
@@ -2,8 +2,7 @@
 # $FreeBSD$
 
 PORTNAME=	suricata
-DISTVERSION=	4.1.5
-PORTREVISION=	1
+DISTVERSION=	4.1.6
 CATEGORIES=	security
 MASTER_SITES=	https://www.openinfosecfoundation.org/download/
 PKGNAMESUFFIX=	4
@@ -21,7 +20,7 @@ LIB_DEPENDS=	libpcre.so:devel/pcre \
 
 USES=		autoreconf cpe gmake iconv:translit libtool pathfix pkgconfig
 
-CONFLICTS_INSTALL=	libhtp suricata5
+CONFLICTS_INSTALL=	libhtp suricata suricata5
 
 USE_LDCONFIG=	yes
 USE_RC_SUBR=	${PORTNAME}

--- a/security/suricata4/distinfo
+++ b/security/suricata4/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1569423715
-SHA256 (suricata-4.1.5.tar.gz) = cee5f6535cd7fe63fddceab62eb3bc66a63fc464466c88ec7a41b7a1331ac74b
-SIZE (suricata-4.1.5.tar.gz) = 15729747
+TIMESTAMP = 1578025372
+SHA256 (suricata-4.1.6.tar.gz) = 8441ac89016106459ade2112fcde58b3f789e4beb2fd8bfa081ffb75eec75fe0
+SIZE (suricata-4.1.6.tar.gz) = 15763728

--- a/security/suricata4/files/patch-alert-pf.diff
+++ b/security/suricata4/files/patch-alert-pf.diff
@@ -1,6 +1,6 @@
-diff -ruN ./suricata-4.1.5.orig/src/Makefile.am ./suricata-4.1.5/src/Makefile.am
---- ./suricata-4.1.5.orig/src/Makefile.am	2019-09-23 07:44:03.000000000 -0400
-+++ ./src/Makefile.am	2019-09-25 10:41:16.000000000 -0400
+diff -ruN ./suricata-4.1.6.orig/src/Makefile.am ./suricata-4.1.6/src/Makefile.am
+--- ./suricata-4.1.6.orig/src/Makefile.am	2019-12-13 07:50:27.000000000 -0500
++++ ./src/Makefile.am	2020-01-02 23:12:22.000000000 -0500
 @@ -10,6 +10,7 @@
  suricata_SOURCES = \
  alert-debuglog.c alert-debuglog.h \
@@ -9,9 +9,9 @@ diff -ruN ./suricata-4.1.5.orig/src/Makefile.am ./suricata-4.1.5/src/Makefile.am
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
  alert-unified2-alert.c alert-unified2-alert.h \
-diff -ruN ./suricata-4.1.5.orig/src/Makefile.in ./suricata-4.1.5/src/Makefile.in
---- ./suricata-4.1.5.orig/src/Makefile.in	2019-09-23 07:44:19.000000000 -0400
-+++ ./src/Makefile.in	2019-09-25 10:42:32.000000000 -0400
+diff -ruN ./suricata-4.1.6.orig/src/Makefile.in ./suricata-4.1.6/src/Makefile.in
+--- ./suricata-4.1.6.orig/src/Makefile.in	2019-12-13 07:50:43.000000000 -0500
++++ ./src/Makefile.in	2020-01-02 23:13:53.000000000 -0500
 @@ -112,7 +112,7 @@
  am__installdirs = "$(DESTDIR)$(bindir)"
  PROGRAMS = $(bin_PROGRAMS)
@@ -21,7 +21,7 @@ diff -ruN ./suricata-4.1.5.orig/src/Makefile.in ./suricata-4.1.5/src/Makefile.in
  	alert-unified2-alert.$(OBJEXT) app-layer.$(OBJEXT) \
  	app-layer-dcerpc.$(OBJEXT) app-layer-dcerpc-udp.$(OBJEXT) \
  	app-layer-detect-proto.$(OBJEXT) app-layer-dnp3.$(OBJEXT) \
-@@ -654,6 +654,7 @@
+@@ -656,6 +656,7 @@
  suricata_SOURCES = \
  alert-debuglog.c alert-debuglog.h \
  alert-fastlog.c alert-fastlog.h \
@@ -29,8 +29,8 @@ diff -ruN ./suricata-4.1.5.orig/src/Makefile.in ./suricata-4.1.5/src/Makefile.in
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
  alert-unified2-alert.c alert-unified2-alert.h \
-diff -ruN ./suricata-4.1.5.orig/src/alert-pf.c ./suricata-4.1.5/src/alert-pf.c
---- ./suricata-4.1.5.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
+diff -ruN ./suricata-4.1.6.orig/src/alert-pf.c ./suricata-4.1.6/src/alert-pf.c
+--- ./suricata-4.1.6.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
 +++ ./src/alert-pf.c	2019-09-25 10:59:45.000000000 -0400
 @@ -0,0 +1,1141 @@
 +/* Copyright (C) 2007-2019 Open Information Security Foundation
@@ -1174,8 +1174,8 @@ diff -ruN ./suricata-4.1.5.orig/src/alert-pf.c ./suricata-4.1.5/src/alert-pf.c
 +    return TM_ECODE_OK;
 +}
 +
-diff -ruN ./suricata-4.1.5.orig/src/alert-pf.h ./suricata-4.1.5/src/alert-pf.h
---- ./suricata-4.1.5.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
+diff -ruN ./suricata-4.1.6.orig/src/alert-pf.h ./suricata-4.1.6/src/alert-pf.h
+--- ./suricata-4.1.6.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
 +++ ./src/alert-pf.h	2019-06-05 14:27:11.000000000 -0400
 @@ -0,0 +1,59 @@
 +/* Copyright (C) 2007-2019 Open Information Security Foundation
@@ -1237,9 +1237,9 @@ diff -ruN ./suricata-4.1.5.orig/src/alert-pf.h ./suricata-4.1.5/src/alert-pf.h
 +
 +#endif /* __ALERT_PF_H__ */
 +
-diff -ruN ./suricata-4.1.5.orig/src/output.c ./suricata-4.1.5/src/output.c
---- ./suricata-4.1.5.orig/src/output.c	2019-09-23 07:44:03.000000000 -0400
-+++ ./src/output.c	2019-09-25 10:44:10.000000000 -0400
+diff -ruN ./suricata-4.1.6.orig/src/output.c ./suricata-4.1.6/src/output.c
+--- ./suricata-4.1.6.orig/src/output.c	2019-12-13 07:50:27.000000000 -0500
++++ ./src/output.c	2020-01-02 23:15:32.000000000 -0500
 @@ -43,6 +43,7 @@
  #include "alert-fastlog.h"
  #include "alert-unified2-alert.h"
@@ -1257,9 +1257,9 @@ diff -ruN ./suricata-4.1.5.orig/src/output.c ./suricata-4.1.5/src/output.c
      /* prelue log */
      AlertPreludeRegister();
      /* syslog log */
-diff -ruN ./suricata-4.1.5.orig/src/suricata-common.h ./suricata-4.1.5/src/suricata-common.h
---- ./suricata-4.1.5.orig/src/suricata-common.h	2019-09-23 07:44:03.000000000 -0400
-+++ ./src/suricata-common.h	2019-09-25 10:45:05.000000000 -0400
+diff -ruN ./suricata-4.1.6.orig/src/suricata-common.h ./suricata-4.1.6/src/suricata-common.h
+--- ./suricata-4.1.6.orig/src/suricata-common.h	2019-12-13 07:50:27.000000000 -0500
++++ ./src/suricata-common.h	2020-01-02 23:16:04.000000000 -0500
 @@ -440,6 +440,7 @@
      LOGGER_PRELUDE,
      LOGGER_PCAP,

--- a/security/suricata4/files/patch-pfSense-ARMv6_ARMv7.diff
+++ b/security/suricata4/files/patch-pfSense-ARMv6_ARMv7.diff
@@ -1,6 +1,6 @@
-diff -ruN ./suricata-4.1.5.orig/configure.ac ./suricata-4.1.5/configure.ac
---- ./suricata-4.1.5.orig/configure.ac	2019-09-23 07:44:04.000000000 -0400
-+++ ./configure.ac	2019-09-25 10:36:44.000000000 -0400
+diff -ruN ./suricata-4.1.6.orig/configure.ac ./suricata-4.1.6/configure.ac
+--- ./suricata-4.1.6.orig/configure.ac	2019-12-13 07:50:27.000000000 -0500
++++ ./configure.ac	2020-01-02 23:06:45.000000000 -0500
 @@ -272,6 +272,23 @@
      esac
      AC_MSG_RESULT(ok)
@@ -25,7 +25,7 @@ diff -ruN ./suricata-4.1.5.orig/configure.ac ./suricata-4.1.5/configure.ac
      # enable modifications for AFL fuzzing
      AC_ARG_ENABLE(afl,
             AS_HELP_STRING([--enable-afl], Enable AFL fuzzing logic[])], [enable_afl="$enableval"],[enable_afl=no])
-@@ -2392,6 +2409,15 @@
+@@ -2426,6 +2443,15 @@
              fi
          fi
      fi

--- a/security/suricata4/pkg-plist
+++ b/security/suricata4/pkg-plist
@@ -124,7 +124,7 @@ man/man1/suricata.1.gz
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/util.pyc
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/version.py
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/version.pyc
-%%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata_update-1.0.5-py%%PYTHON_VER%%.egg-info
+%%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata_update-1.0.6-py%%PYTHON_VER%%.egg-info
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricatasc/__init__.py
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricatasc/__init__.pyc
 @sample %%ETCDIR%%/classification.config.sample


### PR DESCRIPTION
### Suricata4 v4.1.6
This updates the Suricata 4.x branch to the latest upstream stable version. Release Notes for this version can be viewed [here](https://suricata-ids.org/2019/12/13/suricata-4-1-6-released/).

**Note:** this version is intended for non-AMD64 hardware that cannot run the Suricata 5.x branch due to Rust language dependencies.
