### PR TITLE
Allow multiple IP in ListenIP for Zabbix Agent. Issue #9272

### DIFF
--- a/net-mgmt/pfSense-pkg-zabbix-agent/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME?=	pfSense-pkg-zabbix-agent
 PORTVERSION=	1.0.4
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-zabbix-agent/files/usr/local/pkg/zabbix-agent.inc
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/files/usr/local/pkg/zabbix-agent.inc
@@ -46,24 +46,45 @@ function php_deinstall_zabbix_agent() {
 function validate_input_zabbix_agent($post, &$input_errors) {
 
 	if (isset($post['agentenabled'])) {
-		if (!preg_match("/\w+/", $post['server'])) {
+		if ($post['server'] != '') {
+			foreach (explode(",", $post['server']) as $srv) {
+				$srv = trim($srv);
+				if (!is_ipaddr($srv) && !is_hostname($srv)) {
+					$input_errors[] = htmlspecialchars($srv) .
+					" is not a valid IP address or hostname for 'Server'.";
+				}
+			}
+		} else {
 			$input_errors[] = "Server field is required.";
 		}
 
-		if (!preg_match("/\w+/", $post['hostname'])) {
+		if ($post['serveractive'] != '') {
+			foreach (explode(",", $post['serveractive']) as $sact) {
+				$sact = trim($sact);
+				if (!is_ipaddr($sact) && !is_hostname($sact) &&
+				    !is_ipaddrwithport($sact) && !is_hostnamewithport($sact)) {
+					$input_errors[] = htmlspecialchars($sact) .
+					" is not a valid IP address or hostname with port for 'Server Active'.";
+				}
+			}
+		}
+
+		if (!is_domain($post['hostname'])) {
 			$input_errors[] = "Hostname field is required.";
 		}
 
 		if ($post['listenip'] != '') {
-			if (!is_ipaddr_configured($post['listenip']) && !preg_match("/(127.0.0.1|0.0.0.0)/", $post['listenip'])) {
-				$input_errors[] = "'Listen IP' is not a configured IP address.";
+			foreach (explode(",", $post['listenip']) as $listip) {
+				$listip = trim($listip);
+				if (!is_ipaddr_configured($listip) && !preg_match("/(127.0.0.1|0.0.0.0|::1|::)/", $listip)) {
+					$input_errors[] = htmlspecialchars($listip) .
+					" is not a configured IP address for 'Listen IP'.";
+				}
 			}
 		}
 
 		if ($post['listenport'] != '') {
-			if (!is_numericint($post['listenport'])) {
-				$input_errors[] = "'Listen Port' value is not numeric.";
-			} elseif ($post['listenport'] < 1 || $post['listenport'] > 65535) {
+			if (!is_port($post['listenport'])) {
 				$input_errors[] = "You must enter a valid value for 'Listen Port'.";
 			}
 		}

--- a/net-mgmt/pfSense-pkg-zabbix-agent/files/usr/local/pkg/zabbix-agent.xml
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/files/usr/local/pkg/zabbix-agent.xml
@@ -90,7 +90,7 @@
 			<default_value>0.0.0.0</default_value>
 			<type>input</type>
 			<size>60</size>
-			<description>Listen IP for connections from the server. (Default: 0.0.0.0 - all interfaces)</description>
+			<description>Comma-separated list of IP addresses for connections from the server. (Default: 0.0.0.0 - all IPv4 interfaces)</description>
 		</field>
 		<field>
 			<fielddescr>Listen Port</fielddescr>


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/9272
Ready for review

This PR allow to enter multiple comma-separated Listen IPs,
And also allow to use :: and ::/1 IPv6 addresses 