### PR TITLE
Change UPS Type field to optional

### DIFF
--- a/sysutils/pfSense-pkg-apcupsd/files/usr/local/pkg/apcupsd.xml
+++ b/sysutils/pfSense-pkg-apcupsd/files/usr/local/pkg/apcupsd.xml
@@ -148,7 +148,7 @@
 			</description>
 			<type>input</type>
 			<size>60</size>
-			<required>true</required>
+			<required>false</required>
 		</field>
 		<field>
 			<fielddescr>Device</fielddescr>


### PR DESCRIPTION
UPS Type field needs to be optional not required as usb UPS devices need that field to be set to "BLANK".  Its not possible to use a usb UPS with that field set to required.