### PR TITLE
OpenVPN Client export server protocol definition. Issue 10369

### DIFF
--- a/security/pfSense-pkg-openvpn-client-export/Makefile
+++ b/security/pfSense-pkg-openvpn-client-export/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-openvpn-client-export
-PORTVERSION=	1.4.20
+PORTVERSION=	1.4.21
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
+++ b/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
@@ -845,7 +845,8 @@ function openvpn_client_export_sharedkey_config($srvid, $useaddr, $proxy, $nokey
 
 	/* TODO: Protocol could move to after remote. If client is 2.4, can be copied direct from server. Perhaps leverage openvpn_client_export_build_remote_lines() */
 	$conf .= "proto {$proto}\n";
-	$conf .= "remote {$server_host} {$server_port}\n";
+	$remoteproto = strtolower($settings['protocol']);
+	$conf .= "remote {$server_host} {$server_port} {$remoteproto}\n";
 
 	if ($settings['local_network']) {
 		list($ip, $mask) = explode('/', $settings['local_network']);
@@ -982,7 +983,8 @@ function openvpn_client_export_build_remote_lines($settings, $useaddr, $interfac
 			$remotes[] = "remote {$dest['host']} {$dest['port']} {$dest['proto']}";
 		}
 	} else {
-		$remotes[] = "remote {$server_host} {$settings['local_port']} {$proto}";
+		$remoteproto = strtolower($settings['protocol']);
+		$remotes[] = "remote {$server_host} {$settings['local_port']} {$remoteproto}";
 	}
 
 	return implode($nl, $remotes);


### PR DESCRIPTION
 Redmine Issue: https://redmine.pfsense.org/issues/10369
 Ready for review

An exact definition of the OpenVPN remote server protocol must be present,
Otherwise, it may try to establish a connection with the wrong version of IP protocol.

see https://redmine.pfsense.org/issues/10368