### PR TITLE
FRR frr_ipsec_reload() enable check. Fixes #10737

### DIFF
--- a/net/pfSense-pkg-frr/Makefile
+++ b/net/pfSense-pkg-frr/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-frr
-PORTVERSION=	0.6.6
+PORTVERSION=	0.6.7
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr.inc
@@ -169,7 +169,8 @@ function frr_plugin_carp($pluginparams) {
 function frr_ipsec_reload() {
 	global $config;
 	init_config_arr(array('installedpackages', 'frr', 'config', 0));
-	if (!empty($config['installedpackages']['frr']['config'][0]['ignoreipsecrestart'])) {
+	if (!empty($config['installedpackages']['frr']['config'][0]['ignoreipsecrestart']) ||
+	    empty($config['installedpackages']['frr']['config'][0]['enable']) || !is_process_running('zebra')) {
 		return;
 	}
 


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10737
- [X] Ready for review

`frr_ipsec_reload()` must check that the FRR service is enabled and that the `zebra` process is running before run `cycleinterface`