### PR TITLE
ARPwatch improvements. Issue #10770

### DIFF
--- a/net-mgmt/pfSense-pkg-arpwatch/Makefile
+++ b/net-mgmt/pfSense-pkg-arpwatch/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-arpwatch
 PORTVERSION=	0.2.0
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.inc
+++ b/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.inc
@@ -63,9 +63,11 @@ function arpwatch_install_command() {
 			    .' '.$disable_zero
 			    .' '.$enable_zeropad
 			    .' -f '.escapeshellarg($arp_file)
-			    .' -i '.escapeshellarg($ifname)
-			    .' -w '.escapeshellarg($notifications_recipient)
-			    ."\n";
+			    .' -i '.escapeshellarg($ifname);
+			if (!empty($notifications_recipient)) {
+			    $rc['start'] .= ' -w '.escapeshellarg($notifications_recipient);
+			}
+			$rc['start'] .= "\n";
 		}
 	}
 
@@ -108,7 +110,8 @@ function arpwatch_validate_input($post, &$input_errors) {
 		}
 	}
 
-	if (filter_var($post['notifications_recipient'], FILTER_VALIDATE_EMAIL) === false) {
+	if (!empty($post['notifications_recipient']) &&
+	    (filter_var($post['notifications_recipient'], FILTER_VALIDATE_EMAIL) === false)) {
 		$input_errors[] = gettext("{$post['notifications_recipient']} is not a valid email address.");
 	}
 
@@ -167,7 +170,8 @@ function arpwatch_parse_database() {
 			$oui = strtolower(substr($mac, 0, 8));
 			$matches = array();
 
-			if (preg_match("/^$oui\s+(.*)$/m", file_get_contents(ARPWATCH_LOCAL_DIR.'/ethercodes.dat'), $matches)) {
+			if (file_exists(ARPWATCH_LOCAL_DIR.'/ethercodes.dat') && 
+			    preg_match("/^$oui\s+(.*)$/m", file_get_contents(ARPWATCH_LOCAL_DIR.'/ethercodes.dat'), $matches)) {
 				$vendor = $matches[1];
 			} else {
 				$vendor = 'unknown';
@@ -228,7 +232,8 @@ $fd = fopen('php://stdin','r');
 $message = stream_get_contents($fd);
 fclose($fd);
 
-if (false !== $message) {
+if ((false !== $message) && ((false === strpos($message, ': Cron ')) ||
+    ($config['installedpackages']['arpwatch']['config'][0]['cron_disable'] != 'on'))) {
 	$subject = array();
 	preg_match('/^Subject: (.*)$/m', $message, $subject);
 	init_config_arr(array('installedpackages', 'arpwatch', 'config', 0, 'row'));

--- a/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.xml
+++ b/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.xml
@@ -78,7 +78,13 @@
 			<description>The email address that will receive notifications (warning: may send a lot of notifications in busy networks).</description>
 			<type>input</type>
 			<size>50</size>
-			<required/>
+		</field>
+		<field>
+			<fielddescr>Disable Cron emails</fielddescr>
+			<fieldname>disable_cron</fieldname>
+			<type>checkbox</type>
+			<description>Disables Cron email notifications from other packages.</description>
+			<default_value>on</default_value>
 		</field>
 		<field>
 			<fielddescr>Zero padded ethernet addresses</fielddescr>


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10770
- [X] Ready for review

- Allow to disable email notifications by removing recipient email  https://redmine.pfsense.org/issues/10770 
- Do not send cron email notifications https://redmine.pfsense.org/issues/10771
- Do not show PHP error if `ethercodes.dat` file is not found:
`[22-Jul-2020 10:11:21 Europe/Moscow] PHP Warning:  file_get_contents(/usr/local/arpwatch/ethercodes.dat): failed to open stream: No such file or directory in /usr/local/pkg/arpwatch.inc on line 170`