### PR TITLE
Telegraf CA file creation fix. Issue #10218

### DIFF
--- a/net-mgmt/pfSense-pkg-Telegraf/Makefile
+++ b/net-mgmt/pfSense-pkg-Telegraf/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-Telegraf
 PORTVERSION=	0.9
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.inc
+++ b/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.inc
@@ -63,7 +63,7 @@ function telegraf_resync_config() {
 	if (count($a_ca)) {
 		$ca_pem = '';
 		foreach ($a_ca as $ca) {
-			$ca_pem .= base64_decode($ca['crt']);
+			$ca_pem .= base64_decode($ca['crt']) . "\n";
 		}
 		file_put_contents($ca_pem_file, $ca_pem);
 	}


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/10218
Ready for review

I'm running the 2.4.5-RC with Telegraf package 0.9_1 and found that Telegraf wouldn't start when I have more then one CA in pfSense.
After checking the created telegraf.ca I found that there is a missing newline after the first certificate, so it looked like this:

-----END CERTIFICATE----------BEGIN CERTIFICATE-----

which is invalid.

The fix is quite simple, look at line 67 in telegraf.inc and change it from
$ca_pem .= base64_decode($ca['crt']);
to
$ca_pem .= base64_decode($ca['crt'])."\n";

actual fix by Grimson Gretzleburg