### PR TITLE
suricata4 -- Update Suricata4 binary to v4.1.8 to keep pace with upstream 4.x  stable branch.

### DIFF
--- a/security/suricata4/Makefile
+++ b/security/suricata4/Makefile
@@ -2,7 +2,7 @@
 # $FreeBSD$
 
 PORTNAME=	suricata
-DISTVERSION=	4.1.7
+DISTVERSION=	4.1.8
 CATEGORIES=	security
 MASTER_SITES=	https://www.openinfosecfoundation.org/download/
 PKGNAMESUFFIX=	4

--- a/security/suricata4/distinfo
+++ b/security/suricata4/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1582990943
-SHA256 (suricata-4.1.7.tar.gz) = a1f55ce9a1c4f3aa0cc206f6707ab126c95c0205c871039dc8bb0e8c3586178c
-SIZE (suricata-4.1.7.tar.gz) = 15765787
+TIMESTAMP = 1593532725
+SHA256 (suricata-4.1.8.tar.gz) = c8a83a05f57cedc0ef81d833ddcfdbbfdcdb6f459a91b1b15dc2d5671f1aecbb
+SIZE (suricata-4.1.8.tar.gz) = 15786311

--- a/security/suricata4/files/patch-alert-pf.diff
+++ b/security/suricata4/files/patch-alert-pf.diff
@@ -1,6 +1,6 @@
-diff -ruN ./suricata-4.1.7.orig/src/Makefile.am ./suricata-4.1.7/src/Makefile.am
---- ./suricata-4.1.7.orig/src/Makefile.am	2020-02-13 08:49:02.000000000 -0500
-+++ ./src/Makefile.am	2020-02-29 10:04:49.000000000 -0500
+diff -ruN ./suricata-4.1.8.orig/src/Makefile.am ./suricata-4.1.8/src/Makefile.am
+--- ./suricata-4.1.8.orig/src/Makefile.am	2020-04-27 14:59:47.000000000 -0400
++++ ./src/Makefile.am	2020-06-30 12:10:25.000000000 -0400
 @@ -10,6 +10,7 @@
  suricata_SOURCES = \
  alert-debuglog.c alert-debuglog.h \
@@ -9,9 +9,9 @@ diff -ruN ./suricata-4.1.7.orig/src/Makefile.am ./suricata-4.1.7/src/Makefile.am
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
  alert-unified2-alert.c alert-unified2-alert.h \
-diff -ruN ./suricata-4.1.7.orig/src/Makefile.in ./suricata-4.1.7/src/Makefile.in
---- ./suricata-4.1.7.orig/src/Makefile.in	2020-02-13 08:49:18.000000000 -0500
-+++ ./src/Makefile.in	2020-02-29 10:06:34.000000000 -0500
+diff -ruN ./suricata-4.1.8.orig/src/Makefile.in ./suricata-4.1.8/src/Makefile.in
+--- ./suricata-4.1.8.orig/src/Makefile.in	2020-04-27 15:00:03.000000000 -0400
++++ ./src/Makefile.in	2020-06-30 12:12:19.000000000 -0400
 @@ -112,7 +112,7 @@
  am__installdirs = "$(DESTDIR)$(bindir)"
  PROGRAMS = $(bin_PROGRAMS)
@@ -29,8 +29,8 @@ diff -ruN ./suricata-4.1.7.orig/src/Makefile.in ./suricata-4.1.7/src/Makefile.in
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
  alert-unified2-alert.c alert-unified2-alert.h \
-diff -ruN ./suricata-4.1.7.orig/src/alert-pf.c ./suricata-4.1.7/src/alert-pf.c
---- ./suricata-4.1.7.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
+diff -ruN ./suricata-4.1.8.orig/src/alert-pf.c ./suricata-4.1.8/src/alert-pf.c
+--- ./suricata-4.1.8.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
 +++ ./src/alert-pf.c	2020-02-29 10:29:27.000000000 -0500
 @@ -0,0 +1,1151 @@
 +/* Copyright (C) 2007-2020 Open Information Security Foundation
@@ -1184,8 +1184,8 @@ diff -ruN ./suricata-4.1.7.orig/src/alert-pf.c ./suricata-4.1.7/src/alert-pf.c
 +    return TM_ECODE_OK;
 +}
 +
-diff -ruN ./suricata-4.1.7.orig/src/alert-pf.h ./suricata-4.1.7/src/alert-pf.h
---- ./suricata-4.1.7.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
+diff -ruN ./suricata-4.1.8.orig/src/alert-pf.h ./suricata-4.1.8/src/alert-pf.h
+--- ./suricata-4.1.8.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
 +++ ./src/alert-pf.h	2020-02-29 10:02:39.000000000 -0500
 @@ -0,0 +1,59 @@
 +/* Copyright (C) 2007-2020 Open Information Security Foundation
@@ -1247,9 +1247,9 @@ diff -ruN ./suricata-4.1.7.orig/src/alert-pf.h ./suricata-4.1.7/src/alert-pf.h
 +
 +#endif /* __ALERT_PF_H__ */
 +
-diff -ruN ./suricata-4.1.7.orig/src/output.c ./suricata-4.1.7/src/output.c
---- ./suricata-4.1.7.orig/src/output.c	2020-02-13 08:49:02.000000000 -0500
-+++ ./src/output.c	2020-02-29 10:08:09.000000000 -0500
+diff -ruN ./suricata-4.1.8.orig/src/output.c ./suricata-4.1.8/src/output.c
+--- ./suricata-4.1.8.orig/src/output.c	2020-04-27 14:59:47.000000000 -0400
++++ ./src/output.c	2020-06-30 12:14:54.000000000 -0400
 @@ -43,6 +43,7 @@
  #include "alert-fastlog.h"
  #include "alert-unified2-alert.h"
@@ -1267,9 +1267,9 @@ diff -ruN ./suricata-4.1.7.orig/src/output.c ./suricata-4.1.7/src/output.c
      /* prelue log */
      AlertPreludeRegister();
      /* syslog log */
-diff -ruN ./suricata-4.1.7.orig/src/suricata-common.h ./suricata-4.1.7/src/suricata-common.h
---- ./suricata-4.1.7.orig/src/suricata-common.h	2020-02-13 08:49:02.000000000 -0500
-+++ ./src/suricata-common.h	2020-02-29 10:08:57.000000000 -0500
+diff -ruN ./suricata-4.1.8.orig/src/suricata-common.h ./suricata-4.1.8/src/suricata-common.h
+--- ./suricata-4.1.8.orig/src/suricata-common.h	2020-04-27 14:59:48.000000000 -0400
++++ ./src/suricata-common.h	2020-06-30 12:15:52.000000000 -0400
 @@ -440,6 +440,7 @@
      LOGGER_PRELUDE,
      LOGGER_PCAP,

--- a/security/suricata4/files/patch-pfSense-ARMv6_ARMv7.diff
+++ b/security/suricata4/files/patch-pfSense-ARMv6_ARMv7.diff
@@ -1,6 +1,6 @@
-diff -ruN ./suricata-4.1.7.orig/configure.ac ./suricata-4.1.7/configure.ac
---- ./suricata-4.1.7.orig/configure.ac	2020-02-13 08:49:02.000000000 -0500
-+++ ./configure.ac	2020-02-29 09:57:37.000000000 -0500
+diff -ruN ./suricata-4.1.8.orig/configure.ac ./suricata-4.1.8/configure.ac
+--- ./suricata-4.1.8.orig/configure.ac	2020-04-27 14:59:48.000000000 -0400
++++ ./configure.ac	2020-06-30 12:06:02.000000000 -0400
 @@ -272,6 +272,23 @@
      esac
      AC_MSG_RESULT(ok)

--- a/security/suricata4/pkg-plist
+++ b/security/suricata4/pkg-plist
@@ -124,7 +124,7 @@ man/man1/suricata.1.gz
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/util.pyc
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/version.py
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/version.pyc
-%%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata_update-1.0.6-py%%PYTHON_VER%%.egg-info
+%%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata_update-1.0.7-py%%PYTHON_VER%%.egg-info
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricatasc/__init__.py
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricatasc/__init__.pyc
 @sample %%ETCDIR%%/classification.config.sample


### PR DESCRIPTION
### Suricata4 v4.1.8

This updates the Suricata4 binary on pfSense to the latest 4.1.8 upstream version. Release Notes for this version can be found here:  [https://suricata-ids.org/2020/04/28/suricata-4-1-8-released/](https://suricata-ids.org/2020/04/28/suricata-4-1-8-released/)

This binary version is for the matching _pfSense-pkg-suricata4_ GUI package and is designed for ARM 32-bit platforms where Rust is not available.