### PR TITLE
suricatat4 - Update binary to version 4.1.7 and don't block on noalert signatures.

### DIFF
--- a/security/suricata4/Makefile
+++ b/security/suricata4/Makefile
@@ -2,8 +2,7 @@
 # $FreeBSD$
 
 PORTNAME=	suricata
-DISTVERSION=	4.1.6
-PORTREVISION=	1
+DISTVERSION=	4.1.7
 CATEGORIES=	security
 MASTER_SITES=	https://www.openinfosecfoundation.org/download/
 PKGNAMESUFFIX=	4

--- a/security/suricata4/distinfo
+++ b/security/suricata4/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1578025372
-SHA256 (suricata-4.1.6.tar.gz) = 8441ac89016106459ade2112fcde58b3f789e4beb2fd8bfa081ffb75eec75fe0
-SIZE (suricata-4.1.6.tar.gz) = 15763728
+TIMESTAMP = 1582990943
+SHA256 (suricata-4.1.7.tar.gz) = a1f55ce9a1c4f3aa0cc206f6707ab126c95c0205c871039dc8bb0e8c3586178c
+SIZE (suricata-4.1.7.tar.gz) = 15765787

--- a/security/suricata4/files/patch-alert-pf.diff
+++ b/security/suricata4/files/patch-alert-pf.diff
@@ -1,6 +1,6 @@
-diff -ruN ./suricata-4.1.6.orig/src/Makefile.am ./suricata-4.1.6/src/Makefile.am
---- ./suricata-4.1.6.orig/src/Makefile.am	2019-12-13 07:50:27.000000000 -0500
-+++ ./src/Makefile.am	2020-01-02 23:12:22.000000000 -0500
+diff -ruN ./suricata-4.1.7.orig/src/Makefile.am ./suricata-4.1.7/src/Makefile.am
+--- ./suricata-4.1.7.orig/src/Makefile.am	2020-02-13 08:49:02.000000000 -0500
++++ ./src/Makefile.am	2020-02-29 10:04:49.000000000 -0500
 @@ -10,6 +10,7 @@
  suricata_SOURCES = \
  alert-debuglog.c alert-debuglog.h \
@@ -9,9 +9,9 @@ diff -ruN ./suricata-4.1.6.orig/src/Makefile.am ./suricata-4.1.6/src/Makefile.am
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
  alert-unified2-alert.c alert-unified2-alert.h \
-diff -ruN ./suricata-4.1.6.orig/src/Makefile.in ./suricata-4.1.6/src/Makefile.in
---- ./suricata-4.1.6.orig/src/Makefile.in	2019-12-13 07:50:43.000000000 -0500
-+++ ./src/Makefile.in	2020-01-02 23:13:53.000000000 -0500
+diff -ruN ./suricata-4.1.7.orig/src/Makefile.in ./suricata-4.1.7/src/Makefile.in
+--- ./suricata-4.1.7.orig/src/Makefile.in	2020-02-13 08:49:18.000000000 -0500
++++ ./src/Makefile.in	2020-02-29 10:06:34.000000000 -0500
 @@ -112,7 +112,7 @@
  am__installdirs = "$(DESTDIR)$(bindir)"
  PROGRAMS = $(bin_PROGRAMS)
@@ -21,7 +21,7 @@ diff -ruN ./suricata-4.1.6.orig/src/Makefile.in ./suricata-4.1.6/src/Makefile.in
  	alert-unified2-alert.$(OBJEXT) app-layer.$(OBJEXT) \
  	app-layer-dcerpc.$(OBJEXT) app-layer-dcerpc-udp.$(OBJEXT) \
  	app-layer-detect-proto.$(OBJEXT) app-layer-dnp3.$(OBJEXT) \
-@@ -656,6 +656,7 @@
+@@ -659,6 +659,7 @@
  suricata_SOURCES = \
  alert-debuglog.c alert-debuglog.h \
  alert-fastlog.c alert-fastlog.h \
@@ -29,11 +29,11 @@ diff -ruN ./suricata-4.1.6.orig/src/Makefile.in ./suricata-4.1.6/src/Makefile.in
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
  alert-unified2-alert.c alert-unified2-alert.h \
-diff -ruN ./suricata-4.1.6.orig/src/alert-pf.c ./suricata-4.1.6/src/alert-pf.c
---- ./suricata-4.1.6.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/alert-pf.c	2019-09-25 10:59:45.000000000 -0400
-@@ -0,0 +1,1141 @@
-+/* Copyright (C) 2007-2019 Open Information Security Foundation
+diff -ruN ./suricata-4.1.7.orig/src/alert-pf.c ./suricata-4.1.7/src/alert-pf.c
+--- ./suricata-4.1.7.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
++++ ./src/alert-pf.c	2020-02-29 10:29:27.000000000 -0500
+@@ -0,0 +1,1151 @@
++/* Copyright (C) 2007-2020 Open Information Security Foundation
 + *
 + * You can copy, redistribute or modify this Program under the terms of
 + * the GNU General Public License version 2 as published by the Free
@@ -51,7 +51,7 @@ diff -ruN ./suricata-4.1.6.orig/src/alert-pf.c ./suricata-4.1.6/src/alert-pf.c
 + *
 + * Portions of this module are based on previous works of the following:
 + *
-+ * Copyright (c) 2019  Bill Meeks
++ * Copyright (c) 2020  Bill Meeks
 + * Copyright (c) 2012  Ermal Luci
 + * Copyright (c) 2006  Antonio Benojar <zz.stalker@gmail.com>
 + * Copyright (c) 2005  Antonio Benojar <zz.stalker@gmail.com>
@@ -969,6 +969,11 @@ diff -ruN ./suricata-4.1.6.orig/src/alert-pf.c ./suricata-4.1.6/src/alert-pf.c
 +        if (unlikely(pa->s == NULL)) {
 +            continue;
 +        }
++
++        /* Don't block alerts where SIG_FLAG_NOALERT is set for the Signature */
++        if (pa->s->flags & SIG_FLAG_NOALERT) {
++            continue;
++        }
 +        SC_ATOMIC_ADD(alert_pf_alerts, 1);
 +
 +	/* If blocking only DROP rules and alert is not from a DROP rule, ignore it */
@@ -1080,6 +1085,11 @@ diff -ruN ./suricata-4.1.6.orig/src/alert-pf.c ./suricata-4.1.6/src/alert-pf.c
 +        if (unlikely(pa->s == NULL)) {
 +            continue;
 +        }
++
++        /* Don't block alerts where SIG_FLAG_NOALERT is set for the Signature */
++        if (pa->s->flags & SIG_FLAG_NOALERT) {
++            continue;
++        }
 +        SC_ATOMIC_ADD(alert_pf_alerts, 1);
 +
 +        /* If blocking only DROP rules and alert is not from a DROP rule, ignore it */
@@ -1174,11 +1184,11 @@ diff -ruN ./suricata-4.1.6.orig/src/alert-pf.c ./suricata-4.1.6/src/alert-pf.c
 +    return TM_ECODE_OK;
 +}
 +
-diff -ruN ./suricata-4.1.6.orig/src/alert-pf.h ./suricata-4.1.6/src/alert-pf.h
---- ./suricata-4.1.6.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/alert-pf.h	2019-06-05 14:27:11.000000000 -0400
+diff -ruN ./suricata-4.1.7.orig/src/alert-pf.h ./suricata-4.1.7/src/alert-pf.h
+--- ./suricata-4.1.7.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
++++ ./src/alert-pf.h	2020-02-29 10:02:39.000000000 -0500
 @@ -0,0 +1,59 @@
-+/* Copyright (C) 2007-2019 Open Information Security Foundation
++/* Copyright (C) 2007-2020 Open Information Security Foundation
 + *
 + * You can copy, redistribute or modify this Program under the terms of
 + * the GNU General Public License version 2 as published by the Free
@@ -1196,7 +1206,7 @@ diff -ruN ./suricata-4.1.6.orig/src/alert-pf.h ./suricata-4.1.6/src/alert-pf.h
 + *
 + * Portions of this module are based on previous works of the following:
 + *
-+ * Copyright (c) 2019  Bill Meeks
++ * Copyright (c) 2020  Bill Meeks
 + * Copyright (c) 2012  Ermal Luci
 + * Copyright (c) 2006  Antonio Benojar <zz.stalker@gmail.com>
 + * Copyright (c) 2005  Antonio Benojar <zz.stalker@gmail.com>
@@ -1237,9 +1247,9 @@ diff -ruN ./suricata-4.1.6.orig/src/alert-pf.h ./suricata-4.1.6/src/alert-pf.h
 +
 +#endif /* __ALERT_PF_H__ */
 +
-diff -ruN ./suricata-4.1.6.orig/src/output.c ./suricata-4.1.6/src/output.c
---- ./suricata-4.1.6.orig/src/output.c	2019-12-13 07:50:27.000000000 -0500
-+++ ./src/output.c	2020-01-02 23:15:32.000000000 -0500
+diff -ruN ./suricata-4.1.7.orig/src/output.c ./suricata-4.1.7/src/output.c
+--- ./suricata-4.1.7.orig/src/output.c	2020-02-13 08:49:02.000000000 -0500
++++ ./src/output.c	2020-02-29 10:08:09.000000000 -0500
 @@ -43,6 +43,7 @@
  #include "alert-fastlog.h"
  #include "alert-unified2-alert.h"
@@ -1257,9 +1267,9 @@ diff -ruN ./suricata-4.1.6.orig/src/output.c ./suricata-4.1.6/src/output.c
      /* prelue log */
      AlertPreludeRegister();
      /* syslog log */
-diff -ruN ./suricata-4.1.6.orig/src/suricata-common.h ./suricata-4.1.6/src/suricata-common.h
---- ./suricata-4.1.6.orig/src/suricata-common.h	2019-12-13 07:50:27.000000000 -0500
-+++ ./src/suricata-common.h	2020-01-02 23:16:04.000000000 -0500
+diff -ruN ./suricata-4.1.7.orig/src/suricata-common.h ./suricata-4.1.7/src/suricata-common.h
+--- ./suricata-4.1.7.orig/src/suricata-common.h	2020-02-13 08:49:02.000000000 -0500
++++ ./src/suricata-common.h	2020-02-29 10:08:57.000000000 -0500
 @@ -440,6 +440,7 @@
      LOGGER_PRELUDE,
      LOGGER_PCAP,

--- a/security/suricata4/files/patch-pfSense-ARMv6_ARMv7.diff
+++ b/security/suricata4/files/patch-pfSense-ARMv6_ARMv7.diff
@@ -1,6 +1,6 @@
-diff -ruN ./suricata-4.1.6.orig/configure.ac ./suricata-4.1.6/configure.ac
---- ./suricata-4.1.6.orig/configure.ac	2019-12-13 07:50:27.000000000 -0500
-+++ ./configure.ac	2020-01-02 23:06:45.000000000 -0500
+diff -ruN ./suricata-4.1.7.orig/configure.ac ./suricata-4.1.7/configure.ac
+--- ./suricata-4.1.7.orig/configure.ac	2020-02-13 08:49:02.000000000 -0500
++++ ./configure.ac	2020-02-29 09:57:37.000000000 -0500
 @@ -272,6 +272,23 @@
      esac
      AC_MSG_RESULT(ok)
@@ -25,7 +25,7 @@ diff -ruN ./suricata-4.1.6.orig/configure.ac ./suricata-4.1.6/configure.ac
      # enable modifications for AFL fuzzing
      AC_ARG_ENABLE(afl,
             AS_HELP_STRING([--enable-afl], Enable AFL fuzzing logic[])], [enable_afl="$enableval"],[enable_afl=no])
-@@ -2426,6 +2443,15 @@
+@@ -2451,6 +2468,15 @@
              fi
          fi
      fi


### PR DESCRIPTION
### Suricata-4.1.7
This updates the _suricata4_ port on pfSense to the latest stable upstream version of Suricata, 4.1.7. Release notes for Suricata 4.1.7 can be found [here](https://suricata-ids.org/2020/02/13/suricata-4-1-7-released/). One change is added to the pfSense custom blocking output plugin in this release. The blocking plugin now checks the signature flags in each passed alert for the "noalert" option and skips blocking for any signature with a "noalert" keyword.