### PR TITLE
pfSense-pkg-snort-4.1 -- Fix Logs Mgmt not purging rotated logs and support 2.9.16 Snort

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-snort
-PORTVERSION=	4.0
-PORTREVISION=	14
+PORTVERSION=	4.1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +12,7 @@ COMMENT=	pfSense package snort
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	snort>=2.9.15.1:security/snort \
+RUN_DEPENDS=	snort>=2.9.16:security/snort \
 		barnyard2>=0:security/barnyard2
 
 NO_BUILD=	yes

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_cron_misc.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_cron_misc.inc
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2019-2020 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2019 Bill Meeks
+ * Copyright (c) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,6 +55,12 @@ function snort_check_dir_size_limit($snortloglimitsize) {
 		// Clean-up the logs for each configured Snort instance
 		foreach ($config['installedpackages']['snortglobal']['rule'] as $value) {
 			$if_real = get_real_interface($value['interface']);
+
+			// Skip instances where pfSense physical interface has been removed
+			if ($if_real == "") {
+				continue;
+			}
+
 			$snort_uuid = $value['uuid'];
 			$snort_log_dir = SNORTLOGDIR . "/snort_{$if_real}{$snort_uuid}";
 			syslog(LOG_NOTICE, gettext("[Snort] Truncating logs for {$value['descr']} ({$if_real})..."));
@@ -69,6 +75,13 @@ function snort_check_dir_size_limit($snortloglimitsize) {
 				}
 			}
 
+			// Now cleanup any existing rotated alert log files
+			$list = array();
+			$list = glob("{$snort_log_dir}/alert.*");
+			foreach ($list as $file) {
+				unlink_if_exists($file);
+			}
+
 			// Cleanup any perfmon stats logs
 			$files = array();
 			$list = glob("{$snort_log_dir}/*");
@@ -80,7 +93,7 @@ function snort_check_dir_size_limit($snortloglimitsize) {
 				unlink_if_exists($file);
 
 			// Cleanup any AppID stats logs
-			$files = glob("{$snort_log_dir}/appid-stats.log.*");
+			$files = glob("{$snort_log_dir}/app-stats.log.*");
 			foreach ($files as $file)
 				unlink_if_exists($file);
 
@@ -176,9 +189,33 @@ if (!is_array($config['installedpackages']['snortglobal']['rule']))
 if ($config['installedpackages']['snortglobal']['enable_log_mgmt'] == 'on') {
 	foreach ($config['installedpackages']['snortglobal']['rule'] as $value) {
 		$if_real = get_real_interface($value['interface']);
+
+		// Skip instances where pfSense physical interface has been removed
+		if ($if_real == "") {
+			continue;
+		}
+
 		$snort_log_dir = SNORTLOGDIR . "/snort_{$if_real}{$value['uuid']}";
+
+		// Check if any logs need to be rotated
 		foreach ($logs as $k => $p) {
 			snort_check_rotate_log("{$snort_log_dir}/{$k}", $p['limit']*1024, $p['retention']);
+		}
+
+		// Prune aged-out rotated alert log files if any exist
+		if ($config['installedpackages']['snortglobal']['alert_log_retention'] > 0) {
+			$now = time();
+			$rotated_files = glob("{$snort_log_dir}/alert.*");
+			$prune_count = 0;
+			foreach ($rotated_files as $file) {
+				if (($now - filemtime($file)) > ($config['installedpackages']['snortglobal']['alert_log_retention'] * 3600)) {
+					$prune_count++;
+					unlink_if_exists($file);
+				}
+			}
+			unset($rotated_files);
+			if ($prune_count > 0)
+				log_error(gettext("[Snort] Alerts log file cleanup job removed {$prune_count} rotated alert log file(s) from {$snort_log_dir}/..."));
 		}
 
 		// Prune aged-out event packet capture files if any exist

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -47,7 +47,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 		define("SNORT_BIN_VERSION", $matches[0]);
 	}
 	else {
-		define("SNORT_BIN_VERSION", "2.9.15.1");
+		define("SNORT_BIN_VERSION", "2.9.16");
 	}
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_log_mgmt.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_log_mgmt.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -262,7 +262,7 @@ print ($section);
 						<td><?=gettext("Snort alerts and event details");?></td>
 					</tr>
 					<tr>
-						<td>appid-stats</td>
+						<td>app-stats</td>
 						<td><select name="appid_stats_log_limit_size" class="form-control" id="appid_stats_log_limit_size">
 							<?php foreach ($log_sizes as $k => $l): ?>
 								<option value="<?=$k;?>"


### PR DESCRIPTION
### pfSense-pkg-snort-4.1
This update adds support for the latest 2.9.16 version of the Snort binary and corrects a Logs Management bug identifed by Redmine Issue #10494.

**New Features:**
None

**Bug Fixes:**
1. The Logs Management cron task is not detecting and removing rotated alert and AppID stats files. See [Redmine Issue #10494](https://redmine.pfsense.org/issues/10494).