### PR TITLE
net-mgmt/pfSense-pkg-arpwatch: Never clobber database on install

### DIFF
--- a/net-mgmt/pfSense-pkg-arpwatch/Makefile
+++ b/net-mgmt/pfSense-pkg-arpwatch/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-arpwatch
 PORTVERSION=	0.2.0
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.inc
+++ b/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.inc
@@ -43,10 +43,6 @@ function arpwatch_install_command() {
 		arpwatch_update_vendors($enable_zeropad);
 	}
 
-	if ($clear_database) {
-		arpwatch_clear_database();
-	}
-
 	$rc = array();
 	$rc['file'] = 'arpwatch.sh';
 
@@ -88,7 +84,9 @@ function arpwatch_install_command() {
 }
 
 function arpwatch_deinstall_command() {
-	arpwatch_clear_database();
+	if ($clear_database) {
+		arpwatch_clear_database();
+	}
 	arpwatch_uninstall_sendmail_proxy();
 }
 

--- a/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.xml
+++ b/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.xml
@@ -115,7 +115,7 @@
 			<fielddescr>Clear database</fielddescr>
 			<fieldname>clear_database</fieldname>
 			<type>checkbox</type>
-			<description>Reset the database of collected mac/ip addresses before starting Arpwatch.</description>
+			<description>Reset the database of collected mac/ip addresses when uninstalling or upgrading Arpwatch.</description>
 		</field>
 	</fields>
 	<custom_php_install_command>


### PR DESCRIPTION
and only clobber on deinstall if clear_database is enabled.