### PR TITLE
pfSense-pkg-suricata-5.0.2_2 - 'rules_update_starttime' minutes value needs padding

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	5.0.2
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -667,7 +667,7 @@ function suricata_rules_up_install_cron($should_install=true) {
 	if (!empty($config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'])) {
 		$suricata_rules_upd_time = $config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'];
 	} else {
-		$suricata_rules_upd_time = "00:" . strval(random_int(0, 59));
+		$suricata_rules_upd_time = "00:" . str_pad(strval(random_int(0,59)), 2, "00", STR_PAD_LEFT);
 	}
 
 	if ($suricata_rules_up_info_ck == "6h_up") {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -145,8 +145,9 @@ if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_t
 /* the same minute past the hour for rules updates.       */
 /**********************************************************/
 if (empty($config['installedpackages']['suricata']['config'][0]['autoruleupdatetime']) || 
-	  $config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'] == '00:05') {
-	$config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'] = "00:" . strval(random_int(0, 59));
+	$config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'] == '00:05' || 
+	strlen($config['installedpackages']['suricata']['config'][0]['autoruleupdatetime']) < 5) {
+	$config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'] = "00:" . str_pad(strval(random_int(0,59)), 2, "00", STR_PAD_LEFT);
 	$updated_cfg = true;
 }
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -65,7 +65,7 @@ else {
 
 // Do input validation on parameters
 if (empty($pconfig['autoruleupdatetime']))
-	$pconfig['autoruleupdatetime'] = '00:' . strval(random_int(0, 59));
+	$pconfig['autoruleupdatetime'] = '00:' . str_pad(strval(random_int(0,59)), 2, "00", STR_PAD_LEFT);
 
 if (empty($pconfig['log_to_systemlog_facility']))
 	$pconfig['log_to_systemlog_facility'] = "local1";


### PR DESCRIPTION
### pfSense-pkg-suricata-5.0.2_2

**New Features:**
None

**Bug Fixes:**
1. The **Rules Update Start Time** minutes value must be padded to 2 digits when the integer value is less than 10.