### PR TITLE
pfBlockerNG-devel, certificate options and :80 port on vip for DNSBL feature

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1017,6 +1017,9 @@ accesslog.filename		= "|/usr/local/bin/php -f /usr/local/pkg/pfblockerng/pfblock
 		ssl.ec-curve	= "secp384r1"
 	}
 
+	\$SERVER["socket"] == "{$pfb['dnsbl_vip']}:80" {
+	}
+	
 	\$SERVER["socket"] == "{$pfb['dnsbl_vip']}:443" {
 		ssl.engine	= "enable"
 		ssl.pemfile	= "/var/unbound/dnsbl_cert.pem"
@@ -1037,28 +1040,30 @@ EOF;
 
 // Function to create DNSBL SSL certificate
 function pfb_create_dnsbl_cert() {
-	global $pfb;
+	global $pfb, $config, $cert_strict_values;
 
-	$dn = array (	'countryName'		=> 'CA',
-			'stateOrProvinceName'	=> 'ST_DNSBL',
-			'localityName'		=> 'LN_DNSBL',
-			'organizationName'	=> 'ON_DNSBL',
-			'organizationalUnitName'=> 'OU_DNSBL',
-			'commonName'		=> 'CN_DNSBL',
-			'emailAddress'		=> 'dnsbl@example.com'
-			);
+	$cert = array();
+	$cert['refid'] = uniqid();
+	$cert['descr'] = sprintf(gettext("pfBlockerNG DNSBL (%s)"), $cert['refid']);
+	$cert_hostname = "{$config['system']['hostname']}-PFbNG-DNSBL-{$cert['refid']}";
 
-	$pkey_config = array (	'digest_alg'		=> 'sha256',
-				'private_key_bits'	=> 2048,
-				'private_key_type'	=> OPENSSL_KEYTYPE_RSA
-				);
+	$dn = array(
+		'organizationName' => "pfBlockerNG DNSBL Self-Signed Certificate",
+		'commonName' => $cert_hostname,
+		'subjectAltName' => "DNS:{$cert_hostname}");
 
-	$pkey	= openssl_pkey_new($pkey_config);
-	$csr	= openssl_csr_new($dn, $pkey);
-	$cert	= openssl_csr_sign($csr, NULL, $pkey, 3650);
-
-	openssl_pkey_export($pkey, $privatekey);
-	openssl_x509_export($cert, $publickey);
+	$old_err_level = error_reporting(0); /* otherwise openssl_ functions throw warnings directly to a page screwing menu tab */
+	if (!cert_create($cert, null, 2048, $cert_strict_values['max_server_cert_lifetime'], $dn, "self-signed", "sha256")) {
+		while ($ssl_err = openssl_error_string()) {
+			log_error(sprintf(gettext("Error creating pfBlockerNG DNSBL Certificate: openssl library returns: %s"), $ssl_err));
+		}
+		error_reporting($old_err_level);
+		return null;
+	}
+	error_reporting($old_err_level);
+	$privatekey = base64_decode($cert['prv']);
+	$publickey = base64_decode($cert['crt']);
+ 
 	@file_put_contents("{$pfb['dnsbl_cert']}", "{$privatekey}{$publickey}", LOCK_EX);
 }
 

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1053,7 +1053,7 @@ function pfb_create_dnsbl_cert() {
 		'subjectAltName' => "DNS:{$cert_hostname}");
 
 	$old_err_level = error_reporting(0); /* otherwise openssl_ functions throw warnings directly to a page screwing menu tab */
-	if (!cert_create($cert, null, 2048, $cert_strict_values['max_server_cert_lifetime'], $dn, "self-signed", "sha256")) {
+	if (!cert_create($cert, null, 2048, $cert_strict_values['max_server_cert_lifetime'] ?? 398, $dn, "self-signed", "sha256")) {
 		while ($ssl_err = openssl_error_string()) {
 			log_error(sprintf(gettext("Error creating pfBlockerNG DNSBL Certificate: openssl library returns: %s"), $ssl_err));
 		}

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/widgets/javascript/pfblockerng.js
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/widgets/javascript/pfblockerng.js
@@ -24,7 +24,7 @@
 var pfBlockerNGFailedTimer;
 var pfBlockerNGWidgetTimer;
 
-<!-- update timers (10000 ms = 10 seconds, 60000 ms = 1 minute, 300000 ms = 5 mins) -->
+/* update timers (10000 ms = 10 seconds, 60000 ms = 1 minute, 300000 ms = 5 mins) */
 var pfBlockerNGupdateFailedDelay	= 300000;
 var pfBlockerNGupdateWidgetDelay	= 10000;
 


### PR DESCRIPTION
pfBlockerNG-devel, certificate options and :80 port on vip for DNSBL feature

- use a server-certificate with that purpose(x509_extensions) so Chrome doesn't complain about wrong cert usage (without option to skip..)
- use a random serial to avoid possible conflict with Firefox remembering the old CA-cert with same serial..
- Also listen on :80 for dnsBL.

(p.s. the old cert /var/unbound/dnsbl_cert.pem needs to be removed manually..)