### PR TITLE
Feature #10356 - Support for additional notification methods

### DIFF
--- a/sysutils/pfSense-pkg-Service_Watchdog/Makefile
+++ b/sysutils/pfSense-pkg-Service_Watchdog/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-Service_Watchdog
-PORTVERSION=	1.8.6
+PORTVERSION=	1.8.7
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-Service_Watchdog/files/usr/local/pkg/servicewatchdog.inc
+++ b/sysutils/pfSense-pkg-Service_Watchdog/files/usr/local/pkg/servicewatchdog.inc
@@ -102,7 +102,7 @@ function servicewatchdog_check_services() {
 			$error_message = "Service Watchdog detected service {$svc['name']} stopped. Restarting {$svc['name']} ({$descr})";
 			log_error($error_message);
 			if (isset($svc['notify'])) {
-				notify_via_smtp($error_message);
+				notify_all_remote($error_message);
 			}
 			service_control_start($svc['name'], $svc);
 		}


### PR DESCRIPTION
Redmine link: https://redmine.pfsense.org/issues/10356

Refer to feature #10354 Telegram Notification Support in the main pfsense package.
This will allow the service watchdog to take advantage of this feature.