### PR TITLE
pfSense-pkg-snort-4.0_12 - support 2.9.15.1 binary; add ALERTS tab persistent filter

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.0
-PORTREVISION=	11
+PORTREVISION=	12
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package snort
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	snort>=2.9.15:security/snort \
+RUN_DEPENDS=	snort>=2.9.15.1:security/snort \
 		barnyard2>=0:security/barnyard2
 
 NO_BUILD=	yes

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2020 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2019 Bill Meeks
+ * Copyright (c) 2013-2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1310,7 +1310,8 @@ function snort_load_rules_map($rules_path) {
 	 * Read all the rules into the map array.
 	 * The structure of the map array is:
 	 *
-	 *  map[gid][sid]['rule']['category']['action']['disabled']['managed']['flowbits']
+	 *  map[gid][sid]['rule']['category']['action']['disabled']['managed']['noalert']
+	 *     ['default_state']['default_action']['state_toggled']['modified']['flowbits']
 	 *
 	 *  where:
 	 *   gid            = Generator ID from rule, or 1 if general text rule
@@ -1320,12 +1321,14 @@ function snort_load_rules_map($rules_path) {
 	 *   action         = alert, drop, reject or pass
 	 *   disabled       = 1 if rule is disabled (commented out), 0 if 
 	 *                    rule is enabled
+	 *   managed        = 1 if rule is auto-managed by SID MGMT process,
+	 *                    0 if not auto-managed 
+	 *   noalert        = 1 if rule contains "noalert" or "flowbits:noalert" options
+	 *                    0 if not
 	 *   default_state  = 1 if rule is default enabled, 0 if default disabled
 	 *   default_action = alert, drop, reject or pass  
 	 *   state_toggled  = 1 if rule was toggled by SID MGMT process,
 	 *                    0 if not toggled
-	 *   managed        = 1 if rule is auto-managed by SID MGMT process,
-	 *                    0 if not auto-managed 
 	 *   modified       = 1 if rule action or content is modified by SID MGMT or
 	 *                      IPS Policy process,
 	 *                    0 if not modified
@@ -1422,6 +1425,14 @@ function snort_load_rules_map($rules_path) {
 				$map_ref[$gid][$sid]['disabled'] = 1;
 			else
 				$map_ref[$gid][$sid]['disabled'] = 0;
+
+			// Check for "noalert;" rule option
+			if (strpos($rule, 'noalert;') !== FALSE) {
+				$map_ref[$gid][$sid]['noalert'] = 1;
+			} else {
+				$map_ref[$gid][$sid]['noalert'] = 0;
+			}				
+
 
 			/* Grab the rule action (this is for a future option) */
 			$matches = array();
@@ -2576,7 +2587,7 @@ function snort_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results = F
 					$changecount++;
 					$modcount++;
 				}
-				elseif ($action == 'drop' && $rule_map[$k1][$k2]['action'] != 'drop') {
+				elseif ($action == 'drop' && $rule_map[$k1][$k2]['action'] != 'drop' && !in_array('noalert', $rule_map[$k1][$k2]['flowbits']) && $rule_map[$k1][$k2]['noalert'] == 0) {
 					if ($tmp = preg_replace('/\s*alert\s*/', 'drop ', $rule_map[$k1][$k2]['rule'], 1)) {
 						$rule_map[$k1][$k2]['rule'] = $tmp;
 						$rule_map[$k1][$k2]['action'] = 'drop';
@@ -2586,7 +2597,7 @@ function snort_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results = F
 						$modcount++;
 					}
 				}
-				elseif ($action == 'reject' && $rule_map[$k1][$k2]['action'] != 'reject') {
+				elseif ($action == 'reject' && $rule_map[$k1][$k2]['action'] != 'reject' && !in_array('noalert', $rule_map[$k1][$k2]['flowbits']) && $rule_map[$k1][$k2]['noalert'] == 0) {
 					if ($tmp = preg_replace('/\s*alert\s*/', 'reject ', $rule_map[$k1][$k2]['rule'], 1)) {
 						$rule_map[$k1][$k2]['rule'] = $tmp;
 						$rule_map[$k1][$k2]['action'] = 'reject';

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2020 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2019 Bill Meeks
+ * Copyright (c) 2013-2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,7 +47,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 		define("SNORT_BIN_VERSION", $matches[0]);
 	}
 	else {
-		define("SNORT_BIN_VERSION", "2.9.15");
+		define("SNORT_BIN_VERSION", "2.9.15.1");
 	}
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -6,7 +6,7 @@
  * Copyright (c) 2006-2020 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
- * Copyright (c) 2019 Bill Meeks
+ * Copyright (c) 2020 Bill Meeks
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
  * All rights reserved.
  *
@@ -129,10 +129,22 @@ function snort_escape_filter_regex($filtertext) {
 	return str_replace('/', '\/', str_replace('\/', '/', $filtertext));
 }
 
-function snort_match_filter_field($flent, $fields) {
+function snort_match_filter_field($flent, $fields, $exact_match = FALSE) {
 	foreach ($fields as $key => $field) {
 		if ($field == null)
 			continue;
+
+		// Only match whole field string when
+		// performing an exact match.
+		if ($exact_match) {
+			if ($flent[$key] == $field) {
+				return true;
+			}
+			else {
+				return false;
+			}
+		}
+
 		if ((strpos($field, '!') === 0)) {
 			$field = substr($field, 1);
 			$field_regex = snort_escape_filter_regex($field);
@@ -210,9 +222,32 @@ if (isset($_POST['resolve'])) {
 }
 # --- AJAX REVERSE DNS RESOLVE End ---
 
+# Check for persisted filtering of alerts log entries and populate
+# the required $filterfieldsarray when persisting filtered entries.
+if ($_POST['persist_filter'] == "yes" && !empty($_POST['persist_filter_content'])) {
+	$filterlogentries = TRUE;
+	$persist_filter_log_entries = "yes";
+	$filterlogentries_exact_match = $_POST['persist_filter_exact_match'];
+	$filterfieldsarray = json_decode($_POST['persist_filter_content'], TRUE);
+}
+else {
+	$filterlogentries = FALSE;
+	$persist_filter_log_entries = "";
+	$filterfieldsarray = array();
+}
+
 if ($_POST['filterlogentries_submit']) {
 	// Set flag for filtering alert entries
 	$filterlogentries = TRUE;
+	$persist_filter_log_entries = "yes";
+
+	// Set 'exact match only' flag if enabled
+	if ($_POST['filterlogentries_exact_match'] == 'on') {
+		$filterlogentries_exact_match = TRUE;
+	}
+	else {
+		$filterlogentries_exact_match = FALSE;
+	}
 
 	// -- IMPORTANT --
 	// Note the order of these fields must match the order decoded from the alerts log
@@ -238,6 +273,7 @@ if ($_POST['filterlogentries_submit']) {
 
 if ($_POST['filterlogentries_clear']) {
 	$filterlogentries = TRUE;
+	$persist_filter_log_entries = "";
 	$filterfieldsarray = array();
 }
 
@@ -714,6 +750,13 @@ $group->add(new Form_Select(
 	$filterfieldsarray[13],
 	array( 0 => "", "alert" => "Alert", "drop" => "Drop", "log" => "Log", "pass" => "Pass", "reject" => "Reject", "sdrop" => "SDrop" )
 ))->setHelp('Action');
+$group->add(new Form_Checkbox(
+	'filterlogentries_exact_match',
+	'Exact Match Only',
+	null,
+	$filterlogentries_exact_match == "on" ? true:false,
+	'on'
+))->setHelp('Exact Match');
 $group->add(new Form_Button(
 	'filterlogentries_submit',
 	' ' . 'Filter',
@@ -732,6 +775,7 @@ $section->add($group);
 $form->add($section);
 // ========== END Log filter Panel =============================================================
 
+// ========== Hidden form controls ==============
 if (isset($instanceid)) {
 	$form->addGlobal(new Form_Input(
 		'id',
@@ -770,6 +814,29 @@ $form->addGlobal(new Form_Input(
 	'hidden',
 	''
 ));
+if ($persist_filter_log_entries == "yes") {
+	$form->addGlobal(new Form_Input(
+		'persist_filter',
+		'persist_filter',
+		'hidden',
+		$persist_filter_log_entries
+	));
+
+	$form->addGlobal(new Form_Input(
+		'persist_filter_exact_match',
+		'persist_filter_exact_match',
+		'hidden',
+		$filterlogentries_exact_match
+	));
+
+	// Pass the $filterfieldsarray variable as serialized data
+	$form->addGlobal(new Form_Input(
+		'persist_filter_content',
+		'persist_filter_content',
+		'hidden',
+		json_encode($filterfieldsarray)
+	));
+}
 
 $tab_array = array();
 	$tab_array[0] = array(gettext("Snort Interfaces"), false, "/snort/snort_interfaces.php");
@@ -834,7 +901,7 @@ if (file_exists("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/alert")) {
 			if(count($fields) < 14 || count($fields) > 15)
 				continue;
 
-			if ($filterlogentries && !snort_match_filter_field($fields, $filterfieldsarray)) {
+			if ($filterlogentries && !snort_match_filter_field($fields, $filterfieldsarray, $filterlogentries_exact_match)) {
 				continue;
 			}
 


### PR DESCRIPTION
### pfSense-pkg-snort-4.0_12
This updates the Snort GUI package for pfSense-2.5-DEVEL to support the latest 2.9.15.1 Snort binary. One new feature and one bug fix is included in this release.

**New Features:**
1. Filter Panel parameters, when filtering is enabled on the ALERTS tab, are now persistent across page submits so that previously defined filtering parameters do not reset when submitting a revised filter. A new "Exact Match" option was also added to the Filter Panel. When checked, this causes matches only when each provided filter parameter matches exactly. When unchecked, filter values will match on partial strings.

**Bug Fixes:**
1. When SID MGMT changes rules to DROP, it is not skipping rules containing "_flowbits:noalert_" tags. This results in dropped traffic without any logged alert about the drop action.