### PR TITLE
Remove conditional assignments in pfSense-repo makefile

### DIFF
--- a/sysutils/pfSense-repo/Makefile
+++ b/sysutils/pfSense-repo/Makefile
@@ -25,10 +25,10 @@ DATADIR=	${PREFIX}/share/pfSense
 
 .include <bsd.port.pre.mk>
 
-PFSENSE_REPOS?=	pfSense-repo pfSense-repo-devel
-PFSENSE_REPOS_${ARCH}?=	${PFSENSE_REPOS}
-PFSENSE_DEFAULT_REPO?=	pfSense-repo-devel
-PFSENSE_DEFAULT_REPO_${ARCH}?=	${PFSENSE_DEFAULT_REPO}
+PFSENSE_REPOS=	pfSense-repo pfSense-repo-devel
+PFSENSE_REPOS_${ARCH}=	${PFSENSE_REPOS}
+PFSENSE_DEFAULT_REPO=	pfSense-repo-devel
+PFSENSE_DEFAULT_REPO_${ARCH}=	${PFSENSE_DEFAULT_REPO}
 DEFAULT_REPO=	${DATADIR}/pkg/repos/${PFSENSE_DEFAULT_REPO_${ARCH}}.conf
 TMP_PLIST_FILES=${PFSENSE_REPOS_${ARCH}:C/$/.conf/} \
 		${PFSENSE_REPOS_${ARCH}:C/$/.descr/} \


### PR DESCRIPTION
In non-pfsense builds, these four PFSENSE variables are already defined, so renaming logic in builder_common.sh does not get applied.  Changing "?=" to "=" allows builder_common.sh logic to work as expected.

See 2.5 Development Snapshot "Minor issues with non-pfSense rename logic"  discussion and redmine #10161