### PR TITLE
pfBlockerNG SafeSearch install fix. Issue #9874

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG-devel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-pfBlockerNG-devel
 PORTVERSION=	2.2.5
-PORTREVISION=	31
+PORTREVISION=	32
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -83,6 +83,8 @@ do-install:
 		${STAGEDIR}${PREFIX}/www/pfblockerng
 	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/pfblockerng/pfblockerng_sync.php \
 		${STAGEDIR}${PREFIX}/www/pfblockerng
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/pfblockerng/pfblockerng_safesearch.php \
+		${STAGEDIR}${PREFIX}/www/pfblockerng
 	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/pfblockerng/pfblockerng_threats.php \
 		${STAGEDIR}${PREFIX}/www/pfblockerng
 	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/pfblockerng/pfblockerng_log.php \
@@ -102,6 +104,14 @@ do-install:
 	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/pfblockerng/shallalist_global_usage \
 		${STAGEDIR}${PREFIX}/pkg/pfblockerng
 	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/pfblockerng/ut1_global_usage \
+		${STAGEDIR}${PREFIX}/pkg/pfblockerng
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/pfblockerng/pfb_dnsbl.firefoxdoh.conf \
+		${STAGEDIR}${PREFIX}/pkg/pfblockerng
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/pfblockerng/pfb_dnsbl.safesearch.conf \
+		${STAGEDIR}${PREFIX}/pkg/pfblockerng
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/pfblockerng/pfb_dnsbl.youtube_restrict.conf \
+		${STAGEDIR}${PREFIX}/pkg/pfblockerng
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/pfblockerng/pfb_dnsbl.youtube_restrictmoderate.conf \
 		${STAGEDIR}${PREFIX}/pkg/pfblockerng
 	${INSTALL_DATA} -m 0755 ${FILESDIR}${PREFIX}/pkg/pfblockerng/pfblockerng.sh \
 		${STAGEDIR}${PREFIX}/pkg/pfblockerng

--- a/net/pfSense-pkg-pfBlockerNG-devel/pkg-plist
+++ b/net/pfSense-pkg-pfBlockerNG-devel/pkg-plist
@@ -1,6 +1,10 @@
 /etc/inc/priv/pfblockerng.priv.inc
 pkg/pfblockerng.xml
 pkg/pfblockerng/dnsbl_tld
+pkg/pfblockerng/pfb_dnsbl.firefoxdoh.conf
+pkg/pfblockerng/pfb_dnsbl.safesearch.conf
+pkg/pfblockerng/pfb_dnsbl.youtube_restrict.conf
+pkg/pfblockerng/pfb_dnsbl.youtube_restrictmoderate.conf
 pkg/pfblockerng/pfblockerng.inc
 pkg/pfblockerng/pfblockerng.sh
 pkg/pfblockerng/pfblockerng_extra.inc
@@ -20,6 +24,7 @@ www/pfblockerng/pfblockerng_feeds.php
 www/pfblockerng/pfblockerng_general.php
 www/pfblockerng/pfblockerng_ip.php
 www/pfblockerng/pfblockerng_log.php
+www/pfblockerng/pfblockerng_safesearch.php
 www/pfblockerng/pfblockerng_sync.php
 www/pfblockerng/pfblockerng_threats.php
 www/pfblockerng/pfblockerng_update.php


### PR DESCRIPTION
 Redmine Issue: https://redmine.pfsense.org/issues/9874
 Ready for review

SafeSearch install fix