### PR TITLE
Snort VPN pass list improvements. Fixes #8688

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.1
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -472,7 +472,7 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
 
 	// Grab a list of vpns enabled - these come back as CIDR mask networks
 	if ($vpns == 'yes') {
-		$vpns_list = filter_get_vpns_list();
+		$vpns_list = snort_get_vpns_list();
 		if (!empty($vpns_list)) {
 			/* Convert the returned space-delimited string to an array */
 			/* and then add each VPN address to our HOME_NET array.    */
@@ -4415,4 +4415,125 @@ EOD;
 		}
 	}
 }
+
+function snort_get_vpns_list() {
+	global $config;
+
+	$vpns = "";
+	$vpns_arr = array();
+
+	/* IPsec */
+	if (!function_exists('ipsec_enabled')) {
+		require_once("ipsec.inc");
+	}
+	if (ipsec_enabled()) {
+		if (is_array($config['ipsec']['client']) && isset($config['ipsec']['client']['enable'])) {
+			/* Virtual Address Pool */
+			if (isset($config['ipsec']['client']['pool_address']) &&
+			    isset($config['ipsec']['client']['pool_netbits'])) {
+				$client_subnet = "{$config['ipsec']['client']['pool_address']}/{$config['ipsec']['client']['pool_netbits']}";
+				if (is_subnetv4($client_subnet)) {
+					 $vpns_arr[] = $client_subnet;
+				}
+			}
+			/* Virtual IPv6 Address Pool */
+			if (isset($config['ipsec']['client']['pool_address_v6']) &&
+			    isset($config['ipsec']['client']['pool_netbits_v6'])) {
+				$client_subnet = "{$config['ipsec']['client']['pool_address_v6']}/{$config['ipsec']['client']['pool_netbits_v6']}";
+				if (is_subnetv6($client_subnet)) {
+					$vpns_arr[] = text_to_compressed_ip6($client_subnet);
+				}
+			}
+			/* Mobile warriors */
+			if (isset($config['ipsec']['mobilekey'])) {
+				foreach ($config['ipsec']['mobilekey'] as $key) {
+					if (!empty($key['pool_address']) &&
+					    !empty($key['pool_netbits'])) {
+						$vpns_subnet = "{$key['pool_address']}/{$key['pool_netbits']}";
+						if (is_subnetv4($vpns_subnet)) {
+							$vpns_arr[] = $vpns_subnet;
+						}
+					}
+				}
+			}
+		}
+		/* Site-to-Site IPsec */
+		if (is_array($config['ipsec']['phase2'])) {
+			foreach ($config['ipsec']['phase2'] as $ph2ent) {
+				if ((!$ph2ent['mobile']) && ($ph2ent['mode'] != 'transport') &&
+				    !isset($ph2ent['disabled'])) {
+					if (!is_array($ph2ent['remoteid'])) {
+						continue;
+					}
+					$ph2ent['remoteid']['mode'] = $ph2ent['mode'];
+					$vpns_subnet = ipsec_idinfo_to_cidr($ph2ent['remoteid']);
+					if (is_subnetv4($vpns_subnet)) {
+						$vpns_arr[] = $vpns_subnet;
+					}
+					if (is_subnetv6($vpns_subnet)) {
+						$vpns_arr[] = text_to_compressed_ip6($vpns_subnet);
+					}
+				}
+			}
+		}
+	}
+	/* OpenVPN */
+	foreach (array('client', 'server') as $type) {
+		if (is_array($config['openvpn']["openvpn-$type"])) {
+			foreach ($config['openvpn']["openvpn-$type"] as $settings) {
+				if (is_array($settings)) {
+					if (!isset($settings['disable'])) {
+						$remote_networks = explode(',', $settings['remote_network']);
+						foreach ($remote_networks as $remote_network) {
+							if (is_subnetv4($remote_network)) {
+								$vpns_arr[] = $remote_network;
+							}
+						}
+						if (is_subnetv4($settings['tunnel_network'])) {
+							$vpns_arr[] = $settings['tunnel_network'];
+						}
+						if (isset($settings['remote_networkv6'])) {
+							$remote_networks = explode(',', $settings['remote_networkv6']);
+							foreach ($remote_networks as $remote_network) {
+								if (is_subnetv6($remote_network)) {
+									$vpns_arr[] = text_to_compressed_ip6($remote_network);
+								}
+							}
+							if (is_subnetv6($settings['tunnel_networkv6'])) {
+								$vpns_arr[] = text_to_compressed_ip6($settings['tunnel_networkv6']);
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	/* PPPoE Server */
+ 	if (is_array($config['pppoes']['pppoe'])) {
+		foreach ($config['pppoes']['pppoe'] as $pppoe) {
+			if ($pppoe['mode'] == "server") {
+				if (is_ipaddrv4($pppoe['remoteip'])) {
+					$pppoesub = gen_subnetv4($pppoe['remoteip'], $pppoe['pppoe_subnet']);
+					if (is_subnetv4($pppoesub)) {
+						$vpns_arr[] = $pppoesub;
+					}
+				}
+			}
+		}
+	}
+	/* L2TP Server */
+	if ($config['l2tp']['mode'] == "server") {
+		$l2tp_net = "{$config['l2tp']['remoteip']}/{$config['l2tp']['l2tp_subnet']}";
+		if (is_subnetv4($l2tp_net)) {
+			$vpns_arr[] = $l2tp_net;
+		}
+	}
+
+	if (!empty($vpns_arr)) {
+		$vpns = implode(" ", array_diff($vpns_arr, array("0.0.0.0/0", "::/0")));
+	}
+
+	return $vpns;
+}
+
 ?>


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/8688
- [X] Ready for review

`filter_get_vpns_list()` returns only:
- IPsec Mobile IPv4 subnet
- IPsec site-to-site networks
- OpenVPN client/server Tunnel Network / Remote Network IPv4
- PPPoE server networks

but not:
- IPsec Mobile IPv6 subnet
- IPsec Mobile warriors IPs (VPN / IPsec / Pre-Shared Keys / Edit)
- OpenVPN client/server Tunnel Network / Remote Network IPv6
- L2TP VPN network

new `snort_get_vpns_list()` returns all

TODO: same for snort 3.x and suricata