### PR TITLE
pfSense-pkg-snort-4.1_1 - Add packet capture and new OpenAppID binary logging

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.1
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_cron_misc.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_cron_misc.inc
@@ -92,7 +92,12 @@ function snort_check_dir_size_limit($snortloglimitsize) {
 			foreach ($files as $file)
 				unlink_if_exists($file);
 
-			// Cleanup any AppID stats logs
+			// Cleanup any rotated AppID alerts logs
+			$files = glob("{$snort_log_dir}/appid.alerts.*");
+			foreach ($files as $file)
+				unlink_if_exists($file);
+
+			// Cleanup any rotated AppID stats logs
 			$files = glob("{$snort_log_dir}/app-stats.log.*");
 			foreach ($files as $file)
 				unlink_if_exists($file);
@@ -220,7 +225,7 @@ if ($config['installedpackages']['snortglobal']['enable_log_mgmt'] == 'on') {
 			}
 			unset($rotated_files);
 			if ($prune_count > 0)
-				log_error(gettext("[Snort] Alerts log file cleanup job removed {$prune_count} rotated alert log file(s) from {$snort_log_dir}/..."));
+				syslog(LOG_NOTICE, gettext("[Snort] Alerts log file cleanup job removed {$prune_count} rotated alert log file(s) from {$snort_log_dir}/..."));
 		}
 
 		// Prune aged-out event packet capture files if any exist
@@ -276,7 +281,23 @@ if ($config['installedpackages']['snortglobal']['enable_log_mgmt'] == 'on') {
 				syslog(LOG_NOTICE, gettext("[Snort] perfmon stats logs cleanup job removed {$prune_count} file(s) from {$snort_log_dir}/..."));
 		}
 
-		// Prune any aged-out AppID stats logs if any exist
+		// Prune any aged-out rotated AppID alerts logs if any exist
+		if ($value['appid_alerts_log_retention'] > 0) {
+			$now = time();
+			$files = glob("{$snort_log_dir}/appid.alerts.*");
+			$prune_count = 0;
+			foreach ($files as $f) {
+				if (($now - filemtime($f)) > ($value['appid_alerts_log_retention'] * 3600)) {
+					$prune_count++;
+					unlink_if_exists($f);
+				}
+			}
+			unset($files);
+			if ($prune_count > 0)
+				syslog(LOG_NOTICE, gettext("[Snort] AppID alerts logs cleanup job removed {$prune_count} appid.alerts file(s) from {$snort_log_dir}/..."));
+		}
+
+		// Prune any aged-out rotated AppID stats logs if any exist
 		if ($value['appid_stats_log_retention'] > 0) {
 			$now = time();
 			$files = glob("{$snort_log_dir}/app-stats.log.*");

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_cron_misc.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_cron_misc.inc
@@ -97,6 +97,11 @@ function snort_check_dir_size_limit($snortloglimitsize) {
 			foreach ($files as $file)
 				unlink_if_exists($file);
 
+			// Cleanup any packet capture logs
+			$files = glob("{$snort_log_dir}/snort.log.*");
+			foreach ($files as $file)
+				unlink_if_exists($file);
+
 			// This is needed if snort is run as snort user
 			mwexec('/bin/chmod 660 {$snort_log_dir}/*', true);
 
@@ -231,7 +236,7 @@ if ($config['installedpackages']['snortglobal']['enable_log_mgmt'] == 'on') {
 			}
 			unset($rotated_files);
 			if ($prune_count > 0)
-				syslog(LOG_NOTICE, gettext("[Snort] Alert pcap file cleanup job removed {$prune_count} pcap file(s) from {$snort_log_dir}/..."));
+				syslog(LOG_NOTICE, gettext("[Snort] Alert tcpdump packet capture file cleanup job removed {$prune_count} tcpdump packet capture file(s) from {$snort_log_dir}/..."));
 		}
 
 		// Prune any aged-out Barnyard2 archived logs if any exist

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_conf_template.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_conf_template.inc
@@ -99,6 +99,7 @@ output alert_csv: alert timestamp,sig_generator,sig_id,sig_rev,msg,proto,src,src
 {$snortunifiedlog_type}
 {$spoink_type}
 {$tcpdump_type}
+{$appid_type}
 						
 # Misc Includes #
 {$snort_misc_include_rules}

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_conf_template.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_conf_template.inc
@@ -98,6 +98,7 @@ output alert_csv: alert timestamp,sig_generator,sig_id,sig_rev,msg,proto,src,src
 {$alertsystemlog_type}
 {$snortunifiedlog_type}
 {$spoink_type}
+{$tcpdump_type}
 						
 # Misc Includes #
 {$snort_misc_include_rules}

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
@@ -153,6 +153,20 @@ else {
 	$tcpdump_type = "";
 }
 
+/* define unified2 binary log for OpenAppID alert events */
+if ($snortcfg['appid_preproc'] == "on") {
+	$appid_type = "output alert_unified2: filename appid.alerts, appid_event_types, nostamp";
+	if (!empty($snortcfg['appid_alerts_log_limit_size'])) {
+		$appid_type .= ", limit " . $snortcfg['appid_alerts_log_limit_size'];
+	}
+	else {
+		$appid_type .= ", limit 500K";
+	}
+}
+else {
+	$appid_type = "";
+}
+
 /* define selected suppress file */
 $suppress_file_name = "";
 $suppress = snort_find_list($snortcfg['suppresslistname'], 'suppress');

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2020 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2019 Bill Meeks
+ * Copyright (c) 2013-2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -140,6 +140,17 @@ if ($snortcfg['blockoffenders7'] == "on" && $snortcfg['ips_mode'] == "ips_mode_l
 	if ($snortcfg['blockoffenderskill'] == "on") {
 		$spoink_type .= ",kill";
 	}
+}
+
+/* define tcpdump log type */
+if ($snortcfg['enable_pkt_caps'] == "on") {
+	$tcpdump_type = "output log_tcpdump: " . SNORTLOGDIR . "/snort_{$if_real}{$snort_uuid}/snort.log";
+	if ( !empty($snortcfg['tcpdump_file_size'])) {
+		$tcpdump_type .= " " . $snortcfg['tcpdump_file_size'] . "M";
+	}
+}
+else {
+	$tcpdump_type = "";
 }
 
 /* define selected suppress file */

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
@@ -81,6 +81,8 @@ if (empty($config['installedpackages']['snortglobal']['enable_log_mgmt'])) {
 	$config['installedpackages']['snortglobal']['enable_log_mgmt'] = "on";
 	$config['installedpackages']['snortglobal']['alert_log_limit_size'] = "500";
 	$config['installedpackages']['snortglobal']['alert_log_retention'] = "336";
+	$config['installedpackages']['snortglobal']['appid_alerts_log_retention'] = "336";
+	$config['installedpackages']['snortglobal']['appid_alerts_log_limit_size'] = "500";
 	$config['installedpackages']['snortglobal']['appid_stats_log_limit_size'] = "1000";
 	$config['installedpackages']['snortglobal']['appid_stats_log_retention'] = "168";
 	$config['installedpackages']['snortglobal']['event_pkts_log_limit_size'] = "0";
@@ -91,10 +93,22 @@ if (empty($config['installedpackages']['snortglobal']['enable_log_mgmt'])) {
 	$config['installedpackages']['snortglobal']['stats_log_retention'] = "168";
 	$updated_cfg = true;
 }
-if (empty($config['installedpackages']['snortglobal']['appid_stats_log_limit_size']))
+if (empty($config['installedpackages']['snortglobal']['appid_stats_log_limit_size'])) {
 	$config['installedpackages']['snortglobal']['appid_stats_log_limit_size'] = "1000";
-if (empty($config['installedpackages']['snortglobal']['appid_stats_log_retention']))
+	$updated_cfg = true;
+}
+if (empty($config['installedpackages']['snortglobal']['appid_stats_log_retention'])) {
 	$config['installedpackages']['snortglobal']['appid_stats_log_retention'] = "168";
+	$updated_cfg = true;
+}
+if (empty($config['installedpackages']['snortglobal']['appid_alerts_log_limit_size'])) {
+	$config['installedpackages']['snortglobal']['appid_alerts_log_limit_size'] = "500";
+	$updated_cfg = true;
+}
+if (empty($config['installedpackages']['snortglobal']['appid_alerts_log_retention'])) {
+	$config['installedpackages']['snortglobal']['appid_alerts_log_retention'] = "336";
+	$updated_cfg = true;
+}
 
 /**********************************************************/
 /* Create new VERBOSE_LOGGING setting if not set          */

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2011-2020 Rubicon Communications, LLC (Netgate)
  * Copyright (C) 2008-2009 Robert Zelaya
- * Copyright (c) 2019 Bill Meeks
+ * Copyright (c) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -167,6 +167,10 @@ elseif (isset($id) && !isset($a_rule[$id])) {
 }
 
 // Set defaults for empty key parameters
+if (empty($pconfig['enable_pkt_caps']))
+	$pconfig['enable_pkt_caps'] = "off";
+if (empty($pconfig['tcpdump_file_size']))
+	$pconfig['tcpdump_file_size'] = "128";
 if (empty($pconfig['blockoffendersip']))
 	$pconfig['blockoffendersip'] = "both";
 if (empty($pconfig['blockoffenderskill']))
@@ -281,6 +285,8 @@ if ($_POST['save'] && !$input_errors) {
 		if ($_POST['performance']) $natent['performance'] = $_POST['performance']; else  unset($natent['performance']);
 		if ($_POST['snaplen'] && is_numeric($_POST['snaplen'])) $natent['snaplen'] = $_POST['snaplen'];
 		if ($_POST['ips_mode']) $natent['ips_mode'] = $_POST['ips_mode']; else unset($natent['ips_mode']);
+		if ($_POST['enable_pkt_caps'] == "on") $natent['enable_pkt_caps'] = 'on'; else $natent['enable_pkt_caps'] = 'off';
+		if ($_POST['tcpdump_file_size'] && is_numeric($_POST['tcpdump_file_size'])) $natent['tcpdump_file_size'] = $_POST['tcpdump_file_size'];
 		if ($_POST['blockoffenders7'] == "on") $natent['blockoffenders7'] = 'on'; else $natent['blockoffenders7'] = 'off';
 		if ($_POST['blockoffenderskill'] == "on") $natent['blockoffenderskill'] = 'on'; else $natent['blockoffenderskill'] = 'off';
 		if ($_POST['blockoffendersip']) $natent['blockoffendersip'] = $_POST['blockoffendersip']; else unset($natent['blockoffendersip']);
@@ -596,6 +602,19 @@ $section->addInput(new Form_Select(
 	array(  'log_emerg' => gettext('LOG_EMERG'), 'log_crit' => gettext('LOG_CRIT'), 'log_alert' => gettext('LOG_ALERT'), 'log_err' => gettext('LOG_ERR'), 
 		'log_warning' => gettext('LOG_WARNING'), 'log_notice' => gettext('LOG_NOTICE'), 'log_info' => gettext('LOG_INFO'), 'log_debug' => gettext('LOG_DEBUG') )
 ))->setHelp('Select system log Priority (Level) to use for reporting. Default is LOG_ALERT.');
+$section->addInput(new Form_Checkbox(
+	'enable_pkt_caps',
+	'Enable Packet Captures',
+	'Checking this option will automatically capture packets that generate a Snort alert into a tcpdump compatible file',
+	$pconfig['enable_pkt_caps'] == 'on' ? true:false,
+	'on'
+));
+$section->addInput(new Form_Input(
+	'tcpdump_file_size',
+	'Packet Capture File Size',
+	'number',
+	$pconfig['tcpdump_file_size']
+))->setHelp('Enter a value in megabytes for the packet capture file size limit. Default is 128 megabytes. When the limit is reached, the current packet capture file in directory ' . SNORTLOGDIR . '/snort_' . get_real_interface($pconfig['interface']) . $pconfig['uuid'] . ' is rotated and a new file opened.');
 
 $form->add($section);
 
@@ -888,11 +907,18 @@ events.push(function(){
 		hideSelect('alertsystemlog_priority', hide);
 	}
 
+	function toggle_enable_pkt_caps() {
+		var hide = ! $('#enable_pkt_caps').prop('checked');
+		hideInput('tcpdump_file_size', hide);
+	}
+
 	function enable_change() {
 		var hide = ! $('#enable').prop('checked');
 		disableInput('alertsystemlog', hide);
 		disableInput('alertsystemlog_facility', hide);
 		disableInput('alertsystemlog_priority', hide);
+		disableInput('enable_pkt_caps', hide);
+		disableInput('tcpdump_file_size', hide);
 		disableInput('blockoffenders7', hide);
 		disableInput('ips_mode', hide);
 		disableInput('blockoffenderskill', hide);
@@ -970,6 +996,11 @@ events.push(function(){
 		enable_blockoffenders();
 	});
 
+	// When 'enable_pkt_caps' is clicked, disable/enable associated form controls
+	$('#enable_pkt_caps').click(function() {
+		toggle_enable_pkt_caps();
+	});
+
 	$('#ips_mode').on('change', function() {
 		if ($('#ips_mode').val() == 'ips_mode_inline') {
 			hideCheckbox('blockoffenderskill', true);
@@ -989,6 +1020,7 @@ events.push(function(){
 	enable_change();
 	enable_blockoffenders();
 	toggle_system_log();
+	toggle_enable_pkt_caps();
 });
 //]]>
 </script>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_log_mgmt.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_log_mgmt.php
@@ -50,6 +50,8 @@ else {
 	$pconfig['event_pkts_log_retention'] = $config['installedpackages']['snortglobal']['event_pkts_log_retention'];
 	$pconfig['appid_stats_log_limit_size'] = $config['installedpackages']['snortglobal']['appid_stats_log_limit_size'];
 	$pconfig['appid_stats_log_retention'] = $config['installedpackages']['snortglobal']['appid_stats_log_retention'];
+	$pconfig['appid_alerts_log_retention'] = $config['installedpackages']['snortglobal']['appid_alerts_log_retention'];
+	$pconfig['appid_alerts_log_limit_size'] = $config['installedpackages']['snortglobal']['appid_alerts_log_limit_size'];
 }
 // Load up some arrays with selection values (we use these later).
 // The keys in the $retentions array are the retention period
@@ -81,6 +83,8 @@ if (!isset($pconfig['event_pkts_log_retention']))
 	$pconfig['event_pkts_log_retention'] = "336";
 if (!isset($pconfig['appid_stats_log_retention']))
 	$pconfig['appid_stats_log_retention'] = "168";
+if (!isset($pconfig['appid_alerts_log_retention']))
+	$pconfig['appid_alerts_log_retention'] = "336";
 
 // Set default log file size limits
 if (!isset($pconfig['alert_log_limit_size']))
@@ -91,6 +95,8 @@ if (!isset($pconfig['sid_changes_log_limit_size']))
 	$pconfig['sid_changes_log_limit_size'] = "250";
 if (!isset($pconfig['appid_stats_log_limit_size']))
 	$pconfig['appid_stats_log_limit_size'] = "1000";
+if (!isset($pconfig['appid_alerts_log_limit_size']))
+	$pconfig['appid_alerts_log_limit_size'] = "500";
 
 if (isset($_POST['ResetAll'])) {
 
@@ -100,12 +106,14 @@ if (isset($_POST['ResetAll'])) {
 	$pconfig['sid_changes_log_retention'] = "336";
 	$pconfig['event_pkts_log_retention'] = "336";
 	$pconfig['appid_stats_log_retention'] = "168";
+	$pconfig['appid_alerts_log_retention'] = "336";
 
 	$pconfig['alert_log_limit_size'] = "500";
 	$pconfig['stats_log_limit_size'] = "500";
 	$pconfig['sid_changes_log_limit_size'] = "250";
 	$pconfig['event_pkts_log_limit_size'] = "0";
 	$pconfig['appid_stats_log_limit_size'] = "1000";
+	$pconfig['appid_alerts_log_limit_size'] = "500";
 
 	/* Log a message at the top of the page to inform the user */
 	$savemsg = gettext("All log management settings on this page have been reset to their defaults.  Click APPLY if you wish to keep these new settings.");
@@ -147,6 +155,8 @@ if (isset($_POST['save']) || isset($_POST['apply'])) {
 		$config['installedpackages']['snortglobal']['event_pkts_log_retention'] = $_POST['event_pkts_log_retention'];
 		$config['installedpackages']['snortglobal']['appid_stats_log_limit_size'] = $_POST['appid_stats_log_limit_size'];
 		$config['installedpackages']['snortglobal']['appid_stats_log_retention'] = $_POST['appid_stats_log_retention'];
+		$config['installedpackages']['snortglobal']['appid_alerts_log_limit_size'] = $_POST['appid_alerts_log_limit_size'];
+		$config['installedpackages']['snortglobal']['appid_alerts_log_retention'] = $_POST['appid_alerts_log_retention'];
 
 		write_config("Snort pkg: saved updated configuration for LOGS MGMT.");
 		sync_snort_package_config();
@@ -260,6 +270,26 @@ print ($section);
 							</select>
 						</td>
 						<td><?=gettext("Snort alerts and event details");?></td>
+					</tr>
+					<tr>
+						<td>appid-alerts</td>
+						<td><select name="appid_alerts_log_limit_size" class="form-control" id="appid_alerts_log_limit_size">
+							<?php foreach ($log_sizes as $k => $l): ?>
+								<option value="<?=$k;?>"
+								<?php if ($k == $pconfig['appid_alerts_log_limit_size']) echo " selected"; ?>>
+									<?=htmlspecialchars($l);?></option>
+							<?php endforeach; ?>
+							</select>
+						</td>
+						<td><select name="appid_alerts_log_retention" class="form-control" id="appid_alerts_log_retention">
+							<?php foreach ($retentions as $k => $p): ?>
+								<option value="<?=$k;?>"
+								<?php if ($k == $pconfig['appid_alerts_log_retention']) echo " selected"; ?>>
+									<?=htmlspecialchars($p);?></option>
+							<?php endforeach; ?>
+							</select>
+						</td>
+						<td><?=gettext("Application ID Alerts");?></td>
 					</tr>
 					<tr>
 						<td>app-stats</td>


### PR DESCRIPTION
**pfSense-pkg-snort-4.1_1**
This update to the Snort GUI package for pfSense-2.5 DEVEL adds two new features.

**New Features:**
1. Add an option on the INTERFACE SETTINGS tab to enable tcpdump compatible packet captures from alerts. A capture file size limit can also be set. Once a capture file exceeds the limit, it is rotated and a new capture file is opened. The packet captures are stored in the interface's logging subdirectory under _/var/log/snort_. The filename is _snort.log_. Rotated files have a UNIX timestamp appended to the name.

2. Add a new binary Unified2 format log file for OpenAppID alerts. This file is for future use. It resides in the interface's logging subdirectory under _/var/log/snort_. On the LOG MGMT tab you can configure size and retention limits for the OpenAppID alerts log. The filename is _appid.alerts_. Rotated files have a UNIX timestamp appended to the name.