### PR TITLE
Return image based on Accept headers rather than URL

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/www/index.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/www/index.php
@@ -40,7 +40,13 @@ else {
 	header("Pragma: no-cache");
 	header("Expires: Sat, 26 Jul 2014 05:00:00 GMT");
 
-	if (empty($ptype['REQUEST_URI']) || $ptype['REQUEST_URI'] != '/') {
+	$primary_mime = 'text';
+	$accept_header = getallheaders()['Accept'];
+	if ($accept_header) {
+		$primary_mime = explode('/', $accept_header, 2)[0];
+	}
+
+	if ($primary_mime == 'image') {
 		$type = 'DNSBL-1x1';
 		header("Content-Type: image/gif");
 		echo base64_decode('R0lGODlhAQABAJAAAP8AAAAAACH5BAUQAAAALAAAAAABAAEAAAICBAEAOw==');


### PR DESCRIPTION
In my setup, I find that a lot of the time the check that's currently in place doesn't hold true which results in me seeing blank pages when I click a link with a tracker behind it rather than the page indicating a block.

While I know this is a minor inconvenience, it probably makes sense to use the hints provided by the browser about the kind of data it's expecting rather than the URL - In this case, if the url is fetched via, e.g. an `<img>` tag, all browsers I have tested will make their top priority an image mime in the Accept header, which will trigger this new check.

Paired with the SSL improvements in https://github.com/pfsense/FreeBSD-ports/pull/778 I think this could make for much better UX.

I'm also considering methods for making it possible to "proceed" in cases where the blocked domain is just serving as a redirect, if that would be interesting.

> I'll happily admit that I don't know if this is the preferred way to submit patches! Please let me know if there's a better place. It looks like the contributing guidelines are specific to the FreeBSD ports tree, not the pfsense fork, which can/should probably be addressed if it's not accurate.