### PR TITLE
Revise radvd to eliminate leave/join group sequences

### DIFF
--- a/net/radvd/Makefile
+++ b/net/radvd/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=	radvd
 PORTVERSION=	2.18
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	net
 MASTER_SITES=	http://www.litech.org/radvd/dist/
 

--- a/net/radvd/files/patch-device-bsd44.c
+++ b/net/radvd/files/patch-device-bsd44.c
@@ -1,14 +1,30 @@
 --- device-bsd44.c.orig	2018-02-18 22:45:02 UTC
 +++ device-bsd44.c
-@@ -126,8 +126,32 @@ ret:
+@@ -126,8 +126,46 @@ ret:
  	return -1;
  }
  
 -int setup_allrouters_membership(int sock, struct Interface *iface) { return 0; }
++#define MAX_IFACE 50
 +int setup_allrouters_membership(int sock, struct Interface *iface) 
 +{
++	static int socket_count = 0;
++	static int msockets[MAX_IFACE] = {};
++	int i;
 +	struct ipv6_mreq mreq;
- 
++
++	for (i=0;i<socket_count;i++) {
++		if (msockets[i] == sock) {
++			return 0;
++		}
++	}
++	if (socket_count < MAX_IFACE-1) {
++		msockets[socket_count] = sock;
++		socket_count++;
++		flog(LOG_INFO, "adding ipv6-allrouters on %s, sock: %d, iface->props.if_index:%d",
++			iface->props.name, sock, iface->props.if_index);
++	}
++
 +	memset(&mreq, 0, sizeof(mreq));
 +	mreq.ipv6mr_interface = iface->props.if_index;
 +
@@ -19,22 +35,20 @@
 +		return (-1);
 +	}
 +
-+	/* XXX: See pfSense ticket #2878 */
-+	setsockopt(sock, IPPROTO_IPV6, IPV6_LEAVE_GROUP, &mreq, sizeof(mreq));
-+
 +	if (setsockopt(sock, IPPROTO_IPV6, IPV6_JOIN_GROUP,
 +			&mreq, sizeof(mreq)) < 0) {
-+		flog(LOG_ERR, "can't join ipv6-allrouters on %s", iface->props.name);
++		flog(LOG_ERR, "can't join ipv6-allrouters on %s, sock: %d, iface->props.if_index:%d, error: %s(%d)",
++			iface->props.name, sock, iface->props.if_index, strerror(errno), errno);
 +		return (-1);
 +	}
 +
 +	return 0; 
 +}
-+
+
  int set_interface_linkmtu(const char *iface, uint32_t mtu)
  {
  	dlog(LOG_DEBUG, 4, "setting LinkMTU (%u) for %s is not supported", mtu, iface);
-@@ -161,5 +185,5 @@ int check_ip6_forwarding(void)
+@@ -161,5 +199,5 @@ int check_ip6_forwarding(void)
  int check_ip6_iface_forwarding(const char *iface)
  {
  	dlog(LOG_DEBUG, 4, "checking ipv6 forwarding of interface not supported");


### PR DESCRIPTION
Redmine Issue #9577
see also Forum topic "ipv6 broken; radvd; can't join ipv6-allrouters on <interface>"

changes to be committed:
	modified:   net/radvd/Makefile
	modified:   net/radvd/files/patch-device-bsd44.c

Revised the patch device-bsd44.c to not leave allrouters_members un-necessarily