### PR TITLE
LLDPd integrated switch workaround. Issue #9635

### DIFF
--- a/net-mgmt/pfSense-pkg-lldpd/Makefile
+++ b/net-mgmt/pfSense-pkg-lldpd/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-lldpd
-PORTVERSION=	0.9.10
+PORTVERSION=	0.9.11
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-lldpd/files/usr/local/pkg/lldpd/lldpd.inc
+++ b/net-mgmt/pfSense-pkg-lldpd/files/usr/local/pkg/lldpd/lldpd.inc
@@ -120,11 +120,24 @@ function lldpd_sync_config() {
 	
 	/* Interface list */
 	$interfaces = array();
-	foreach (explode(',', $lldpd_config['interfaces']) as $i) {
-		foreach (get_parent_physical_interface($i) as $p) {
-			$interfaces[$p] = $p;
+	$int_switch = array();
+	if (file_exists("/etc/inc/switch.inc")) {
+		require_once('switch.inc');
+		if (!empty(switch_get_devices())) {
+			$int_switch = switch_get_uplink_ports();
 		}
 	}
+	foreach (explode(',', $lldpd_config['interfaces']) as $i) {
+		foreach (get_parent_physical_interface($i) as $p) {
+			if (!empty($int_switch) && in_array($p, $int_switch)) {
+				$int = get_real_interface($i);
+				$interfaces[$int] = $int;
+			} else {
+				$interfaces[$p] = $p;
+			}
+		}
+	}
+	$interfaces = array_unique($interfaces);
 	if (count($interfaces)) {
 		$cmd .= ' -I ' . escapeshellarg(implode(',', $interfaces));
 	}
@@ -134,7 +147,11 @@ function lldpd_sync_config() {
 		$cmd .= ' -r';
 	} else {
 		/* Chassis interface */
-		$chassis = implode(',', get_parent_physical_interface($lldpd_config['chassis']));
+		$chassis_int = get_parent_physical_interface($lldpd_config['chassis']);
+		if (!empty($int_switch) && empty(array_diff($int_switch, $chassis_int))) {
+			$chassis_int = array(get_real_interface($lldpd_config['chassis']));
+		}
+		$chassis = implode(',', $chassis_int);
 		if (isset($chassis)) {
 			$cmd .= ' -C ' . escapeshellarg($chassis);
 		}


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/9635
Ready for review

Add a workaround for appliances with integrated switches to allow run LLDPd on it,
as by default LLDPd uses parent physical interface to run, which doesn't work with integrated switches