### PR TITLE
ACME key type change on renew. Fixes #10656

### DIFF
--- a/security/pfSense-pkg-acme/Makefile
+++ b/security/pfSense-pkg-acme/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-acme
 PORTVERSION=	0.6.8
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
@@ -1370,10 +1370,31 @@ function & get_certificate($name) {
 			echo "\n{$cert['prv']}";
 			$desc = "Acme: Add new certificate & key.";
 			write_config($desc);
-		} elseif (   $certificate['keylength'] == 'custom'
-				  && $cert['prv'] != $certificate['keypaste']) {
+		} elseif (($certificate['keylength'] == 'custom') && ($cert['prv'] != $certificate['keypaste'])) {
 			echo "\n getCertificatePSK updating custom key";
 			$cert['prv'] = $certificate['keypaste']; // (already base64-encoded)
+		} elseif ($certificate['keylength'] != 'custom') {
+			$res_key = openssl_pkey_get_private(base64_decode($cert['prv']));
+			$key_details = openssl_pkey_get_details($res_key);
+			if ($key_details['type'] == OPENSSL_KEYTYPE_RSA) {
+				$keybits = $key_details['bits'];
+			} else {
+				$keybits = $key_details['ec']['curve_name'];
+			}
+			if (is_numeric($certificate['keylength'])) {
+				$newkeybits = $certificate['keylength'];
+			} else {
+				if ($certificate['keylength'] == 'ec-256') {
+					$newkeybits = 'prime256v1';
+				} else {
+					$newkeybits = 'secp384r1';
+				}
+			}
+			if ($keybits != $newkeybits) {
+				echo "\n getCertificatePSK updating key";
+				$privatekey = generateDomainKey($certificatename, $ca, $domain, $certificate['keylength']);
+				$cert['prv'] = base64_encode($privatekey);
+			}
 		}
 
 		return base64_decode($cert['prv']);


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10656
- [X] Ready for review

Fix for issue:
> changing the private key configuration item from ECDSDA to RSA appears to succeed, but when re-issuing or renewing the key it silently continues to use the old private key type. At best this is very confusing when the configuration now shows one type of private key, but they system is actually receiving and using a previously configured type.