### PR TITLE
pfSense-pkg-snort-3.2.9.12 - Fix edge case install bug and add packet capture option

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-snort
-PORTVERSION=	3.2.9.11
+PORTVERSION=	3.2.9.12
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -3926,9 +3926,7 @@ function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol,
 	unset(\$g["snort_postinstall"]);
 	log_error(gettext("[snort] XMLRPC pkg sync: Generating snort.conf file using Master Host settings..."));
 	\$rebuild_rules = true;
-	conf_mount_rw();
 	sync_snort_package_config();
-	conf_mount_ro();
 	\$rebuild_rules = false;
 	{$snortstart}
 	log_error(gettext("[snort] XMLRPC pkg sync process on this host is complete..."));

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_cron_misc.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_cron_misc.inc
@@ -93,6 +93,11 @@ function snort_check_dir_size_limit($snortloglimitsize) {
 			foreach ($files as $file)
 				unlink_if_exists($file);
 
+			// Cleanup any packet capture logs
+			$files = glob("{$snort_log_dir}/snort.log.*");
+			foreach ($files as $file)
+				unlink_if_exists($file);
+
 			// This is needed if snort is run as snort user
 			mwexec('/bin/chmod 660 {$snort_log_dir}/*', true);
 
@@ -227,7 +232,7 @@ if ($config['installedpackages']['snortglobal']['enable_log_mgmt'] == 'on') {
 			}
 			unset($rotated_files);
 			if ($prune_count > 0)
-				log_error(gettext("[Snort] Alert pcap file cleanup job removed {$prune_count} pcap file(s) from {$snort_log_dir}/..."));
+				log_error(gettext("[Snort] Alert tcpdump packet capture file cleanup job removed {$prune_count} tcpdump packet capture file(s) from {$snort_log_dir}/..."));
 		}
 
 		// Prune any aged-out Barnyard2 archived logs if any exist

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_cron_misc.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_cron_misc.inc
@@ -88,7 +88,12 @@ function snort_check_dir_size_limit($snortloglimitsize) {
 			foreach ($files as $file)
 				unlink_if_exists($file);
 
-			// Cleanup any AppID stats logs
+			// Cleanup any rotated AppID alerts logs
+			$files = glob("{$snort_log_dir}/appid.alerts.*");
+			foreach ($files as $file)
+				unlink_if_exists($file);
+
+			// Cleanup any rotated AppID stats logs
 			$files = glob("{$snort_log_dir}/app-stats.log.*");
 			foreach ($files as $file)
 				unlink_if_exists($file);
@@ -272,7 +277,23 @@ if ($config['installedpackages']['snortglobal']['enable_log_mgmt'] == 'on') {
 				log_error(gettext("[Snort] perfmon stats logs cleanup job removed {$prune_count} file(s) from {$snort_log_dir}/..."));
 		}
 
-		// Prune any aged-out AppID stats logs if any exist
+		// Prune any aged-out rotated AppID alerts logs if any exist
+		if ($value['appid_alerts_log_retention'] > 0) {
+			$now = time();
+			$files = glob("{$snort_log_dir}/appid.alerts.*");
+			$prune_count = 0;
+			foreach ($files as $f) {
+				if (($now - filemtime($f)) > ($value['appid_alerts_log_retention'] * 3600)) {
+					$prune_count++;
+					unlink_if_exists($f);
+				}
+			}
+			unset($files);
+			if ($prune_count > 0)
+				log_error(gettext("[Snort] AppID alerts logs cleanup job removed {$prune_count} appid.alerts file(s) from {$snort_log_dir}/..."));
+		}
+
+		// Prune any aged-out rotated AppID stats logs if any exist
 		if ($value['appid_stats_log_retention'] > 0) {
 			$now = time();
 			$files = glob("{$snort_log_dir}/app-stats.log.*");

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -68,12 +68,6 @@ $snort_filename = "snortrules-snapshot-{$snortver}.tar.gz";
 $snort_filename_md5 = "{$snort_filename}.md5";
 $snort_rule_url = VRT_DNLD_URL;
 
-/* Mount the Snort conf directories R/W, if not already, so we can modify files there */
-if (!is_subsystem_dirty('mount')) {
-	conf_mount_rw();
-	$mounted_rw = TRUE;
-}
-
 /* Set up Emerging Threats rules filenames and URL */
 if ($etpro == "on") {
 	$emergingthreats_filename = SNORT_ETPRO_DNLD_FILENAME;
@@ -829,10 +823,6 @@ if (is_dir("{$tmpfname}")) {
 snort_update_status(gettext("The Rules update has finished.") . "\n");
 log_error(gettext("[Snort] The Rules update has finished."));
 error_log(gettext("The Rules update has finished.  Time: " . date("Y-m-d H:i:s"). "\n\n"), 3, SNORT_RULES_UPD_LOGFILE);
-
-/* Remount filesystem read-only if we changed it in this module */
-if ($mounted_rw == TRUE)
-	conf_mount_ro();
 
 /* Save this update status to the rulesupd_status file */
 $status = time() . '|';

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_conf_template.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_conf_template.inc
@@ -94,6 +94,7 @@ output alert_csv: alert timestamp,sig_generator,sig_id,sig_rev,msg,proto,src,src
 {$alertsystemlog_type}
 {$snortunifiedlog_type}
 {$spoink_type}
+{$tcpdump_type}
 						
 # Misc Includes #
 {$snort_misc_include_rules}

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_conf_template.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_conf_template.inc
@@ -95,6 +95,7 @@ output alert_csv: alert timestamp,sig_generator,sig_id,sig_rev,msg,proto,src,src
 {$snortunifiedlog_type}
 {$spoink_type}
 {$tcpdump_type}
+{$appid_type}
 						
 # Misc Includes #
 {$snort_misc_include_rules}

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
@@ -153,6 +153,20 @@ else {
 	$tcpdump_type = "";
 }
 
+/* define unified2 binary log for OpenAppID alert events */
+if ($snortcfg['appid_preproc'] == "on") {
+	$appid_type = "output alert_unified2: filename appid.alerts, appid_event_types, nostamp";
+	if (!empty($snortcfg['appid_alerts_log_limit_size'])) {
+		$appid_type .= ", limit " . $snortcfg['appid_alerts_log_limit_size'];
+	}
+	else {
+		$appid_type .= ", limit 500K";
+	}
+}
+else {
+	$appid_type = "";
+}
+
 /* define selected suppress file */
 $suppress_file_name = "";
 $suppress = snort_find_list($snortcfg['suppresslistname'], 'suppress');

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2020 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2019 Bill Meeks
+ * Copyright (c) 2013-2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -140,6 +140,17 @@ if ($snortcfg['blockoffenders7'] == "on") {
 	/* write Pass List */
 	@file_put_contents("{$snortcfgdir}/{$snortcfg['whitelistname']}", implode("\n", $spoink_wlist));
 	$spoink_type = "output alert_pf: {$snortcfgdir}/{$snortcfg['whitelistname']},snort2c,{$snortcfg['blockoffendersip']},{$pfkill}";
+}
+
+/* define tcpdump log type */
+if ($snortcfg['enable_pkt_caps'] == "on") {
+	$tcpdump_type = "output log_tcpdump: " . SNORTLOGDIR . "/snort_{$if_real}{$snort_uuid}/snort.log";
+	if ( !empty($snortcfg['tcpdump_file_size'])) {
+		$tcpdump_type .= " " . $snortcfg['tcpdump_file_size'] . "M";
+	}
+}
+else {
+	$tcpdump_type = "";
 }
 
 /* define selected suppress file */

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
@@ -81,6 +81,8 @@ if (empty($config['installedpackages']['snortglobal']['enable_log_mgmt'])) {
 	$config['installedpackages']['snortglobal']['enable_log_mgmt'] = "on";
 	$config['installedpackages']['snortglobal']['alert_log_limit_size'] = "500";
 	$config['installedpackages']['snortglobal']['alert_log_retention'] = "336";
+	$config['installedpackages']['snortglobal']['appid_alerts_log_retention'] = "336";
+	$config['installedpackages']['snortglobal']['appid_alerts_log_limit_size'] = "500";
 	$config['installedpackages']['snortglobal']['appid_stats_log_limit_size'] = "1000";
 	$config['installedpackages']['snortglobal']['appid_stats_log_retention'] = "168";
 	$config['installedpackages']['snortglobal']['event_pkts_log_limit_size'] = "0";
@@ -91,10 +93,22 @@ if (empty($config['installedpackages']['snortglobal']['enable_log_mgmt'])) {
 	$config['installedpackages']['snortglobal']['stats_log_retention'] = "168";
 	$updated_cfg = true;
 }
-if (empty($config['installedpackages']['snortglobal']['appid_stats_log_limit_size']))
+if (empty($config['installedpackages']['snortglobal']['appid_stats_log_limit_size'])) {
 	$config['installedpackages']['snortglobal']['appid_stats_log_limit_size'] = "1000";
-if (empty($config['installedpackages']['snortglobal']['appid_stats_log_retention']))
+	$updated_cfg = true;
+}
+if (empty($config['installedpackages']['snortglobal']['appid_stats_log_retention'])) {
 	$config['installedpackages']['snortglobal']['appid_stats_log_retention'] = "168";
+	$updated_cfg = true;
+}
+if (empty($config['installedpackages']['snortglobal']['appid_alerts_log_limit_size'])) {
+	$config['installedpackages']['snortglobal']['appid_alerts_log_limit_size'] = "500";
+	$updated_cfg = true;
+}
+if (empty($config['installedpackages']['snortglobal']['appid_alerts_log_retention'])) {
+	$config['installedpackages']['snortglobal']['appid_alerts_log_retention'] = "336";
+	$updated_cfg = true;
+}
 
 /**********************************************************/
 /* Create new VERBOSE_LOGGING setting if not set          */

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2020 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2019 Bill Meeks
+ * Copyright (c) 2013-2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -233,8 +233,6 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 	update_status(gettext("Finished rebuilding Snort configuration files.") . "\n");
 	log_error(gettext("[Snort] Finished rebuilding installation from saved settings."));
 }
-
-/* We're finished with conf partition mods, return to read-only */
 
 /* If an existing Snort Dashboard Widget container is not found, */
 /* then insert our default Widget Dashboard container.           */

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
@@ -64,25 +64,18 @@ unlink_if_exists("{$g['varrun_path']}/snort_pkg_starting.lck");
 /* Set flag for post-install in progress */
 $g['snort_postinstall'] = true;
 
-/* Set conf partition to read-write so we can make changes there */
-
-/* cleanup default files */
-@rename("{$snortdir}/snort.conf-sample", "{$snortdir}/snort.conf");
-@rename("{$snortdir}/threshold.conf-sample", "{$snortdir}/threshold.conf");
-@rename("{$snortdir}/sid-msg.map-sample", "{$snortdir}/sid-msg.map");
-@rename("{$snortdir}/unicode.map-sample", "{$snortdir}/unicode.map");
-@rename("{$snortdir}/file_magic.conf-sample", "{$snortdir}/file_magic.conf");
-@rename("{$snortdir}/classification.config-sample", "{$snortdir}/classification.config");
-@rename("{$snortdir}/generators-sample", "{$snortdir}/generators");
-@rename("{$snortdir}/reference.config-sample", "{$snortdir}/reference.config");
-@rename("{$snortdir}/gen-msg.map-sample", "{$snortdir}/gen-msg.map");
-@rename("{$snortdir}/attribute_table.dtd-sample", "{$snortdir}/attribute_table.dtd");
-
-/* fix up the preprocessor rules filenames from a PBI package install */
-$preproc_rules = array("decoder.rules", "preprocessor.rules", "sensitive-data.rules");
-foreach ($preproc_rules as $file) {
-	if (file_exists("{$snortdir}/preproc_rules/{$file}-sample"))
-		@rename("{$snortdir}/preproc_rules/{$file}-sample", "{$snortdir}/preproc_rules/{$file}");
+/*****************************************************************/
+/* In the event this is a reinstall (or update), then recreate   */
+/* critical map, config and preprocessor rules files from the    */
+/* package sample templates.                                     */
+/*****************************************************************/
+$map_files = array("/unicode.map", "/gen-msg.map", "/classification.config", "/reference.config", 
+		   "/attribute_table.dtd", "/preproc_rules/preprocessor.rules", 
+		   "/preproc_rules/decoder.rules" , "/preproc_rules/sensitive-data.rules" );
+foreach ($map_files as $f) {
+	if (file_exists(SNORTDIR .  $f . "-sample") && !file_exists(SNORTDIR . $f)) {
+		copy(SNORTDIR .  $f . "-sample", SNORTDIR . $f);
+	}
 }
 
 /* Remove any previously installed scripts since we rebuild them */

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2020 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2019 Bill Meeks
+ * Copyright (c) 2013-2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,7 +41,6 @@ $snortlibdir = SNORT_PBI_BASEDIR . "lib";
 $snortlogdir = SNORTLOGDIR;
 $rcdir = RCFILEPREFIX;
 $snort_rules_upd_log = SNORT_RULES_UPD_LOGFILE;
-$mounted_rw = FALSE;
 
 log_error(gettext("[Snort] Snort package uninstall in progress..."));
 
@@ -125,14 +124,6 @@ if ($config['installedpackages']['snortglobal']['clearlogs'] == 'on') {
 }
 
 /**********************************************************/
-/* If not already, set Snort conf partition to read-write */
-/* so we can make changes there                           */
-/**********************************************************/
-if (!is_subsystem_dirty('mount')) {
-	$mounted_rw = TRUE;
-}
-
-/**********************************************************/
 /* Remove files and directories that pkg will not because */
 /* we changed or created them post-install.               */
 /**********************************************************/
@@ -190,11 +181,5 @@ else {
 	log_error(gettext("[Snort] Package files removed but all Snort configuration info has been retained."));
 }
 
-/**********************************************************/
-/* We're finished with conf partition mods, return to     */
-/* read-only if we changed it.                            */
-/**********************************************************/
-if ($mounted_rw == TRUE) {
-}
 return true;
 ?>

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -162,6 +162,17 @@ if (is_array($config['installedpackages']['snortglobal']['rule']) && count($conf
 }
 
 /**********************************************************/
+/* Clear IP addresses we placed in <snort2c> pf table if  */
+/* that option is enabled on GLOBAL SETTINGS tab or if    */
+/* the package and its configuration are being removed.   */
+/**********************************************************/
+if (($config['installedpackages']['snortglobal']['clearblocks'] != 'off') ||
+    ($config['installedpackages']['snortglobal']['forcekeepsettings'] != 'on')) {
+	syslog(LOG_NOTICE, gettext("[Snort] Flushing <snort2c> firewall table to remove addresses blocked by Snort..."));
+	mwexec("/sbin/pfctl -t snort2c -T flush");
+}
+
+/**********************************************************/
 /* Keep this as a last step because it is the total       */
 /* removal of the configuration settings when the user    */
 /* has elected to not retain the package configuration.   */
@@ -171,8 +182,6 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] != 'on') {
 	unset($config['installedpackages']['snortglobal']);
 	unset($config['installedpackages']['snortsync']);
 	unlink_if_exists("{$snort_rules_upd_log}");
-	log_error(gettext("[Snort] Flushing <snort2c> firewall table to remove addresses blocked by Snort..."));
-	mwexec("/sbin/pfctl -t snort2c -T flush");
 	rmdir_recursive("{$snortlogdir}");
 	rmdir_recursive("{$g['vardb_path']}/snort");
 	write_config("Removing Snort configuration");

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -127,28 +127,29 @@ if ($config['installedpackages']['snortglobal']['clearlogs'] == 'on') {
 /* Remove files and directories that pkg will not because */
 /* we changed or created them post-install.               */
 /**********************************************************/
-log_error(gettext("[Snort] Removing package files..."));
-if (is_dir("{$snortdir}/appid")) {
-	rmdir_recursive("{$snortdir}/appid");
-}
-if (is_dir("{$snortdir}/rules")) {
-	rmdir_recursive("{$snortdir}/rules");
-}
-if (is_dir("{$snortdir}/signatures")) {
-	rmdir_recursive("{$snortdir}/signatures");
-}
-if (is_dir("{$snortdir}/preproc_rules")) {
-	rmdir_recursive("{$snortdir}/preproc_rules");
+syslog(LOG_NOTICE, gettext("[Snort] Removing GUI package-modified files..."));
+if (is_dir(SNORT_APPID_ODP_PATH)) {
+	rmdir_recursive(SNORT_APPID_ODP_PATH);
 }
 if (is_dir("/usr/local/lib/snort_dynamicrules")) {
 	rmdir_recursive("/usr/local/lib/snort_dynamicrules");
 }
-unlink_if_exists("{$snortdir}/*.md5");
-unlink_if_exists("{$snortdir}/*.conf");
-unlink_if_exists("{$snortdir}/*.map");
-unlink_if_exists("{$snortdir}/*.config");
-unlink_if_exists("{$snortdir}/attribute_table.dtd");
-unlink_if_exists("{$snortdir}/rulesupd_status");
+if (is_dir(SNORTDIR . "/signatures")) {
+	rmdir_recursive(SNORTDIR . "/signatures");
+}
+unlink_if_exists(SNORTDIR . "/*.md5");
+unlink_if_exists(SNORTDIR . "/rules/*.txt");
+unlink_if_exists(SNORTDIR . "/classification.config");
+unlink_if_exists(SNORTDIR . "/reference.config");
+unlink_if_exists(SNORTDIR . "/unicode.map");
+unlink_if_exists(SNORTDIR . "/rulesupd_status");
+unlink_if_exists(SNORTDIR . "/preproc_rules/*.rules");
+unlink_if_exists(SNORTDIR . "/rules/" . VRT_FILE_PREFIX . "*.rules");
+unlink_if_exists(SNORTDIR . "/rules/" . ET_OPEN_FILE_PREFIX . "*.rules");
+unlink_if_exists(SNORTDIR . "/rules/" . ET_PRO_FILE_PREFIX . "*.rules");
+unlink_if_exists(SNORTDIR . "/rules/" . GPL_FILE_PREFIX . "*.rules");
+unlink_if_exists(SNORTDIR . "/rules/" . "appid.rules");
+unlink_if_exists(SNORT_APPID_RULES_PATH . OPENAPPID_FILE_PREFIX . "*.rules");
 
 if (is_array($config['installedpackages']['snortglobal']['rule']) && count($config['installedpackages']['snortglobal']['rule']) > 0) {
 	foreach ($config['installedpackages']['snortglobal']['rule'] as $snortcfg) {

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
@@ -162,9 +162,7 @@ if (!$input_errors) {
 		write_config("Snort pkg: modified global settings.");
 
 		/* create whitelist and homenet file, then sync files */
-		conf_mount_rw();
 		sync_snort_package_config();
-		conf_mount_ro();
 
 		/* forces page to reload new settings */
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_log_mgmt.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_log_mgmt.php
@@ -50,6 +50,8 @@ else {
 	$pconfig['event_pkts_log_retention'] = $config['installedpackages']['snortglobal']['event_pkts_log_retention'];
 	$pconfig['appid_stats_log_limit_size'] = $config['installedpackages']['snortglobal']['appid_stats_log_limit_size'];
 	$pconfig['appid_stats_log_retention'] = $config['installedpackages']['snortglobal']['appid_stats_log_retention'];
+	$pconfig['appid_alerts_log_retention'] = $config['installedpackages']['snortglobal']['appid_alerts_log_retention'];
+	$pconfig['appid_alerts_log_limit_size'] = $config['installedpackages']['snortglobal']['appid_alerts_log_limit_size'];
 }
 // Load up some arrays with selection values (we use these later).
 // The keys in the $retentions array are the retention period
@@ -81,6 +83,8 @@ if (!isset($pconfig['event_pkts_log_retention']))
 	$pconfig['event_pkts_log_retention'] = "336";
 if (!isset($pconfig['appid_stats_log_retention']))
 	$pconfig['appid_stats_log_retention'] = "168";
+if (!isset($pconfig['appid_alerts_log_retention']))
+	$pconfig['appid_alerts_log_retention'] = "336";
 
 // Set default log file size limits
 if (!isset($pconfig['alert_log_limit_size']))
@@ -91,6 +95,8 @@ if (!isset($pconfig['sid_changes_log_limit_size']))
 	$pconfig['sid_changes_log_limit_size'] = "250";
 if (!isset($pconfig['appid_stats_log_limit_size']))
 	$pconfig['appid_stats_log_limit_size'] = "1000";
+if (!isset($pconfig['appid_alerts_log_limit_size']))
+	$pconfig['appid_alerts_log_limit_size'] = "500";
 
 if (isset($_POST['ResetAll'])) {
 
@@ -100,12 +106,14 @@ if (isset($_POST['ResetAll'])) {
 	$pconfig['sid_changes_log_retention'] = "336";
 	$pconfig['event_pkts_log_retention'] = "336";
 	$pconfig['appid_stats_log_retention'] = "168";
+	$pconfig['appid_alerts_log_retention'] = "336";
 
 	$pconfig['alert_log_limit_size'] = "500";
 	$pconfig['stats_log_limit_size'] = "500";
 	$pconfig['sid_changes_log_limit_size'] = "250";
 	$pconfig['event_pkts_log_limit_size'] = "0";
 	$pconfig['appid_stats_log_limit_size'] = "1000";
+	$pconfig['appid_alerts_log_limit_size'] = "500";
 
 	/* Log a message at the top of the page to inform the user */
 	$savemsg = gettext("All log management settings on this page have been reset to their defaults.  Click APPLY if you wish to keep these new settings.");
@@ -147,6 +155,8 @@ if (isset($_POST['save']) || isset($_POST['apply'])) {
 		$config['installedpackages']['snortglobal']['event_pkts_log_retention'] = $_POST['event_pkts_log_retention'];
 		$config['installedpackages']['snortglobal']['appid_stats_log_limit_size'] = $_POST['appid_stats_log_limit_size'];
 		$config['installedpackages']['snortglobal']['appid_stats_log_retention'] = $_POST['appid_stats_log_retention'];
+		$config['installedpackages']['snortglobal']['appid_alerts_log_limit_size'] = $_POST['appid_alerts_log_limit_size'];
+		$config['installedpackages']['snortglobal']['appid_alerts_log_retention'] = $_POST['appid_alerts_log_retention'];
 
 		write_config("Snort pkg: saved updated configuration for LOGS MGMT.");
 		sync_snort_package_config();
@@ -261,6 +271,28 @@ print ($section);
 						</td>
 						<td><?=gettext("Snort alerts and event details");?></td>
 					</tr>
+
+					<tr>
+						<td>appid-alerts</td>
+						<td><select name="appid_alerts_log_limit_size" class="form-control" id="appid_alerts_log_limit_size">
+							<?php foreach ($log_sizes as $k => $l): ?>
+								<option value="<?=$k;?>"
+								<?php if ($k == $pconfig['appid_alerts_log_limit_size']) echo " selected"; ?>>
+									<?=htmlspecialchars($l);?></option>
+							<?php endforeach; ?>
+							</select>
+						</td>
+						<td><select name="appid_alerts_log_retention" class="form-control" id="appid_alerts_log_retention">
+							<?php foreach ($retentions as $k => $p): ?>
+								<option value="<?=$k;?>"
+								<?php if ($k == $pconfig['appid_alerts_log_retention']) echo " selected"; ?>>
+									<?=htmlspecialchars($p);?></option>
+							<?php endforeach; ?>
+							</select>
+						</td>
+						<td><?=gettext("Application ID Alerts");?></td>
+					</tr>
+
 					<tr>
 						<td>app-stats</td>
 						<td><select name="appid_stats_log_limit_size" class="form-control" id="appid_stats_log_limit_size">


### PR DESCRIPTION
### pfSense-pkg-snort-3.2.9.12
This update for the Snort GUI package corrects a rare edge-case install bug, removes a pair of deprecated system calls, fixes an issue with clearing blocked hosts on package uninstall and adds two new features.

**New Features:**
1. Add option for packet logging to INTERFACES EDIT tab. When enabled, Snort will capture packets associated with an alert and store them in a tcpdump compatible output file in the logging directory for the Snort interface.

2. In preparation for Barnyard2 removal, migrate some OpenAppID logging to a stand-alone unified2 log file (_appid.alerts_) in the logging directory for the Snort interface. Future package enhancements will utilize this binary logging file. New settings were added to the LOGS MGMT tab to allow configuration of size and retention limits for these logs.

**Bug Fixes:**
1. Fix up code in the post-install process so that the critical _unicode.map_ and other _*-sample_ files are retained and used to replace any primary files that are incorrectly removed by a package update.

2. Remove deprecated calls to the old _conf_mount_rw()_ and _conf_mount_ro()_ system functions as they are no longer required in current pfSense environments.

3. The option to "Remove Blocked Hosts" is not honored when uninstalling the Snort package but retaining configuration settings.