### PR TITLE
Build HAProxy Package with buildin Prometheus exporter. Implement #10500

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/Makefile
+++ b/net/pfSense-pkg-haproxy-devel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-haproxy-devel
 PORTVERSION=	0.60
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/10500
Ready for review

However, PROMEX is not built by default with HAProxy. It is provided as an extra
component for everyone want to use it. So you need to explicitly build HAProxy
with the PROMEX service, using the Makefile variable "EXTRA_OBJS". For instance:
`    make TARGET=linux-glibc EXTRA_OBJS="contrib/prometheus-exporter/service-prometheus.o"`

if HAProxy provides the PROMEX service, the following build option will be
reported by the command "haproxy -vv":

>     Built with the Prometheus exporter as a service

https://github.com/haproxy/haproxy/blob/master/contrib/prometheus-exporter/README

needs testing on 2.5 first