### PR TITLE
LLDPd AgentX support. Issue #8574

### DIFF
--- a/net-mgmt/pfSense-pkg-lldpd/Makefile
+++ b/net-mgmt/pfSense-pkg-lldpd/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-lldpd
-PORTVERSION=	0.9.9
+PORTVERSION=	0.9.10
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-lldpd/files/usr/local/pkg/lldpd/lldpd.inc
+++ b/net-mgmt/pfSense-pkg-lldpd/files/usr/local/pkg/lldpd/lldpd.inc
@@ -155,6 +155,10 @@ function lldpd_sync_config() {
 		}
 	}
 
+	if ($lldpd_config['agentx'] == 'yes') {
+		$cmd .= ' -x';
+	}
+
 	/* Write the rc script */
 	$start = "	$cmd";
 	$stop = "	/usr/bin/killall -q lldpd";

--- a/net-mgmt/pfSense-pkg-lldpd/files/usr/local/www/lldpd_settings.php
+++ b/net-mgmt/pfSense-pkg-lldpd/files/usr/local/www/lldpd_settings.php
@@ -64,6 +64,7 @@ if ($_POST) {
 		$lldpd['enable'] = $pconfig['enable'];
 		$lldpd['receiveonly'] = $pconfig['receiveonly'];
 		$lldpd['interfaces'] = $pconfig['interfaces'];
+		$lldpd['agentx'] = $pconfig['agentx'];
 		$lldpd['chassis'] = $pconfig['chassis'];
 		$lldpd['management'] = $pconfig['management'];
 
@@ -148,6 +149,13 @@ $section->addInput(new Form_Checkbox(
 	'Receive Only Mode',
 	'Do not transmit discovery frames, even in response to received frames',
 	$pconfig['receiveonly']
+));
+
+$section->addInput(new Form_Checkbox(
+	'agentx',
+	'Enable AgentX',
+	'With this option, lldpd will enable an SNMP subagent using AgentX protocol',
+	$pconfig['agentx']
 ));
 
 $section->addInput(new Form_Select(


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/8574
Ready for review

The lldpd-package provided by the package manager seems to be compiled with AgentX-support, but there is nowhere to activate it using the GUI. 
An AgentX sub-agent can connect to Net-SNMP and would in this case make LLDP-information available over SNMP.

In the Net-SNMP configuration, AgentX is already enabled:
```
grep agentx /var/etc/netsnmpd.conf
master agentx
```

original patch by Nicklas Björk (from the redmine page)