### PR TITLE
pfSense-pkg-snort-3.2.9.10_2 - Add persistent filters on ALERTS tab and bug fix.

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	3.2.9.10
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package snort
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	snort>=2.9.15:security/snort \
+RUN_DEPENDS=	snort>=2.9.15.1:security/snort \
 		barnyard2>=0:security/barnyard2
 
 NO_BUILD=	yes

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_iprep_list_browser.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_iprep_list_browser.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2020 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2014 Bill Meeks
+ * Copyright (c) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,11 +53,11 @@ $target = htmlspecialchars($_POST['target']);
 	<table class="table table-striped table-hover table-condensed">
 		<thead>
 			<tr>
-				<th><img src="/filebrowser/images/icon_home.gif" alt="Home" title="Home" /></th>
+				<th><img src="/vendor/filebrowser/images/icon_home.gif" alt="Home" title="Home" /></th>
 				<th><b><?=$path;?></b></th>
 				<th><b><?=gettext('File Size'); ?></th>
 				<th class="fbClose pull-right">
-					<img onClick="$('<?=$container;?>').hide();" border="0" src="/filebrowser/images/icon_cancel.gif" alt="Close" title="Close" />
+					<img onClick="$('<?=$container;?>').hide();" border="0" src="/vendor/filebrowser/images/icon_cancel.gif" alt="Close" title="Close" />
 				</th>
 			</tr>
 		</thead>
@@ -103,7 +103,7 @@ $target = htmlspecialchars($_POST['target']);
 				<td class="fbFile" id="<?=$fqpn;?>">
 					<?php $filename = str_replace("//","/", "{$path}/{$file}"); ?>
 					<div onClick="$('<?=$target;?>').value='<?=$filename?>'; $('<?=$container;?>').hide();">
-						<img src="/filebrowser/images/file_<?=$type;?>.gif" alt="" title="">&nbsp;<?=$file;?>
+						<img src="/vendor/filebrowser/images/file_<?=$type;?>.gif" alt="" title="">&nbsp;<?=$file;?>
 					</div>
 				</td>
 				<td><?=$size;?></td>


### PR DESCRIPTION
### pfSense-pkg-snort-3.2.9.10_2
This updates the Snort GUI package on pfSense-2.4.4 RELEASE to support the latest 2.9.15.1 Snort binary. One new feature is added to the GUI and one reported bug is corrected.

**New Features:**
1. Filter Panel parameters, when filtering is enabled on the ALERTS tab, are now persistent across page submits so that previously defined filtering parameters do not reset when submitting a revised filter. A new "Exact Match" option was also added to the Filter Panel. When checked, this causes matches only when each provided filter parameter matches exactly. When unchecked, filter values will match on partial strings.

**Bug Fixes:**
1. On IP REP tab, the file browser icons are broken due to an incorrect image source file path.