### PR TITLE
rawserial driver for lcdproc. Issue #10243

### DIFF
--- a/sysutils/pfSense-pkg-LCDproc/Makefile
+++ b/sysutils/pfSense-pkg-LCDproc/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-LCDproc
-PORTVERSION=	0.10.7
+PORTVERSION=	0.10.8
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc.inc
+++ b/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc.inc
@@ -428,6 +428,12 @@ function sync_package_lcdproc() {
 				$config_text .= "Device={$realport}\n";
 				$config_text .= "Size={$lcdproc_config['size']}\n";
 				break;
+			case "rawserial":
+				$config_text .= "[{$lcdproc_config['driver']}]\n";
+				$config_text .= "Device={$realport}\n";
+				$config_text .= "Size={$lcdproc_config['size']}\n";
+				$config_text .= "UpdateRate=1\n";
+				break;
 			case "sdeclcd":
 				$config_text .= "[{$lcdproc_config['driver']}]\n";
 				break;

--- a/sysutils/pfSense-pkg-LCDproc/files/usr/local/www/packages/lcdproc/lcdproc.php
+++ b/sysutils/pfSense-pkg-LCDproc/files/usr/local/www/packages/lcdproc/lcdproc.php
@@ -177,6 +177,7 @@ $section->addInput(
 			'NoritakeVFD'  => 'NoritakeVFD',
 			'picolcd'      => 'picolcd',
 			'pyramid'      => 'pyramid',
+			'rawserial'    => 'rawserial'
 			'sdeclcd'      => 'Watchguard Firebox with SDEC',
 			'sed1330'      => 'sed1330',
 			'sed1520'      => 'sed1520',


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/10243
Ready for review


Rawserial driver has been avalbile since 0.5.7 this will dump raw serial data to the serial port. Hackers/makers can then parse the output with an arduino to display on an LCD. This Pull request adds raw serial as an option in the gui.

original PR: https://github.com/pfsense/FreeBSD-ports/pull/684