### PR TITLE
Fix syslog-ng TLS support. Issue #8631

### DIFF
--- a/sysutils/pfSense-pkg-syslog-ng/Makefile
+++ b/sysutils/pfSense-pkg-syslog-ng/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-syslog-ng
 PORTVERSION=	1.15
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
@@ -448,13 +448,9 @@ function syslogng_build_cert() {
 
 	if ($ca != false) {
 		$ca_content = base64_decode($ca['crt']);
-		$temp_file_name = tempnam(sys_get_temp_dir(), 'syslog-ng');
+		$ca_details = openssl_x509_parse($ca_content);
 
-		file_put_contents($temp_file_name, $ca_content);
-		$ca_hash = trim(shell_exec("/usr/bin/openssl x509 -noout -hash -in " . $temp_file_name));
-		unlink($temp_file_name);
-
-		file_put_contents(SYSLOGNG_DIR . "/ca.d/" . $ca_hash . ".0", $ca_content);
+		file_put_contents(SYSLOGNG_DIR . "/ca.d/" . $ca_details['hash'] . ".0", $ca_content);
 	}
 }
 ?>

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
@@ -447,7 +447,14 @@ function syslogng_build_cert() {
 	}
 
 	if ($ca != false) {
-		file_put_contents(SYSLOGNG_DIR . "/ca.d/cacert.pem", base64_decode($ca['crt']));
+		$ca_content = base64_decode($ca['crt']);
+		$temp_file_name = tempnam(sys_get_temp_dir(), 'syslog-ng');
+
+		file_put_contents($temp_file_name, $ca_content);
+		$ca_hash = trim(shell_exec("/usr/bin/openssl x509 -noout -hash -in " . $temp_file_name));
+		unlink($temp_file_name);
+
+		file_put_contents(SYSLOGNG_DIR . "/ca.d/" . $ca_hash . ".0", $ca_content);
 	}
 }
 ?>


### PR DESCRIPTION
The TLS support currently is broken because the CA certificate file name is not correct. For this reason the clients certificate can't be verified.

Currently the CA certificate is being stored as "cacert.pem" but as you can see in the syslog-ng [documentation](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.16/administration-guide/56) it must be "$distinguished_name_hash.0".

> Copy the CA certificate (for example cacert.pem) of the Certificate Authority that issued the certificate of the syslog-ng clients to the syslog-ng server, for example into the /opt/syslog-ng/etc/syslog-ng/ca.d directory.
> 
> Issue the following command on the certificate: openssl x509 -noout -hash -in cacert.pem The result is a hash (for example 6d2962a8), a series of alphanumeric characters based on the Distinguished Name of the certificate.
> 
> Issue the following command to create a symbolic link to the certificate that uses the hash returned by the previous command and the .0 suffix.