### PR TITLE
OpenVPN export legacy remote proto. Issue #10369

### DIFF
--- a/security/pfSense-pkg-openvpn-client-export/Makefile
+++ b/security/pfSense-pkg-openvpn-client-export/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-openvpn-client-export
-PORTVERSION=	1.4.21
+PORTVERSION=	1.4.22
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
+++ b/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
@@ -181,7 +181,7 @@ EOF;
 	}
 	
 	// determine basic variables
-	$remotes = openvpn_client_export_build_remote_lines($settings, $useaddr, $interface, $expformat, $nl);
+	$remotes = openvpn_client_export_build_remote_lines($settings, $useaddr, $interface, $expformat, $nl, $legacy);
 	$cipher = $settings['crypto'];
 	$digest = !empty($settings['digest']) ? $settings['digest'] : "SHA1";
 
@@ -944,7 +944,7 @@ function openvpn_client_export_sharedkey_config($srvid, $useaddr, $proxy, $nokey
 	}
 }
 
-function openvpn_client_export_build_remote_lines($settings, $useaddr, $interface, $expformat, $nl) {
+function openvpn_client_export_build_remote_lines($settings, $useaddr, $interface, $expformat, $nl, $legacy=false) {
 	global $config;
 	$remotes = array();
 	if (($useaddr == "serveraddr") || ($useaddr == "servermagic") || ($useaddr == "servermagichost")) {
@@ -983,7 +983,7 @@ function openvpn_client_export_build_remote_lines($settings, $useaddr, $interfac
 			$remotes[] = "remote {$dest['host']} {$dest['port']} {$dest['proto']}";
 		}
 	} else {
-		$remoteproto = strtolower($settings['protocol']);
+		$remoteproto = $legacy ? $proto : strtolower($settings['protocol']);
 		$remotes[] = "remote {$server_host} {$settings['local_port']} {$remoteproto}";
 	}
 


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/10369
Ready for review

OpenVPN < 2.4 doesn't support remote IPv4/IPv6 protocol definition (udp4/udp6/tcp4/tcp6),
If checkbox **Legacy Client** is set, it must generate compatible config (udp/tcp).

see https://forum.netgate.com/topic/152577/pfsense-openvpn-client-export-problem