### PR TITLE
Suricata - update to latest upstream version 5.0.1.

### DIFF
--- a/security/suricata/Makefile
+++ b/security/suricata/Makefile
@@ -1,5 +1,5 @@
 # Created by: Patrick Tracanelli <eksffa@freebsdbrasil.com.br>
-# $FreeBSD:$
+# $FreeBSD$
 
 PORTNAME=	suricata
 DISTVERSION=	5.0.1

--- a/security/suricata/Makefile
+++ b/security/suricata/Makefile
@@ -1,5 +1,5 @@
 # Created by: Patrick Tracanelli <eksffa@freebsdbrasil.com.br>
-# $FreeBSD$
+# $FreeBSD: head/security/suricata/Makefile 520857 2019-12-25 13:30:20Z amdmi3 $
 
 PORTNAME=	suricata
 DISTVERSION=	5.0.1
@@ -21,7 +21,7 @@ LIB_DEPENDS=	libpcre.so:devel/pcre \
 
 USES=		autoreconf cpe gmake iconv:translit libtool pathfix pkgconfig
 
-CONFLICTS_INSTALL=	libhtp suricata5
+CONFLICTS_INSTALL=	libhtp suricata4 suricata5
 
 USE_LDCONFIG=	yes
 USE_RC_SUBR=	${PORTNAME}
@@ -76,7 +76,7 @@ LUA_CONFIGURE_ON=		--enable-lua \
 				--with-liblua-includes=${LUA_INCDIR} \
 				--with-liblua-libraries=${LUA_LIBDIR}
 
-LUAJIT_LIB_DEPENDS=		libluajit-5.1.so:lang/luajit-openresty
+LUAJIT_LIB_DEPENDS=		libluajit-5.1.so:lang/luajit
 LUAJIT_CONFIGURE_ON=		--enable-luajit
 
 NSS_LIB_DEPENDS=		libnss3.so:security/nss \

--- a/security/suricata/Makefile
+++ b/security/suricata/Makefile
@@ -1,5 +1,5 @@
 # Created by: Patrick Tracanelli <eksffa@freebsdbrasil.com.br>
-# $FreeBSD: head/security/suricata/Makefile 520857 2019-12-25 13:30:20Z amdmi3 $
+# $FreeBSD:$
 
 PORTNAME=	suricata
 DISTVERSION=	5.0.1
@@ -76,7 +76,7 @@ LUA_CONFIGURE_ON=		--enable-lua \
 				--with-liblua-includes=${LUA_INCDIR} \
 				--with-liblua-libraries=${LUA_LIBDIR}
 
-LUAJIT_LIB_DEPENDS=		libluajit-5.1.so:lang/luajit
+LUAJIT_LIB_DEPENDS=		libluajit-5.1.so:lang/luajit-openresty
 LUAJIT_CONFIGURE_ON=		--enable-luajit
 
 NSS_LIB_DEPENDS=		libnss3.so:security/nss \

--- a/security/suricata/files/patch-alert-pf.diff
+++ b/security/suricata/files/patch-alert-pf.diff
@@ -31,9 +31,9 @@ diff -ruN ./suricata-5.0.1.orig/src/Makefile.in ./suricata-5.0.1/src/Makefile.in
  alert-unified2-alert.c alert-unified2-alert.h \
 diff -ruN ./suricata-5.0.1.orig/src/alert-pf.c ./suricata-5.0.1/src/alert-pf.c
 --- ./suricata-5.0.1.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/alert-pf.c	2019-09-25 10:59:45.000000000 -0400
-@@ -0,0 +1,1141 @@
-+/* Copyright (C) 2007-2019 Open Information Security Foundation
++++ ./src/alert-pf.c	2020-01-06 14:22:20.000000000 -0500
+@@ -0,0 +1,1151 @@
++/* Copyright (C) 2007-2020 Open Information Security Foundation
 + *
 + * You can copy, redistribute or modify this Program under the terms of
 + * the GNU General Public License version 2 as published by the Free
@@ -51,7 +51,7 @@ diff -ruN ./suricata-5.0.1.orig/src/alert-pf.c ./suricata-5.0.1/src/alert-pf.c
 + *
 + * Portions of this module are based on previous works of the following:
 + *
-+ * Copyright (c) 2019  Bill Meeks
++ * Copyright (c) 2020  Bill Meeks
 + * Copyright (c) 2012  Ermal Luci
 + * Copyright (c) 2006  Antonio Benojar <zz.stalker@gmail.com>
 + * Copyright (c) 2005  Antonio Benojar <zz.stalker@gmail.com>
@@ -969,6 +969,11 @@ diff -ruN ./suricata-5.0.1.orig/src/alert-pf.c ./suricata-5.0.1/src/alert-pf.c
 +        if (unlikely(pa->s == NULL)) {
 +            continue;
 +        }
++
++        /* Don't block alerts where SIG_FLAG_NOALERT is set for the Signature */
++        if (pa->s->flags & SIG_FLAG_NOALERT) {
++            continue;
++        }
 +        SC_ATOMIC_ADD(alert_pf_alerts, 1);
 +
 +	/* If blocking only DROP rules and alert is not from a DROP rule, ignore it */
@@ -1078,6 +1083,11 @@ diff -ruN ./suricata-5.0.1.orig/src/alert-pf.c ./suricata-5.0.1/src/alert-pf.c
 +    for (i = 0; i < p->alerts.cnt; i++) {
 +        const PacketAlert *pa = &p->alerts.alerts[i];
 +        if (unlikely(pa->s == NULL)) {
++            continue;
++        }
++
++        /* Don't block alerts where SIG_FLAG_NOALERT is set for the Signature */
++        if (pa->s->flags & SIG_FLAG_NOALERT) {
 +            continue;
 +        }
 +        SC_ATOMIC_ADD(alert_pf_alerts, 1);

--- a/security/suricata/files/patch-alert-pf.diff
+++ b/security/suricata/files/patch-alert-pf.diff
@@ -1,0 +1,1270 @@
+diff -ruN ./suricata-5.0.1.orig/src/Makefile.am ./suricata-5.0.1/src/Makefile.am
+--- ./suricata-5.0.1.orig/src/Makefile.am	2019-12-13 07:14:51.000000000 -0500
++++ ./src/Makefile.am	2019-12-28 20:36:34.000000000 -0500
+@@ -10,6 +10,7 @@
+ suricata_SOURCES = \
+ alert-debuglog.c alert-debuglog.h \
+ alert-fastlog.c alert-fastlog.h \
++alert-pf.c alert-pf.h \
+ alert-prelude.c alert-prelude.h \
+ alert-syslog.c alert-syslog.h \
+ alert-unified2-alert.c alert-unified2-alert.h \
+diff -ruN ./suricata-5.0.1.orig/src/Makefile.in ./suricata-5.0.1/src/Makefile.in
+--- ./suricata-5.0.1.orig/src/Makefile.in	2019-12-13 07:15:07.000000000 -0500
++++ ./src/Makefile.in	2019-12-28 20:38:21.000000000 -0500
+@@ -110,7 +110,7 @@
+ am__installdirs = "$(DESTDIR)$(bindir)"
+ PROGRAMS = $(bin_PROGRAMS)
+ am_suricata_OBJECTS = alert-debuglog.$(OBJEXT) alert-fastlog.$(OBJEXT) \
+-	alert-prelude.$(OBJEXT) alert-syslog.$(OBJEXT) \
++	alert-pf.$(OBJEXT) alert-prelude.$(OBJEXT) alert-syslog.$(OBJEXT) \
+ 	alert-unified2-alert.$(OBJEXT) app-layer.$(OBJEXT) \
+ 	app-layer-dcerpc.$(OBJEXT) app-layer-dcerpc-udp.$(OBJEXT) \
+ 	app-layer-detect-proto.$(OBJEXT) app-layer-dnp3.$(OBJEXT) \
+@@ -661,6 +661,7 @@
+ suricata_SOURCES = \
+ alert-debuglog.c alert-debuglog.h \
+ alert-fastlog.c alert-fastlog.h \
++alert-pf.c alert-pf.h \
+ alert-prelude.c alert-prelude.h \
+ alert-syslog.c alert-syslog.h \
+ alert-unified2-alert.c alert-unified2-alert.h \
+diff -ruN ./suricata-5.0.1.orig/src/alert-pf.c ./suricata-5.0.1/src/alert-pf.c
+--- ./suricata-5.0.1.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
++++ ./src/alert-pf.c	2019-09-25 10:59:45.000000000 -0400
+@@ -0,0 +1,1141 @@
++/* Copyright (C) 2007-2019 Open Information Security Foundation
++ *
++ * You can copy, redistribute or modify this Program under the terms of
++ * the GNU General Public License version 2 as published by the Free
++ * Software Foundation.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * version 2 along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
++ * 02110-1301, USA.
++ *
++ * Portions of this module are based on previous works of the following:
++ *
++ * Copyright (c) 2019  Bill Meeks
++ * Copyright (c) 2012  Ermal Luci
++ * Copyright (c) 2006  Antonio Benojar <zz.stalker@gmail.com>
++ * Copyright (c) 2005  Antonio Benojar <zz.stalker@gmail.com>
++ *
++ * Copyright (c) 2003, 2004 Armin Wolfermann:
++ * 
++ * The AlertPfBlock() function is based 
++ * on Armin Wolfermann's pftabled-1.03 functions.
++ *
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR `AS IS'' AND ANY EXPRESS OR
++ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
++ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
++ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
++ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
++ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
++ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
++ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++ */
++
++/**
++ * \file
++ *
++ * \author Bill Meeks <billmeeks8@gmail.com>
++ *
++ * Inserts blocks for IP alerts into the pf firewall used in NetBSD and FreeBSD, 
++ * and logs the event, including the IP address, in "block.log".
++ *
++ *    # alert-pf blocking plugin
++ *    - alert-pf:
++ *        enabled: yes/no            # "yes" to enable blocking plugin
++ *        kill-state: yes/no         # "yes" to kill open state table entries associated with blocked IP addresses (default is "yes")
++ *        pass-list: <filename>      # complete path and filename for txt file of single IP addresses or CIDR networks that should never be blocked
++ *        block-ip: src/dst/both     # which IP in packet to block (default is BOTH)
++ *        pf-table: <pf table name>  # name of packet filter firewall table where block IP addresses should be added.  This table must exist!
++ *        block-drops-only: yes/no   # only insert blocks in packet filter firewall table for rules having DROP action keyword (default is "no")
++ *
++ */
++
++#include "suricata-common.h"
++#include "conf.h"
++#include "output.h"
++#include "threads.h"
++#include "tm-threads.h"
++#include "threadvars.h"
++
++#include "alert-pf.h"
++
++#include "util-atomic.h"
++#include "util-debug.h"
++#include "util-logopenfile.h"
++#include "util-print.h"
++#include "util-proto-name.h"
++#include "util-radix-tree.h"
++#include "util-time.h"
++
++#include <sys/types.h>
++#include <sys/ioctl.h>
++#include <sys/sysctl.h>
++#include <sys/socket.h>
++#include <sys/stat.h>
++#include <ctype.h>
++#include <net/if.h>
++#include <net/pfvar.h>
++#include <net/route.h>
++#include <netinet/in.h>
++#include <arpa/inet.h>
++#include <err.h>
++#include <unistd.h>
++#include <regex.h>
++#include <ifaddrs.h>
++#include <pthread.h>
++
++#define PFDEVICE	"/dev/pf"
++#define WLMAX		4096
++#define MODULE_NAME	"AlertPf"
++#define DEFAULT_LOG_FILENAME "block.log"
++#define MAX_RTMSG_SIZE 2048
++
++enum spblock { BLOCK_SRC, BLOCK_DST, BLOCK_BOTH };
++
++TmEcode AlertPfThreadInit(ThreadVars *, const void *, void **);
++TmEcode AlertPfThreadDeinit(ThreadVars *, void *);
++void AlertPfExitPrintStats(ThreadVars *, void *);
++static void AlertPfDeInitCtx(OutputCtx *);
++
++int AlertPfCondition(ThreadVars *tv, const Packet *p);
++int AlertPf(ThreadVars *tv, void *data, const Packet *p);
++
++TmEcode AlertPfIPv4(ThreadVars *, void *, const Packet *);
++TmEcode AlertPfIPv6(ThreadVars *, void *, const Packet *);
++
++void AlertPfRegister(void)
++{
++    OutputRegisterPacketModule(LOGGER_ALERT_PF, MODULE_NAME, "alert-pf",
++        AlertPfInitCtx, AlertPf, AlertPfCondition,
++        AlertPfThreadInit, AlertPfThreadDeinit,
++        AlertPfExitPrintStats);
++}
++
++/**
++ * Return TRUE only for valid packets we want
++ * to process.
++ */
++int AlertPfCondition(ThreadVars *tv, const Packet *p)
++{
++    if (p->alerts.cnt == 0)
++        return FALSE;
++    if (!IPH_IS_VALID(p))
++        return FALSE;
++    return TRUE;
++}
++
++/**
++ * This holds global structures and variables.
++ * Each thread gets a pointer to this data.
++ */
++typedef struct _AlertPfCtx_ {
++    char *pftable; 
++    int kill_state;
++    enum spblock block_ip;
++    SCRadixTree *tree;
++    LogFileCtx* file_ctx;
++    int block_drops;
++} AlertPfCtx;
++
++/**
++ * This holds per-thread specific structures and variables.
++ */
++typedef struct AlertPfThread_ {
++    AlertPfCtx* ctx;       /* Pointer to the global context data */
++    int fd;                /* pf device handle */
++} AlertPfThread;
++
++SC_ATOMIC_DECLARE(uint64_t, alert_pf_blocks);  /* Atomic counter, to hold block count */
++SC_ATOMIC_DECLARE(uint64_t, alert_pf_alerts);  /* Atomic counter, to hold alerts count */
++
++// Used for Interface IP change monitoring thread
++pthread_t alert_pf_ifmon_thread;
++
++// Read-only data to associate with Radix Tree entries
++int alertpf_user_data = 1;
++
++static int AlertPfInitIfaceList(AlertPfCtx *);
++static int AlertPfParseIfamAddress(struct sockaddr *, Address *);
++static void AlertPf_IflistMaint(Address *, AlertPfCtx *, u_char);
++static int AlertPf_parse_line(char *, FILE *);
++static int AlertPfLoadPassList(char *, AlertPfCtx *);
++static int AlertPfDeviceInit(void);
++static int AlertPfTableExists(char *);
++static int AlertPfBlock(AlertPfThread *, const Address *);
++
++void *AlertPfMonitorIfaceChanges(void *);
++
++/**
++ * This is a required function for freeing the
++ * 'user_data' element required for a Radix Tree
++ * entry.  Since we do not really need unique
++ * 'user_data' for an entry, we supply a dummy
++ * temp pointer when adding a Radix Tree entry.
++ * This function is called by the Radix Tree code
++ * when deleting a Tree entry to free the pointer.
++ */
++static void AlertPfFreeUserData(void *data)
++{
++   /* We have nothing to actually delete, so just return. */
++   return;
++}
++
++/**
++ * This opens the pf device and returns a file descriptor.
++ */
++static int AlertPfDeviceInit(void)
++{
++    return(open(PFDEVICE, O_RDWR));
++}
++
++/** \brief Verifies the supplied pf table exists
++ *  \param *tablename pointer to pf table name string
++ *  \retval -1 on error, 1 if table exists or 0 if not
++ */
++static int AlertPfTableExists(char *tablename)
++{
++    int i;
++    int dev;
++    struct pfioc_table io;
++    struct pfr_table *table_aux = NULL;
++	
++    memset(&io, 0x00, sizeof(struct pfioc_table));
++	
++    io.pfrio_buffer = table_aux;
++    io.pfrio_esize  = sizeof(struct pfr_table);
++    io.pfrio_size   = 0;
++
++    dev = AlertPfDeviceInit();
++    if (dev == -1) {
++        SCLogError(SC_ERR_SYSCALL, "Failed to open pf device.");
++        return -1;
++    }
++	
++    if(ioctl(dev, DIOCRGETTABLES, &io)) {  
++        SCLogError(SC_ERR_SYSCALL, "AlertPfTableExists() => ioctl() DIOCRGETTABLES: %s\n", strerror(errno));
++        return -1;
++    }
++	
++    table_aux = (struct pfr_table*)malloc(sizeof(struct pfr_table)*io.pfrio_size);
++	
++    if (table_aux == NULL) { 
++        SCLogError(SC_ERR_SYSCALL, "AlertPfTableExists() => malloc(): %s\n", strerror(errno));
++        return -1;
++    }
++	
++    io.pfrio_buffer = table_aux;
++    io.pfrio_esize = sizeof(struct pfr_table);
++	
++    if(ioctl(dev, DIOCRGETTABLES, &io)) {
++        SCLogError(SC_ERR_SYSCALL, "AlertPfTableExists() => ioctl() DIOCRGETTABLES: %s\n", strerror(errno));
++        return -1;
++    }
++
++    for(i=0; i < io.pfrio_size; i++) {
++        if (!strcmp(table_aux[i].pfrt_name, tablename))
++            return 1;	
++    }
++	
++    return 0;
++}
++
++/** \brief Inserts the passed IP address into the pf block table
++ *  \param *data pointer to AlertPfThread structure for current thread
++ *  \param *net_addr pointer to IP address to block
++ *  \retval -1 on error, 1 if IP blocked, 0 if already blocked
++ */
++static int AlertPfBlock(AlertPfThread *data, const Address *net_addr) 
++{ 
++    struct pfioc_table io; 
++    struct pfr_table table; 
++    struct pfr_addr addr; 
++
++    if (data->fd < 0)
++        data->fd = AlertPfDeviceInit();
++    if (data->fd == -1) {
++        SCLogError(SC_ERR_SYSCALL, "AlertPfDeviceInit() => no pf device\n");
++        return -1;
++    }
++
++    memset(&io,    0x00, sizeof(struct pfioc_table)); 
++    memset(&table, 0x00, sizeof(struct pfr_table)); 
++    memset(&addr,  0x00, sizeof(struct pfr_addr)); 
++            
++    strlcpy(table.pfrt_name, data->ctx->pftable, PF_TABLE_NAME_SIZE); 
++        
++    net_addr->family == AF_INET ? memcpy(&addr.pfra_ip4addr.s_addr, net_addr->addr_data32, sizeof(in_addr_t)) : memcpy(&addr.pfra_ip6addr, net_addr->addr_data8, sizeof(struct in6_addr));
++
++    addr.pfra_af  = net_addr->family; 
++    addr.pfra_net = net_addr->family == AF_INET ? 32 : 128;
++
++    io.pfrio_table  = table; 
++    io.pfrio_buffer = &addr; 
++    io.pfrio_esize  = sizeof(addr); 
++    io.pfrio_size   = 1; 
++        
++    if (ioctl(data->fd, DIOCRADDADDRS, &io)) {
++        SCLogError(SC_ERR_SYSCALL, "AlertPfBlock() => ioctl() DIOCRADDADDRS: %s\n", strerror(errno));
++        return (-1);
++    }
++ 
++    if (io.pfrio_nadd > 0) {
++        SC_ATOMIC_ADD(alert_pf_blocks, 1);
++    }
++
++    if (data->ctx->kill_state) {
++        struct pfioc_state_kill psk;
++
++        memset(&psk, 0, sizeof(psk));
++        memset(&psk.psk_src.addr.v.a.mask, 0xff, sizeof(psk.psk_src.addr.v.a.mask));
++        psk.psk_af = net_addr->family;
++        if (psk.psk_af == AF_INET)
++            memcpy(&psk.psk_src.addr.v.a.addr.v4.s_addr, net_addr->addr_data32, sizeof(in_addr_t));
++        else if (psk.psk_af == AF_INET6)
++            memcpy(&psk.psk_src.addr.v.a.addr.v6, net_addr->addr_data8, sizeof(struct in6_addr));
++        else {
++            SCLogError(SC_ERR_UNKNOWN_VALUE, "AlertPfBlock() unknown address family type: %d for source IP.", psk.psk_af);
++            return (-1);
++        }
++
++        /* Attempt to clear any open states for source IP */
++        if (ioctl(data->fd, DIOCKILLSTATES, &psk))
++            SCLogError(SC_ERR_SYSCALL, "AlertPfBlock() => ioctl() DIOCKILLSTATES: %s\n", strerror(errno));
++
++        memset(&psk, 0, sizeof(psk));
++        memset(&psk.psk_dst.addr.v.a.mask, 0xff, sizeof(psk.psk_dst.addr.v.a.mask));
++        psk.psk_af = net_addr->family;
++        if (psk.psk_af == AF_INET)
++            memcpy(&psk.psk_dst.addr.v.a.addr.v4.s_addr, net_addr->addr_data32, sizeof(in_addr_t));
++        else if (psk.psk_af == AF_INET6)
++            memcpy(&psk.psk_dst.addr.v.a.addr.v6, net_addr->addr_data8, sizeof(struct in6_addr));
++        else {
++            SCLogError(SC_ERR_UNKNOWN_VALUE, "AlertPfBlock() unknown address family type: %d for destination IP.", psk.psk_af);
++            return (-1);
++        }
++
++        /* Attempt to clear any open states for destination IP */
++        if (ioctl(data->fd, DIOCKILLSTATES, &psk))
++            SCLogError(SC_ERR_SYSCALL, "AlertPfBlock() => ioctl() DIOCKILLSTATES: %s\n", strerror(errno));
++    }
++
++    /* Return the number of effective IP blocks inserted */
++    return (io.pfrio_nadd); 
++}
++
++/** \brief Load and parse a single line of text from Pass List file
++ *  \param buf buffer of length WLMAX to receive a line of text from Pass List file
++ *  \param *wfile FILE pointer to open Pass List text file
++ *  \retval buf[] filled with next line of text from Pass List file
++ *  \retval 0 on EOF, 1 if success or -1 if line exceed WLMAX length
++ */
++static int AlertPf_parse_line(char buf[WLMAX], FILE* wfile)
++{
++    static char     next_ch = '\n';
++    int             i = 0;
++
++    if (feof(wfile))
++        return (0);
++
++    do {
++        next_ch = fgetc(wfile);
++        if (i < WLMAX)
++            buf[i++] = next_ch;
++    } while (!feof(wfile) && next_ch != '\n');
++
++    if (i >= WLMAX)
++        return (-1);
++
++    buf[--i] = '\0';
++    return (1);
++}
++
++/** \brief Load and parse a Pass List text file and insert
++ *   the IP addresses and networks (in CIDR form) into a
++ *   Radix Tree for easy searching.
++ *  \param *plfile pointer to Pass List filename string
++ *  \param *ctx pointer to AlertPfCtx global data structure
++ *  \retval false (0) if error, true (-1) if success
++ */
++static int AlertPfLoadPassList(char *plfile, AlertPfCtx *ctx)
++{
++    FILE *wfile;
++    struct flock lock;
++    char cad[WLMAX];
++    int ret;
++    int count = 0;
++
++    /* If we do not have a valid Radix Tree, then exit. */
++    if (ctx->tree == NULL) {
++        SCLogWarning(SC_WARN_UNCOMMON, "alert-pf -> There is no valid Radix Tree to contain the Pass List IP data.");
++        return 0;
++    }
++
++    wfile = fopen(plfile, "r");
++    if (wfile == NULL) {
++        SCLogError(SC_ERR_FATAL, "alert-pf -> Unable to open Pass List file: %s", strerror(errno));
++        return (0);
++    }
++
++    memset(&lock, 0x00, sizeof(struct flock));
++    lock.l_type = F_RDLCK;
++    fcntl(fileno(wfile), F_SETLKW, &lock);
++
++    memset(cad, 0, WLMAX);
++    while((ret = AlertPf_parse_line(cad, wfile)) != 0) {
++        if (ret == 1 && strlen(cad) > 0) {
++            /* is it an IPv6 address? */
++            if (strchr(cad, ':') != NULL) {
++                if (SCRadixAddKeyIPV6String(cad, ctx->tree, (void *)&alertpf_user_data) == NULL) {
++                    SCLogInfo("alert-pf -> Invalid IP(%s) parameter provided in Pass List, skipping...", cad);
++                    continue;
++                }
++                count++;
++            }
++            else {
++                if (SCRadixAddKeyIPV4String(cad, ctx->tree, (void *)&alertpf_user_data) == NULL) {
++                    SCLogInfo("alert-pf -> Invalid IP(%s) parameter provided in Pass List, skipping...", cad);
++                    continue;
++                }
++                count++;
++            }
++        } else if (ret == -1)
++            SCLogInfo("alert-pf -> Error occurred parsing line(%s) in Pass List, skipping...", cad);
++    }
++
++    lock.l_type = F_UNLCK;
++    fcntl(fileno(wfile), F_SETLKW, &lock);
++    fclose(wfile);
++
++    if (count == 1)
++        SCLogInfo("alert-pf -> Pass List %s parsed: %d IP address loaded.", plfile, count);
++    else
++        SCLogInfo("alert-pf -> Pass List %s parsed: %d IP addresses loaded.", plfile, count);
++
++    return (-1);
++}
++
++/** \brief Grab all firewall interface addresses and insert
++ *   the IP addresses into a Radix Tree for easy searching.
++ *  \param *ctx pointer to AlertPfCtx global data structure
++ *  \retval false (0) if error, true (-1) if success
++ */
++static int AlertPfInitIfaceList(AlertPfCtx *ctx)
++{
++    struct ifaddrs *ifap, *ifa;
++    char tmp[46];
++
++    /* If we don't have a valid Radix Tree, then exit. */
++    if (ctx->tree == NULL)
++        return -1;
++
++    if (getifaddrs(&ifap) == 0) {
++        SCLogInfo("alert-pf -> Creating automatic firewall interface IP address Pass List.");
++        for (ifa = ifap; ifa != NULL; ifa = ifa->ifa_next) {
++            if (ifa->ifa_addr) {
++                switch (ifa->ifa_addr->sa_family) {
++                    case AF_INET:
++                        PrintInet(AF_INET, (const void *)&((struct sockaddr_in *)ifa->ifa_addr)->sin_addr.s_addr, tmp, sizeof(tmp));
++                        SCLogInfo("alert-pf -> adding firewall interface %s IPv4 address %s to automatic interface IP Pass List.", ifa->ifa_name, tmp);
++                        SCRadixAddKeyIPV4((uint8_t *)(&((struct sockaddr_in *)ifa->ifa_addr)->sin_addr.s_addr), ctx->tree, (void *)&alertpf_user_data);
++                    break;
++
++                    case AF_INET6:
++                        PrintInet(AF_INET6, (const void *)&((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr.s6_addr, tmp, sizeof(tmp));
++                        SCLogInfo("alert-pf -> adding firewall interface %s IPv6 address %s to automatic interface IP Pass List.", ifa->ifa_name, tmp);
++                        SCRadixAddKeyIPV6((uint8_t *)(&((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr.s6_addr), ctx->tree, (void *)&alertpf_user_data);
++                        break;
++
++                    default:
++                        continue;
++                }
++            }
++        }
++        freeifaddrs(ifap);
++        return -1;
++    }
++    else
++        return 0;
++}
++
++/** \brief Parse an if_addr RTM structure to grab the IP address
++ *   and write it into the passed Address structure.
++ *  \param *sa pointer to if_addr data sockaddr structure from Kernel routing message
++ *  \param *ip pointer to Address structure to receive IP address
++ *  \retval false (0) if error, true (-1) if success
++ */
++static int AlertPfParseIfamAddress(struct sockaddr *sa, Address *ip)
++{
++	if (sa == NULL) {
++		return 0;
++	}
++
++	switch (sa->sa_family) {
++		case AF_INET:
++			if (((struct sockaddr_in *)(void *)sa)->sin_addr.s_addr == INADDR_ANY) {
++				return 0;
++			}
++			ip->family = AF_INET;
++			memcpy(&ip->addr_data32, &((struct sockaddr_in *)(void *)sa)->sin_addr.s_addr, sizeof(ip->addr_data32));
++			return 1;
++
++		case AF_INET6:
++			if (IN6_IS_ADDR_UNSPECIFIED(&((struct sockaddr_in6 *)(void *)sa)->sin6_addr)) {
++				return 0;
++			}
++			ip->family = AF_INET6;
++			memcpy(&ip->addr_data8, &((struct sockaddr_in6 *)(void *)sa)->sin6_addr.s6_addr, sizeof(ip->addr_data8));
++			return 1;
++
++		default:
++			break;
++	}
++	return 0;
++}
++
++/** \brief Add/remove interface IP address from Radix tree
++ *  \param *ip pointer to Address structure containing IP address
++ *  \param *ctx pointer to AlertPfCtx global data structure
++ *  \param action value from Kernel Routing Message
++ */
++static void AlertPf_IflistMaint(Address *ip, AlertPfCtx *ctx, u_char action)
++{
++	char tmp[46];
++	void *user_data = NULL;
++
++	// Validate passed pointers
++	if (ip == NULL || ctx == NULL)
++		return;
++
++	// Validate Radix Tree exists
++	if (ctx->tree == NULL)
++		return;
++
++	switch (action) {
++		case RTM_NEWADDR:
++			// Check if new address already in list
++			if (ip->family == AF_INET) {
++				(void)SCRadixFindKeyIPV4ExactMatch((uint8_t *)&ip->addr_data32, ctx->tree, &user_data);
++				if (user_data == NULL) {
++					// Not already in list, so add it
++					SCRadixAddKeyIPV4((uint8_t *)&ip->addr_data32, ctx->tree, (void *)&alertpf_user_data);
++    					PrintInet(AF_INET, (const void *)&ip->addr_data32, tmp, sizeof(tmp));
++					SCLogInfo("alert-pf -> added address %s to automatic firewall interface IP Pass List.", tmp);
++				}
++			}
++			else if (ip->family == AF_INET6) {
++				(void)SCRadixFindKeyIPV6ExactMatch((uint8_t *)&ip->addr_data8, ctx->tree, &user_data);
++				if (user_data == NULL) {
++					// Not already in list, so add it
++					SCRadixAddKeyIPV6((uint8_t *)&ip->addr_data8, ctx->tree, (void *)&alertpf_user_data);
++    					PrintInet(AF_INET6, (const void *)&ip->addr_data8, tmp, sizeof(tmp));
++					SCLogInfo("alert-pf -> added address %s to automatic firewall interface IP Pass List.", tmp);
++				}
++			}
++			break;
++
++		case RTM_DELADDR:
++			// Delete the passed IP address only if it is in our IP List
++			if (ip->family == AF_INET) {
++				(void)SCRadixFindKeyIPV4ExactMatch((uint8_t *)&ip->addr_data32, ctx->tree, &user_data);
++				if (user_data != NULL) {
++					// In list, so delete it
++					SCRadixRemoveKeyIPV4((uint8_t *)&ip->addr_data32, ctx->tree);
++    					PrintInet(AF_INET, (const void *)&ip->addr_data32, tmp, sizeof(tmp));
++					SCLogInfo("alert-pf -> deleted address %s from automatic firewall interface IP Pass List.", tmp);
++				}
++			}
++			else if (ip->family == AF_INET6) {
++				(void)SCRadixFindKeyIPV6ExactMatch((uint8_t *)&ip->addr_data8, ctx->tree, &user_data);
++				if (user_data != NULL) {
++					// In list, so delete it
++					SCRadixRemoveKeyIPV6((uint8_t *)&ip->addr_data8, ctx->tree);
++    					PrintInet(AF_INET6, (const void *)&ip->addr_data8, tmp, sizeof(tmp));
++					SCLogInfo("alert-pf -> deleted address %s from automatic firewall interface IP Pass List.", tmp);
++				}
++			}
++			break;
++
++		default:
++			SCLogWarning(SC_WARN_UNCOMMON, "alert-pf -> AlertPf_IflistMaint() received unrecognized action parameter.");
++			return;
++	}
++	return;
++}
++
++/**
++ * This initializes the data for a new thread.
++ */
++TmEcode AlertPfThreadInit(ThreadVars *t, const void *initdata, void **data)
++{
++    AlertPfThread *apft;
++
++    if(initdata == NULL)
++    {
++        SCLogDebug("Error getting context for Alert-PF.  \"initdata\" argument NULL");
++        return TM_ECODE_FAILED;
++    }
++
++    apft = SCMalloc(sizeof(AlertPfThread));
++
++    if (unlikely(apft == NULL))
++        return TM_ECODE_FAILED;
++    memset(apft, 0, sizeof(AlertPfThread));
++
++    /* Use the Ouput Context */
++    apft->ctx = ((OutputCtx *)initdata)->data;
++
++    /* Open the pf device */
++    apft->fd = AlertPfDeviceInit();
++    if (apft->fd == -1) {
++        SCLogError(SC_ERR_SYSCALL, "Failed to open pf device, alert-pf module thread init failed.");
++        return TM_ECODE_FAILED;
++    }
++
++    *data = (void *)apft;
++    return TM_ECODE_OK;
++}
++
++/**
++ * This clears and releases the data for a thread.
++ */
++TmEcode AlertPfThreadDeinit(ThreadVars *t, void *data)
++{
++    AlertPfThread *apft = (AlertPfThread *)data;
++
++    if (apft == NULL) {
++        SCLogDebug("AlertPfThreadDeinit done (error)");
++        return TM_ECODE_FAILED;
++    }
++
++    /* Close the pf device */
++    close(apft->fd);
++
++    /* clear memory */
++    memset(apft, 0, sizeof(AlertPfThread));
++    SCFree(apft);
++
++    return TM_ECODE_OK;
++}
++
++/** \brief Print the pf alert module blocking stats.
++ *  \param *tv pointer to ThreadVars structure
++ *  \param *data pointer to AlertPfThread structure
++ */
++void AlertPfExitPrintStats(ThreadVars *tv, void *data)
++{
++    AlertPfThread *apft = (AlertPfThread *)data;
++    if (apft == NULL) {
++        return;
++    }
++
++    uint64_t blocks = SC_ATOMIC_GET(alert_pf_blocks);
++    uint64_t alerts = SC_ATOMIC_GET(alert_pf_alerts);
++    if (blocks == 1)
++        SCLogInfo("alert-pf output inserted %" PRIu64 " IP address block", blocks);
++    else
++        SCLogInfo("alert-pf output inserted %" PRIu64 " IP address blocks", blocks);
++
++    if (alerts == 1)
++        SCLogInfo("alert-pf output processed %" PRIu64 " alert", alerts);
++    else
++        SCLogInfo("alert-pf output processed %" PRIu64 " alerts", alerts);
++
++    SC_ATOMIC_DESTROY(alert_pf_blocks);
++    SC_ATOMIC_DESTROY(alert_pf_alerts);
++}
++
++/** \brief Thread for monitoring firewall interface IP address changes.
++ *  \param *args pointer to global AlertPfCtx structure
++ */
++void *AlertPfMonitorIfaceChanges(void *args)
++{
++	int sock = -1;
++	int fib;
++	size_t fib_len = sizeof(fib);
++	ssize_t len;
++	char msg[MAX_RTMSG_SIZE];
++	char ifname[IFNAMSIZ];
++	char *p;
++	Address addr;
++	struct rt_msghdr *rtm;
++	struct ifa_msghdr *ifam;
++	struct sockaddr *sa;
++
++	AlertPfCtx *ctx = args;
++
++	sock = socket(PF_ROUTE, SOCK_RAW, 0);
++	if (sock == -1) {
++		SCLogWarning(SC_WARN_UNCOMMON, "Failed to create routing messages socket(PF_ROUTE): %s.  Dynamic IP changes on firewall interfaces will not be monitored!", strerror(errno));
++		return (NULL);
++	}
++
++	if (sysctlbyname("net.my_fibnum", &fib, &fib_len, NULL, 0) < 0)
++	{  
++		SCLogWarning(SC_WARN_UNCOMMON, "alert-pf -> Failed to obtain active route table FIB so using all FIBs by default.");
++		fib = RT_ALL_FIBS;
++	}
++
++	SCLogInfo("alert-pf -> Firewall interface IP address change notification monitoring thread started.");
++
++	setsockopt(sock, SOL_SOCKET, SO_SETFIB, (void *)&fib, sizeof(fib));
++
++	// Loop forever receiving and handling kernel RTM messages
++	for (;;) {
++
++		len = read(sock, &msg, sizeof(msg));
++		if (len == -1)
++			continue;
++
++		rtm = (struct rt_msghdr *)msg;
++		if (rtm->rtm_version != RTM_VERSION)
++			continue;
++
++		ifam = (struct ifa_msghdr *)msg;
++
++		switch (rtm->rtm_type) {
++			case RTM_NEWADDR:
++			case RTM_DELADDR:
++				// Make sure all address info we need is present in the message
++				// by checking the RTAX bit mask.
++				if (ifam->ifam_addrs != 0xb4)
++					continue;
++				break;
++
++			default:
++				continue;
++		}
++
++		// Get the interface address that is changing (should be third sockaddr structure in msg)
++		p = (char *)((char *)ifam + sizeof(struct ifa_msghdr));
++		p += SA_SIZE((struct sockaddr *)p);
++		p += SA_SIZE((struct sockaddr *)p);
++		sa = (struct sockaddr *)p;
++
++		// Make sure we have a valid non-zero IP address in that sockaddr structure
++		if (!AlertPfParseIfamAddress(sa, &addr)) {
++			SCLogWarning(SC_WARN_UNCOMMON, "alert-pf -> Firewall interface IP change notification thread received an invalid IP address via kernel routing message socket.");
++			continue;
++		}
++
++		// OK, now either delete it from or add it to the interface IP list
++		SCLogInfo("alert-pf -> Received notification of IP address change on interface %s.", if_indextoname(ifam->ifam_index, ifname));
++		AlertPf_IflistMaint(&addr, ctx, ifam->ifam_type);
++	}
++
++	return (NULL);
++}
++
++/** \brief Initialize the pf alert blocking module.
++ *  \param *conf pointer to module's ConfNode structure
++ * \return A newly allocated AlertPfCtx structure, or NULL
++ */
++OutputInitResult AlertPfInitCtx(ConfNode *conf)
++{
++    AlertPfCtx *ctx;
++    OutputInitResult result = { NULL, false };
++    LogFileCtx *logfile_ctx;
++    const char *pass_list_name;
++    const char *kill_state;
++    const char *block_ip;
++    const char *block_drops;
++    const char *pf_table;
++    OutputCtx *output_ctx;
++
++    pass_list_name = ConfNodeLookupChildValue(conf, "pass-list");
++    if (pass_list_name == NULL) {
++        SCLogWarning(SC_WARN_UNCOMMON, "alert-pf: No Pass List was specified.");
++    }
++
++    kill_state = ConfNodeLookupChildValue(conf, "kill-state");
++    block_ip = ConfNodeLookupChildValue(conf, "block-ip");
++    pf_table = ConfNodeLookupChildValue(conf, "pf-table");
++    block_drops = ConfNodeLookupChildValue(conf, "block-drops-only");
++
++    if (unlikely(pf_table == NULL)) {
++        SCLogError(SC_ERR_INVALID_ARGUMENT, "alert-pf: No PF table name specified, module init failed.");
++        exit(EXIT_FAILURE);
++    }
++
++    ctx = SCMalloc(sizeof(AlertPfCtx));
++    if (unlikely(ctx == NULL)) {
++        SCLogError(SC_ERR_MEM_ALLOC, "alert-pf: Unable to allocate memory for AlertPfCtx, module init failed.");
++        exit(EXIT_FAILURE);
++    }
++
++    /* Create a Radix Tree to hold PASS LIST IP addresses */
++    ctx->tree = SCRadixCreateRadixTree(AlertPfFreeUserData, NULL);
++    if (unlikely(ctx->tree == NULL))
++        SCLogWarning(SC_ERR_RADIX_TREE_GENERIC, "alert-pf: Failed to create Radix Tree for IP address lookups.  Pass List functionality is auto-disabled!");
++
++    /* Grab all firewall interface IP addresses and save in Radix Tree */
++    if (!AlertPfInitIfaceList(ctx))
++        SCLogWarning(SC_ERR_SYSCALL, "alert-pf: Failed to create the list of firewall interface addresses for auto-whitelisting.");
++
++    /* Create a LogFileCtx for the block.log output */
++    logfile_ctx = LogFileNewCtx();
++    if (logfile_ctx == NULL) {
++        SCLogDebug("AlertPfInitCtx: Could not create new LogFileCtx");
++        SCFree(ctx);
++        return result;
++    }
++
++    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME, 0) < 0) {
++        LogFileFreeCtx(logfile_ctx);
++        SCLogDebug("AlertPfInitCtx: Could not create new LogFileCtx");
++        SCFree(ctx);
++        return result;
++    }
++
++    ctx->file_ctx = logfile_ctx;
++
++    /* Parse the remaining arguments for this plugin from */
++    /* the suricata.yaml conf file.                       */
++    ctx->kill_state = 1;
++    if (kill_state == NULL) {
++        SCLogWarning(SC_ERR_INVALID_ARGUMENT, "alert-pf: kill-state parameter not recognized, defaulting to 'yes'.");
++    }
++    if (kill_state && ConfValIsFalse(kill_state))
++        ctx->kill_state = 0;
++
++    ctx->block_drops = 0;
++    if (block_drops == NULL) {
++        SCLogWarning(SC_ERR_INVALID_ARGUMENT, "alert-pf: block-drops-only parameter not recognized, defaulting to 'no'.");
++    }
++    if (block_drops && ConfValIsTrue(block_drops))
++        ctx->block_drops = 1;
++
++    if (block_ip == NULL) {
++        SCLogWarning(SC_ERR_INVALID_ARGUMENT, "alert-pf: block-ip parameter not recognized, defaulting to 'both'.");
++    }
++    if (block_ip && !strncasecmp("src", block_ip, strlen("src")))
++        ctx->block_ip = BLOCK_SRC;
++    else if (block_ip && !strncasecmp("dst", block_ip, strlen("dst")))
++        ctx->block_ip = BLOCK_DST;
++    else
++        ctx->block_ip = BLOCK_BOTH;
++
++    if (pass_list_name) {
++	if (!AlertPfLoadPassList(SCStrdup(pass_list_name), ctx)) {
++            SCLogWarning(SC_WARN_UNCOMMON, "alert-pf: supplied Pass List file was not processed!");
++        }
++    }
++
++    ctx->pftable = SCStrdup(pf_table);
++
++    /* TODO -- add validation of pf table */
++    if (AlertPfTableExists(ctx->pftable) != 1) {
++        LogFileFreeCtx(logfile_ctx);
++        SCFree(ctx);
++        SCLogError(SC_ERR_INVALID_ARGUMENT, "alert-pf: Could not validate pf table: %s, module init failed.", pf_table);
++        exit(EXIT_FAILURE);
++    }
++
++    output_ctx = SCCalloc(1, sizeof(OutputCtx));
++    if (unlikely(output_ctx == NULL)) {
++        LogFileFreeCtx(logfile_ctx);
++        SCFree(ctx);
++        SCLogError(SC_ERR_MEM_ALLOC, "alert-pf: Unable to allocate memory for OutputCtx, module init failed.");
++        exit(EXIT_FAILURE);
++    }
++    output_ctx->data = ctx;
++    output_ctx->DeInit = AlertPfDeInitCtx;
++    SC_ATOMIC_INIT(alert_pf_blocks);
++    SC_ATOMIC_INIT(alert_pf_alerts);
++
++    const char *block;
++    switch (ctx->block_ip) {
++        case BLOCK_SRC:
++            block = "src";
++            break;
++
++        case BLOCK_DST:
++            block = "dst";
++            break;
++
++        default:
++            block = "both";
++    }
++
++    /* Set defaults for any missing conf arguments */
++    const char *state = ctx->kill_state ? "on" : "off";
++    const char *drops = ctx->block_drops ? "on" : "off";
++
++    if (pthread_create(&alert_pf_ifmon_thread, NULL, AlertPfMonitorIfaceChanges, ctx))
++        SCLogError(SC_ERR_SYSCALL, "Failed to create Interface IP Address change monitoring thread for 'alert-pf' output plugin.");
++    else
++        SCLogInfo("alert-pf -> Created firewall interface IP change monitor thread for auto-whitelisting of firewall interface IP addresses.");
++
++    SCLogInfo("alert-pf output initialized, pf-table=%s  block-ip=%s  kill-state=%s  block-drops-only=%s", ctx->pftable, block, state, drops);
++
++    result.ctx = output_ctx;
++    result.ok = true;
++    return result;
++}
++
++/** \brief This releases the memory used by the global
++ * AlertPfCtx data structure.
++ */
++static void AlertPfDeInitCtx(OutputCtx *output_ctx)
++{
++    AlertPfCtx *ctx = (AlertPfCtx *)output_ctx->data;
++    LogFileFreeCtx(ctx->file_ctx);
++    SCRadixReleaseRadixTree(ctx->tree);
++    SCFree(ctx);
++    SCFree(output_ctx);
++}
++
++/** \brief This processes an IPv4 alert and inserts the appropriate
++ * block if the IP address is not on the Pass List.
++ */
++TmEcode AlertPfIPv4(ThreadVars *tv, void *data, const Packet *p)
++{
++    AlertPfThread *apft = (AlertPfThread *)data;
++    int i;
++    char proto[16] = "";
++    char timebuf[64];
++    char srcip[16], dstip[16];
++    void *user_data = NULL;
++
++    if (p->alerts.cnt == 0)
++        return TM_ECODE_OK;
++
++    CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
++    PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), srcip, sizeof(srcip));
++    PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), dstip, sizeof(dstip));
++
++    if (SCProtoNameValid(IPV4_GET_IPPROTO(p)) == TRUE) {
++        strlcpy(proto, known_proto[IPV4_GET_IPPROTO(p)], sizeof(proto));
++    } else {
++        snprintf(proto, sizeof(proto), "PROTO:%03" PRIu32, IPV4_GET_IPPROTO(p));
++    }
++
++    for (i = 0; i < p->alerts.cnt; i++) {
++        const PacketAlert *pa = &p->alerts.alerts[i];
++        if (unlikely(pa->s == NULL)) {
++            continue;
++        }
++        SC_ATOMIC_ADD(alert_pf_alerts, 1);
++
++	/* If blocking only DROP rules and alert is not from a DROP rule, ignore it */
++	if (apft->ctx->block_drops && !(pa->action & ACTION_DROP)) {
++	    continue;
++	}
++
++        switch (apft->ctx->block_ip) {
++
++            case BLOCK_BOTH:
++                /* Block only if IP is not in Pass List */
++                (void)SCRadixFindKeyIPV4BestMatch((uint8_t *)&GET_IPV4_SRC_ADDR_U32(p), apft->ctx->tree, &user_data);
++                if (user_data == NULL) {
++                    if (AlertPfBlock(apft, &p->src) > 0) {
++                        SCMutexLock(&apft->ctx->file_ctx->fp_mutex);
++                        fprintf(apft->ctx->file_ctx->fp, "%s  [Block Src] [**] [%" PRIu32 ":%" PRIu32 ":%"
++                                PRIu32 "] %s [**] [Classification: %s] [Priority: %"PRIu32"]"
++                                " {%s} %s:%" PRIu32 "\n", timebuf, pa->s->gid,
++                                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
++                                proto, srcip, p->sp);
++                        fflush(apft->ctx->file_ctx->fp);
++                        SCMutexUnlock(&apft->ctx->file_ctx->fp_mutex);
++                    }
++                }
++                user_data = NULL;
++                (void)SCRadixFindKeyIPV4BestMatch((uint8_t *)&GET_IPV4_DST_ADDR_U32(p), apft->ctx->tree, &user_data);
++                if (user_data == NULL) {
++                    if (AlertPfBlock(apft, &p->dst) > 0) {
++                        SCMutexLock(&apft->ctx->file_ctx->fp_mutex);
++                        fprintf(apft->ctx->file_ctx->fp, "%s  [Block Dst] [**] [%" PRIu32 ":%" PRIu32 ":%"
++                                PRIu32 "] %s [**] [Classification: %s] [Priority: %"PRIu32"]"
++                                " {%s} %s:%" PRIu32 "\n", timebuf, pa->s->gid,
++                                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
++                                proto, dstip, p->dp);
++                        fflush(apft->ctx->file_ctx->fp);
++                        SCMutexUnlock(&apft->ctx->file_ctx->fp_mutex);
++                    }
++                }
++                break;
++
++            case BLOCK_SRC:
++                /* Block SRC only if IP is not in Pass List */
++                (void)SCRadixFindKeyIPV4BestMatch((uint8_t *)&GET_IPV4_SRC_ADDR_U32(p), apft->ctx->tree, &user_data);
++                if (user_data == NULL) {
++                    if (AlertPfBlock(apft, &p->src) > 0) {
++                        SCMutexLock(&apft->ctx->file_ctx->fp_mutex);
++                        fprintf(apft->ctx->file_ctx->fp, "%s  [Block Src] [**] [%" PRIu32 ":%" PRIu32 ":%"
++                                PRIu32 "] %s [**] [Classification: %s] [Priority: %"PRIu32"]"
++                                " {%s} %s:%" PRIu32 "\n", timebuf, pa->s->gid,
++                                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
++                                proto, srcip, p->sp);
++                        fflush(apft->ctx->file_ctx->fp);
++                        SCMutexUnlock(&apft->ctx->file_ctx->fp_mutex);
++                    }
++                }
++                break;
++
++            case BLOCK_DST:
++                /* Block DST only if IP is not in Pass List */
++                (void)SCRadixFindKeyIPV4BestMatch((uint8_t *)&GET_IPV4_DST_ADDR_U32(p), apft->ctx->tree, &user_data);
++                if (user_data == NULL) {
++                    if (AlertPfBlock(apft, &p->dst) > 0) {
++                        SCMutexLock(&apft->ctx->file_ctx->fp_mutex);
++                        fprintf(apft->ctx->file_ctx->fp, "%s  [Block Dst] [**] [%" PRIu32 ":%" PRIu32 ":%"
++                                PRIu32 "] %s [**] [Classification: %s] [Priority: %"PRIu32"]"
++                                " {%s} %s:%" PRIu32 "\n", timebuf, pa->s->gid,
++                                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
++                                proto, dstip, p->dp);
++                        fflush(apft->ctx->file_ctx->fp);
++                        SCMutexUnlock(&apft->ctx->file_ctx->fp_mutex);
++                    }
++                }
++        }
++
++        /* Once we block the first alert for this packet, we're done */
++        return TM_ECODE_OK;
++    }
++
++    return TM_ECODE_OK;
++}
++
++/** \brief This processes an IPv6 alert and inserts the appropriate
++ * block if the IP address is not on the Pass List.
++ */
++TmEcode AlertPfIPv6(ThreadVars *tv, void *data, const Packet *p)
++{
++    AlertPfThread *apft = (AlertPfThread *)data;
++    int i;
++    char proto[16] = "";
++    char timebuf[64];
++    char srcip[46], dstip[46];
++    void *user_data = NULL;
++
++    if (p->alerts.cnt == 0)
++        return TM_ECODE_OK;
++
++    CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
++    PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), srcip, sizeof(srcip));
++    PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), dstip, sizeof(dstip));
++
++    if (SCProtoNameValid(IPV6_GET_L4PROTO(p)) == TRUE) {
++        strlcpy(proto, known_proto[IPV6_GET_L4PROTO(p)], sizeof(proto));
++    } else {
++        snprintf(proto, sizeof(proto), "PROTO:%03" PRIu32, IPV6_GET_L4PROTO(p));
++    }
++
++    for (i = 0; i < p->alerts.cnt; i++) {
++        const PacketAlert *pa = &p->alerts.alerts[i];
++        if (unlikely(pa->s == NULL)) {
++            continue;
++        }
++        SC_ATOMIC_ADD(alert_pf_alerts, 1);
++
++        /* If blocking only DROP rules and alert is not from a DROP rule, ignore it */
++        if (apft->ctx->block_drops && !(pa->action & ACTION_DROP)) {
++            continue;
++        }
++
++        switch (apft->ctx->block_ip) {
++
++    	    case BLOCK_BOTH:
++                /* Block only if IP is not in Pass List */
++                (void)SCRadixFindKeyIPV6BestMatch((uint8_t *)&GET_IPV6_SRC_ADDR(p), apft->ctx->tree, &user_data);
++                if (user_data == NULL) {
++                    if (AlertPfBlock(apft, &p->src) > 0) {
++                        SCMutexLock(&apft->ctx->file_ctx->fp_mutex);
++                        fprintf(apft->ctx->file_ctx->fp, "%s  [Block Src] [**] [%" PRIu32 ":%" PRIu32 ":%"
++                                PRIu32 "] %s [**] [Classification: %s] [Priority: %"PRIu32"]"
++                                " {%s} %s:%" PRIu32 "\n", timebuf, pa->s->gid,
++                                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
++                                proto, srcip, p->sp);
++                        fflush(apft->ctx->file_ctx->fp);
++                        SCMutexUnlock(&apft->ctx->file_ctx->fp_mutex);
++                    }
++                }
++                user_data = NULL;
++                (void)SCRadixFindKeyIPV6BestMatch((uint8_t *)&GET_IPV6_DST_ADDR(p), apft->ctx->tree, &user_data);
++                if (user_data == NULL) {
++                    if (AlertPfBlock(apft, &p->dst) > 0) {
++                        SCMutexLock(&apft->ctx->file_ctx->fp_mutex);
++                        fprintf(apft->ctx->file_ctx->fp, "%s  [Block Dst] [**] [%" PRIu32 ":%" PRIu32 ":%"
++                                PRIu32 "] %s [**] [Classification: %s] [Priority: %"PRIu32"]"
++                                " {%s} %s:%" PRIu32 "\n", timebuf, pa->s->gid,
++                                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
++                                proto, dstip, p->dp);
++                        fflush(apft->ctx->file_ctx->fp);
++                        SCMutexUnlock(&apft->ctx->file_ctx->fp_mutex);
++                    }
++                }
++	        break;
++
++	    case BLOCK_SRC:
++                /* Block SRC only if IP is not in Pass List */
++                (void)SCRadixFindKeyIPV6BestMatch((uint8_t *)&GET_IPV6_SRC_ADDR(p), apft->ctx->tree, &user_data);
++                if (user_data == NULL) {
++                    if (AlertPfBlock(apft, &p->src) > 0) {
++                        SCMutexLock(&apft->ctx->file_ctx->fp_mutex);
++                        fprintf(apft->ctx->file_ctx->fp, "%s  [Block Src] [**] [%" PRIu32 ":%" PRIu32 ":%"
++                                PRIu32 "] %s [**] [Classification: %s] [Priority: %"PRIu32"]"
++                                " {%s} %s:%" PRIu32 "\n", timebuf, pa->s->gid,
++                                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
++                                proto, srcip, p->sp);
++                        fflush(apft->ctx->file_ctx->fp);
++                        SCMutexUnlock(&apft->ctx->file_ctx->fp_mutex);
++                    }
++                }
++	        break;
++
++	    case BLOCK_DST:
++                /* Block DST only if IP is not in Pass List */
++                (void)SCRadixFindKeyIPV6BestMatch((uint8_t *)&GET_IPV6_DST_ADDR(p), apft->ctx->tree, &user_data);
++                if (user_data == NULL) {
++                    if (AlertPfBlock(apft, &p->dst) > 0) {
++                        SCMutexLock(&apft->ctx->file_ctx->fp_mutex);
++                        fprintf(apft->ctx->file_ctx->fp, "%s  [Block Dst] [**] [%" PRIu32 ":%" PRIu32 ":%"
++                                PRIu32 "] %s [**] [Classification: %s] [Priority: %"PRIu32"]"
++                                " {%s} %s:%" PRIu32 "\n", timebuf, pa->s->gid,
++                                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
++                                proto, dstip, p->dp);
++                        fflush(apft->ctx->file_ctx->fp);
++                        SCMutexUnlock(&apft->ctx->file_ctx->fp_mutex);
++                    }
++                }
++        }
++        /* Once we block the first alert for this packet, we're done */
++        return TM_ECODE_OK;
++    }
++
++    return TM_ECODE_OK;
++}
++
++/** \brief This processes an IP alert and routes it to the
++ * appropriate handler.
++ */
++int AlertPf (ThreadVars *tv, void *data, const Packet *p)
++{
++    if (PKT_IS_IPV4(p)) {
++        return AlertPfIPv4(tv, data, p);
++    } else if (PKT_IS_IPV6(p)) {
++        return AlertPfIPv6(tv, data, p);
++    }
++
++    return TM_ECODE_OK;
++}
++
+diff -ruN ./suricata-5.0.1.orig/src/alert-pf.h ./suricata-5.0.1/src/alert-pf.h
+--- ./suricata-5.0.1.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
++++ ./src/alert-pf.h	2019-06-05 14:27:11.000000000 -0400
+@@ -0,0 +1,59 @@
++/* Copyright (C) 2007-2019 Open Information Security Foundation
++ *
++ * You can copy, redistribute or modify this Program under the terms of
++ * the GNU General Public License version 2 as published by the Free
++ * Software Foundation.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * version 2 along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
++ * 02110-1301, USA.
++ *
++ * Portions of this module are based on previous works of the following:
++ *
++ * Copyright (c) 2019  Bill Meeks
++ * Copyright (c) 2012  Ermal Luci
++ * Copyright (c) 2006  Antonio Benojar <zz.stalker@gmail.com>
++ * Copyright (c) 2005  Antonio Benojar <zz.stalker@gmail.com>
++ * Copyright (c) 2003, 2004 Armin Wolfermann:
++ *
++ * All rights reserved.
++ */
++
++/**
++ * \file
++ *
++ * \author Bill Meeks <billmeeks8@gmail.com>
++ */
++
++#ifndef __ALERT_PF_H__
++#define __ALERT_PF_H__
++
++/**
++ * define these macros since we need them in <net/pfvar.h>
++ * and Suricata by default uses it's own customized
++ * <queue.h> file that omits these particular macros.
++ */
++#define SLIST_HEAD(name, type)						\
++struct name {								\
++	struct type *slh_first;	/* first element */			\
++}
++
++#define	SLIST_HEAD_INITIALIZER(head)					\
++	{ NULL }
++
++#define SLIST_ENTRY(type)						\
++struct {								\
++	struct type *sle_next;	/* next element */			\
++}
++
++void AlertPfRegister (void);
++OutputInitResult AlertPfInitCtx(ConfNode *);
++
++#endif /* __ALERT_PF_H__ */
++
+diff -ruN ./suricata-5.0.1.orig/src/output.c ./suricata-5.0.1/src/output.c
+--- ./suricata-5.0.1.orig/src/output.c	2019-12-13 07:14:51.000000000 -0500
++++ ./src/output.c	2019-12-28 20:40:42.000000000 -0500
+@@ -43,6 +43,7 @@
+ #include "alert-fastlog.h"
+ #include "alert-unified2-alert.h"
+ #include "alert-debuglog.h"
++#include "alert-pf.h"
+ #include "alert-prelude.h"
+ #include "alert-syslog.h"
+ #include "output-json-alert.h"
+@@ -1048,6 +1049,8 @@
+     AlertFastLogRegister();
+     /* debug log */
+     AlertDebugLogRegister();
++    /* alerf pf */
++    AlertPfRegister();
+     /* prelue log */
+     AlertPreludeRegister();
+     /* syslog log */
+diff -ruN ./suricata-5.0.1.orig/src/suricata-common.h ./suricata-5.0.1/src/suricata-common.h
+--- ./suricata-5.0.1.orig/src/suricata-common.h	2019-12-13 07:14:51.000000000 -0500
++++ ./src/suricata-common.h	2019-12-28 20:42:17.000000000 -0500
+@@ -461,6 +461,7 @@
+     LOGGER_PRELUDE,
+     LOGGER_PCAP,
+     LOGGER_JSON_METADATA,
++    LOGGER_ALERT_PF,
+     LOGGER_SIZE,
+ } LoggerId;
+ 

--- a/security/suricata/files/suricata.in
+++ b/security/suricata/files/suricata.in
@@ -1,5 +1,5 @@
 #!/bin/sh
-# $FreeBSD$
+# $FreeBSD: head/security/suricata/files/suricata.in 454649 2017-11-21 18:55:28Z zeising $
 
 # PROVIDE: suricata
 # REQUIRE: DAEMON

--- a/security/suricata/files/suricata.in
+++ b/security/suricata/files/suricata.in
@@ -1,5 +1,5 @@
 #!/bin/sh
-# $FreeBSD:$
+# $FreeBSD$
 
 # PROVIDE: suricata
 # REQUIRE: DAEMON

--- a/security/suricata/files/suricata.in
+++ b/security/suricata/files/suricata.in
@@ -1,5 +1,5 @@
 #!/bin/sh
-# $FreeBSD: head/security/suricata/files/suricata.in 454649 2017-11-21 18:55:28Z zeising $
+# $FreeBSD:$
 
 # PROVIDE: suricata
 # REQUIRE: DAEMON


### PR DESCRIPTION
### Suricata-5.0.1
This updates the Suricata binary package to v5.0.1 for use on AMD64 architectures. The Release Notes for v5.0.1 can be viewed [here](https://suricata-ids.org/2019/12/13/suricata-5-0-1-released/).