### PR TITLE
Telegraf add lsof dependency. Issue #10522

### DIFF
--- a/net-mgmt/pfSense-pkg-Telegraf/Makefile
+++ b/net-mgmt/pfSense-pkg-Telegraf/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-Telegraf
 PORTVERSION=	0.9
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,8 @@ COMMENT=	pfSense package Telegraf
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	telegraf:net-mgmt/telegraf
+RUN_DEPENDS=	telegraf:net-mgmt/telegraf \
+		lsof:sysutils/lsof
 
 NO_BUILD=	yes
 NO_MTREE=	yes


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/10522
Ready for review

Enabling netstat from the web interface (as part of Telegraf) ... fails. The error message can be seen from a command line test run,
telegraf --test --input-filter netstat --config /usr/local/etc/telegraf.conf:
```
2020-05-03T03:18:31Z I! Starting Telegraf 1.13.4
2020-05-03T03:18:31Z E! [inputs.netstat] Error in plugin: error getting net connections info: exec: "lsof": executable file not found in $PATH
2020-05-03T03:18:31Z E! [telegraf] Error running agent: One or more input plugins had an error
```

from https://github.com/influxdata/telegraf/blob/master/plugins/inputs/net/NETSTAT_README.md:
```
Netstat Input Plugin
This plugin collects TCP connections state and UDP socket counts by using **lsof**.
```