### PR TITLE
pfSense-pkg-suricata4-4.1.7_2 - Randomize rules update checks to minimize load on update sites.

### DIFF
--- a/security/pfSense-pkg-suricata4/Makefile
+++ b/security/pfSense-pkg-suricata4/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata4
 PORTVERSION=	4.1.7
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata4/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata4/files/arm/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -139,6 +139,18 @@ if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_t
 }
 
 /**********************************************************/
+/* Randomize the Rules Update Start Time minutes field    */
+/* per request of Snort.org team to minimize impact of    */
+/* large numbers of pfSense users hitting Snort.org at    */
+/* the same minute past the hour for rules updates.       */
+/**********************************************************/
+if (empty($config['installedpackages']['suricata']['config'][0]['autoruleupdatetime']) || 
+	  $config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'] == '00:05') {
+	$config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'] = "00:" . strval(random_int(0, 59));
+	$updated_cfg = true;
+}
+
+/**********************************************************/
 /* Set default log size and retention limits if not set   */
 /**********************************************************/
 if (!isset($config['installedpackages']['suricata']['config'][0]['alert_log_retention']) && $config['installedpackages']['suricata']['config'][0]['alert_log_retention'] != '0') {

--- a/security/pfSense-pkg-suricata4/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata4/files/usr/local/pkg/suricata/suricata.inc
@@ -667,7 +667,7 @@ function suricata_rules_up_install_cron($should_install=true) {
 	if (!empty($config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'])) {
 		$suricata_rules_upd_time = $config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'];
 	} else {
-		$suricata_rules_upd_time = "00:03";
+		$suricata_rules_upd_time = "00:" . strval(random_int(0, 59));
 	}
 
 	if ($suricata_rules_up_info_ck == "6h_up") {

--- a/security/pfSense-pkg-suricata4/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata4/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2019 Bill Meeks
+ * Copyright (C) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -404,6 +404,9 @@ if (file_exists(SURICATA_RULES_UPD_LOGFILE)) {
 else {
 	file_put_contents(SURICATA_RULES_UPD_LOGFILE, "");
 }
+
+/* Sleep for random number of seconds between 0 and 35 to spread load on rules site */
+sleep(random_int(0, 35));
 
 /* Log start time for this rules update */
 error_log(gettext("Starting rules update...  Time: " . date("Y-m-d H:i:s") . "\n"), 3, SURICATA_RULES_UPD_LOGFILE);

--- a/security/pfSense-pkg-suricata4/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata4/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -139,6 +139,18 @@ if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_t
 }
 
 /**********************************************************/
+/* Randomize the Rules Update Start Time minutes field    */
+/* per request of Snort.org team to minimize impact of    */
+/* large numbers of pfSense users hitting Snort.org at    */
+/* the same minute past the hour for rules updates.       */
+/**********************************************************/
+if (empty($config['installedpackages']['suricata']['config'][0]['autoruleupdatetime']) || 
+	  $config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'] == '00:05') {
+	$config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'] = "00:" . strval(random_int(0, 59));
+	$updated_cfg = true;
+}
+
+/**********************************************************/
 /* Set default log size and retention limits if not set   */
 /**********************************************************/
 if (!isset($config['installedpackages']['suricata']['config'][0]['alert_log_retention']) && $config['installedpackages']['suricata']['config'][0]['alert_log_retention'] != '0') {

--- a/security/pfSense-pkg-suricata4/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata4/files/usr/local/www/suricata/suricata_global.php
@@ -65,7 +65,7 @@ else {
 
 // Do input validation on parameters
 if (empty($pconfig['autoruleupdatetime']))
-	$pconfig['autoruleupdatetime'] = '00:30';
+	$pconfig['autoruleupdatetime'] = '00:' . strval(random_int(0, 59));
 
 if (empty($pconfig['log_to_systemlog_facility']))
 	$pconfig['log_to_systemlog_facility'] = "local1";
@@ -316,7 +316,7 @@ $section->addInput(new Form_Input(
 	'Snort Rules Filename',
 	'text',
 	$pconfig['snort_rules_file']
-))->setHelp('Enter the rules tarball filename (filename only, do not include the URL.)<br />Example: snortrules-snapshot-29130.tar.gz<br />DO NOT specify a Snort3 rules file!  Snort3 rules are incompatible witih Suricata 4.x and will break your installation!');
+))->setHelp('Enter the rules tarball filename (filename only, do not include the URL.)<br />Example: snortrules-snapshot-29151.tar.gz<br />DO NOT specify a Snort3 rules file!  Snort3 rules are incompatible witih Suricata and will break your installation!');
 $section->addInput(new Form_Input(
 	'oinkcode',
 	'Snort Oinkmaster Code',
@@ -371,7 +371,11 @@ $section->addInput(new Form_Input(
 	'Update Start Time',
 	'text',
 	$pconfig['autoruleupdatetime']
-))->setHelp('Enter the rule update start time in 24-hour format (HH:MM). Default is 00:30.<br /><br />Rules will update at the interval chosen above starting at the time specified here. For example, using the default start time of 00:30 and choosing 12 Hours for the interval, the rules will update at 00:03 and 12:03 each day.');
+))->setHelp('Enter the rule update start time in 24-hour format (HH:MM).  Default is 00 hours with a randomly chosen minutes value.  ' . 
+			'Rules will update at the interval chosen above starting at the time specified here. ' . 
+			'For example, using a start time of 00:08 and choosing 12 Hours for the interval, ' . 
+			'the rules will update at 00:08 and 12:08 each day. The randomized minutes value should ' . 
+			'be retained to minimize the impact to the rules update site from large numbers of simultaneous requests.');
 $section->addInput(new Form_Checkbox(
 	'live_swap_updates',
 	'Live Rule Swap on Update',


### PR DESCRIPTION
### pfSense-pkg-suricata4-4.1.7_2
This update randomizes the periodic rules update check to spread the load on the rules update sites due to the large number of pfSense Suricata installations. The former default value had large numbers of machines hitting the rules update sites at precisely 5 minutes past the midnight hour local time.

**New Features:**

1. The **Rules Update Start Time** on the GLOBAL SETTINGS tab now has a random minute for the default start time for first-time users.

2. For existing users who have never changed their **Rules Update Start Time** from the old default of 00:05, the minutes value will be randomized and stored.

3. The PHP module that performs the actual rules update check will randomly sleep for between 0 and 35 seconds before actually making connection to the Snort.org site.

**Bug Fixes:**
None