### PR TITLE
Set Snort autoflowbit checkbox (2.4.5). Issue #8830

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	3.2.9.10
+PORTREVISION=	1	
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
@@ -442,6 +442,8 @@ if ($_POST['save'] && !$input_errors) {
 			$natent['sf_appid_statslog'] = "on";
 			$natent['sf_appid_stats_period'] = "300";
 
+			$natent['autoflowbitrules'] = 'on';
+
 			$a_rule[] = $natent;
 		}
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
@@ -54,6 +54,8 @@ if (isset($id) && $a_nat[$id]) {
 		$pconfig['autoflowbitrules'] = $a_nat[$id]['autoflowbitrules'] == 'on' ? 'on' : 'off';;
 	$pconfig['ips_policy_enable'] = $a_nat[$id]['ips_policy_enable'] == 'on' ? 'on' : 'off';;
 	$pconfig['ips_policy'] = $a_nat[$id]['ips_policy'];
+} else {
+	$pconfig['autoflowbitrules'] = 'on';
 }
 
 $if_real = get_real_interface($pconfig['interface']);


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/8830
Ready for review

same as https://github.com/pfsense/FreeBSD-ports/pull/760 but for pfSense 2.4.5

Snort (version 4.0_10), visit Global Settings, enable some rulesets, visit Update and run an update. Once that's done visit Interfaces, add an interface, go to the Categories tab and see that the Automatic flowbit resolution setting is unchecked. Below that, notice the message that reads:

> If checked, Snort will auto-enable rules required for checked flowbits. Default is Checked.

This PR simply sets the default value for this checkbox to on when adding a new interface.