### PR TITLE
Support Snort 2.9.16.1 and improve ALERTS tab and INTERFACE SETTINGS logic.

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -1,8 +1,8 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-snort
-PORTVERSION=	4.1.1
-PORTREVISION=	1
+PORTVERSION=	4.1.2
+PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package snort
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	snort>=2.9.16:security/snort
+RUN_DEPENDS=	snort>=2.9.16.1:security/snort
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -539,6 +539,11 @@ function snort_start($snortcfg, $if_real, $background=FALSE) {
 	else
 		$quiet = "-q --suppress-config-log";
 
+	// If Snort is already running on this interface, stop it before restarting
+	if (snort_is_running($if_real)) {
+		snort_stop($snortcfg, $if_real);
+	}
+
 	if ($snortcfg['enable'] == 'on' && $if_real <> "" && !isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid")) {
 
 		// Adjust the interface specification and DAQ type according to operating mode

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -47,7 +47,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 		define("SNORT_BIN_VERSION", $matches[0]);
 	}
 	else {
-		define("SNORT_BIN_VERSION", "2.9.16");
+		define("SNORT_BIN_VERSION", "2.9.16.1");
 	}
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -920,64 +920,59 @@ if (file_exists("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/alert")) {
 			/* Protocol */
 			$alert_proto = $fields[5];
 			/* Action */
-			if (isset($fields[13])) {
-
-				// If not using Inline IPS Mode or not blocking offenders, then ALERT is
-				// the only valid action so force the current event's action to ALERT.
-				if ($a_instance[$instanceid]['ips_mode'] != 'ips_mode_inline' || $a_instance[$instanceid]['blockoffenders7'] != 'on') {
-					$fields[13] = "alert";
-				}
+			if (isset($fields[13]) && $a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' && $a_instance[$instanceid]['blockoffenders7'] == 'on') {
 
 				switch ($fields[13]) {
 
 					case "alert":
-						$alert_action = '<i class="fa fa-exclamation-triangle text-warning text-center" title="';
+						$alert_action = '<i class="fa fa-exclamation-triangle icon-pointer text-warning text-center" title="';
 						if (isset($alertsid[$fields[1]][$fields[2]])) {
-							$alert_action .= gettext("Rule action is User-Forced to ALERT") . '"</i>';
+							$alert_action .= gettext("Rule action is User-Forced to ALERT. Click to force a different action for this rule.");
 						}
 						else {
-							$alert_action .= gettext("Rule action is ALERT") . '"</i>';
+							$alert_action .= gettext("Rule action is ALERT. Click to force a different action for this rule.");
 						}
 						break;
 
 					case "drop":
-						$alert_action = '<i class="fa fa-thumbs-down text-danger text-center" title="';
+						$alert_action = '<i class="fa fa-thumbs-down icon-pointer text-danger text-center" title="';
 						if (isset($dropsid[$fields[1]][$fields[2]])) {
-							$alert_action .= gettext("Rule action is User-Forced to DROP") . '"</i>';
+							$alert_action .= gettext("Rule action is User-Forced to DROP. Click to force a different action for this rule.");
 						}
 						else {
-							$alert_action .=  gettext("Rule action is DROP") . '"</i>';
+							$alert_action .=  gettext("Rule action is DROP. Click to force a different action for this rule.");
 						}
 						break;
 
 					case "reject":
-						$alert_action = '<i class="fa fa-hand-stop-o text-warning text-center" title="';
+						$alert_action = '<i class="fa fa-hand-stop-o icon-pointer text-warning text-center" title="';
 						if (isset($rejectsid[$fields[1]][$fields[2]])) {
-							$alert_action .= gettext("Rule action is User-Forced to REJECT") . '"</i>';
+							$alert_action .= gettext("Rule action is User-Forced to REJECT. Click to force a different action for this rule.");
 						}
 						else {
-							$alert_action .= gettext("Rule action is REJECT") . '"</i>';
+							$alert_action .= gettext("Rule action is REJECT. Click to force a different action for this rule.");
 						}
 						break;
 
 					case "sdrop":
-						$alert_action = '<i class="fa fa-thumbs-o-down text-danger text-center" title="' . gettext("Rule action is SDROP") . '"</i>';
+						$alert_action = '<i class="fa fa-thumbs-o-down icon-pointer text-danger text-center" title="' . gettext("Rule action is SDROP. Click to force a different action for this rule.");
 						break;
 
 					case "log":
-						$alert_action = '<i class="fa fa-tasks text-center" title="' . gettext("Rule action is LOG") . '"</i>';
+						$alert_action = '<i class="fa fa-tasks icon-pointer text-center" title="' . gettext("Rule action is LOG. Click to force a different action for this rule.") . '"</i>';
 						break;
 
-					case "log":
-						$alert_action = '<i class="fa fa-thumbs-up text-success text-center" title="' . gettext("Rule action is PASS") . '"</i>';
+					case "pass":
+						$alert_action = '<i class="fa fa-thumbs-up icon-pointer text-success text-center" title="' . gettext("Rule action is PASS. Click to force a different action for this rule.");
 						break;
 
 					default:
-						$alert_action = '<i class="fa fa-question-circle text-danger text-center" title="' . gettext("Rule action is unrecognized!") . '"</i>';
+						$alert_action = '<i class="fa fa-question-circle icon-pointer text-danger text-center" title="' . gettext("Rule action is unrecognized!. Click to force a different action for this rule.");
 				}
+				$alert_action .= '" onClick="toggleAction(\'' . $fields[1] . '\', \'' . $fields[2] . '\');"</i>';
 			}
 			else {
-				$alert_action = '<i class="fa fa-exclamation-triangle text-warning text-center" title="' . gettext("Rule action is ALERT") . '"</i>';
+				$alert_action = '<i class="fa fa-exclamation-triangle text-warning text-center" title="' . gettext("Rule action is ALERT.") . '"</i>';
 			}
 			/* Disposition (not currently used, so just set to "Allow") */
 			$alert_disposition = isset($fields[14])?$fields[14]:gettext("Allow");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_blocked.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_blocked.php
@@ -249,7 +249,7 @@ print($form);
 ?>
 
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=sprintf(gettext("Last %s Hosts Blocked by Snort"), $bnentries)?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=sprintf(gettext("Last %s Hosts Blocked by Snort (only applicable to Legacy Blocking Mode interfaces)"), $bnentries)?></h2></div>
 	<div class="panel-body table-responsive">
 
 		<table class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>
@@ -348,12 +348,12 @@ print($form);
 					<td colspan="4" style="text-align:center;" class="alert-info">
 						<?php	if (!empty($blocked_ips_array)) {
 							if ($counter > 1)
-								print($counter . gettext(" host IP addresses are currently being blocked by Snort."));
+								print($counter . gettext(" host IP addresses are currently being blocked by Snort on Legacy Mode Blocking interfaces."));
 							else
-								print($counter . gettext(" host IP address is currently being blocked Snort."));
+								print($counter . gettext(" host IP address is currently being blocked Snort on Legacy Blocking Mode interfaces."));
 						}
 						else {
-							print(gettext("There are currently no hosts being blocked by Snort."));
+							print(gettext("There are currently no hosts being blocked by Snort on Legacy Mode Blocking interfaces."));
 						}
 						?>
 					</td>


### PR DESCRIPTION
###pfSense-pkg-snort-4.1.2
This update to the Snort GUI package provides support for the Snort 2.9.16.1 binary. It also includes a couple of feature enhancements.

**New Features:**
1. You can now customize the ACTION for a triggered rule showing on the ALERTS tab by clicking the icon under the **Action** column.

2. When making configuration changes on the INTERFACE SETTINGS tab for an interface, the program logic can now sense certain critical changes and automatically restart Snort on the interface to activate the new settings.

**Bug Fixes:**
None