### PR TITLE
Fix openvpn-client-export.inc Missing New Line After NCP Parameter

### DIFF
--- a/security/openvpn-client-export/Makefile
+++ b/security/openvpn-client-export/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	openvpn-client-export
-PORTVERSION=	2.4.8
+PORTVERSION=	2.4.9
 CATEGORIES=	security
 MASTER_SITES=	http://files.pfsense.org/packages/openvpn-client-export/
 

--- a/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
+++ b/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
@@ -204,11 +204,11 @@ EOF;
 
 	if ($legacy == 0) {
 		if ($settings['ncp_enable'] == "disabled") {
-			$conf .= "ncp-disable\n";
+			$conf .= "ncp-disable{$nl}";
 		} else {
 			/* If the ncp-ciphers list is empty, don't specify a list so OpenVPN's default will be used. */
 			if (!empty($settings['ncp-ciphers'])) {
-				$conf .= "ncp-ciphers " . str_replace(',', ':', $settings['ncp-ciphers']) . "\n";
+				$conf .= "ncp-ciphers " . str_replace(',', ':', $settings['ncp-ciphers']) . "{$nl}";
 			}
 		}
 	}


### PR DESCRIPTION
Fix openvpn-client-export.inc Missing New Line After NCP Parameter in Client Config

This pull request fixes the issue whereas the "auth alg" digest algorithm client config parameter is erroneously merged into the same config line as the "ncp-disable" or "ncp-ciphers cipher_list" config line.

e.g. without this patch an exported .ovpn client config with NCP disabled and digest algorithm set to SHA1 would start like the following:

dev tun
persist-tun
persist-key
cipher AES-128-GCM
ncp-disableauth SHA1
tls-client
client
.
.
.

However "ncp-disable" and "auth SHA1" should be on seperate lines as in:

dev tun
persist-tun
persist-key
cipher AES-128-GCM
ncp-disable
auth SHA1
tls-client
client
.
.
.