### PR TITLE
Suricata 5.0.3 -- Update Suricata binary to version 5.0.3 to keep pace with upstream.

### DIFF
--- a/security/suricata/Makefile
+++ b/security/suricata/Makefile
@@ -2,8 +2,7 @@
 # $FreeBSD$
 
 PORTNAME=	suricata
-DISTVERSION=	5.0.2
-PORTREVISION=	3
+DISTVERSION=	5.0.3
 CATEGORIES=	security
 MASTER_SITES=	https://www.openinfosecfoundation.org/download/
 

--- a/security/suricata/distinfo
+++ b/security/suricata/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1581674131
-SHA256 (suricata-5.0.2.tar.gz) = 7f30cac92feeab2a9281b6059b96f9f163dce9aadcc959a6c0b9a2f6d750cee7
-SIZE (suricata-5.0.2.tar.gz) = 23735393
+TIMESTAMP = 1593532636
+SHA256 (suricata-5.0.3.tar.gz) = 34413ecdad2ff2452526dbcd22f1279afd0935151916c0ff9cface4b0b5665db
+SIZE (suricata-5.0.3.tar.gz) = 23744731

--- a/security/suricata/files/patch-alert-pf.diff
+++ b/security/suricata/files/patch-alert-pf.diff
@@ -1,6 +1,6 @@
-diff -ruN ./suricata-5.0.2.orig/src/Makefile.am ./suricata-5.0.2/src/Makefile.am
---- ./suricata-5.0.2.orig/src/Makefile.am	2020-02-13 05:58:27.000000000 -0500
-+++ ./src/Makefile.am	2020-02-29 10:17:44.000000000 -0500
+diff -ruN ./suricata-5.0.3.orig/src/Makefile.am ./suricata-5.0.3/src/Makefile.am
+--- ./suricata-5.0.3.orig/src/Makefile.am	2020-04-28 06:06:20.000000000 -0400
++++ ./src/Makefile.am	2020-06-30 12:23:55.000000000 -0400
 @@ -10,6 +10,7 @@
  suricata_SOURCES = \
  alert-debuglog.c alert-debuglog.h \
@@ -9,9 +9,9 @@ diff -ruN ./suricata-5.0.2.orig/src/Makefile.am ./suricata-5.0.2/src/Makefile.am
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
  alert-unified2-alert.c alert-unified2-alert.h \
-diff -ruN ./suricata-5.0.2.orig/src/Makefile.in ./suricata-5.0.2/src/Makefile.in
---- ./suricata-5.0.2.orig/src/Makefile.in	2020-02-13 05:58:43.000000000 -0500
-+++ ./src/Makefile.in	2020-02-29 10:18:53.000000000 -0500
+diff -ruN ./suricata-5.0.3.orig/src/Makefile.in ./suricata-5.0.3/src/Makefile.in
+--- ./suricata-5.0.3.orig/src/Makefile.in	2020-04-28 06:06:35.000000000 -0400
++++ ./src/Makefile.in	2020-06-30 12:25:12.000000000 -0400
 @@ -110,7 +110,7 @@
  am__installdirs = "$(DESTDIR)$(bindir)"
  PROGRAMS = $(bin_PROGRAMS)
@@ -29,8 +29,8 @@ diff -ruN ./suricata-5.0.2.orig/src/Makefile.in ./suricata-5.0.2/src/Makefile.in
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
  alert-unified2-alert.c alert-unified2-alert.h \
-diff -ruN ./suricata-5.0.2.orig/src/alert-pf.c ./suricata-5.0.2/src/alert-pf.c
---- ./suricata-5.0.2.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
+diff -ruN ./suricata-5.0.3.orig/src/alert-pf.c ./suricata-5.0.3/src/alert-pf.c
+--- ./suricata-5.0.3.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
 +++ ./src/alert-pf.c	2020-01-06 14:22:20.000000000 -0500
 @@ -0,0 +1,1151 @@
 +/* Copyright (C) 2007-2020 Open Information Security Foundation
@@ -1184,8 +1184,8 @@ diff -ruN ./suricata-5.0.2.orig/src/alert-pf.c ./suricata-5.0.2/src/alert-pf.c
 +    return TM_ECODE_OK;
 +}
 +
-diff -ruN ./suricata-5.0.2.orig/src/alert-pf.h ./suricata-5.0.2/src/alert-pf.h
---- ./suricata-5.0.2.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
+diff -ruN ./suricata-5.0.3.orig/src/alert-pf.h ./suricata-5.0.3/src/alert-pf.h
+--- ./suricata-5.0.3.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
 +++ ./src/alert-pf.h	2020-02-29 10:25:58.000000000 -0500
 @@ -0,0 +1,59 @@
 +/* Copyright (C) 2007-2020 Open Information Security Foundation
@@ -1247,9 +1247,9 @@ diff -ruN ./suricata-5.0.2.orig/src/alert-pf.h ./suricata-5.0.2/src/alert-pf.h
 +
 +#endif /* __ALERT_PF_H__ */
 +
-diff -ruN ./suricata-5.0.2.orig/src/output.c ./suricata-5.0.2/src/output.c
---- ./suricata-5.0.2.orig/src/output.c	2020-02-13 05:58:28.000000000 -0500
-+++ ./src/output.c	2020-02-29 10:20:55.000000000 -0500
+diff -ruN ./suricata-5.0.3.orig/src/output.c ./suricata-5.0.3/src/output.c
+--- ./suricata-5.0.3.orig/src/output.c	2020-04-28 06:06:20.000000000 -0400
++++ ./src/output.c	2020-06-30 12:26:27.000000000 -0400
 @@ -43,6 +43,7 @@
  #include "alert-fastlog.h"
  #include "alert-unified2-alert.h"
@@ -1269,9 +1269,9 @@ diff -ruN ./suricata-5.0.2.orig/src/output.c ./suricata-5.0.2/src/output.c
      /* prelue log */
      AlertPreludeRegister();
      /* syslog log */
-diff -ruN ./suricata-5.0.2.orig/src/suricata-common.h ./suricata-5.0.2/src/suricata-common.h
---- ./suricata-5.0.2.orig/src/suricata-common.h	2020-02-13 05:58:28.000000000 -0500
-+++ ./src/suricata-common.h	2020-02-29 10:21:45.000000000 -0500
+diff -ruN ./suricata-5.0.3.orig/src/suricata-common.h ./suricata-5.0.3/src/suricata-common.h
+--- ./suricata-5.0.3.orig/src/suricata-common.h	2020-04-28 06:06:20.000000000 -0400
++++ ./src/suricata-common.h	2020-06-30 12:26:59.000000000 -0400
 @@ -461,6 +461,7 @@
      LOGGER_PRELUDE,
      LOGGER_PCAP,

--- a/security/suricata/pkg-plist
+++ b/security/suricata/pkg-plist
@@ -128,7 +128,7 @@ man/man1/suricata.1.gz
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/util.pyc
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/version.py
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/version.pyc
-%%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata_update-1.1.1-py%%PYTHON_VER%%.egg-info
+%%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata_update-1.1.2-py%%PYTHON_VER%%.egg-info
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricatasc/__init__.py
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricatasc/__init__.pyc
 %%DATADIR%%/rules/app-layer-events.rules


### PR DESCRIPTION
This updates the Suricata binary on pfSense to the latest 5.0.3 version from upstream. Release Notes can be found here:  [https://suricata-ids.org/2020/04/28/suricata-5-0-3-released/](https://suricata-ids.org/2020/04/28/suricata-5-0-3-released/).

This binary update is compatible with both pfSense-2.4.5 and pfSense-2.5 AMD64 versions. This version is not compatible with ARM 32-bit hardware platforms!