### PR TITLE
Syslog-ng initial TLS config fix. Issue #10490

### DIFF
--- a/sysutils/pfSense-pkg-syslog-ng/Makefile
+++ b/sysutils/pfSense-pkg-syslog-ng/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-syslog-ng
 PORTVERSION=	1.15
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
@@ -134,7 +134,7 @@ function syslogng_build_default_objects($settings) {
 	if ($settings['default_protocol'] == 'tls') {
 		safe_mkdir(SYSLOGNG_DIR);
 		safe_mkdir(SYSLOGNG_DIR . "/ca.d");
-		syslogng_build_cert();
+		syslogng_build_cert($settings);
 		$default_objects[0]['objectparameters'] .= " tls(
 		    key-file('/var/etc/syslog-ng/syslog-ng.key')
 		    cert-file('/var/etc/syslog-ng/syslog-ng.cert')
@@ -433,10 +433,9 @@ function syslogng_get_ca_or_certs($type, $consumer = 'IPsec') {
 	return $c_arr;
 }
 
-function syslogng_build_cert() {
+function syslogng_build_cert($settings) {
 	global $config;
 
-	$settings = $config['installedpackages']['syslogng']['config'][0];
 	$ca = lookup_ca($settings['dca']);
 	$cert = lookup_cert($settings['certificate']);
 


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/10490
Ready for review

On initial setup, `syslogng_build_cert()` tries to get the parameters from `$config`, but it needs to get it from `$post`, because `$config` has no tls configuration parameters