### PR TITLE
pfSense-pkg-suricata-4.1.6_1 - Support Suricata 4.1.6, fix GeoLite2 DB and others.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	4.1.6
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata4>=4.1.5:security/suricata4 \
+RUN_DEPENDS=	suricata4>=4.1.6:security/suricata4 \
 		barnyard2:security/barnyard2
 
 NO_BUILD=	yes

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -292,10 +292,17 @@ if ($suricatacfg['enable_file_store'] == 'on') {
 	if (!file_exists("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/file.waldo"))
 		@file_put_contents("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/file.waldo", "");
 	$file_store_waldo = "waldo: file.waldo";
+	if (!empty($suricatacfg['file_store_logdir'])) {
+		$file_store_logdir = base64_decode($suricatacfg['file_store_logdir']);
+	}
+	else {
+		$file_store_logdir = "filestore";
+	}
 }
 else {
 	$file_store_enabled = "no";
 	$file_store_waldo = "#waldo: file.waldo";
+	$file_store_logdir = "filestore";
 }
 
 if ($suricatacfg['enable_pcap_log'] == 'on')

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2019 Bill Meeks
+ * Copyright (C) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,12 +44,12 @@ foreach ($config_files as $file) {
 
 // Set HOME_NET and EXTERNAL_NET for the interface
 $home_net_list = suricata_build_list($suricatacfg, $suricatacfg['homelistname']);
-$home_net = implode(",", $home_net_list);
+$home_net = implode(", ", $home_net_list);
 $home_net = trim($home_net);
 $external_net = "";
 if (!empty($suricatacfg['externallistname']) && $suricatacfg['externallistname'] != 'default') {
 	$external_net_list = suricata_build_list($suricatacfg, $suricatacfg['externallistname'], false, true);
-	$external_net = implode(",", $external_net_list);
+	$external_net = implode(", ", $external_net_list);
 	$external_net = "[" . trim($external_net) . "]";
 }
 else {
@@ -78,14 +78,14 @@ $suricata_servers = array (
 	"sql_servers" => "\$HOME_NET", "telnet_servers" => "\$HOME_NET", "dnp3_server" => "\$HOME_NET",
 	"dnp3_client" => "\$HOME_NET", "modbus_server" => "\$HOME_NET", "modbus_client" => "\$HOME_NET",
 	"enip_server" => "\$HOME_NET", "enip_client" => "\$HOME_NET", "ftp_servers" => "\$HOME_NET", "ssh_servers" => "\$HOME_NET", 
-	"aim_servers" => "64.12.24.0/23,64.12.28.0/23,64.12.161.0/24,64.12.163.0/24,64.12.200.0/24,205.188.3.0/24,205.188.5.0/24,205.188.7.0/24,205.188.9.0/24,205.188.153.0/24,205.188.179.0/24,205.188.248.0/24", 
+	"aim_servers" => "64.12.24.0/23, 64.12.28.0/23, 64.12.161.0/24, 64.12.163.0/24, 64.12.200.0/24, 205.188.3.0/24, 205.188.5.0/24, 205.188.7.0/24, 205.188.9.0/24, 205.188.153.0/24, 205.188.179.0/24, 205.188.248.0/24", 
 	"sip_servers" => "\$HOME_NET"
 );
 $addr_vars = "";
 	foreach ($suricata_servers as $alias => $avalue) {
 		if (!empty($suricatacfg["def_{$alias}"]) && is_alias($suricatacfg["def_{$alias}"])) {
 			$avalue = trim(filter_expand_alias($suricatacfg["def_{$alias}"]));
-			$avalue = preg_replace('/\s+/', ',', trim($avalue));
+			$avalue = preg_replace('/\s+/', ', ', trim($avalue));
 		}
 		$addr_vars .= "    " . strtoupper($alias) . ": \"{$avalue}\"\n";
 	}
@@ -101,14 +101,14 @@ $suricata_ports = array(
 	"ssh_ports" => $ssh_port, 
 	"shellcode_ports" => "!80", 
 	"DNP3_PORTS" => "20000", 
-	"file_data_ports" => "\$HTTP_PORTS,110,143", 
-	"sip_ports" => "5060,5061,5600"
+	"file_data_ports" => "\$HTTP_PORTS, 110, 143", 
+	"sip_ports" => "5060, 5061, 5600"
 );
 $port_vars = "";
 	foreach ($suricata_ports as $alias => $avalue) {
 		if (!empty($suricatacfg["def_{$alias}"]) && is_alias($suricatacfg["def_{$alias}"])) {
 			$avalue = trim(filter_expand_alias($suricatacfg["def_{$alias}"]));
-			$avalue = preg_replace('/\s+/', ',', trim($avalue));
+			$avalue = preg_replace('/\s+/', ', ', trim($avalue));
 		}
 		$port_vars .= "    " . strtoupper($alias) . ": \"{$avalue}\"\n";
 	}

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2019-2020 Rubicon Communications, LLC (Netgate)
- * Copyright (C) 2019 Bill Meeks
+ * Copyright (C) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -369,6 +369,20 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 	}    
 	if (!isset($pconfig['eve_log_drop'])) {
 		$pconfig['eve_log_drop'] = "on";
+		$updated_cfg = true;
+	}
+
+	if (!isset($pconfig['eve_log_http_extended_headers'])) {
+		$pconfig['eve_log_http_extended_headers'] = "accept, accept-charset, accept-datetime, accept-encoding, accept-language, accept-range, age, allow, authorization, cache-control, ";
+		$pconfig['eve_log_http_extended_headers'] .= "connection, content-encoding, content-language, content-length, content-location, content-md5, content-range, content-type, cookie, ";
+		$pconfig['eve_log_http_extended_headers'] .= "date, dnt, etags, from, last-modified, link, location, max-forwards, origin, pragma, proxy-authenticate, proxy-authorization, range, ";
+		$pconfig['eve_log_http_extended_headers'] .= "referrer, refresh, retry-after, server, set-cookie, te, trailer, transfer-encoding, upgrade, vary, via, warning, www-authenticate, ";
+		$pconfig['eve_log_http_extended_headers'] .= "x-authenticated-user, x-flash-version, x-forwarded-proto, x-requested-with";
+		$updated_cfg = true;
+	}
+
+	if (!isset($pconfig['eve_log_smtp_extended_fields'])) {
+		$pconfig['eve_log_smtp_extended_fields'] = "received, x-mailer, x-originating-ip, relays, reply-to, bcc";
 		$updated_cfg = true;
 	}
 

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -99,10 +99,12 @@ if (empty($config['installedpackages']['suricata']['config'][0]['sid_list_migrat
 }
 
 /**********************************************************/
-/* Create new Auto GeoIP update setting if not set        */
+/* Default Auto GeoLite2 DB update setting to "off" due   */
+/* to recent MaxMind changes to the GeoLite2 database     */
+/* download permissions.                                  */
 /**********************************************************/
-if (empty($config['installedpackages']['suricata']['config'][0]['autogeoipupdate'])) {
-	$config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] = "on";
+if (empty($config['installedpackages']['suricata']['config'][0]['autogeoipupdate']) || empty($config['installedpackages']['suricata']['config'][0]['maxmind_geoipdb_key'])) {
+	$config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] = "off";
 	$updated_cfg = true;
 }
 

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_post_install.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2019 Bill Meeks
+ * Copyright (c) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,11 +87,11 @@ foreach ($map_files as $f) {
 	}
 }
 
-// Download the latest GeoIP DB updates and create cron task if the feature is not disabled
-if ($config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] != 'off') {
+// Download the latest GeoIP DB updates and create cron task if the feature is enabled
+if ($config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] == 'on' && !empty($config['installedpackages']['suricata']['config'][0]['maxmind_geoipdb_key'])) {
 	syslog(LOG_NOTICE, gettext("[Suricata] Installing free GeoLite2 country IP database file in /usr/local/share/suricata/GeoLite2/..."));
 	include("/usr/local/pkg/suricata/suricata_geoipupdate.php");
-	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_geoipupdate.php", TRUE, 0, 6, "*", "*", "*", "root");
+	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_geoipupdate.php", TRUE, 0, 6, "*", "*", "1", "root");
 }
 
 // Download the latest ET IQRisk updates and create cron task if the feature is not disabled

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -111,7 +111,7 @@ outputs:
   - file-store:
       version: 2
       enabled: {$file_store_enabled}
-      log-dir: files
+      dir: {$file_store_logdir}
       force-magic: {$json_log_magic}
       {$json_log_hash}
       {$file_store_waldo}

--- a/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/arm/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2019 Bill Meeks
+ * Copyright (c) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -111,6 +111,9 @@ elseif (isset($id) && !isset($a_rule[$id])) {
 		$pconfig = array();
 	}
 }
+
+// Get real interface where this Suricata instance runs
+$if_real = get_real_interface($a_rule[$id]['interface']);
 
 // Set defaults for any empty key parameters
 if (empty($pconfig['blockoffendersip']))
@@ -237,6 +240,9 @@ if (empty($pconfig['intf_promisc_mode']))
 if (empty($pconfig['intf_snaplen']))
 	$pconfig['intf_snaplen'] = "1518";
 
+if (empty($pconfig['file_store_logdir']))
+	$pconfig['file_store_logdir'] = base64_encode("{$suricatalogdir}suricata_{$if_real}{$a_rule[$id]['uuid']}/filestore");
+
 // See if creating a new interface by duplicating an existing one
 if (strcasecmp($action, 'dup') == 0) {
 
@@ -357,6 +363,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['enable_tracked_files_magic'] == "on") { $natent['enable_tracked_files_magic'] = 'on'; }else{ $natent['enable_tracked_files_magic'] = 'off'; }
 		if ($_POST['tracked_files_hash']) $natent['tracked_files_hash'] = $_POST['tracked_files_hash'];
 		if ($_POST['enable_file_store'] == "on") { $natent['enable_file_store'] = 'on'; }else{ $natent['enable_file_store'] = 'off'; }
+		if ($_POST['file_store_logdir']) $natent['file_store_logdir'] = base64_encode($_POST['file_store_logdir']);
 		if ($_POST['enable_eve_log'] == "on") { $natent['enable_eve_log'] = 'on'; }else{ $natent['enable_eve_log'] = 'off'; }
 		if ($_POST['runmode']) $natent['runmode'] = $_POST['runmode']; else unset($natent['runmode']);
 		if ($_POST['max_pending_packets']) $natent['max_pending_packets'] = $_POST['max_pending_packets']; else unset($natent['max_pending_packets']);
@@ -805,12 +812,14 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['enable_tracked_files_magic'] == 'on' ? true:false,
 	'on'
 ));
+
 $section->addInput(new Form_Select(
 	'tracked_files_hash',
 	'Tracked-Files Checksum',
 	$pconfig['tracked_files_hash'],
 	array("none" => "None", "md5" => "MD5", "sha1" => "SHA1", "sha256" => "SHA256")
 ))->setHelp('Suricata will generate checksums for all logged Tracked Files using the chosen algorithm. Default is None.');
+
 $section->addInput(new Form_Checkbox(
 	'enable_file_store',
 	'Enable File-Store',
@@ -818,6 +827,13 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['enable_file_store'] == 'on' ? true:false,
 	'on'
 ));
+
+$section->addInput(new Form_Input(
+	'file_store_logdir',
+	'File Store Logging Directory',
+	'text',
+	base64_decode($pconfig['file_store_logdir'])
+))->setHelp('Enter directory path for saving the files extracted from application layer streams. Default path is "' . SURICATALOGDIR . 'suricata_' . $if_real . $a_rule[$id]['uuid'] . '/filestore".');
 
 $section->addInput(new Form_Checkbox(
 	'enable_pcap_log',
@@ -1541,6 +1557,11 @@ events.push(function(){
 		hideCheckbox('tls_log_extended', hide);
 	}
 
+	function toggle_enable_file_store() {
+		var hide = ! $('#enable_file_store').prop('checked');
+		hideInput('file_store_logdir', hide);
+	}
+
 	function toggle_json_file_log() {
 		var hide = ! $('#enable_json_file_log').prop('checked');
 		hideCheckbox('append_json_file_log', hide);
@@ -1673,6 +1694,7 @@ events.push(function(){
 		disableInput('enable_tracked_files_magic', disable);
 		disableInput('tracked_files_hash', disable);
 		disableInput('enable_file_store', disable);
+		disableInput('file_store_logdir', disable);
 		disableInput('enable_pcap_log', disable);
 		disableInput('max_pcap_log_size', disable);
 		disableInput('max_pcap_log_files', disable);
@@ -1795,6 +1817,10 @@ events.push(function(){
 		toggle_tls_log();
 	});
 
+	$('#enable_file_store').click(function() {
+		toggle_enable_file_store();
+	});
+
 	$('#enable_json_file_log').click(function() {
 		toggle_json_file_log();
 	});
@@ -1888,6 +1914,7 @@ events.push(function(){
 	toggle_stats_log();
 	toggle_http_log();
 	toggle_tls_log();
+	toggle_enable_file_store();
 	toggle_json_file_log();
 	toggle_pcap_log();
 	toggle_eve_log();

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2019 Bill Meeks
+ * Copyright (C) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -2548,7 +2548,7 @@ function suricata_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results 
 					$changecount++;
 					$modcount++;
 				}
-				elseif ($action == 'drop' && $rule_map[$k1][$k2]['action'] != 'drop') {
+				elseif ($action == 'drop' && $rule_map[$k1][$k2]['action'] != 'drop' && !in_array('noalert', $rule_map[$k1][$k2]['flowbits'])) {
 					if ($tmp = preg_replace('/\s*alert\s*/', 'drop ', $rule_map[$k1][$k2]['rule'], 1)) {
 						$rule_map[$k1][$k2]['rule'] = $tmp;
 						$rule_map[$k1][$k2]['action'] = 'drop';
@@ -2558,7 +2558,7 @@ function suricata_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results 
 						$modcount++;
 					}
 				}
-				elseif ($action == 'reject' && $rule_map[$k1][$k2]['action'] != 'reject') {
+				elseif ($action == 'reject' && $rule_map[$k1][$k2]['action'] != 'reject' && !in_array('noalert', $rule_map[$k1][$k2]['flowbits'])) {
 					if ($tmp = preg_replace('/\s*alert\s*/', 'reject ', $rule_map[$k1][$k2]['rule'], 1)) {
 						$rule_map[$k1][$k2]['rule'] = $tmp;
 						$rule_map[$k1][$k2]['action'] = 'reject';

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -1359,7 +1359,7 @@ function suricata_load_rules_map($rules_path) {
 	 * Read all the rules into the map array.
 	 * The structure of the map array is:
 	 *
-	 *  map[gid][sid]['rule']['category']['action']['disabled']['managed']
+	 *  map[gid][sid]['rule']['category']['action']['disabled']['managed']['noalert']
          *     ['default_state']['default_action']['state_toggled']['modified']['flowbits']
 	 *
 	 *  where:
@@ -1372,6 +1372,8 @@ function suricata_load_rules_map($rules_path) {
 	 *                    rule is enabled
 	 *   managed        = 1 if rule is auto-managed by SID MGMT process,
 	 *                    0 if not auto-managed
+	 *   noalert        = 1 if rule contains "noalert" or "flowbits:noalert"
+	 *		        options
 	 *   default_state  = 1 if rule is default enabled, 0 if default disabled
 	 *   default_action = alert, drop, reject or pass  
 	 *   state_toggled  = 1 if rule was toggled by SID MGMT process,
@@ -1475,6 +1477,13 @@ function suricata_load_rules_map($rules_path) {
 			$map_ref[$gid][$sid]['state_toggled'] = 0;
 			$map_ref[$gid][$sid]['modified'] = 0;
 			$map_ref[$gid][$sid]['managed'] = 0;
+
+			// Check for "noalert;" rule option
+			if (strpos($rule, 'noalert;') !== FALSE) {
+				$map_ref[$gid][$sid]['noalert'] = 1;
+			} else {
+				$map_ref[$gid][$sid]['noalert'] = 0;
+			}				
 
 			// Grab the rule action
 			$matches = array();
@@ -2548,7 +2557,7 @@ function suricata_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results 
 					$changecount++;
 					$modcount++;
 				}
-				elseif ($action == 'drop' && $rule_map[$k1][$k2]['action'] != 'drop' && !in_array('noalert', $rule_map[$k1][$k2]['flowbits'])) {
+				elseif ($action == 'drop' && $rule_map[$k1][$k2]['action'] != 'drop' && !in_array('noalert', $rule_map[$k1][$k2]['flowbits']) && $rule_map[$k1][$k2]['noalert'] == 0) {
 					if ($tmp = preg_replace('/\s*alert\s*/', 'drop ', $rule_map[$k1][$k2]['rule'], 1)) {
 						$rule_map[$k1][$k2]['rule'] = $tmp;
 						$rule_map[$k1][$k2]['action'] = 'drop';
@@ -2558,7 +2567,7 @@ function suricata_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results 
 						$modcount++;
 					}
 				}
-				elseif ($action == 'reject' && $rule_map[$k1][$k2]['action'] != 'reject' && !in_array('noalert', $rule_map[$k1][$k2]['flowbits'])) {
+				elseif ($action == 'reject' && $rule_map[$k1][$k2]['action'] != 'reject' && !in_array('noalert', $rule_map[$k1][$k2]['flowbits']) && $rule_map[$k1][$k2]['noalert'] == 0) {
 					if ($tmp = preg_replace('/\s*alert\s*/', 'reject ', $rule_map[$k1][$k2]['rule'], 1)) {
 						$rule_map[$k1][$k2]['rule'] = $tmp;
 						$rule_map[$k1][$k2]['action'] = 'reject';

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2019 Bill Meeks
+ * Copyright (C) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,18 +44,18 @@ foreach ($config_files as $file) {
 
 // Set HOME_NET and EXTERNAL_NET for the interface
 $home_net_list = suricata_build_list($suricatacfg, $suricatacfg['homelistname']);
-$home_net = implode(",", $home_net_list);
+$home_net = implode(", ", $home_net_list);
 $home_net = trim($home_net);
 $external_net = "";
 if (!empty($suricatacfg['externallistname']) && $suricatacfg['externallistname'] != 'default') {
 	$external_net_list = suricata_build_list($suricatacfg, $suricatacfg['externallistname'], false, true);
-	$external_net = implode(",", $external_net_list);
+	$external_net = implode(", ", $external_net_list);
 	$external_net = "[" . trim($external_net) . "]";
 }
 else {
 	$external_net = "[";
 	foreach ($home_net_list as $ip)
-		$external_net .= "!{$ip},";
+		$external_net .= "!{$ip}, ";
 	$external_net = trim($external_net, ', ') . "]";
 }
 
@@ -78,14 +78,14 @@ $suricata_servers = array (
 	"sql_servers" => "\$HOME_NET", "telnet_servers" => "\$HOME_NET", "dnp3_server" => "\$HOME_NET",
 	"dnp3_client" => "\$HOME_NET", "modbus_server" => "\$HOME_NET", "modbus_client" => "\$HOME_NET",
 	"enip_server" => "\$HOME_NET", "enip_client" => "\$HOME_NET", "ftp_servers" => "\$HOME_NET", "ssh_servers" => "\$HOME_NET", 
-	"aim_servers" => "64.12.24.0/23,64.12.28.0/23,64.12.161.0/24,64.12.163.0/24,64.12.200.0/24,205.188.3.0/24,205.188.5.0/24,205.188.7.0/24,205.188.9.0/24,205.188.153.0/24,205.188.179.0/24,205.188.248.0/24", 
+	"aim_servers" => "64.12.24.0/23, 64.12.28.0/23, 64.12.161.0/24, 64.12.163.0/24, 64.12.200.0/24, 205.188.3.0/24, 205.188.5.0/24, 205.188.7.0/24, 205.188.9.0/24, 205.188.153.0/24, 205.188.179.0/24, 205.188.248.0/24", 
 	"sip_servers" => "\$HOME_NET"
 );
 $addr_vars = "";
 	foreach ($suricata_servers as $alias => $avalue) {
 		if (!empty($suricatacfg["def_{$alias}"]) && is_alias($suricatacfg["def_{$alias}"])) {
 			$avalue = trim(filter_expand_alias($suricatacfg["def_{$alias}"]));
-			$avalue = preg_replace('/\s+/', ',', trim($avalue));
+			$avalue = preg_replace('/\s+/', ', ', trim($avalue));
 		}
 		$addr_vars .= "    " . strtoupper($alias) . ": \"{$avalue}\"\n";
 	}
@@ -101,14 +101,14 @@ $suricata_ports = array(
 	"ssh_ports" => $ssh_port, 
 	"shellcode_ports" => "!80", 
 	"DNP3_PORTS" => "20000", 
-	"file_data_ports" => "\$HTTP_PORTS,110,143", 
-	"sip_ports" => "5060,5061,5600"
+	"file_data_ports" => "\$HTTP_PORTS, 110, 143", 
+	"sip_ports" => "5060, 5061, 5600"
 );
 $port_vars = "";
 	foreach ($suricata_ports as $alias => $avalue) {
 		if (!empty($suricatacfg["def_{$alias}"]) && is_alias($suricatacfg["def_{$alias}"])) {
 			$avalue = trim(filter_expand_alias($suricatacfg["def_{$alias}"]));
-			$avalue = preg_replace('/\s+/', ',', trim($avalue));
+			$avalue = preg_replace('/\s+/', ', ', trim($avalue));
 		}
 		$port_vars .= "    " . strtoupper($alias) . ": \"{$avalue}\"\n";
 	}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -282,10 +282,17 @@ if ($suricatacfg['enable_file_store'] == 'on') {
 	if (!file_exists("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/file.waldo"))
 		@file_put_contents("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/file.waldo", "");
 	$file_store_waldo = "waldo: file.waldo";
+	if (!empty($suricatacfg['file_store_logdir'])) {
+		$file_store_logdir = base64_decode($suricatacfg['file_store_logdir']);
+	}
+	else {
+		$file_store_logdir = "filestore";
+	}
 }
 else {
 	$file_store_enabled = "no";
 	$file_store_waldo = "#waldo: file.waldo";
+	$file_store_logdir = "filestore";
 }
 
 if ($suricatacfg['enable_pcap_log'] == 'on')

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2019 Bill Meeks
+ * Copyright (C) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,14 +59,8 @@ else {
 // Set the output filename for the downloaded DB archive
 $tmpfile = $geoip_tmppath . "GeoLite2-Country.mmdb.gz";
 
-// Set the URL string.  We supply the MD5 hash for our
-// current file.  The server will compare it to the
-// value for the latest file and return the HTTP
-// Response Code "304" if no newer file is available.
-// If a newer file is available, the server will send
-// it to us.  We obtain and examine the CURLINFO_RESPONSE_CODE
-// value to see which result occurs.
-$url = "https://updates.maxmind.com/geoip/databases/GeoLite2-Country/update?db_md5=" . $md5_hash;
+// Set the URL string.
+$url = "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=" . $config['installedpackages']['suricata']['config'][0]['maxmind_geoipdb_key'] . "&suffix=tar.gz";
 
 // Get a file handle for CURL and then start the CURL
 // transfer.

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2019-2020 Rubicon Communications, LLC (Netgate)
- * Copyright (C) 2019 Bill Meeks
+ * Copyright (C) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -388,6 +388,20 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 	}    
 	if (!isset($pconfig['eve_log_drop'])) {
 		$pconfig['eve_log_drop'] = "on";
+		$updated_cfg = true;
+	}
+
+	if (!isset($pconfig['eve_log_http_extended_headers'])) {
+		$pconfig['eve_log_http_extended_headers'] = "accept, accept-charset, accept-datetime, accept-encoding, accept-language, accept-range, age, allow, authorization, cache-control, ";
+		$pconfig['eve_log_http_extended_headers'] .= "connection, content-encoding, content-language, content-length, content-location, content-md5, content-range, content-type, cookie, ";
+		$pconfig['eve_log_http_extended_headers'] .= "date, dnt, etags, from, last-modified, link, location, max-forwards, origin, pragma, proxy-authenticate, proxy-authorization, range, ";
+		$pconfig['eve_log_http_extended_headers'] .= "referrer, refresh, retry-after, server, set-cookie, te, trailer, transfer-encoding, upgrade, vary, via, warning, www-authenticate, ";
+		$pconfig['eve_log_http_extended_headers'] .= "x-authenticated-user, x-flash-version, x-forwarded-proto, x-requested-with";
+		$updated_cfg = true;
+	}
+
+	if (!isset($pconfig['eve_log_smtp_extended_fields'])) {
+		$pconfig['eve_log_smtp_extended_fields'] = "received, x-mailer, x-originating-ip, relays, reply-to, bcc";
 		$updated_cfg = true;
 	}
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -99,10 +99,12 @@ if (empty($config['installedpackages']['suricata']['config'][0]['sid_list_migrat
 }
 
 /**********************************************************/
-/* Create new Auto GeoIP update setting if not set        */
+/* Default Auto GeoLite2 DB update setting to "off" due   */
+/* to recent MaxMind changes to the GeoLite2 database     */
+/* download permissions.                                  */
 /**********************************************************/
-if (empty($config['installedpackages']['suricata']['config'][0]['autogeoipupdate'])) {
-	$config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] = "on";
+if (empty($config['installedpackages']['suricata']['config'][0]['autogeoipupdate']) || empty($config['installedpackages']['suricata']['config'][0]['maxmind_geoipdb_key'])) {
+	$config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] = "off";
 	$updated_cfg = true;
 }
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2019 Bill Meeks
+ * Copyright (c) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,11 +87,11 @@ foreach ($map_files as $f) {
 	}
 }
 
-// Download the latest GeoIP DB updates and create cron task if the feature is not disabled
-if ($config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] != 'off') {
+// Download the latest GeoIP DB updates and create cron task if the feature is enabled
+if ($config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] == 'on' && !empty($config['installedpackages']['suricata']['config'][0]['maxmind_geoipdb_key'])) {
 	syslog(LOG_NOTICE, gettext("[Suricata] Installing free GeoLite2 country IP database file in /usr/local/share/suricata/GeoLite2/..."));
 	include("/usr/local/pkg/suricata/suricata_geoipupdate.php");
-	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_geoipupdate.php", TRUE, 0, 6, "*", "*", "*", "root");
+	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_geoipupdate.php", TRUE, 0, 6, "*", "*", "1", "root");
 }
 
 // Download the latest ET IQRisk updates and create cron task if the feature is not disabled

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -111,7 +111,7 @@ outputs:
   - file-store:
       version: 2
       enabled: {$file_store_enabled}
-      log-dir: files
+      dir: {$file_store_logdir}
       force-magic: {$json_log_magic}
       {$json_log_hash}
       {$file_store_waldo}

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -218,7 +218,7 @@ $section->addInput(new Form_Checkbox(
 	'enable_iprep',
 	'Enable',
 	'Use IP Reputation Lists on this interface. Default is NOT Checked.',
-	$pconfig['enable_iprep'],
+	$pconfig['enable_iprep'] == 'on' ? true:false,
 	'on'
 ));
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -1118,24 +1118,25 @@ print($section);
 						<td style="padding-left: 8px;"><i class="fa fa-adn text-success"></i></td><td style="padding-left: 4px;"><small><?=gettext('Auto-enabled by SID Mgmt');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-adn text-warning"></i></td><td style="padding-left: 4px;"><small><?=gettext('Action/content modified by SID Mgmt');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-exclamation-triangle text-warning"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is alert');?></small></td>
-				<?php if ($a_rule[$id]['ips_mode'] == 'ips_mode_inline' && $a_rule[$id]['blockoffenders'] == 'on') : ?>
-						<td style="padding-left: 8px;"><i class="fa fa-hand-stop-o text-warning"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is reject');?></small></td>
-				<?php else : ?>
-						<td><td></td></td>
-				<?php endif; ?>
+						<td style="padding-left: 8px;"><i class="fa fa-exclamation-triangle text-success"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule contains noalert option');?></small></td>
 					</tr>
 					<tr>
 						<td></td>
 						<td style="padding-left: 8px;"><i class="fa fa-times-circle-o text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Default Disabled');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-times-circle text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Disabled by user');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-adn text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Auto-disabled by SID Mgmt');?></small></td>
-						<td><td></td></td>
+						<td></td><td></td>
 				<?php if ($a_rule[$id]['blockoffenders'] == 'on') : ?>
 						<td style="padding-left: 8px;"><i class="fa fa-thumbs-down text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is drop');?></small></td>
+					<?php if ($a_rule[$id]['ips_mode'] == 'ips_mode_inline') : ?>
+						<td style="padding-left: 8px;"><i class="fa fa-hand-stop-o text-warning"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is reject');?></small></td>
+					<?php else : ?>
+						<td></td><td></td>
+					<?php endif; ?>
 				<?php else : ?>
-						<td><td></td></td>
+						<td></td><td></td>
 				<?php endif; ?>
-						<td><td></td></td>
+						<td></td><td></td>
 					</tr>
 				</tbody>
 			</table>
@@ -1259,6 +1260,12 @@ print($section);
 									$title_act .= gettext("  Click to change rule action.");
 								}
 
+								// Rules with "noalert;" option enabled get special treatment
+								if ($v['noalert'] == 1) {
+									$iconact_class = 'class="fa fa-exclamation-triangle text-success text-center"';
+									$title_act = gettext("Rule contains the 'noalert;' and/or 'flowbits:noalert;' options.");
+								}
+
 								// Pick off the first section of the rule (prior to the start of the MSG field),
 								// and then use a REGX split to isolate the remaining fields into an array.
 								$tmp = substr($v['rule'], 0, strpos($v['rule'], "("));
@@ -1279,6 +1286,13 @@ print($section);
 								$destination_port = $rule_content[6]; //destination port field
 								$message = suricata_get_msg($v['rule']); // description field
 								$sid_tooltip = gettext("View the raw text for this rule");
+
+								// Show text of "noalert;" flagged rules in Bootstrap SUCCESS color
+								if ($v['noalert'] == 1) {
+									$tag_class = ' class="text-success" ';
+								} else {
+									$tag_class = "";
+								}
 					?>
 								<tr class="text-nowrap">
 									<td><?=$textss; ?>
@@ -1289,7 +1303,7 @@ print($section);
 						<?php endif; ?>
 									</td>
 
-						<?php if ($a_rule[$id]['blockoffenders'] == 'on') : ?>
+						<?php if ($a_rule[$id]['blockoffenders'] == 'on' && $v['noalert'] == 0) : ?>
 								       <td><?=$textss; ?><a id="rule_<?=$gid; ?>_<?=$sid; ?>_action" href="#" onClick="toggleAction('<?=$sid; ?>', '<?=$gid; ?>');" 
 										<?=$iconact_class; ?> title="<?=$title_act; ?>"></a><?=$textse; ?>
 								       </td>
@@ -1306,22 +1320,22 @@ print($section);
 										onclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');" 
 										title="<?=$sid_tooltip;?>"><?=$textss . $sid . $textse;?></a>
 								       </td>
-								       <td ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
+								       <td <?=$tag_class;?> ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
 										<?=$textss . $protocol . $textse;?>
 							       	       </td>
-								       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
+								       <td <?=$tag_class;?> style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
 										<?=$srcspan . $source;?></span>
 								       </td>
-								       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
+								       <td <?=$tag_class;?> style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
 										<?=$srcprtspan . $source_port;?></span>
 								       </td>
-								       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
+								       <td <?=$tag_class;?> style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
 										<?=$dstspan . $destination;?></span>
 								       </td>
-								       <td style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
+								       <td <?=$tag_class;?> style="text-overflow: ellipsis; overflow: hidden; white-space:no-wrap" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
 									       <?=$dstprtspan . $destination_port;?></span>
 								       </td>
-									<td style="word-wrap:break-word; white-space:normal" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
+									<td <?=$tag_class;?> style="word-wrap:break-word; white-space:normal" ondblclick="showRuleContents('<?=$gid;?>','<?=$sid;?>');">
 										<?=$textss . $message . $textse;?>
 								       </td>
 								</tr>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -1401,7 +1401,7 @@ print($section);
 					<i class="fa fa-save icon-embed-btn"></i>
 					<?=gettext("Save");?>
 				</button>
-				<button type="button" class="btn btn-sm btn-warning" id="cancelcancel_sid_action" name="cancel_sid_action" value="<?=gettext("Cancel");?>" data-dismiss="modal" title="<?=gettext("Abandon changes and quit selector");?>">
+				<button type="button" class="btn btn-sm btn-warning" id="cancel_sid_action" name="cancel_sid_action" value="<?=gettext("Cancel");?>" data-dismiss="modal" title="<?=gettext("Abandon changes and quit selector");?>">
 					<?=gettext("Cancel");?>
 				</button>
 			</div>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2019 Bill Meeks
+ * Copyright (c) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1141,7 +1141,7 @@ print($section);
 			</table>
 		</div>
 
-		<table  style="table-layout: fixed; width: 100%;" class="table table-striped table-hover table-condensed">
+		<table style="table-layout: fixed; width: 100%;" class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>
 			<colgroup>
 				<col width="5%">
 				<col width="5%">
@@ -1155,17 +1155,17 @@ print($section);
 				<col>
 			</colgroup>
 			<thead>
-			   <tr>
-				<th><?=gettext("State");?></th>
-				<th><?=gettext("Action");?></th>
-				<th><?=gettext("GID");?></th>
-				<th><?=gettext("SID");?></th>
-				<th><?=gettext("Proto");?></th>
-				<th><?=gettext("Source");?></th>
-				<th><?=gettext("SPort");?></th>
-				<th><?=gettext("Destination");?></th>
-				<th><?=gettext("DPort");?></th>
-				<th><?=gettext("Message");?></th>
+			   <tr class="sortableHeaderRowIdentifier">
+				<th data-sortable="false"><?=gettext("State");?></th>
+				<th data-sortable="false"><?=gettext("Action");?></th>
+				<th data-sortable="true" data-sortable-type="numeric"><?=gettext("GID");?></th>
+				<th data-sortable="true" data-sortable-type="numeric"><?=gettext("SID");?></th>
+				<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Proto");?></th>
+				<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Source");?></th>
+				<th data-sortable="true" data-sortable-type="alpha"><?=gettext("SPort");?></th>
+				<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Destination");?></th>
+				<th data-sortable="true" data-sortable-type="alpha"><?=gettext("DPort");?></th>
+				<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Message");?></th>
 			   </tr>
 			</thead>
 			<tbody>
@@ -1387,7 +1387,7 @@ print($section);
 					<i class="fa fa-save icon-embed-btn"></i>
 					<?=gettext("Save");?>
 				</button>
-				<button type="button" class="btn btn-sm btn-warning" id="cancel" name="cancel" value="<?=gettext("Cancel");?>" data-dismiss="modal" title="<?=gettext("Abandon changes and quit selector");?>">
+				<button type="button" class="btn btn-sm btn-warning" id="cancelcancel_sid_action" name="cancel_sid_action" value="<?=gettext("Cancel");?>" data-dismiss="modal" title="<?=gettext("Abandon changes and quit selector");?>">
 					<?=gettext("Cancel");?>
 				</button>
 			</div>
@@ -1424,7 +1424,7 @@ print($section);
 					<i class="fa fa-save icon-embed-btn"></i>
 					<?=gettext("Save");?>
 				</button>
-				<button type="button" class="btn btn-sm btn-warning" id="cancel" name="cancel" value="<?=gettext("Cancel");?>" data-dismiss="modal" title="<?=gettext("Abandon changes and quit selector");?>">
+				<button type="button" class="btn btn-sm btn-warning" id="cancel_state_action" name="cancelcancel_state_action" value="<?=gettext("Cancel");?>" data-dismiss="modal" title="<?=gettext("Abandon changes and quit selector");?>">
 					<?=gettext("Cancel");?>
 				</button>
 			</div>


### PR DESCRIPTION
### pfSense-pkg-suricata-4.1.6_1
This GUI package update provides support for the latest version of the Suricata binary (v4.1.6). It also corrects five bugs and adds four new features.

**New Features:**
1. Added column sorting to the RULES tab so it behaves the same as the ALERTS tab.
2. Make filters on ALERTS tab sticky across other actions such as suppressing alerts or disabling a SID. Currently any applied filter resets. [Redmine Issue #9902](https://redmine.pfsense.org/issues/9902).
3. Highlight rules with "_noalerts;_" option on RULES tab by coloring the text using the Bootstrap class "text-success" and using a different ACTION icon.
4. Added option to set unique logging directory for _file-store_ configuration section in suricata.yaml.

**Bug Fixes:**
1. When creating HOME_NET and EXTERNAL_NET (and other ipvars), make sure there is a comma followed by a space for each IP entry. Failure to do so with intermixed IPv4 and IPv6 addresses results in failure to start with no ERRCODE given. See[ Suricata Redmine Issue #3222](https://redmine.openinfosecfoundation.org/issues/3222).
2. Use of _explode()_ function in _suricata_interfaces_edit.php_ generates a warning because the second parameter of the function call is not interpreted as an empty string due to being uninitialized on green-field installs.
3. When SID MGMT changes rules to DROP or REJECT, it is not skipping rules containing a "_flowbits:noalert;_" tag. This can result in dropped traffic without any logged alert about the drop or reject action.
4. The IP Reputation List enable option on the IPREP tab actually defaults to "ON" when it should default to "OFF".
5. Maxmind GeoLite2 IP DB now requires a license key for GeoIP2 database downloads. Add support for user-supplied license key.