### PR TITLE
HAProxy SSL/TLS Compatibility Mode option. Implements #10779

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/Makefile
+++ b/net/pfSense-pkg-haproxy-devel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-haproxy-devel
 PORTVERSION=	0.60
-PORTREVISION=	6
+PORTREVISION=	7
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -1508,6 +1508,31 @@ function haproxy_writeconf($configpath) {
 		fwrite ($fd, "\tchroot\t\t\t\t$chroot_dir\n");
 		fwrite ($fd, "\tdaemon\n");
 
+		if ($a_global['sslcompatibilitymode'] == 'modern') {
+			/* https://ssl-config.mozilla.org/#server=haproxy&version=2.1&config=modern&openssl=1.1.1d&guideline=5.4 */
+			fwrite ($fd, "\tssl-default-bind-ciphersuites\tTLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256\n");
+			fwrite ($fd, "\tssl-default-bind-options\tno-sslv3 no-tlsv10 no-tlsv11 no-tlsv12 no-tls-tickets\n");
+			fwrite ($fd, "\tssl-default-server-ciphersuites\tTLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256\n");
+			fwrite ($fd, "\tssl-default-server-options\tno-sslv3 no-tlsv10 no-tlsv11 no-tlsv12 no-tls-tickets\n");
+
+		} elseif ($a_global['sslcompatibilitymode'] == 'intermediate') {
+			/* https://ssl-config.mozilla.org/#server=haproxy&version=2.1&config=intermediate&openssl=1.1.1d&guideline=5.4 */
+			fwrite ($fd, "\tssl-default-bind-ciphers\tECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384\n");
+			fwrite ($fd, "\tssl-default-bind-ciphersuites\tTLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256\n");
+			fwrite ($fd, "\tssl-default-bind-options\tno-sslv3 no-tlsv10 no-tlsv11 no-tls-tickets\n");
+			fwrite ($fd, "\tssl-default-server-ciphers\tECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384\n");
+			fwrite ($fd, "\tssl-default-server-ciphersuites\tTLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256\n");
+			fwrite ($fd, "\tssl-default-server-options\tno-sslv3 no-tlsv10 no-tlsv11 no-tls-tickets\n");
+		} elseif ($a_global['sslcompatibilitymode'] == 'old') {
+			/* https://ssl-config.mozilla.org/#server=haproxy&version=2.1&config=old&openssl=1.1.1d&guideline=5.4 */
+			fwrite ($fd, "\tssl-default-bind-ciphers\tECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA\n");
+			fwrite ($fd, "\tssl-default-bind-ciphersuites\tTLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256\n");
+			fwrite ($fd, "\tssl-default-bind-options\tno-sslv3 no-tls-tickets\n");
+			fwrite ($fd, "\tssl-default-server-ciphers\tECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA\n");
+			fwrite ($fd, "\tssl-default-server-ciphersuites\tTLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256\n");
+			fwrite ($fd, "\tssl-default-server-options\tno-sslv3 no-tls-tickets\n");
+
+		}
 		if ($a_global['ssldefaultdhparam']) {
 			fwrite ($fd, "\ttune.ssl.default-dh-param\t{$a_global['ssldefaultdhparam']}\n");
 		}

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_global.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_global.php
@@ -29,9 +29,10 @@ require_once("haproxy/haproxy_utils.inc");
 require_once("haproxy/haproxy_htmllist.inc");
 require_once("haproxy/pkg_haproxy_tabs.inc");
 
-$simplefields = array('nbthread', 'hard_stop_after', 'localstats_refreshtime', 'localstats_sticktable_refreshtime', 'log-send-hostname', 'ssldefaultdhparam',
-  'email_level', 'email_myhostname', 'email_from', 'email_to',
-  'resolver_retries', 'resolver_timeoutretry', 'resolver_holdvalid');
+$simplefields = array('nbthread', 'hard_stop_after', 'localstats_refreshtime', 'localstats_sticktable_refreshtime',
+	'log-send-hostname', 'sslcompatibilitymode', 'ssldefaultdhparam', 'email_level', 'email_myhostname',
+	'email_from', 'email_to', 'resolver_retries', 'resolver_timeoutretry', 'resolver_holdvalid');
+$sslcompatibilitymodes = array('auto' => 'Auto', 'modern' => 'Modern', 'intermediate' => 'Intermediate', 'old' => 'Old');
 
 $none = array();
 $none['']['name'] = "Dont log";
@@ -403,6 +404,20 @@ $section->addInput(new Form_Input('email_to', 'Mail to', 'text', $pconfig['email
 $form->add($section);
 
 $section = new Form_Section('Tuning');
+
+$section->addInput(new Form_Select(
+	'sslcompatibilitymode',
+	'SSL/TLS Compatibility Mode',
+	$pconfig['sslcompatibilitymode'],
+	$sslcompatibilitymodes
+))->setHelp(<<<EOD
+	The SSL/TLS Compatibility Mode determines which cipher suites and TLS versions are supported by default.<br />
+	Old mode disables SSLv3 and appropriate ciphers.<br />
+	Intermediate mode also disables HIGH ciphers, SHA1, TLS v1.0 and TLS v1.1.<br />
+	Modern mode also disables TLS v1.2, leaving only TLS v1.3 and AEAD ciphers.<br />
+	If unsure leave it as 'Auto'.
+EOD
+);
 
 $section->add(group_input_with_text(
 	'ssldefaultdhparam',


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10779
- [X] Ready for review

Allows to select SSL/TLS Compatibility Mode in the same manner as Squid SSL Proxy Compatibility Mode option.

Intermediate: https://ssl-config.mozilla.org/#server=haproxy&version=2.1&config=intermediate&openssl=1.1.1d&guideline=5.4
Modern: https://ssl-config.mozilla.org/#server=haproxy&version=2.1&config=modern&openssl=1.1.1d&guideline=5.4