### PR TITLE
Move some FRR advanced options to address-family. Fixes #10647

### DIFF
--- a/net/pfSense-pkg-frr/Makefile
+++ b/net/pfSense-pkg-frr/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-frr
 PORTVERSION=	0.6.5
+PORTREVISION=	1
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_bgp.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_bgp.inc
@@ -180,10 +180,15 @@ function frr_bgp_generate_router() {
 		}
 		$bgpconf .= "\n";
 	}
-
-	/* (Re)distribute */
+	/* Address-family options */
 	foreach (array('ipv4', 'ipv6') as $ipfamily) {
 		$familyconf = '';
+		if (is_array($config['installedpackages']['frrbgpadvanced']['config'])) {
+			$frr_bgpadv_conf = &$config['installedpackages']['frrbgpadvanced']['config'][0];
+		} else {
+			$frr_bgpadv_conf = false;
+		}
+		/* (Re)distribute */
 		foreach (array('connected', 'static', 'kernel', 'ospf') as $redist) {
 			if ($redist == 'connected') {
 				$source = 'connectedsubnets';
@@ -208,6 +213,43 @@ function frr_bgp_generate_router() {
 					}
 					$familyconf .= "\n";
 				}
+			}
+		}
+		if ($frr_bgpadv_conf) {
+			/* Aggregate Behavior */
+			foreach ($frr_bgpadv_conf['row'] as $aggr) {
+				if ((is_subnetv4($aggr['aggregateaddr']) && ($ipfamily == 'ipv4')) ||
+				    (is_subnetv6($aggr['aggregateaddr']) && ($ipfamily == 'ipv6'))) {
+					$familyconf .= "   aggregate-address {$aggr['aggregateaddr']}";
+					if (!empty($aggr['aggregateasset'])) {
+						$familyconf .= " as-set";
+					}
+					if (!empty($aggr['aggregatesummaryonly'])) {
+						$familyconf .= " summary-only";
+					}
+					$familyconf .= "\n";
+				}
+			}
+			/* Admin distance requires both a distance value and a subnet/prefix */
+			if (frr_validate_intrange($frr_bgpadv_conf['distanceadmin'], 1, 255) &&
+			    (is_subnetv4($frr_bgpadv_conf['distanceadminprefix']) && ($ipfamily == 'ipv4')) ||
+			    (is_subnetv6($frr_bgpadv_conf['distanceadminprefix']) && ($ipfamily == 'ipv6'))) {
+				$familyconf .= "   distance {$frr_bgpadv_conf['distanceadmin']} {$frr_bgpadv_conf['distanceadminprefix']}";
+				if (in_array($frr_bgpadv_conf['distanceadminacl'], frr_get_list_values(frr_get_accesslist_list())) &&
+				    ($frr_bgpadv_conf['distanceadminacl'] != "none")) {
+					$familyconf .= " {$frr_bgpadv_conf['distanceadminacl']}";
+				}
+				$familyconf .= "\n";
+			}
+			/* For BGP distance, all three values must be set. */
+			if (frr_validate_intrange($frr_bgpadv_conf['bgpdistanceext'], 1, 255) &&
+			    frr_validate_intrange($frr_bgpadv_conf['bgpdistanceint'], 1, 255) &&
+			    frr_validate_intrange($frr_bgpadv_conf['bgpdistancelocal'], 1, 255)) {
+				$familyconf .= "   distance bgp {$frr_bgpadv_conf['bgpdistanceext']} {$frr_bgpadv_conf['bgpdistanceint']} {$frr_bgpadv_conf['bgpdistancelocal']}\n";
+			}
+			if (in_array($frr_bgpadv_conf['tablemap'], frr_get_list_values(frr_get_routemap_list())) &&
+			    ($frr_bgpadv_conf['tablemap'] != "none")) {
+				$familyconf .= "   table-map {$frr_bgpadv_conf['tablemap']}\n";
 			}
 		}
 		if (!empty($familyconf)) {
@@ -235,12 +277,6 @@ function frr_bgp_generate_routeradvanced() {
 	if (frr_validate_ulong($frr_bgpadv_conf['default_localpref'])) {
 		$advconf .= "  bgp default local-preference {$frr_bgpadv_conf['default_localpref']}\n";
 	}
-	/* TODO: Candidate for moving to address-family */
-	if (in_array($frr_bgpadv_conf['tablemap'], frr_get_list_values(frr_get_routemap_list())) &&
-	    ($frr_bgpadv_conf['tablemap'] != "none")) {
-		$advconf .= "  table-map {$frr_bgpadv_conf['tablemap']}\n";
-	}
-
 	/* Advanced Timers */
 	if (frr_validate_ulong($frr_bgpadv_conf['timers_coalesce'], 1)) {
 		$advconf .= "  coalesce-time {$frr_bgpadv_conf['timers_coalesce']}\n";
@@ -281,20 +317,6 @@ function frr_bgp_generate_routeradvanced() {
 		$advconf .= "  no bgp client-to-client reflection\n";
 	}
 
-	/* Aggregate Behavior -- Candidate for moving to address-family */
-	foreach ($frr_bgpadv_conf['row'] as $aggr) {
-		if (is_subnetv4($aggr['aggregateaddr'])) {
-			$advconf .= "  aggregate-address {$aggr['aggregateaddr']}";
-			if (!empty($aggr['aggregateasset'])) {
-				$advconf .= " as-set";
-			}
-			if (!empty($aggr['aggregatesummaryonly'])) {
-				$advconf .= " summary-only";
-			}
-			$advconf .= "\n";
-		}
-	}
-
 	/* Multi-Exit Discriminator */
 	if (!empty($frr_bgpadv_conf['meddeterministic'])) {
 		$advconf .= "  bgp deterministic-med\n";
@@ -331,27 +353,6 @@ function frr_bgp_generate_routeradvanced() {
 	if ($add_confedpeers) {
 		$advconf .= "  bgp confederation peers {$frr_bgpadv_conf['confedpeers']}\n";
 	}
-
-	/* Distance -- Candidate for moving to address-family (both)*/
-
-	/* Admin distance requires both a distance value and a subnet/prefix */
-	if (frr_validate_intrange($frr_bgpadv_conf['distanceadmin'], 1, 255) &&
-	    is_subnetv4($frr_bgpadv_conf['distanceadminprefix'])) {
-		$advconf .= "  distance {$frr_bgpadv_conf['distanceadmin']} {$frr_bgpadv_conf['distanceadminprefix']}";
-		if (in_array($frr_bgpadv_conf['distanceadminacl'], frr_get_list_values(frr_get_accesslist_list())) &&
-		    ($frr_bgpadv_conf['distanceadminacl'] != "none")) {
-			$advconf .= " {$frr_bgpadv_conf['distanceadminacl']}";
-		}
-		$advconf .= "\n";
-	}
-
-	/* For BGP distance, all three values must be set. */
-	if (frr_validate_intrange($frr_bgpadv_conf['bgpdistanceext'], 1, 255) &&
-	    frr_validate_intrange($frr_bgpadv_conf['bgpdistanceint'], 1, 255) &&
-	    frr_validate_intrange($frr_bgpadv_conf['bgpdistancelocal'], 1, 255)) {
-		$advconf .= "  distance bgp {$frr_bgpadv_conf['bgpdistanceext']} {$frr_bgpadv_conf['bgpdistanceint']} {$frr_bgpadv_conf['bgpdistancelocal']}\n";
-	}
-
 	/* Best Path Selection */
 	if (!empty($frr_bgpadv_conf['bgpbestpathasconfed'])) {
 		$advconf .= "  bgp bestpath as-path confed\n";


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10647
- [X] Ready for review

Allow to use IPv6 in `aggregate-address` and `distance`
Move `aggregate-address`, `distance` and `table-map` options to address-family
