### PR TITLE
Add Iperf verbose output option. Issue #10357

### DIFF
--- a/benchmarks/pfSense-pkg-iperf/Makefile
+++ b/benchmarks/pfSense-pkg-iperf/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-iperf
 PORTVERSION=	3.0.2
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	benchmarks
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/benchmarks/pfSense-pkg-iperf/files/usr/local/pkg/iperf.xml
+++ b/benchmarks/pfSense-pkg-iperf/files/usr/local/pkg/iperf.xml
@@ -129,6 +129,12 @@
 			<description>Enter the UDP bandwidth to send at in bits/sec. (Default is 1Mbit/sec.)</description>
 			<type>input</type>
 		</field>
+		<field>
+			<fielddescr>Verbose output</fielddescr>
+			<fieldname>verbose</fieldname>
+			<description>Show more detailed output.</description>
+			<type>checkbox</type>
+		</field>
 	</fields>
 	<custom_add_php_command>
 	<![CDATA[
@@ -154,6 +160,9 @@
 		}
 		if ($_POST['port'] != "") {
 			$iperf_options .= " -p " . escapeshellarg($_POST['port']);
+		}
+		if ($_POST['verbose'] != "") {
+			$iperf_options .= " -V ";
 		}
 		$iperf_options .= " -c " . escapeshellarg($_POST['hostname']);
 		system("/usr/local/bin/iperf3" . $iperf_options);


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/10357
Ready for review

iperf verbose output (-V) shows more detailed information, including TCP MSS, CPU utilization, time 
and version:
```
iperf 3.7
FreeBSD test.int 12.0-RELEASE-p10 FreeBSD 12.0-RELEASE-p10 ce9563d5729(RELENG_2_5) pfSense amd64
Control connection MSS 1293
Time: Thu, 19 Mar 2020 05:13:39 UTC
Connecting to host 10.1.0.5, port 5201
      Cookie: 4bbcxdrco3hburalbff5vwfcoc2iaa763ygb
      TCP MSS: 1293 (default)
[  5] local 10.11.0.4 port 23135 connected to 10.1.0.5 port 5201
Starting Test: protocol: TCP, 1 streams, 131072 byte blocks, omitting 0 seconds, 10 second test, tos 0
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec   722 KBytes  5.88 Mbits/sec   21   2.51 KBytes       
[  5]   1.00-2.00   sec   255 KBytes  2.10 Mbits/sec   24   1.25 KBytes       
[  5]   2.00-3.01   sec   200 KBytes  1.62 Mbits/sec   17   2.51 KBytes       
[  5]   3.01-4.00   sec   263 KBytes  2.17 Mbits/sec   13   2.51 KBytes       
[  5]   4.00-5.00   sec   233 KBytes  1.90 Mbits/sec   21   2.51 KBytes       
[  5]   5.00-6.00   sec   220 KBytes  1.81 Mbits/sec   19   1.26 KBytes       
[  5]   6.00-7.00   sec   229 KBytes  1.87 Mbits/sec   23   2.51 KBytes       
[  5]   7.00-8.00   sec   241 KBytes  1.98 Mbits/sec   23   1.25 KBytes       
[  5]   8.00-9.00   sec   233 KBytes  1.91 Mbits/sec   21   2.51 KBytes       
[  5]   9.00-10.00  sec   203 KBytes  1.66 Mbits/sec   16   8.83 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
Test Complete. Summary Results:
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  2.73 MBytes  2.29 Mbits/sec  198             sender
[  5]   0.00-10.03  sec  2.66 MBytes  2.23 Mbits/sec                  receiver
CPU Utilization: local/sender 3.8% (0.9%u/3.0%s), remote/receiver 0.3% (0.1%u/0.2%s)
snd_tcp_congestion newreno
rcv_tcp_congestion newreno

iperf Done.
```