### PR TITLE
SIP Trunk plugin for siproxd. Issue #9249

### DIFF
--- a/net/pfSense-pkg-siproxd/Makefile
+++ b/net/pfSense-pkg-siproxd/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-siproxd
-PORTVERSION=	1.1.3
-PORTREVISION=	3
+PORTVERSION=	1.1.4
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-siproxd/files/usr/local/pkg/siproxd.inc
+++ b/net/pfSense-pkg-siproxd/files/usr/local/pkg/siproxd.inc
@@ -338,6 +338,16 @@ function sync_package_siproxd() {
 		}
 	}
 
+	if ($siproxd_conf['plugin_siptrunk'] != "") {
+		fwrite($fout, "load_plugin=plugin_siptrunk.la\n");
+		fwrite($fout, "plugin_siptrunk_name = SIP Trunk\n");
+		if ($siproxd_conf['plugin_siptrunk_account'] != "") {
+			fwrite($fout, "plugin_siptrunk_account = " . $siproxd_conf['plugin_siptrunk_account'] . "\n");
+		}
+		if ($siproxd_conf['plugin_siptrunk_numbers_regex'] != "") {
+			fwrite($fout, "plugin_siptrunk_numbers_regex = " . $siproxd_conf['plugin_siptrunk_numbers_regex'] . "\n");
+		}
+	}
 
 	fclose($fout);
 
@@ -410,6 +420,9 @@ function validate_form_siproxd($post, &$input_errors) {
 	}
 	if ($post['plugin_stun_period'] && (!is_numeric($post['plugin_stun_period']) || ($post['plugin_stun_period'] < 0))) {
 		$input_errors[] = '"STUN Period" must be numeric and greater than 0.';
+	}
+	if (isset($post['plugin_defaulttarget']) && isset($post['plugin_siptrunk'])) {
+		$input_errors[] = 'Plugin SIP Trunk is mutually exclusive with Plugin Default Target.';
 	}
 
 }

--- a/net/pfSense-pkg-siproxd/files/usr/local/pkg/siproxd.xml
+++ b/net/pfSense-pkg-siproxd/files/usr/local/pkg/siproxd.xml
@@ -517,6 +517,29 @@
 			<default_value>192.168.0.0/16,10.0.0.0/8,172.16.0.0/20</default_value>
 		</field>
 		<field>
+			<name>Plugin Settings - SIP Trunk</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>SIP Trunk</fielddescr>
+			<fieldname>plugin_siptrunk</fieldname>
+			<description>Enable SIP Trunk Plugin</description>
+			<sethelp>Plugin to handle SIP Trunks where using *one* single SIP account to which a whole number block is routed. This means an incoming INVITE does carry the target number (in SIP URI or To: header field) but does not really carry any clear indications to which account it belongs to.</sethelp>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>SIP account</fielddescr>
+			<fieldname>plugin_siptrunk_account</fieldname>
+			<description>SIP account in the form of 'sip:user@host', identical as used for registration.</description>
+			<type>input</type>
+		</field>
+		<field>
+			<fielddescr>REGEX number</fielddescr>
+			<fieldname>plugin_siptrunk_numbers_regex</fieldname>
+			<description>Regular expression that matches the whole number block associated with this account. Example: ^555123(10[0-9]|11[012])$</description>
+			<type>input</type>
+		</field>
+		<field>
 			<name>Debug Options</name>
 			<type>listtopic</type>
 		</field>


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/9249
Ready for review

from siproxd.conf.example:

> Plugin_siptrunk
> 
>  Plugin to handle SIP Trunks where using *one* single SIP account a
>  whole number block is routed. This means asn incoming INVITE does carry
>  the target number (in SIP URI or To: header field) but does not really
>  carry any clear indications to which account it belongs to.
>  Thus, we need some help - a mapping of the number blocks used in a SIP
>  trunk and the corresponding SIP account (as used during REGISTER)
> 
>  ..._name:          any name, pure documentation
>  ..._account:       SIP account in the form of 'sip:user@host',
>                     identical as used for registration.
>  ..._numbers_regex: REGEX that matches the whole number block associated
>                     with this account
> 
>  NOTE: plugin_siptrunk is mutually exclusive with plugin_defaulttarget!
>        if the defaulttartet 'plugin is also active, then all incoming calls 
>        on SIP trunks will be redirected to the default target.
> 
> plugin_siptrunk_name = Example Trunk, 555-123100 ... 555-123112
> plugin_siptrunk_account = sip:user@sip.example.org
> plugin_siptrunk_numbers_regex = ^555123(10[0-9]|11[012])$

This PR adds siptrunk configuration to WebGUI