### PR TITLE
ACME hide NameMaster.de hash. Issue #10452

### DIFF
--- a/security/pfSense-pkg-acme/Makefile
+++ b/security/pfSense-pkg-acme/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-acme
-PORTVERSION=	0.6.6
+PORTVERSION=	0.6.7
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_htmllist.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_htmllist.inc
@@ -169,6 +169,7 @@ class HtmlList
 			}
 			if ((stripos($item['name'], 'key') !== false) ||
 			    (stripos($item['name'], 'secret') !== false) ||
+			    (stripos($item['name'], 'sha256') !== false) ||
 			    (stripos($item['name'], 'password') !== false) ||
 			    (stripos($item['name'], 'token') !== false)) {
 				$itemvalue = '********';


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/10452
Ready for review

the new dnsapi-plugin for namemaster.de made it into my pfsense with package version 0.6.6
in Services / Acme / Certificate options: Edit
you can see the password/hashofpassword without open the editing option

NameMaster.de uses `nm_sha256` field name for password hash:
https://github.com/pfsense/FreeBSD-ports/blob/6dbb7316f2e11968ebbdfa6c5da6f5d101cd58f3/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc#L837

but only fields containing `key`, `secret`, `password` or `token` are replaced with ***:
https://github.com/pfsense/FreeBSD-ports/blob/6dbb7316f2e11968ebbdfa6c5da6f5d101cd58f3/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_htmllist.inc#L170

can be merged with https://github.com/pfsense/FreeBSD-ports/pull/837