### PR TITLE
ARPwatch fix db cleanup. Issue #10475

### DIFF
--- a/net-mgmt/pfSense-pkg-arpwatch/Makefile
+++ b/net-mgmt/pfSense-pkg-arpwatch/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-arpwatch
 PORTVERSION=	0.2.0
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.inc
+++ b/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.inc
@@ -37,7 +37,6 @@ function arpwatch_install_command() {
 	$disable_bogons = ($arpwatch_config['disable_bogons'] == 'on') ? '-N' : '';
 	$disable_zero = ($arpwatch_config['disable_zero'] == 'on') ? '-z' : '';
 	$update_vendors = ($arpwatch_config['update_vendors'] == 'on');
-	$clear_database = ($arpwatch_config['clear_database'] == 'on');
 
 	if ($update_vendors) {
 		arpwatch_update_vendors($enable_zeropad);
@@ -84,7 +83,10 @@ function arpwatch_install_command() {
 }
 
 function arpwatch_deinstall_command() {
-	if ($clear_database) {
+	global $config;
+
+	init_config_arr(array('installedpackages', 'arpwatch', 'config', 0));
+	if ($config['installedpackages']['arpwatch']['config'][0]['clear_database'] == 'on') {
 		arpwatch_clear_database();
 	}
 	arpwatch_uninstall_sendmail_proxy();


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/10475
Ready for review

fix for https://github.com/pfsense/FreeBSD-ports/pull/844
to correctly check for 'clear_database' value
otherwise arpwatch mac db is never deleted