### PR TITLE
NRPE CARP plugin install fix. Issue #7895

### DIFF
--- a/net-mgmt/pfSense-pkg-nrpe/Makefile
+++ b/net-mgmt/pfSense-pkg-nrpe/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-nrpe
 PORTVERSION=	3.1
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -26,6 +26,7 @@ do-extract:
 
 do-install:
 	${MKDIR} ${STAGEDIR}${PREFIX}/pkg
+	${MKDIR} ${STAGEDIR}${PREFIX}/libexec/nagios
 	${MKDIR} ${STAGEDIR}/etc/inc/priv
 	${MKDIR} ${STAGEDIR}${DATADIR}
 	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/nrpe.xml \
@@ -37,7 +38,7 @@ do-install:
 	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \
 		${STAGEDIR}${DATADIR}
 	${INSTALL_SCRIPT} ${FILESDIR}${PREFIX}/libexec/nagios/check_carp_freebsd.sh \
-		/usr/local/libexec/nagios/
+                ${STAGEDIR}${PREFIX}/libexec/nagios
 	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
 		${STAGEDIR}${DATADIR}/info.xml
 


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/7895
Ready for review

fix for https://github.com/pfsense/FreeBSD-ports/pull/759

adds

>  ${MKDIR} ${STAGEDIR}${PREFIX}/libexec/nagios

 line to Makefile
