### PR TITLE
Add softflow 1.0.0 features - sampling and PSAMP export. Issue #10220

### DIFF
--- a/net-mgmt/pfSense-pkg-softflowd/Makefile
+++ b/net-mgmt/pfSense-pkg-softflowd/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-softflowd
-PORTVERSION=	1.2.4
+PORTVERSION=	1.2.5
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.inc
+++ b/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.inc
@@ -56,6 +56,9 @@ function sync_package_softflowd() {
 			if (is_numericint($cf['hoplimit'])) {
 				$start .= " -L " . escapeshellarg($cf['hoplimit']);
 			}
+			if (is_numericint($cf['sample']) && ($cf['sample'] > 0)) {
+				$start .= " -s " . escapeshellarg($cf['sample']);
+			}
 			if ($cf['version'] != "") {
 				$start .= " -v " . escapeshellarg($cf['version']);
 			}

--- a/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.xml
+++ b/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.xml
@@ -79,6 +79,13 @@
 			<required/>
 		</field>
 		<field>
+			<fielddescr>Sample</fielddescr>
+			<fieldname>sample</fieldname>
+			<description>Specify periodical sampling rate (denominator). Empty or 0 disables sampling.</description>
+			<default_value>0</default_value>
+			<type>input</type>
+		</field>
+		<field>
 			<fielddescr>Max Flows</fielddescr>
 			<fieldname>maxflows</fieldname>
 			<description>
@@ -106,11 +113,13 @@
 			<description>Select the desired version of the NetFlow protocol (10 means IPFIX).</description>
 			<type>select</type>
 			<options>
+				<option><name>PSAMP</name><value>psamp</value></option>
 				<option><name>10</name><value>10</value></option>
 				<option><name>9</name><value>9</value></option>
 				<option><name>5</name><value>5</value></option>
 				<option><name>1</name><value>1</value></option>
 			</options>
+			<default_value>10</default_value>
 			<required/>
 		</field>
 		<field>


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/10220
Ready for review

Add sampling configuration to softflowd package:
```
  -s sampling_rate        Specify periodical sampling rate (denominator)
```
Add PSAMP export:
```
 -v 1|5|9|10|psamp       NetFlow export packet version
                          10 means IPFIX and psamp means PSAMP (packet sampling)
```

see https://tools.ietf.org/html/rfc5476

original PR https://github.com/pfsense/FreeBSD-ports/pull/700 can be closed

Co-authored-by: <chrono@open-resource.org>
Co-authored-by: <viktor@netgate.com>