### PR TITLE
Add HoneyTrap pfSense port

### DIFF
--- a/security/pfSense-pkg-HoneyTrap/Makefile
+++ b/security/pfSense-pkg-HoneyTrap/Makefile
@@ -10,9 +10,9 @@ EXTRACT_ONLY=	# empty
 MAINTAINER=	remco.verhoef@dutchsec.com
 COMMENT=	PfSense package HoneyTrap
 
-LICENSE=	ART20
+LICENSE=	APACHE20
 
-RUN_DEPENDS=	honeytrap:security/honeytrap
+RUN_DEPENDS=	honeytrap>0:security/honeytrap
 
 NO_BUILD=	yes
 

--- a/security/pfSense-pkg-HoneyTrap/Makefile
+++ b/security/pfSense-pkg-HoneyTrap/Makefile
@@ -1,0 +1,53 @@
+# $FreeBSD$
+
+PORTNAME=	pfSense-pkg-HoneyTrap
+PORTVERSION=	0.1
+CATEGORIES=	security
+MASTER_SITES=	# empty
+DISTFILES=	# empty
+EXTRACT_ONLY=	# empty
+
+MAINTAINER=	remco.verhoef@dutchsec.com
+COMMENT=	PfSense package HoneyTrap
+
+LICENSE=	ART20
+
+RUN_DEPENDS=	honeytrap:security/honeytrap
+
+NO_BUILD=	yes
+
+SUB_FILES=	pkg-install pkg-deinstall
+SUB_LIST=	PORTNAME=${PORTNAME}
+
+do-extract:
+	${MKDIR} ${WRKSRC}
+
+do-install:
+	${MKDIR} ${STAGEDIR}/var/log/honeytrap
+	${MKDIR} ${STAGEDIR}${DATADIR}
+	${MKDIR} ${STAGEDIR}${PREFIX}/pkg/honeytrap
+	${MKDIR} ${STAGEDIR}${PREFIX}/pkg/honeytrap/config
+	${MKDIR} ${STAGEDIR}${PREFIX}/pkg/honeytrap/.data
+	${MKDIR} ${STAGEDIR}${PREFIX}/pkg/priv
+	${MKDIR} ${STAGEDIR}${PREFIX}/www/honeytrap
+	${MKDIR} ${STAGEDIR}${PREFIX}/www/shortcuts
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/honeytrap-plugin.xml \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/honeytrap/config/default.toml \
+		${STAGEDIR}${PREFIX}/pkg/honeytrap/config
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/honeytrap/honeytrap-plugin.inc \
+		${STAGEDIR}${PREFIX}/pkg/honeytrap
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/priv/honeytrap.priv.inc \
+		${STAGEDIR}${PREFIX}/pkg/priv
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/honeytrap/honeytrap_settings.php \
+		${STAGEDIR}${PREFIX}/www/honeytrap/
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/honeytrap/honeytrap_logs.php \
+		${STAGEDIR}${PREFIX}/www/honeytrap/
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/shortcuts/pkg_honeytrap.inc \
+		${STAGEDIR}${PREFIX}/www/shortcuts
+	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \
+		${STAGEDIR}${DATADIR}
+	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
+		${STAGEDIR}${DATADIR}/info.xml
+
+.include <bsd.port.mk>

--- a/security/pfSense-pkg-HoneyTrap/files/pkg-deinstall.in
+++ b/security/pfSense-pkg-HoneyTrap/files/pkg-deinstall.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/local/bin/php -f /etc/rc.packages %%PORTNAME%% ${2}

--- a/security/pfSense-pkg-HoneyTrap/files/pkg-install.in
+++ b/security/pfSense-pkg-HoneyTrap/files/pkg-install.in
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "${2}" != "POST-INSTALL" ]; then
+	exit 0
+fi
+
+/usr/local/bin/php -f /etc/rc.packages %%PORTNAME%% ${2}

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap-plugin.xml
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap-plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <packagegui>
-    <copyright>
-        <![CDATA[
+	<copyright>
+		<![CDATA[
 /*
 * honeytrap-plugin.xml
 *
@@ -20,34 +20,34 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-        ]]>
-    </copyright>
-    <name>HoneyTrap</name>
-    <version>0.1</version>
-    <title>Services/HoneyTrap</title>
-    <include_file>/usr/local/pkg/honeytrap/honeytrap-plugin.inc</include_file>
-    <menu>
-        <name>HoneyTrap</name>
-        <section>Services</section>
-        <url>/honeytrap/honeytrap_settings.php</url>
-    </menu>
-    <service>
-        <name>honeytrap</name>
-        <rcfile>honeytrap-daemon.sh</rcfile>
-        <executable>honeytrap</executable>
-        <description>HoneyTrap daemon</description>
-    </service>
-    <tabs>
-    </tabs>
-    <fields>
-    </fields>
-    <custom_php_install_command>
-        honeytrap_install();
-    </custom_php_install_command>
-    <custom_php_resync_config_command>
-        honeytrap_sync_config();
-    </custom_php_resync_config_command>
-    <custom_php_pre_deinstall_command>
-        honeytrap_deinstall();
-    </custom_php_pre_deinstall_command>
+		]]>
+	</copyright>
+	<name>HoneyTrap</name>
+	<version>0.1</version>
+	<title>Services/HoneyTrap</title>
+	<include_file>/usr/local/pkg/honeytrap/honeytrap-plugin.inc</include_file>
+	<menu>
+		<name>HoneyTrap</name>
+		<section>Services</section>
+		<url>/honeytrap/honeytrap_settings.php</url>
+	</menu>
+	<service>
+		<name>honeytrap</name>
+		<rcfile>honeytrap-daemon.sh</rcfile>
+		<executable>honeytrap</executable>
+		<description>HoneyTrap daemon</description>
+	</service>
+	<tabs>
+	</tabs>
+	<fields>
+	</fields>
+	<custom_php_install_command>
+		honeytrap_install();
+	</custom_php_install_command>
+	<custom_php_resync_config_command>
+		honeytrap_sync_config();
+	</custom_php_resync_config_command>
+	<custom_php_pre_deinstall_command>
+		honeytrap_deinstall();
+	</custom_php_pre_deinstall_command>
 </packagegui>

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap-plugin.xml
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap-plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <packagegui>
-  <copyright>
-    <![CDATA[
+    <copyright>
+        <![CDATA[
 /*
 * honeytrap-plugin.xml
 *
@@ -20,34 +20,34 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-    ]]>
-  </copyright>
-  <name>HoneyTrap</name>
-  <version>0.1</version>
-  <title>Services/HoneyTrap</title>
-  <include_file>/usr/local/pkg/honeytrap/honeytrap-plugin.inc</include_file>
-  <menu>
+        ]]>
+    </copyright>
     <name>HoneyTrap</name>
-    <section>Services</section>
-    <url>/honeytrap/honeytrap_settings.php</url>
-  </menu>
-  <service>
-    <name>honeytrap</name>
-    <rcfile>honeytrap-daemon.sh</rcfile>
-    <executable>honeytrap</executable>
-    <description>HoneyTrap daemon</description>
-  </service>
-  <tabs>
-  </tabs>
-  <fields>
-  </fields>
-  <custom_php_install_command>
-    honeytrap_install();
-  </custom_php_install_command>
-  <custom_php_resync_config_command>
-    honeytrap_sync_config();
-  </custom_php_resync_config_command>
-  <custom_php_pre_deinstall_command>
-    honeytrap_deinstall();
-  </custom_php_pre_deinstall_command>
+    <version>0.1</version>
+    <title>Services/HoneyTrap</title>
+    <include_file>/usr/local/pkg/honeytrap/honeytrap-plugin.inc</include_file>
+    <menu>
+        <name>HoneyTrap</name>
+        <section>Services</section>
+        <url>/honeytrap/honeytrap_settings.php</url>
+    </menu>
+    <service>
+        <name>honeytrap</name>
+        <rcfile>honeytrap-daemon.sh</rcfile>
+        <executable>honeytrap</executable>
+        <description>HoneyTrap daemon</description>
+    </service>
+    <tabs>
+    </tabs>
+    <fields>
+    </fields>
+    <custom_php_install_command>
+        honeytrap_install();
+    </custom_php_install_command>
+    <custom_php_resync_config_command>
+        honeytrap_sync_config();
+    </custom_php_resync_config_command>
+    <custom_php_pre_deinstall_command>
+        honeytrap_deinstall();
+    </custom_php_pre_deinstall_command>
 </packagegui>

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap-plugin.xml
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap-plugin.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<packagegui>
+  <copyright>
+    <![CDATA[
+/*
+* honeytrap-plugin.xml
+*
+* part of pfSense (http://www.pfsense.org)
+* Copyright (c) 2019 DutchSec (https://dutchsec.com/)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+    ]]>
+  </copyright>
+  <name>HoneyTrap</name>
+  <version>0.1</version>
+  <title>Services/HoneyTrap</title>
+  <include_file>/usr/local/pkg/honeytrap/honeytrap-plugin.inc</include_file>
+  <menu>
+    <name>HoneyTrap</name>
+    <section>Services</section>
+    <url>/honeytrap/honeytrap_settings.php</url>
+  </menu>
+  <service>
+    <name>honeytrap</name>
+    <rcfile>honeytrap-daemon.sh</rcfile>
+    <executable>honeytrap</executable>
+    <description>HoneyTrap daemon</description>
+  </service>
+  <tabs>
+  </tabs>
+  <fields>
+  </fields>
+  <custom_php_install_command>
+    honeytrap_install();
+  </custom_php_install_command>
+  <custom_php_resync_config_command>
+    honeytrap_sync_config();
+  </custom_php_resync_config_command>
+  <custom_php_pre_deinstall_command>
+    honeytrap_deinstall();
+  </custom_php_pre_deinstall_command>
+</packagegui>

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/config/default.toml
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/config/default.toml
@@ -1,0 +1,20 @@
+[listener]
+type="socket"
+
+[service.ssh-simulator]
+type="ssh-simulator"
+credentials=["root:root", "root:password"]
+
+[[port]]
+ports=["tcp/8022"]
+services=["ssh-simulator"]
+
+[channel.console]
+type="console"
+
+[[filter]]
+channel=["console"]
+
+[[logging]]
+output="/var/log/honeytrap/logging.log"
+level="debug"

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
@@ -1,0 +1,113 @@
+<?php
+/*
+ * honeytrap-plugin.inc
+ *
+ * part of pfSense (http://www.pfsense.org)
+ * Copyright (c) 2019 DutchSec (https://dutchsec.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once('globals.inc');
+require_once('pfsense-utils.inc');
+require_once('service-utils.inc');
+
+function honeytrap_sync_config() {
+    global $g, $config;
+    $gconfig = $config['installedpackages']['honeytrap']['config'][0];
+
+    if (is_service_running('honeytrap')){
+        log_error('Stopping service honeytrap');
+        stop_service('honeytrap');
+    }
+
+    if (!isset($gconfig['enable']) | $gconfig['enable'] !== 'on') {
+        return;
+    }
+
+    $config_file = $gconfig['config_file'];
+    $part_parts = pathinfo($config_file);
+    $stdout = "{$g['varlog_path']}/honeytrap/{$part_parts['filename']}.log";
+
+    $daemon = '/usr/local/bin/honeytrap';
+    $data_dir = '/usr/local/pkg/honeytrap/.data/';
+    $pid = "{$g['varrun_path']}/honeytrap.pid";
+    $stop = "/bin/kill -INT `/bin/cat {$pid}`";
+    $start = "/usr/sbin/daemon -o {$stdout} -p {$pid} -u honeytrap {$daemon} --data {$data_dir} --config {$config_file}";
+    if (isset($gconfig['truncate']) && $gconfig['truncate'] === 'on') {
+        $clear = "/usr/bin/truncate -c -s 0 {$stdout}".PHP_EOL;
+        $start = $clear ."\t". $start;
+    }
+
+    $write = write_rcfile(array(
+        'file' => 'honeytrap-daemon.sh',
+        'start' => $start,
+        'stop' => $stop
+    )
+    );
+
+    if (platform_booting()) {
+        return;
+    }
+
+    log_error('Starting service honeytrap');
+    start_service('honeytrap');
+}
+
+function honeytrap_install() {
+    global $config, $g;
+
+    if (!isset($config['installedpackages']['honeytrap'])) {
+        $config['installedpackages']['honeytrap'] = array();
+        $config['installedpackages']['honeytrap']['config'] = array();
+    }
+
+    $gconfig =& $config['installedpackages']['honeytrap']['config'][0];
+
+    $gconfig['config_file'] = '/usr/local/pkg/honeytrap/config/default.toml';
+    $gconfig['truncate'] = 'on';
+
+    write_config('HoneyTrap: Add config');
+}
+
+function recursiveDelete($str, $inclusive=false) {
+    if (is_file($str)) {
+        return @unlink($str);
+    }
+    elseif (is_dir($str)) {
+        $scan = glob(rtrim($str,'/').'/*');
+        foreach($scan as $index=>$path) {
+            recursiveDelete($path);
+        }
+        if ($inclusive) {
+            return @rmdir($str);
+        }
+    }
+}
+
+function honeytrap_deinstall() {
+    if (is_service_running('honeytrap')) {
+        log_error('Stopping service honeytrap');
+        stop_service('honeytrap');
+    }
+
+    global $config;
+    unset($config['installedpackages']['honeytrap']);
+
+    write_config('HoneyTrap: Remove config');
+
+    unlink_if_exists('/usr/local/etc/rc.d/honeytrap-daemon.sh');
+    recursiveDelete('/usr/local/pkg/honeytrap/.data/');
+    recursiveDelete("{$g['varlog_path']}/honeytrap/", true);
+}
+?>

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
@@ -71,6 +71,7 @@ function honeytrap_install() {
 
 	$gconfig =& $config['installedpackages']['honeytrap']['config'][0];
 
+	$gconfig['keep'] = 'on';
 	$gconfig['config_file'] = '/usr/local/pkg/honeytrap/config/default.toml';
 	$gconfig['truncate'] = 'on';
 

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
@@ -67,10 +67,7 @@ function honeytrap_sync_config() {
 
 function honeytrap_install() {
 	global $config;
-
-	if (!isset($config['installedpackages']['honeytrap'])) {
-		init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
-	}
+	init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
 
 	$gconfig =& $config['installedpackages']['honeytrap']['config'][0];
 
@@ -81,25 +78,23 @@ function honeytrap_install() {
 }
 
 function honeytrap_deinstall() {
-    update_status('Removing HoneyTrap')
+	update_status('Removing HoneyTrap')
 	if (is_service_running('honeytrap')) {
 		update_status('Stopping HoneyTrap service');
 		stop_service('honeytrap');
 	}
 
-    global $config;
-	if (!isset($config['installedpackages']['honeytrap'])) {
-		init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
-	}
-    $gconfig =& $config['installedpackages']['honeytrap']['config'][0];
+	global $config;
+	init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
+	$gconfig =& $config['installedpackages']['honeytrap']['config'][0];
 
-    if (isset($gconfig['keep']) || $gconfig['keep'] != 'on') {
+	if (isset($gconfig['keep']) || $gconfig['keep'] != 'on') {
 		update_status('Removing HoneyTrap configuration');
-        unset($config['installedpackages']['honeytrap']);
-        write_config('HoneyTrap: Remove config')
-        unlink_if_exists('/usr/local/etc/rc.d/honeytrap-daemon.sh');
-        rmdir_recursive('/usr/local/pkg/honeytrap/.data');
-        rmdir_recursive('/usr/local/pkg/honeytrap/config');
-    }
+		unset($config['installedpackages']['honeytrap']);
+		write_config('HoneyTrap: Remove config')
+		unlink_if_exists('/usr/local/etc/rc.d/honeytrap-daemon.sh');
+		rmdir_recursive('/usr/local/pkg/honeytrap/.data');
+		rmdir_recursive('/usr/local/pkg/honeytrap/config');
+	}
 }
 ?>

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
@@ -81,13 +81,25 @@ function honeytrap_install() {
 }
 
 function honeytrap_deinstall() {
+    update_status('Removing HoneyTrap')
 	if (is_service_running('honeytrap')) {
-		log_error('Stopping service honeytrap');
+		update_status('Stopping HoneyTrap service');
 		stop_service('honeytrap');
 	}
 
-	unlink_if_exists('/usr/local/etc/rc.d/honeytrap-daemon.sh');
-	rmdir_recursive('/usr/local/pkg/honeytrap/.data/');
-	rmdir_recursive("{$g['varlog_path']}/honeytrap/", true);
+    global $config;
+	if (!isset($config['installedpackages']['honeytrap'])) {
+		init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
+	}
+    $gconfig =& $config['installedpackages']['honeytrap']['config'][0];
+
+    if (isset($gconfig['keep']) || $gconfig['keep'] != 'on') {
+		update_status('Removing HoneyTrap configuration');
+        unset($config['installedpackages']['honeytrap']);
+        write_config('HoneyTrap: Remove config')
+        unlink_if_exists('/usr/local/etc/rc.d/honeytrap-daemon.sh');
+        rmdir_recursive('/usr/local/pkg/honeytrap/.data');
+        rmdir_recursive('/usr/local/pkg/honeytrap/config');
+    }
 }
 ?>

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
@@ -37,8 +37,7 @@ function honeytrap_sync_config() {
 	}
 
 	$config_file = $gconfig['config_file'];
-	$part_parts = pathinfo($config_file);
-	$stdout = "{$g['varlog_path']}/honeytrap/{$part_parts['filename']}.log";
+	$stdout = "{$g['varlog_path']}/honeytrap/service.log";
 
 	$daemon = '/usr/local/bin/honeytrap';
 	$data_dir = '/usr/local/pkg/honeytrap/.data/';

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
@@ -78,7 +78,7 @@ function honeytrap_install() {
 }
 
 function honeytrap_deinstall() {
-	update_status('Removing HoneyTrap')
+	update_status('Removing HoneyTrap');
 	if (is_service_running('honeytrap')) {
 		update_status('Stopping HoneyTrap service');
 		stop_service('honeytrap');
@@ -91,7 +91,7 @@ function honeytrap_deinstall() {
 	if (isset($gconfig['keep']) || $gconfig['keep'] != 'on') {
 		update_status('Removing HoneyTrap configuration');
 		unset($config['installedpackages']['honeytrap']);
-		write_config('HoneyTrap: Remove config')
+		write_config('HoneyTrap: Remove config');
 		unlink_if_exists('/usr/local/etc/rc.d/honeytrap-daemon.sh');
 		rmdir_recursive('/usr/local/pkg/honeytrap/.data');
 		rmdir_recursive('/usr/local/pkg/honeytrap/config');

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
@@ -24,6 +24,7 @@ require_once('service-utils.inc');
 
 function honeytrap_sync_config() {
     global $g, $config;
+    init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
     $gconfig = $config['installedpackages']['honeytrap']['config'][0];
 
     if (is_service_running('honeytrap')){
@@ -31,7 +32,7 @@ function honeytrap_sync_config() {
         stop_service('honeytrap');
     }
 
-    if (!isset($gconfig['enable']) | $gconfig['enable'] !== 'on') {
+    if (!isset($gconfig['enable']) || $gconfig['enable'] !== 'on') {
         return;
     }
 
@@ -65,11 +66,10 @@ function honeytrap_sync_config() {
 }
 
 function honeytrap_install() {
-    global $config, $g;
+    global $config;
 
     if (!isset($config['installedpackages']['honeytrap'])) {
-        $config['installedpackages']['honeytrap'] = array();
-        $config['installedpackages']['honeytrap']['config'] = array();
+        init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
     }
 
     $gconfig =& $config['installedpackages']['honeytrap']['config'][0];
@@ -80,34 +80,14 @@ function honeytrap_install() {
     write_config('HoneyTrap: Add config');
 }
 
-function recursiveDelete($str, $inclusive=false) {
-    if (is_file($str)) {
-        return @unlink($str);
-    }
-    elseif (is_dir($str)) {
-        $scan = glob(rtrim($str,'/').'/*');
-        foreach($scan as $index=>$path) {
-            recursiveDelete($path);
-        }
-        if ($inclusive) {
-            return @rmdir($str);
-        }
-    }
-}
-
 function honeytrap_deinstall() {
     if (is_service_running('honeytrap')) {
         log_error('Stopping service honeytrap');
         stop_service('honeytrap');
     }
 
-    global $config;
-    unset($config['installedpackages']['honeytrap']);
-
-    write_config('HoneyTrap: Remove config');
-
     unlink_if_exists('/usr/local/etc/rc.d/honeytrap-daemon.sh');
-    recursiveDelete('/usr/local/pkg/honeytrap/.data/');
-    recursiveDelete("{$g['varlog_path']}/honeytrap/", true);
+    rmdir_recursive('/usr/local/pkg/honeytrap/.data/');
+    rmdir_recursive("{$g['varlog_path']}/honeytrap/", true);
 }
 ?>

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
@@ -88,7 +88,7 @@ function honeytrap_deinstall() {
 	init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
 	$gconfig =& $config['installedpackages']['honeytrap']['config'][0];
 
-	if (isset($gconfig['keep']) || $gconfig['keep'] != 'on') {
+	if (!isset($gconfig['keep']) || $gconfig['keep'] != 'on') {
 		update_status('Removing HoneyTrap configuration');
 		unset($config['installedpackages']['honeytrap']);
 		write_config('HoneyTrap: Remove config');

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/honeytrap/honeytrap-plugin.inc
@@ -23,71 +23,71 @@ require_once('pfsense-utils.inc');
 require_once('service-utils.inc');
 
 function honeytrap_sync_config() {
-    global $g, $config;
-    init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
-    $gconfig = $config['installedpackages']['honeytrap']['config'][0];
+	global $g, $config;
+	init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
+	$gconfig = $config['installedpackages']['honeytrap']['config'][0];
 
-    if (is_service_running('honeytrap')){
-        log_error('Stopping service honeytrap');
-        stop_service('honeytrap');
-    }
+	if (is_service_running('honeytrap')){
+		log_error('Stopping service honeytrap');
+		stop_service('honeytrap');
+	}
 
-    if (!isset($gconfig['enable']) || $gconfig['enable'] !== 'on') {
-        return;
-    }
+	if (!isset($gconfig['enable']) || $gconfig['enable'] !== 'on') {
+		return;
+	}
 
-    $config_file = $gconfig['config_file'];
-    $part_parts = pathinfo($config_file);
-    $stdout = "{$g['varlog_path']}/honeytrap/{$part_parts['filename']}.log";
+	$config_file = $gconfig['config_file'];
+	$part_parts = pathinfo($config_file);
+	$stdout = "{$g['varlog_path']}/honeytrap/{$part_parts['filename']}.log";
 
-    $daemon = '/usr/local/bin/honeytrap';
-    $data_dir = '/usr/local/pkg/honeytrap/.data/';
-    $pid = "{$g['varrun_path']}/honeytrap.pid";
-    $stop = "/bin/kill -INT `/bin/cat {$pid}`";
-    $start = "/usr/sbin/daemon -o {$stdout} -p {$pid} -u honeytrap {$daemon} --data {$data_dir} --config {$config_file}";
-    if (isset($gconfig['truncate']) && $gconfig['truncate'] === 'on') {
-        $clear = "/usr/bin/truncate -c -s 0 {$stdout}".PHP_EOL;
-        $start = $clear ."\t". $start;
-    }
+	$daemon = '/usr/local/bin/honeytrap';
+	$data_dir = '/usr/local/pkg/honeytrap/.data/';
+	$pid = "{$g['varrun_path']}/honeytrap.pid";
+	$stop = "/bin/kill -INT `/bin/cat {$pid}`";
+	$start = "/usr/sbin/daemon -o {$stdout} -p {$pid} -u honeytrap {$daemon} --data {$data_dir} --config {$config_file}";
+	if (isset($gconfig['truncate']) && $gconfig['truncate'] === 'on') {
+		$clear = "/usr/bin/truncate -c -s 0 {$stdout}".PHP_EOL;
+		$start = $clear ."\t". $start;
+	}
 
-    $write = write_rcfile(array(
-        'file' => 'honeytrap-daemon.sh',
-        'start' => $start,
-        'stop' => $stop
-    )
-    );
+	$write = write_rcfile(array(
+		'file' => 'honeytrap-daemon.sh',
+		'start' => $start,
+		'stop' => $stop
+	)
+	);
 
-    if (platform_booting()) {
-        return;
-    }
+	if (platform_booting()) {
+		return;
+	}
 
-    log_error('Starting service honeytrap');
-    start_service('honeytrap');
+	log_error('Starting service honeytrap');
+	start_service('honeytrap');
 }
 
 function honeytrap_install() {
-    global $config;
+	global $config;
 
-    if (!isset($config['installedpackages']['honeytrap'])) {
-        init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
-    }
+	if (!isset($config['installedpackages']['honeytrap'])) {
+		init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
+	}
 
-    $gconfig =& $config['installedpackages']['honeytrap']['config'][0];
+	$gconfig =& $config['installedpackages']['honeytrap']['config'][0];
 
-    $gconfig['config_file'] = '/usr/local/pkg/honeytrap/config/default.toml';
-    $gconfig['truncate'] = 'on';
+	$gconfig['config_file'] = '/usr/local/pkg/honeytrap/config/default.toml';
+	$gconfig['truncate'] = 'on';
 
-    write_config('HoneyTrap: Add config');
+	write_config('HoneyTrap: Add config');
 }
 
 function honeytrap_deinstall() {
-    if (is_service_running('honeytrap')) {
-        log_error('Stopping service honeytrap');
-        stop_service('honeytrap');
-    }
+	if (is_service_running('honeytrap')) {
+		log_error('Stopping service honeytrap');
+		stop_service('honeytrap');
+	}
 
-    unlink_if_exists('/usr/local/etc/rc.d/honeytrap-daemon.sh');
-    rmdir_recursive('/usr/local/pkg/honeytrap/.data/');
-    rmdir_recursive("{$g['varlog_path']}/honeytrap/", true);
+	unlink_if_exists('/usr/local/etc/rc.d/honeytrap-daemon.sh');
+	rmdir_recursive('/usr/local/pkg/honeytrap/.data/');
+	rmdir_recursive("{$g['varlog_path']}/honeytrap/", true);
 }
 ?>

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/priv/honeytrap.priv.inc
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/pkg/priv/honeytrap.priv.inc
@@ -1,0 +1,29 @@
+<?php
+/*
+ * honeytrap.priv.inc
+ *
+ * part of pfSense (http://www.pfsense.org)
+ * Copyright (c) 2019 DutchSec (https://dutchsec.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+global $priv_list;
+
+$priv_list['page-service-honeytrap'] = array();
+$priv_list['page-service-honeytrap']['name'] = 'WebCfg - Services: HoneyTrap package';
+$priv_list['page-service-honeytrap']['descr'] = 'Allow acces to HoneyTrap package GUI';
+$priv_list['page-service-honeytrap']['match'] = array();
+$priv_list['page-service-honeytrap']['match'][] = 'honeytrap/honeytrap_settings.php*';
+$priv_list['page-service-honeytrap']['match'][] = 'honeytrap/honeytrap_logs.php*';
+?>

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/share/pfSense-pkg-HoneyTrap/info.xml
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/share/pfSense-pkg-HoneyTrap/info.xml
@@ -1,0 +1,17 @@
+<pfsensepkgs>
+      <package>
+            <name>HoneyTrap</name>
+            <internal_name>HoneyTrap</internal_name>
+            <pkginfolink>https://github.com/honeytrap/honeytrap</pkginfolink>
+            <descr><![CDATA[HoneyTrap is a modular framework for running, monitoring and managing honeypots.&lt;br /&gt;
+                   Using HoneyTrap you can use sensors, high interaction and low interaction honeypots together,&lt;br /&gt;
+                   while still using the same event mechanisms.&lt;br /&gt;
+                   HoneyTrap consists of services, directors, listeners and channels. It is easy to build new services,&lt;br /&gt;
+                   attach existing honeypots and extend channels or directors.]]></descr>
+            <website>https://dutchsec.com/</website>
+            <category>security</category>
+            <version>%%PKGVERSION%%</version>
+            <status>Beta</status>
+            <configurationfile>honeytrap-plugin.xml</configurationfile>
+      </package>
+</pfsensepkgs>

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/share/pfSense-pkg-HoneyTrap/info.xml
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/share/pfSense-pkg-HoneyTrap/info.xml
@@ -1,17 +1,20 @@
 <pfsensepkgs>
-      <package>
-            <name>HoneyTrap</name>
-            <internal_name>HoneyTrap</internal_name>
-            <pkginfolink>https://github.com/honeytrap/honeytrap</pkginfolink>
-            <descr><![CDATA[HoneyTrap is a modular framework for running, monitoring and managing honeypots.&lt;br /&gt;
-                   Using HoneyTrap you can use sensors, high interaction and low interaction honeypots together,&lt;br /&gt;
-                   while still using the same event mechanisms.&lt;br /&gt;
-                   HoneyTrap consists of services, directors, listeners and channels. It is easy to build new services,&lt;br /&gt;
-                   attach existing honeypots and extend channels or directors.]]></descr>
-            <website>https://dutchsec.com/</website>
-            <category>security</category>
-            <version>%%PKGVERSION%%</version>
-            <status>Beta</status>
-            <configurationfile>honeytrap-plugin.xml</configurationfile>
-      </package>
+	<package>
+		<name>HoneyTrap</name>
+		<internal_name>HoneyTrap</internal_name>
+		<pkginfolink>https://github.com/honeytrap/honeytrap</pkginfolink>
+		<descr><![CDATA[HoneyTrap is a modular framework for running, monitoring and managing honeypots.&lt;br /&gt;
+			   Using HoneyTrap you can use sensors, high interaction and low interaction honeypots together,&lt;br /&gt;
+			   while still using the same event mechanisms.&lt;br /&gt;
+			   HoneyTrap consists of services, directors, listeners and channels. It is easy to build new services,&lt;br /&gt;
+			   attach existing honeypots and extend channels or directors.]]></descr>
+		<website>https://dutchsec.com/</website>
+		<category>security</category>
+		<version>%%PKGVERSION%%</version>
+		<status>Beta</status>
+		<configurationfile>honeytrap-plugin.xml</configurationfile>
+		<logging>
+			<logfilename>honeytrap/service.log</logfilename>
+		</logging>
+	</package>
 </pfsensepkgs>

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_logs.php
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_logs.php
@@ -23,8 +23,7 @@ require_once('globals.inc');
 
 require_once('honeytrap/honeytrap-plugin.inc');
 
-global $config, $g;
-
+init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
 $gconfig = &$config['installedpackages']['honeytrap']['config'][0];
 
 $config_file =  $gconfig['config_file'];
@@ -37,9 +36,9 @@ $pglinks = array('', '/honeytrap/honeytrap_settings.php', '@self');
 $shortcut_section = 'honeytrap';
 include_once('head.inc');
 
-if (!realpath($logfile)) {
+if (!realpath($logfile)):
     print_info_box('Logfile doesn\'t seem to exist');
-} else {
+else:
     $logfile_contents = file_get_contents($logfile);
 
     ?>
@@ -55,8 +54,7 @@ if (!realpath($logfile)) {
     </div>
 </div>
 <?php
-
-}
+endif;
 
 include_once('foot.inc');
 ?>

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_logs.php
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_logs.php
@@ -27,9 +27,8 @@ init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
 $gconfig = &$config['installedpackages']['honeytrap']['config'][0];
 
 $config_file =	$gconfig['config_file'];
-$path_parts = pathinfo($config_file);
 
-$logfile = "{$g['varlog_path']}/honeytrap/{$path_parts['filename']}.log";
+$logfile = "{$g['varlog_path']}/honeytrap/service.log";
 
 $pgtitle = array(gettext("Service"), gettext("HoneyTrap"), gettext('Logs'));
 $pglinks = array('', '/honeytrap/honeytrap_settings.php', '@self');

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_logs.php
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_logs.php
@@ -1,0 +1,62 @@
+<?php
+/*
+* honeytrap_logs.php
+*
+* part of pfSense (http://www.pfsense.org)
+* Copyright (c) 2019 DutchSec (https://dutchsec.com/)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+require_once('guiconfig.inc');
+require_once('globals.inc');
+
+require_once('honeytrap/honeytrap-plugin.inc');
+
+global $config, $g;
+
+$gconfig = &$config['installedpackages']['honeytrap']['config'][0];
+
+$config_file =  $gconfig['config_file'];
+$path_parts = pathinfo($config_file);
+
+$logfile = "{$g['varlog_path']}/honeytrap/{$path_parts['filename']}.log";
+
+$pgtitle = array(gettext("Service"), gettext("HoneyTrap"), gettext('Logs'));
+$pglinks = array('', '/honeytrap/honeytrap_settings.php', '@self');
+$shortcut_section = 'honeytrap';
+include_once('head.inc');
+
+if (!realpath($logfile)) {
+    print_info_box('Logfile doesn\'t seem to exist');
+} else {
+    $logfile_contents = file_get_contents($logfile);
+
+    ?>
+<div class="panel panel-default">
+    <div class="panel-heading"><h2 class="panel-title">HoneyTrap service log</h2></div>
+    <div class="panel-body">
+        <pre>
+<?php
+    echo htmlspecialchars($logfile_contents, ENT_SUBSTITUTE) . PHP_EOL;
+
+    ?>
+        </pre>
+    </div>
+</div>
+<?php
+
+}
+
+include_once('foot.inc');
+?>

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_logs.php
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_logs.php
@@ -26,7 +26,7 @@ require_once('honeytrap/honeytrap-plugin.inc');
 init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
 $gconfig = &$config['installedpackages']['honeytrap']['config'][0];
 
-$config_file =  $gconfig['config_file'];
+$config_file =	$gconfig['config_file'];
 $path_parts = pathinfo($config_file);
 
 $logfile = "{$g['varlog_path']}/honeytrap/{$path_parts['filename']}.log";
@@ -37,21 +37,21 @@ $shortcut_section = 'honeytrap';
 include_once('head.inc');
 
 if (!realpath($logfile)):
-    print_info_box('Logfile doesn\'t seem to exist');
+	print_info_box('Logfile doesn\'t seem to exist');
 else:
-    $logfile_contents = file_get_contents($logfile);
+	$logfile_contents = file_get_contents($logfile);
 
-    ?>
+	?>
 <div class="panel panel-default">
-    <div class="panel-heading"><h2 class="panel-title">HoneyTrap service log</h2></div>
-    <div class="panel-body">
-        <pre>
+	<div class="panel-heading"><h2 class="panel-title">HoneyTrap service log</h2></div>
+	<div class="panel-body">
+		<pre>
 <?php
-    echo htmlspecialchars($logfile_contents, ENT_SUBSTITUTE) . PHP_EOL;
+	echo htmlspecialchars($logfile_contents, ENT_SUBSTITUTE) . PHP_EOL;
 
-    ?>
-        </pre>
-    </div>
+	?>
+		</pre>
+	</div>
 </div>
 <?php
 endif;

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_settings.php
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_settings.php
@@ -89,7 +89,7 @@ $section->addInput(new Form_Checkbox(
 $section->addInput(new Form_Checkbox(
 	'keep',
 	'Keep',
-	'Keep settings on install,upgrade or deinstall',
+	'Keep settings on install, upgrade or deinstall',
 	$gconfig['keep'] === 'on' ? true:false,
 	'on'
 ));
@@ -99,7 +99,7 @@ $section = new Form_Section('Service Settings');
 $section->addInput(new Form_Checkbox(
 	'truncate',
 	'Truncate',
-	'Truncate serice output logs on service start',
+	'Truncate service output logs on service start',
 	$gconfig['truncate'] === 'on' ? true:false,
 	'on'
 ));

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_settings.php
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_settings.php
@@ -93,9 +93,10 @@ $section->addInput(new Form_Checkbox(
 	$gconfig['keep'] === 'on' ? true:false,
 	'on'
 ));
+$form->add($section);
 
-$group = new Form_Group('Service Settings');
-$group->addInput(new Form_Checkbox(
+$section = new Form_Section('Service Settings');
+$section->addInput(new Form_Checkbox(
 	'truncate',
 	'Truncate',
 	'Truncate serice output logs on service start',
@@ -103,13 +104,12 @@ $group->addInput(new Form_Checkbox(
 	'on'
 ));
 
-$group->addInput(new Form_Input(
+$section->addInput(new Form_Input(
 	'config_file',
 	'Config file path',
 	'text',
 	$gconfig['config_file']
 ));
-$section->add($group);
 
 $form->add($section);
 print($form);

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_settings.php
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_settings.php
@@ -33,6 +33,12 @@ if ($_POST && isset($_POST['save'])) {
 		unset($gconfig['enable']);
 	}
 
+	if (isset($_POST['keep']) && $_POST['keep'] == 'on') {
+		$gconfig['keep'] = $_POST['keep'];
+	} else {
+		unset($gconfig['keep']);
+	}
+
 	if (isset($_POST['truncate']) && $_POST['truncate'] == 'on') {
 		$gconfig['truncate'] = $_POST['truncate'];
 	} else {
@@ -71,29 +77,39 @@ if (isset($savemsg)) {
 
 $form = new Form();
 
-$section = new Form_Section('HoneyTrap Service Settings');
+$section = new Form_Section('HoneyTrap General Settings');
 $section->addInput(new Form_Checkbox(
 	'enable',
 	'Enable',
-	'Enable the HoneyTrap service',
+	'Enable HoneyTrap',
 	$gconfig['enable'] === 'on' ? true:false,
 	'on'
 ));
 
 $section->addInput(new Form_Checkbox(
+	'keep',
+	'Keep',
+	'Keep settings on install,upgrade or deinstall',
+	$gconfig['keep'] === 'on' ? true:false,
+	'on'
+));
+
+$group = new Form_Group('Service Settings');
+$group->addInput(new Form_Checkbox(
 	'truncate',
 	'Truncate',
-	'Truncate logs on service start',
+	'Truncate serice output logs on service start',
 	$gconfig['truncate'] === 'on' ? true:false,
 	'on'
 ));
 
-$section->addInput(new Form_Input(
+$group->addInput(new Form_Input(
 	'config_file',
 	'Config file path',
 	'text',
 	$gconfig['config_file']
 ));
+$section->add($group)
 
 $form->add($section);
 print($form);

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_settings.php
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_settings.php
@@ -27,34 +27,34 @@ init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
 $gconfig = &$config['installedpackages']['honeytrap']['config'][0];
 
 if ($_POST && isset($_POST['save'])) {
-    if (isset($_POST['enable']) && $_POST['enable'] == 'on') {
-        $gconfig['enable'] = $_POST['enable'];
-    } else {
-        unset($gconfig['enable']);
-    }
+	if (isset($_POST['enable']) && $_POST['enable'] == 'on') {
+		$gconfig['enable'] = $_POST['enable'];
+	} else {
+		unset($gconfig['enable']);
+	}
 
-    if (isset($_POST['truncate']) && $_POST['truncate'] == 'on') {
-        $gconfig['truncate'] = $_POST['truncate'];
-    } else {
-        unset($gconfig['truncate']);
-    }
+	if (isset($_POST['truncate']) && $_POST['truncate'] == 'on') {
+		$gconfig['truncate'] = $_POST['truncate'];
+	} else {
+		unset($gconfig['truncate']);
+	}
 
-    if (isset($_POST['config_file'])) {
-        $part_parts = pathinfo($_POST['config_file']);
-        if ($part_parts['extension'] != 'toml') {
-            $input_errors[] = "Config file must be a TOML file.\nCurrent extension is {$part_parts['extension']}";
-        } elseif (!realpath($_POST['config_file'])) {
-            $input_errors[] = 'File can\'t be found.';
-        } else {
-            $gconfig['config_file'] = $_POST['config_file'];
-        }
-    }
+	if (isset($_POST['config_file'])) {
+		$part_parts = pathinfo($_POST['config_file']);
+		if ($part_parts['extension'] != 'toml') {
+			$input_errors[] = "Config file must be a TOML file.\nCurrent extension is {$part_parts['extension']}";
+		} elseif (!realpath($_POST['config_file'])) {
+			$input_errors[] = 'File can\'t be found.';
+		} else {
+			$gconfig['config_file'] = $_POST['config_file'];
+		}
+	}
 
-    if (!$input_errors) {
-        $savemsg = 'Successfully modified settings.';
-        write_config($savemsg);
-        honeytrap_sync_config();
-    }
+	if (!$input_errors) {
+		$savemsg = 'Successfully modified settings.';
+		write_config($savemsg);
+		honeytrap_sync_config();
+	}
 }
 
 $pgtitle = array(gettext("Service"), gettext("HoneyTrap"));
@@ -62,37 +62,37 @@ $shortcut_section = 'honeytrap';
 include_once('head.inc');
 
 if (isset($input_errors)) {
-    print_input_errors($input_errors);
+	print_input_errors($input_errors);
 }
 
 if (isset($savemsg)) {
-    print_info_box($savemsg, 'success');
+	print_info_box($savemsg, 'success');
 }
 
 $form = new Form();
 
 $section = new Form_Section('HoneyTrap Service Settings');
 $section->addInput(new Form_Checkbox(
-    'enable',
-    'Enable',
-    'Enable the HoneyTrap service',
-    $gconfig['enable'] === 'on' ? true:false,
-    'on'
+	'enable',
+	'Enable',
+	'Enable the HoneyTrap service',
+	$gconfig['enable'] === 'on' ? true:false,
+	'on'
 ));
 
 $section->addInput(new Form_Checkbox(
-    'truncate',
-    'Truncate',
-    'Truncate logs on service start',
-    $gconfig['truncate'] === 'on' ? true:false,
-    'on'
+	'truncate',
+	'Truncate',
+	'Truncate logs on service start',
+	$gconfig['truncate'] === 'on' ? true:false,
+	'on'
 ));
 
 $section->addInput(new Form_Input(
-    'config_file',
-    'Config file path',
-    'text',
-    $gconfig['config_file']
+	'config_file',
+	'Config file path',
+	'text',
+	$gconfig['config_file']
 ));
 
 $form->add($section);

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_settings.php
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_settings.php
@@ -1,0 +1,104 @@
+<?php
+/*
+ * honeytrap_settings.php
+ *
+ * part of pfSense (http://www.pfsense.org)
+ * Copyright (c) 2019 DutchSec (https://dutchsec.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once('guiconfig.inc');
+require_once('globals.inc');
+
+require_once('honeytrap/honeytrap-plugin.inc');
+
+global $config, $g;
+
+$gconfig = &$config['installedpackages']['honeytrap']['config'][0];
+
+if ($_POST) {
+    if (isset($_POST['save'])) {
+        if (isset($_POST['enable']) && $_POST['enable'] == 'on') {
+            $gconfig['enable'] = $_POST['enable'];
+        } else {
+            unset($gconfig['enable']);
+        }
+
+        if (isset($_POST['truncate']) && $_POST['truncate'] == 'on') {
+            $gconfig['truncate'] = $_POST['truncate'];
+        } else {
+            unset($gconfig['truncate']);
+        }
+
+        if (isset($_POST['config_file'])) {
+            $part_parts = pathinfo($_POST['config_file']);
+            if ($part_parts['extension'] != 'toml') {
+                $input_errors[] = "Config file must be a TOML file.\nCurrent extension is {$part_parts['extension']}";
+            } elseif (!realpath($_POST['config_file'])) {
+                $input_errors[] = 'File can\'t be found.';
+            } else {
+                $gconfig['config_file'] = $_POST['config_file'];
+            }
+        }
+
+        if (!$input_errors) {
+            $savemsg = 'Successfully modified settings.';
+            write_config($savemsg);
+            honeytrap_sync_config();
+        }
+    }
+}
+
+$pgtitle = array(gettext("Service"), gettext("HoneyTrap"));
+$shortcut_section = 'honeytrap';
+include_once('head.inc');
+
+if (isset($input_errors)) {
+    print_input_errors($input_errors);
+}
+
+if (isset($savemsg)) {
+    print_info_box($savemsg, 'success');
+}
+
+$form = new Form();
+
+$section = new Form_Section('HoneyTrap Service Settings');
+$section->addInput(new Form_Checkbox(
+    'enable',
+    'Enable',
+    'Enable the HoneyTrap service',
+    $gconfig['enable'] === 'on' ? true:false,
+    'on'
+));
+
+$section->addInput(new Form_Checkbox(
+    'truncate',
+    'Truncate',
+    'Truncate logs on service start',
+    $gconfig['truncate'] === 'on' ? true:false,
+    'on'
+));
+
+$section->addInput(new Form_Input(
+    'config_file',
+    'Config file path',
+    'text',
+    $gconfig['config_file']
+));
+
+$form->add($section);
+print($form);
+include('foot.inc');
+?>

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_settings.php
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_settings.php
@@ -109,7 +109,7 @@ $group->addInput(new Form_Input(
 	'text',
 	$gconfig['config_file']
 ));
-$section->add($group)
+$section->add($group);
 
 $form->add($section);
 print($form);

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_settings.php
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/www/honeytrap/honeytrap_settings.php
@@ -23,40 +23,37 @@ require_once('globals.inc');
 
 require_once('honeytrap/honeytrap-plugin.inc');
 
-global $config, $g;
-
+init_config_arr(array('installedpackages', 'honeytrap', 'config', 0));
 $gconfig = &$config['installedpackages']['honeytrap']['config'][0];
 
-if ($_POST) {
-    if (isset($_POST['save'])) {
-        if (isset($_POST['enable']) && $_POST['enable'] == 'on') {
-            $gconfig['enable'] = $_POST['enable'];
+if ($_POST && isset($_POST['save'])) {
+    if (isset($_POST['enable']) && $_POST['enable'] == 'on') {
+        $gconfig['enable'] = $_POST['enable'];
+    } else {
+        unset($gconfig['enable']);
+    }
+
+    if (isset($_POST['truncate']) && $_POST['truncate'] == 'on') {
+        $gconfig['truncate'] = $_POST['truncate'];
+    } else {
+        unset($gconfig['truncate']);
+    }
+
+    if (isset($_POST['config_file'])) {
+        $part_parts = pathinfo($_POST['config_file']);
+        if ($part_parts['extension'] != 'toml') {
+            $input_errors[] = "Config file must be a TOML file.\nCurrent extension is {$part_parts['extension']}";
+        } elseif (!realpath($_POST['config_file'])) {
+            $input_errors[] = 'File can\'t be found.';
         } else {
-            unset($gconfig['enable']);
+            $gconfig['config_file'] = $_POST['config_file'];
         }
+    }
 
-        if (isset($_POST['truncate']) && $_POST['truncate'] == 'on') {
-            $gconfig['truncate'] = $_POST['truncate'];
-        } else {
-            unset($gconfig['truncate']);
-        }
-
-        if (isset($_POST['config_file'])) {
-            $part_parts = pathinfo($_POST['config_file']);
-            if ($part_parts['extension'] != 'toml') {
-                $input_errors[] = "Config file must be a TOML file.\nCurrent extension is {$part_parts['extension']}";
-            } elseif (!realpath($_POST['config_file'])) {
-                $input_errors[] = 'File can\'t be found.';
-            } else {
-                $gconfig['config_file'] = $_POST['config_file'];
-            }
-        }
-
-        if (!$input_errors) {
-            $savemsg = 'Successfully modified settings.';
-            write_config($savemsg);
-            honeytrap_sync_config();
-        }
+    if (!$input_errors) {
+        $savemsg = 'Successfully modified settings.';
+        write_config($savemsg);
+        honeytrap_sync_config();
     }
 }
 

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/www/shortcuts/pkg_honeytrap.inc
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/www/shortcuts/pkg_honeytrap.inc
@@ -1,0 +1,29 @@
+<?php
+/*
+ * pkg_honeytrap.inc
+ *
+ * part of pfSense (http://www.pfsense.org)
+ * Copyright (c) 2019 DutchSec (https://dutchsec.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+global $shortcuts;
+
+$shortcuts['honeytrap'] = array();
+$shortcuts['honeytrap']['main'] = "/honeytrap/honeytrap_settings.php";
+$shortcuts['honeytrap']['status'] = "/status_services.php";
+$shortcuts['honeytrap']['log'] = "/honeytrap/honeytrap_logs.php";
+$shortcuts['honeytrap']['service'] = "honeytrap";
+
+?>

--- a/security/pfSense-pkg-HoneyTrap/files/usr/local/www/shortcuts/pkg_honeytrap.inc
+++ b/security/pfSense-pkg-HoneyTrap/files/usr/local/www/shortcuts/pkg_honeytrap.inc
@@ -18,8 +18,6 @@
  * limitations under the License.
  */
 
-global $shortcuts;
-
 $shortcuts['honeytrap'] = array();
 $shortcuts['honeytrap']['main'] = "/honeytrap/honeytrap_settings.php";
 $shortcuts['honeytrap']['status'] = "/status_services.php";

--- a/security/pfSense-pkg-HoneyTrap/pkg-descr
+++ b/security/pfSense-pkg-HoneyTrap/pkg-descr
@@ -1,0 +1,5 @@
+HoneyTrap is a modular framework for running, monitoring and managing honeypots.
+Using HoneyTrap you can use sensors, high interaction and low
+interaction honeypots together, while still using the same event mechanisms.
+HoneyTrap consists of services, directors, listeners and channels. It is easy to
+build new services, attach existing honeypots and extend channels or directors.

--- a/security/pfSense-pkg-HoneyTrap/pkg-plist
+++ b/security/pfSense-pkg-HoneyTrap/pkg-plist
@@ -1,0 +1,10 @@
+pkg/honeytrap-plugin.xml
+pkg/honeytrap/config/default.toml
+pkg/honeytrap/honeytrap-plugin.inc
+pkg/priv/honeytrap.priv.inc
+@dir(honeytrap,honeytrap,4775) pkg/honeytrap/.data
+www/honeytrap/honeytrap_settings.php
+www/honeytrap/honeytrap_logs.php
+www/shortcuts/pkg_honeytrap.inc
+%%DATADIR%%/info.xml
+@dir(honeytrap,honeytrap,4775) /var/log/honeytrap


### PR DESCRIPTION
This PR adds the HoneyTrap pfSense port. The port depends on security/honeytrap so it should be cherry-picked from FreeBSD.
Ticket #9989