### PR TITLE
Send notifications to all platforms.

### DIFF
--- a/sysutils/pfSense-pkg-Service_Watchdog/files/usr/local/pkg/servicewatchdog.inc
+++ b/sysutils/pfSense-pkg-Service_Watchdog/files/usr/local/pkg/servicewatchdog.inc
@@ -102,7 +102,7 @@ function servicewatchdog_check_services() {
 			$error_message = "Service Watchdog detected service {$svc['name']} stopped. Restarting {$svc['name']} ({$descr})";
 			log_error($error_message);
 			if (isset($svc['notify'])) {
-				notify_via_smtp($error_message);
+				notify_all_remote($error_message);
 			}
 			service_control_start($svc['name'], $svc);
 		}


### PR DESCRIPTION
At the moment, the service watchdog will only notify via email. 
Pfsense has the ability to notify via growl as well (although I read it will be removed). 
This change calls the subroutine that will call all notification methods, not just email. 