### PR TITLE
Add support for Snort-2.9.16.1 binary and Inline IPS Mode with netmap.

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -1,8 +1,8 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-snort
-PORTVERSION=	3.2.9.14
-PORTREVISION=	1
+PORTVERSION=	4.1.2
+PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package snort
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	snort>=2.9.16:security/snort
+RUN_DEPENDS=	snort>=2.9.16.1:security/snort
 
 NO_BUILD=	yes
 NO_MTREE=	yes
@@ -133,6 +133,10 @@ do-install:
 	${INSTALL_DATA} ${FILESDIR}/var/db/snort/sidmods/enablesid-sample.conf \
 		${STAGEDIR}/var/db/snort/sidmods
 	${INSTALL_DATA} ${FILESDIR}/var/db/snort/sidmods/modifysid-sample.conf \
+		${STAGEDIR}/var/db/snort/sidmods
+	${INSTALL_DATA} ${FILESDIR}/var/db/snort/sidmods/dropsid-sample.conf \
+		${STAGEDIR}/var/db/snort/sidmods
+	${INSTALL_DATA} ${FILESDIR}/var/db/snort/sidmods/rejectsid-sample.conf \
 		${STAGEDIR}/var/db/snort/sidmods
 	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \
 		${STAGEDIR}${DATADIR}

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -501,30 +501,29 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
 }
 
 /* checks to see if service is running */
-function snort_is_running($snort_uuid, $if_real, $type = 'snort') {
+function snort_is_running($if_real, $type = 'snort') {
 	global $config, $g;
 
-	return isvalidpid("{$g['varrun_path']}/{$type}_{$if_real}{$snort_uuid}.pid");
+	return isvalidpid("{$g['varrun_path']}/{$type}_{$if_real}.pid");
 }
 
 function snort_stop($snortcfg, $if_real) {
 	global $config, $g;
 
-	$snort_uuid = $snortcfg['uuid'];
-	if (isvalidpid("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid")) {
-		log_error("[Snort] Snort STOP for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
-		killbypid("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid");
+	if (isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid")) {
+		syslog(LOG_NOTICE, "[Snort] Snort STOP for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
+		killbypid("{$g['varrun_path']}/snort_{$if_real}.pid");
 
 		// Now wait up to 10 seconds for Snort to actually stop and clear its PID file
 		$count = 0;
 		do {
-			if (!isvalidpid("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid"))
+			if (!isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid"))
 				break;
 			sleep(1);
 			$count++;
 		} while ($count < 10);
 	}
-	unlink_if_exists("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid");
+	unlink_if_exists("{$g['varrun_path']}/snort_{$if_real}.pid");
 }
 
 function snort_start($snortcfg, $if_real, $background=FALSE) {
@@ -533,19 +532,35 @@ function snort_start($snortcfg, $if_real, $background=FALSE) {
 	$snortdir = SNORTDIR;
 	$snortlogdir = SNORTLOGDIR;
 	$snort_uuid = $snortcfg['uuid'];
-	$snortbindir = SNORT_PBI_BINDIR;
+	$snortbindir = SNORT_BINDIR;
 
 	if ($config['installedpackages']['snortglobal']['verbose_logging'] == "on")
 		$quiet = "";
 	else
 		$quiet = "-q --suppress-config-log";
 
-	if ($snortcfg['enable'] == 'on' && !isvalidpid("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid")) {
-		log_error("[Snort] Snort START for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
+	// If Snort is already running on this interface, stop it before restarting
+	if (snort_is_running($if_real)) {
+		snort_stop($snortcfg, $if_real);
+	}
+
+	if ($snortcfg['enable'] == 'on' && $if_real <> "" && !isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid")) {
+
+		// Adjust the interface specification and DAQ type according to operating mode
+		if ($snortcfg['ips_mode'] == "ips_mode_inline" && $snortcfg['blockoffenders7'] == "on") {
+			$iface = $if_real . "^:" . $if_real;
+			$daq_type = "-Q --daq netmap";
+		}
+		else {
+			$iface = $if_real;
+			$daq_type = "--daq pcap --daq-mode passive --treat-drop-as-alert";
+		}
+
+		syslog(LOG_NOTICE, "[Snort] Snort START for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
 		if ($background)
-			mwexec_bg("{$snortbindir}snort -R {$snort_uuid} -D {$quiet} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$if_real}");
+			mwexec_bg("{$snortbindir}snort -R _{$if_real} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface}");
 		else
-			mwexec("{$snortbindir}snort -R {$snort_uuid} -D {$quiet} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$if_real}");
+			mwexec("{$snortbindir}snort -R _{$if_real} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface}");
 	}
 }
 
@@ -563,7 +578,7 @@ function snort_start_all_interfaces($background=FALSE) {
 		return;
 
 	foreach ($config['installedpackages']['snortglobal']['rule'] as $snortcfg) {
-		if ($snortcfg['enable'] != 'on')
+		if ($snortcfg['enable'] != 'on' || get_real_interface($snortcfg['interface']) == "")
 			continue;
 		snort_start($snortcfg, get_real_interface($snortcfg['interface']), $background);
 	}
@@ -627,9 +642,9 @@ function snort_reload_config($snortcfg, $signal="SIGHUP") {
 	/* Only send the SIGHUP if Snort is running and we    */
 	/* can find a valid PID for the process.              */
 	/******************************************************/
-	if (isvalidpid("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid")) {
-		log_error("[Snort] Snort RELOAD CONFIG for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
-		mwexec_bg("/bin/pkill -{$signal} -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid");
+	if (isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid")) {
+		syslog(LOG_NOTICE, "[Snort] Snort RELOAD CONFIG for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
+		mwexec_bg("/bin/pkill -{$signal} -F {$g['varrun_path']}/snort_{$if_real}.pid");
 	}
 }
 
@@ -652,7 +667,7 @@ function snort_post_delete_logs($snort_uuid = 0) {
 		$snort_log_dir = SNORTLOGDIR . "/snort_{$if_real}{$snort_uuid}";
 
 		if ($if_real != '') {
-			/* Clean-up rotated unified2 log if any exist */
+			/* Clean-up rotated unified2 log files if any exist */
 			$filelist = glob("{$snort_log_dir}/*{$snort_uuid}_{$if_real}.u2.*");
 
 			/* Skip the most recently rotated log */
@@ -943,7 +958,7 @@ function snort_rules_up_install_cron($should_install) {
 	}
 }
 
-/* Only run when all ifaces needed to sync. Expects filesystem rw */
+/* Only run when all ifaces needed to sync */
 function sync_snort_package_config() {
 	global $config, $g;
 	global $rebuild_rules;
@@ -964,8 +979,10 @@ function sync_snort_package_config() {
 
 	$snortconf = $config['installedpackages']['snortglobal']['rule'];
 	foreach ($snortconf as $value) {
-		/* Skip configuration of any disabled interface */
-		if ($value['enable'] != 'on')
+		/* Skip configuration of any disabled instance or */
+		/* an instance whose assigned physical interface  */
+		/* has been removed.                              */
+		if (($value['enable'] != 'on') || (get_real_interface($value['interface']) == ""))
 			continue;
 
 		/* create a snort.conf file for interface */
@@ -1227,7 +1244,8 @@ function snort_load_rules_map($rules_path) {
 	 * Read all the rules into the map array.
 	 * The structure of the map array is:
 	 *
-	 *  map[gid][sid]['rule']['category']['action']['disabled']['managed']['flowbits']
+	 *  map[gid][sid]['rule']['category']['action']['disabled']['managed']['noalert']
+	 *     ['default_state']['default_action']['state_toggled']['modified']['flowbits']
 	 *
 	 *  where:
 	 *   gid            = Generator ID from rule, or 1 if general text rule
@@ -1237,12 +1255,14 @@ function snort_load_rules_map($rules_path) {
 	 *   action         = alert, drop, reject or pass
 	 *   disabled       = 1 if rule is disabled (commented out), 0 if 
 	 *                    rule is enabled
+	 *   managed        = 1 if rule is auto-managed by SID MGMT process,
+	 *                    0 if not auto-managed 
+	 *   noalert        = 1 if rule contains "noalert" or "flowbits:noalert" options
+	 *                    0 if not
 	 *   default_state  = 1 if rule is default enabled, 0 if default disabled
 	 *   default_action = alert, drop, reject or pass  
 	 *   state_toggled  = 1 if rule was toggled by SID MGMT process,
 	 *                    0 if not toggled
-	 *   managed        = 1 if rule is auto-managed by SID MGMT process,
-	 *                    0 if not auto-managed 
 	 *   modified       = 1 if rule action or content is modified by SID MGMT or
 	 *                      IPS Policy process,
 	 *                    0 if not modified
@@ -1339,6 +1359,14 @@ function snort_load_rules_map($rules_path) {
 				$map_ref[$gid][$sid]['disabled'] = 1;
 			else
 				$map_ref[$gid][$sid]['disabled'] = 0;
+
+			// Check for "noalert;" rule option
+			if (strpos($rule, 'noalert;') !== FALSE) {
+				$map_ref[$gid][$sid]['noalert'] = 1;
+			} else {
+				$map_ref[$gid][$sid]['noalert'] = 0;
+			}				
+
 
 			/* Grab the rule action (this is for a future option) */
 			$matches = array();
@@ -1606,7 +1634,7 @@ function snort_resolve_flowbits($rules, $active_rules) {
 
 	/* Check $rules array to be sure it is filled.    */
 	if (empty($rules)) {
-		log_error(gettext("[Snort] WARNING: Flowbit resolution not done - no rules in {$snortdir}/rules/ ..."));
+		syslog(LOG_WARNING, gettext("[Snort] WARNING: Flowbit resolution not done - no rules in {$snortdir}/rules/ ..."));
 		return array();
 	}
 
@@ -1679,7 +1707,7 @@ function snort_write_flowbit_rules_file($flowbit_rules, $rule_file) {
 	}
 }
 
-function snort_load_vrt_policy($policy, $all_rules=null) {
+function snort_load_vrt_policy($policy, $mode='alert', $all_rules=null) {
 
 	/************************************************/
 	/* This function returns an array of all rules  */
@@ -1690,6 +1718,12 @@ function snort_load_vrt_policy($policy, $all_rules=null) {
 	/*                  2.  balanced                */
 	/*                  3.  security                */
 	/*                  4.  max-detect              */
+	/*                                              */
+	/*      $mode --> determines rule action        */
+	/*                  1. alert = all rules alert  */
+	/*                  2. policy = rule action     */
+	/*                              set according   */
+	/*                              policy spec.    */
 	/*                                              */
 	/* $all_rules --> optional Rules Map array of   */
 	/*                rules to scan for policy.     */
@@ -1725,6 +1759,19 @@ function snort_load_vrt_policy($policy, $all_rules=null) {
 					if ($arulem2['disabled'] == 1) {
 						$vrt_policy_rules[$k1][$k2]['rule'] = ltrim(substr($arulem2['rule'], strpos($arulem2['rule'], "#") + 1));
 						$vrt_policy_rules[$k1][$k2]['disabled'] = 0;
+					}
+
+					// If policy mode is enabled, grab the suggested action
+					// for this policy and set it as the rule action.
+					if ($mode == 'policy') {
+						$matches = array();
+						if (preg_match('/' . "policy {$policy}-ips" . '([^,|^;]*)/', $arulem2['rule'], $matches)) {
+							if ($tmp = preg_replace('/^\s*alert\s/', trim($matches[1]) . ' ', $vrt_policy_rules[$k1][$k2]['rule'], 1)) {
+								$vrt_policy_rules[$k1][$k2]['rule'] = $tmp;
+								$vrt_policy_rules[$k1][$k2]['action'] = trim($matches[1]);
+								$vrt_policy_rules[$k1][$k2]['modified'] = 1;
+							}
+						}
 					}
 				}
 			}
@@ -1832,7 +1879,7 @@ function snort_parse_sidconf_file($sidconf_file,$split_lines=TRUE) {
 	// we can read like a normal file.
 	$fd = fopen("php://temp", "r+");
 	if ($fd == FALSE) {
-		log_error("[Snort] Failed to open SID MGMT list '{$sidconf_file}' for processing.");
+		syslog(LOG_ERR, "[Snort] Failed to open SID MGMT list '{$sidconf_file}' for processing.");
 		return $sid_mods;
 	}
 	fwrite($fd, base64_decode($list['content']));
@@ -1910,6 +1957,100 @@ function snort_sid_mgmt_list_exist($sid_mgmt_list) {
 	return FALSE;
 }
 
+function snort_process_dropsid(&$rule_map, $snortcfg, $log_results = FALSE, $log_file = NULL) {
+
+	/**********************************************/
+	/* This function loads and processes the list */
+	/* specified by 'drop_sid_file' for the       */
+	/* interface.  The list is assumed to be a    */
+	/* valid dropsid.conf list containing         */
+	/* instructions for modifying the action for  */
+	/* matching rule SIDs.                        */
+	/*                                            */
+	/*     $rule_map ==> reference to array of    */
+	/*                   current rules            */
+	/*  $snortcfg ==> interface config params     */
+	/*  $log_results ==> [optional] 'yes' to log  */
+	/*                   results to $log_file     */
+	/*     $log_file ==> full path and filename   */
+	/*                   of log file to write to  */
+	/*                                            */
+	/*     On Return ==> suitably modified        */
+	/*                   $rule_map array          */
+	/**********************************************/
+
+	$snortlogdir = SNORTLOGDIR;
+	$sid_mods = array();
+
+	// If no rules in $rule_map, then nothing to do
+	if (empty($rule_map)) {
+		return;
+	}
+
+	// Verify the 'drop_sid' list for the interface exists
+	if (!snort_sid_mgmt_list_exist($snortcfg['drop_sid_file'])) {
+		syslog(LOG_ERR, gettext("[Snort] Error - unable to find drop_sid list \"{$snortcfg['drop_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+		return;
+	} else {
+		$sid_mods = snort_parse_sidconf_file($snortcfg['drop_sid_file']);
+	}
+
+	if (!empty($sid_mods)) {
+		snort_modify_sid_state($rule_map, $sid_mods, "drop", $log_results, $log_file);
+	} elseif ($log_results == TRUE && !empty($log_file)) {
+		error_log(gettext("WARNING: no valid SID match tokens found in list \"{$snortcfg['drop_sid_file']}\".\n"), 3, $log_file);
+	}
+
+	unset($sid_mods);
+}
+
+function snort_process_rejectsid(&$rule_map, $snortcfg, $log_results = FALSE, $log_file = NULL) {
+
+	/**********************************************/
+	/* This function loads and processes the list */
+	/* specified by 'reject_sid_file' for the     */
+	/* interface.  The list is assumed to be a    */
+	/* valid rejectsid.conf list containing       */
+	/* instructions for modifying the action for  */
+	/* matching rule SIDs.                        */
+	/*                                            */
+	/*     $rule_map ==> reference to array of    */
+	/*                   current rules            */
+	/*  $snortcfg ==> interface config params     */
+	/*  $log_results ==> [optional] 'yes' to log  */
+	/*                   results to $log_file     */
+	/*     $log_file ==> full path and filename   */
+	/*                   of log file to write to  */
+	/*                                            */
+	/*     On Return ==> suitably modified        */
+	/*                   $rule_map array          */
+	/**********************************************/
+
+	$snortlogdir = SNORTLOGDIR;
+	$sid_mods = array();
+
+	// If no rules in $rule_map, then nothing to do
+	if (empty($rule_map)) {
+		return;
+	}
+
+	// Verify the 'reject_sid' list for the interface exists
+	if (!snort_sid_mgmt_list_exist($snortcfg['reject_sid_file'])) {
+		syslog(LOG_ERR, gettext("[Snort] Error - unable to find reject_sid list \"{$snortcfg['reject_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+		return;
+	} else {
+		$sid_mods = snort_parse_sidconf_file($snortcfg['reject_sid_file']);
+	}
+
+	if (!empty($sid_mods)) {
+		snort_modify_sid_state($rule_map, $sid_mods, "reject", $log_results, $log_file);
+	} elseif ($log_results == TRUE && !empty($log_file)) {
+		error_log(gettext("WARNING: no valid SID match tokens found in list \"{$snortcfg['reject_sid_file']}\".\n"), 3, $log_file);
+	}
+
+	unset($sid_mods);
+}
+
 function snort_sid_mgmt_auto_categories($snortcfg, $log_results = FALSE) {
 
 	/****************************************************/
@@ -1980,7 +2121,7 @@ function snort_sid_mgmt_auto_categories($snortcfg, $log_results = FALSE) {
 				// Attempt to open the 'disable_sid_file' for the interface
 				// Verify the assigned SID Mgmt List still exists in the firewall configuration
 				if (!snort_sid_mgmt_list_exist($snortcfg['disable_sid_file'])) {
-					log_error(gettext("[Snort] Error - unable to open disable_sid list \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+					syslog(LOG_ERR, gettext("[Snort] Error - unable to open disable_sid list \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 					if ($log_results == TRUE) {
 						error_log(gettext("Unable to find disable_sid list \"{$snortcfg['disable_sid_file']}\".\n"), 3, $log_file);
 					}
@@ -2000,7 +2141,7 @@ function snort_sid_mgmt_auto_categories($snortcfg, $log_results = FALSE) {
 
 				// Attempt to open the 'enable_sid_file' for the interface
 				if (!snort_sid_mgmt_list_exist($snortcfg['enable_sid_file'])) {
-					log_error(gettext("[snort] Error - unable to open enable_sid list \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+					syslog(LOG_ERR, gettext("[snort] Error - unable to open enable_sid list \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 					if ($log_results == TRUE) {
 						error_log(gettext("Unable to find enable_sid list \"{$snortcfg['enable_sid_file']}\".\n"), 3, $log_file);
 					}
@@ -2023,7 +2164,7 @@ function snort_sid_mgmt_auto_categories($snortcfg, $log_results = FALSE) {
 
 				// Attempt to open the 'enable_sid_file' for the interface
 				if (!snort_sid_mgmt_list_exist($snortcfg['enable_sid_file'])) {
-					log_error(gettext("[Snort] Error - unable to find enable_sid list \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+					syslog(LOG_ERR, gettext("[Snort] Error - unable to find enable_sid list \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 					if ($log_results == TRUE) {
 						error_log(gettext("Unable to open enable_sid list \"{$snortcfg['enable_sid_file']}\".\n"), 3, $log_file);
 					}
@@ -2044,7 +2185,7 @@ function snort_sid_mgmt_auto_categories($snortcfg, $log_results = FALSE) {
 
 				// Attempt to open the 'disable_sid_file' for the interface
 				if (!snort_sid_mgmt_list_exist($snortcfg['disable_sid_file'])) {
-					log_error(gettext("[Snort] Error - unable to open disable_sid list \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+					syslog(LOG_ERR, gettext("[Snort] Error - unable to open disable_sid list \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 					if ($log_results == TRUE) {
 						error_log(gettext("Unable to find disable_sid list \"{$snortcfg['disable_sid_file']}\".\n"), 3, $log_file);
 					}
@@ -2062,7 +2203,7 @@ function snort_sid_mgmt_auto_categories($snortcfg, $log_results = FALSE) {
 			break;
 
 		default:
-			log_error(gettext("[Snort] Unrecognized 'sid_state_order' value.  Skipping auto CATEGORY mgmt step for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+			syslog(LOG_ALERT, gettext("[Snort] Unrecognized 'sid_state_order' value.  Skipping auto CATEGORY mgmt step for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 			if ($log_results == TRUE) {
 				error_log(gettext("ERROR: unrecognized 'sid_state_order' value.  Skipping auto CATEGORY mgmt step for ") . convert_friendly_interface_to_friendly_descr($snortcfg['interface']). ".\n", 3, $log_file);
 			}
@@ -2215,7 +2356,8 @@ function snort_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results = F
 	/*                  tokens                    */
 	/*      $action ==> modification action for   */
 	/*                  matching SID targets:     */
-	/*                  'enable' or 'disable'     */
+	/*                  'enable', 'disable',      */
+	/*		    'drop' or 'reject'.       */
 	/* $log_results ==> [optional] 'yes' to log   */
 	/*                   results to $log_file     */
 	/*    $log_file ==> full path and filename    */
@@ -2242,13 +2384,27 @@ function snort_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results = F
 	switch ($action) {
 
 		case "enable":
+			$log_what = 'state';
+			$log_action = 'enabled';
 			break;
 
 		case "disable":
+			$log_what = 'state';
+			$log_action = 'disabled';
+			break;
+
+		case "drop":
+			$log_what = 'action';
+			$log_action = 'drop';
+			break;
+
+		case "reject":
+			$log_what = 'action';
+			$log_action = 'reject';
 			break;
 
 		default:
-			log_error(gettext("[Snort] Error - unknown action '{$action}' supplied to snort_modify_sid_state() function...no SIDs modified."));
+			syslog(LOG_ALERT, gettext("[Snort] Error - unknown action '{$action}' supplied to snort_modify_sid_state() function...no SIDs modified."));
 			return $sids;
 	}
 
@@ -2365,13 +2521,33 @@ function snort_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results = F
 					$changecount++;
 					$modcount++;
 				}
+				elseif ($action == 'drop' && $rule_map[$k1][$k2]['action'] != 'drop' && !in_array('noalert', $rule_map[$k1][$k2]['flowbits']) && $rule_map[$k1][$k2]['noalert'] == 0) {
+					if ($tmp = preg_replace('/\s*alert\s*/', 'drop ', $rule_map[$k1][$k2]['rule'], 1)) {
+						$rule_map[$k1][$k2]['rule'] = $tmp;
+						$rule_map[$k1][$k2]['action'] = 'drop';
+						$rule_map[$k1][$k2]['managed'] = 1;
+						$rule_map[$k1][$k2]['modified'] = 1;
+						$changecount++;
+						$modcount++;
+					}
+				}
+				elseif ($action == 'reject' && $rule_map[$k1][$k2]['action'] != 'reject' && !in_array('noalert', $rule_map[$k1][$k2]['flowbits']) && $rule_map[$k1][$k2]['noalert'] == 0) {
+					if ($tmp = preg_replace('/\s*alert\s*/', 'reject ', $rule_map[$k1][$k2]['rule'], 1)) {
+						$rule_map[$k1][$k2]['rule'] = $tmp;
+						$rule_map[$k1][$k2]['action'] = 'reject';
+						$rule_map[$k1][$k2]['managed'] = 1;
+						$rule_map[$k1][$k2]['modified'] = 1;
+						$changecount++;
+						$modcount++;
+					}
+				}
 			}
 		}
 	}
 
 	if ($log_results == TRUE && !empty($log_file)) {
 		error_log(gettext("    Found {$modcount} matching SIDs in the active rules.\n"), 3, $log_file);
-		error_log(gettext("    Changed state for {$changecount} SIDs to '{$action}d'.\n"), 3, $log_file);
+		error_log(gettext("    Changed {$log_what} for {$changecount} SIDs to '{$log_action}'.\n"), 3, $log_file);
 	}
 
 	// Return the array of matching SIDs
@@ -2501,7 +2677,7 @@ function snort_process_enablesid(&$rule_map, $snortcfg, $log_results = FALSE, $l
 
 	// Verify the 'enable_sid' list for the interface exists
 	if (!snort_sid_mgmt_list_exist($snortcfg['enable_sid_file'])) {
-		log_error(gettext("[Snort] Error - unable to find enable_sid list \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+		syslog(LOG_ERR, gettext("[Snort] Error - unable to find enable_sid list \"{$snortcfg['enable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 		return;
 	}
 	else
@@ -2547,7 +2723,7 @@ function snort_process_disablesid(&$rule_map, $snortcfg, $log_results = FALSE, $
 
 	// Verify the 'disable_sid' list for the interface exists
 	if (!snort_sid_mgmt_list_exist($snortcfg['disable_sid_file'])) {
-		log_error(gettext("[Snort] Error - unable to find disable_sid list \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+		syslog(LOG_ERR, gettext("[Snort] Error - unable to find disable_sid list \"{$snortcfg['disable_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 		return;
 	}
 	else {
@@ -2594,7 +2770,7 @@ function snort_process_modifysid(&$rule_map, $snortcfg, $log_results = FALSE, $l
 
 	// Verify the 'modify_sid' list for the interface exists
 	if (!snort_sid_mgmt_list_exist($snortcfg['modify_sid_file'])) {
-		log_error(gettext("[Snort] Error - unable to find modify_sid list \"{$snortcfg['modify_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+		syslog(LOG_ERR, gettext("[Snort] Error - unable to find modify_sid list \"{$snortcfg['modify_sid_file']}\" specified for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 		return;
 	} else {
 		$sid_mods = snort_parse_sidconf_file($snortcfg['modify_sid_file'],FALSE);
@@ -2645,7 +2821,7 @@ function snort_auto_sid_mgmt(&$rule_map, $snortcfg, $log_results = FALSE) {
 	// for the interface.
 	if ($config['installedpackages']['snortglobal']['auto_manage_sids'] == 'on' &&
 	    (!empty($snortcfg['disable_sid_file']) || !empty($snortcfg['enable_sid_file']) || 
-	    !empty($snortcfg['modify_sid_file']))) {
+	    !empty($snortcfg['modify_sid_file']) || !empty($snortcfg['drop_sid_file']) || !empty($snortcfg['reject_sid_file']))) {
 		if ($log_results == TRUE) {
 			error_log(gettext("********************************************************\n"), 3, $log_file);
 			error_log(gettext("Starting auto SID management for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) ."\n"), 3, $log_file);
@@ -2669,6 +2845,18 @@ function snort_auto_sid_mgmt(&$rule_map, $snortcfg, $log_results = FALSE) {
 						error_log(gettext("Processing modify_sid list: {$snortcfg['modify_sid_file']}\n"), 3, $log_file);
 					snort_process_modifysid($rule_map, $snortcfg, $log_results, $log_file);
 				}
+				if (!empty($snortcfg['drop_sid_file']) && ($snortcfg['blockoffenders7'] == 'on' && $snortcfg['ips_mode'] == 'ips_mode_inline')) {
+					if ($log_results == TRUE) {
+						error_log(gettext("Processing drop_sid list: {$snortcfg['drop_sid_file']}\n"), 3, $log_file);
+					}
+					snort_process_dropsid($rule_map, $snortcfg, $log_results, $log_file);
+				}
+				if (!empty($snortcfg['reject_sid_file']) && $snortcfg['blockoffenders7'] == 'on' && $snortcfg['ips_mode'] == 'ips_mode_inline') {
+					if ($log_results == TRUE) {
+						error_log(gettext("Processing reject_sid list: {$snortcfg['reject_sid_file']}\n"), 3, $log_file);
+					}
+					snort_process_rejectsid($rule_map, $snortcfg, $log_results, $log_file);
+				}
 				$result = TRUE;
 				break;
 
@@ -2688,11 +2876,23 @@ function snort_auto_sid_mgmt(&$rule_map, $snortcfg, $log_results = FALSE) {
 						error_log(gettext("Processing modify_sid list: {$snortcfg['modify_sid_file']}\n"), 3, $log_file);
 					snort_process_modifysid($rule_map, $snortcfg, $log_results, $log_file);
 				}
+				if (!empty($snortcfg['drop_sid_file']) && ($snortcfg['blockoffenders7'] == 'on' && $snortcfg['ips_mode'] == 'ips_mode_inline')) {
+					if ($log_results == TRUE) {
+						error_log(gettext("Processing drop_sid list: {$snortcfg['drop_sid_file']}\n"), 3, $log_file);
+					}
+					snort_process_dropsid($rule_map, $snortcfg, $log_results, $log_file);
+				}
+				if (!empty($snortcfg['reject_sid_file']) && $snortcfg['blockoffenders7'] == 'on' && $snortcfg['ips_mode'] == 'ips_mode_inline') {
+					if ($log_results == TRUE) {
+						error_log(gettext("Processing reject_sid list: {$snortcfg['reject_sid_file']}\n"), 3, $log_file);
+					}
+					snort_process_rejectsid($rule_map, $snortcfg, $log_results, $log_file);
+				}
 				$result = TRUE;
 				break;
 
 			default:
-				log_error(gettext("[Snort] Unrecognized 'sid_state_order' value.  Skipping auto SID mgmt step for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
+				syslog(LOG_ALERT, gettext("[Snort] Unrecognized 'sid_state_order' value.  Skipping auto SID mgmt step for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface'])));
 				if ($log_results == TRUE) {
 					error_log(gettext("ERROR: unrecognized 'sid_state_order' value.  Skipping auto SID mgmt step for ") . convert_friendly_interface_to_friendly_descr($snortcfg['interface']). ".\n", 3, $log_file);
 				}
@@ -2789,20 +2989,180 @@ function snort_modify_sids(&$rule_map, $snortcfg) {
 	unset($enablesid, $disablesid);
 }
 
+function snort_modify_sids_action(&$rule_map, $snortcfg) {
+
+	/***********************************************/
+	/* This function modifies the rules in the     */
+	/* passed rules_map array based on values in   */
+	/* the alertsid/dropsid configuration          */
+	/* parameters for the interface.               */
+	/*                                             */
+	/*  $rule_map = array of current rules         */
+	/*  $snortcfg = interface config settings      */
+	/***********************************************/
+
+	if (!isset($snortcfg['rule_sid_force_alert']) && 
+	    !isset($snortcfg['rule_sid_force_drop']) && 
+	    !isset($snortcfg['rule_sid_force_reject'])) {
+		return;
+	}
+
+	/* Load up our SID forced action arrays with manually changed SID actions */
+	$alertsid = snort_load_sid_mods($snortcfg['rule_sid_force_alert']);
+
+	/* DROP is only applicable when blocking offenders is enabled and when    */
+	/* 'block drops only' is enabled, or when using Inline IPS Mode.          */
+	if ($snortcfg['blockoffenders7'] == 'on' && $snortcfg['ips_mode'] == 'ips_mode_inline') {
+		$dropsid = snort_load_sid_mods($snortcfg['rule_sid_force_drop']);
+	}
+	else {
+		$dropsid = array();
+	}
+
+	/* REJECT is only applicable when blocking offenders is enabled and when  */
+	/* Inline IPS Mode is also enabled.                                       */
+	if ($snortcfg['blockoffenders7'] == 'on' && $snortcfg['ips_mode'] == 'ips_mode_inline') {
+		$rejectsid = snort_load_sid_mods($snortcfg['rule_sid_force_reject']);
+	}
+	else {
+		$rejectsid = array();
+	}
+
+	/* Change action for any rules that need to be */
+	/* forced to "alert" with alertsid mods.       */
+	if (!empty($alertsid)) {
+		foreach ($rule_map as $k1 => $rulem) {
+			foreach ($rulem as $k2 => $v) {
+				if (isset($alertsid[$k1][$k2]) && $v['action'] != 'alert') {
+					$matches = array();
+					if (preg_match('/^\s*#*\s*(drop|pass|reject)/i', $v['rule'], $matches)) {
+						$txt_regx = '/^\s*' . "{$matches[1]}" . '\s/';
+						if ($tmp = preg_replace($txt_regx, 'alert ', $v['rule'], 1)) {
+							$rule_map[$k1][$k2]['rule'] = $tmp;
+							$rule_map[$k1][$k2]['action'] = 'alert';
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/* Change action for any rules that need to be */
+	/* forced to "drop" with dropsid mods.         */
+	if (!empty($dropsid)) {
+		foreach ($rule_map as $k1 => $rulem) {
+			foreach ($rulem as $k2 => $v) {
+				if (isset($dropsid[$k1][$k2]) && $v['action'] != 'drop') {
+					$matches = array();
+					if (preg_match('/^\s*#*\s*(alert|pass|reject)/i', $v['rule'], $matches)) {
+						$txt_regx = '/^\s*' . "{$matches[1]}" . '\s/';
+						if ($tmp = preg_replace($txt_regx, 'drop ', $v['rule'], 1)) {
+							$rule_map[$k1][$k2]['rule'] = $tmp;
+							$rule_map[$k1][$k2]['action'] = 'drop';
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/* Change action for any rules that need to be */
+	/* forced to "reject" with rejectsid mods.     */
+	if (!empty($rejectsid)) {
+		foreach ($rule_map as $k1 => $rulem) {
+			foreach ($rulem as $k2 => $v) {
+				if (isset($rejectsid[$k1][$k2]) && $v['action'] != 'reject') {
+					$matches = array();
+					if (preg_match('/^\s*#*\s*(alert|pass|drop)/i', $v['rule'], $matches)) {
+						$txt_regx = '/^\s*' . "{$matches[1]}" . '\s/';
+						if ($tmp = preg_replace($txt_regx, 'reject ', $v['rule'], 1)) {
+							$rule_map[$k1][$k2]['rule'] = $tmp;
+							$rule_map[$k1][$k2]['action'] = 'reject';
+						}
+					}
+				}
+			}
+		}
+	}
+
+	unset($alertsid, $dropsid, $rejectsid);
+}
+
+function snort_get_filtered_rules($rules, $filter) {
+
+	/************************************************/
+	/* This function returns a rules_map array of   */
+	/* of rules filtered using the GID:SID pairs    */
+	/* found in the passed filter criteria array.   */
+	/*                                              */
+	/*   $rules --> file, a directory or an array   */
+	/*              containing rules files to scan  */
+	/*                                              */
+	/*  $filter --> array of GID:SID pairs to use   */
+	/*              for filtering returned rules    */
+	/*              map array.                      */
+	/*                                              */
+	/*  Returns --> rules_map array                 */
+	/************************************************/
+
+	$tmp_map = array();
+	$filtered_map = array();
+
+	// If the filter array is empty, just
+	// return an empty result to save time
+	// since nothing would match.
+	if (empty($filter)) {
+		return $filtered_map;
+	}
+
+	// Load up all the rules from the location passed
+	$tmp_map = snort_load_rules_map($rules);
+
+	// Now walk the loaded filter list and copy
+	// matching GID:SID rules from the target list
+	// over to the filtered array.
+	foreach ($filter as $k1 => $rulem) {
+		foreach($rulem as $k2 => $v) {
+			if (isset($tmp_map[$k1][$k2])) {
+				if (!is_array($filtered_map[$k1])) {
+					$filtered_map[$k1] = array();
+				}
+				if (!is_array($filtered_map[$k1][$k2])) {
+					$filtered_map[$k1][$k2] = array();
+				}
+				$filtered_map[$k1][$k2]['rule'] = $tmp_map[$k1][$k2]['rule'];
+				$filtered_map[$k1][$k2]['category'] = $tmp_map[$k1][$k2]['category'];
+				$filtered_map[$k1][$k2]['action'] = $tmp_map[$k1][$k2]['action'];
+				$filtered_map[$k1][$k2]['modified'] = $tmp_map[$k1][$k2]['modified'];
+				$filtered_map[$k1][$k2]['disabled'] = $tmp_map[$k1][$k2]['disabled'];
+				$filtered_map[$k1][$k2]['flowbits'] = $tmp_map[$k1][$k2]['flowbits'];
+				$filtered_map[$k1][$k2]['managed'] = $tmp_map[$k1][$k2]['managed'];
+				$filtered_map[$k1][$k2]['state_toggled'] = $tmp_map[$k1][$k2]['state_toggled'];
+				$filtered_map[$k1][$k2]['default_state'] = $tmp_map[$k1][$k2]['default_state'];
+				$filtered_map[$k1][$k2]['default_action'] = $tmp_map[$k1][$k2]['default_action'];
+			}
+		}
+	}
+
+	// Clean up and return the filtered list of rules
+	unset($tmp_map);
+	return $filtered_map;
+}
+
 function snort_create_rc() {
 
-/*********************************************************/
-/* This function builds the /usr/local/etc/rc.d/snort.sh */
-/* shell script for starting and stopping Snort.  The    */
-/* script is rebuilt on each package sync operation and  */
-/* after any changes to snort.conf saved in the GUI.     */
-/*********************************************************/
+	/*********************************************************/
+	/* This function builds the /usr/local/etc/rc.d/snort.sh */
+	/* shell script for starting and stopping Snort.  The    */
+	/* script is rebuilt on each package sync operation and  */
+	/* after any changes to snort.conf saved in the GUI.     */
+	/*********************************************************/
 
 	global $config, $g;
 
 	$snortdir = SNORTDIR;
 	$snortlogdir = SNORTLOGDIR;
-	$snortbindir = SNORT_PBI_BINDIR;
+	$snortbindir = SNORT_BINDIR;
 	$rcdir = RCFILEPREFIX;	
 
 	$snortconf = $config['installedpackages']['snortglobal']['rule'];
@@ -2826,24 +3186,40 @@ function snort_create_rc() {
 	// Loop thru each configured interface and build
 	// the shell script.
 	foreach ($snortconf as $value) {
-		// Skip disabled Snort interfaces
-		if ($value['enable'] <> 'on')
+
+		// Attempt to grab physical interface
+		// for this Snort instance.
+		$if_real = get_real_interface($value['interface']);
+
+		// Skip disabled Snort instances or
+		// intances whose pfSense physical
+		// interface has been removed.
+		if (($value['enable'] <> 'on') || ($if_real == ""))
 			continue;
 		$snort_uuid = $value['uuid'];
-		$if_real = get_real_interface($value['interface']);
+
+		// Adjust the interface specification and DAQ type according to operating mode
+		if ($value['ips_mode'] == "ips_mode_inline" && $value['blockoffenders7'] == "on") {
+			$iface = $if_real . "^:" . $if_real;
+			$daq_type = "-Q --daq netmap";
+		}
+		else {
+			$iface = $if_real;
+			$daq_type = "--daq pcap --daq-mode passive --treat-drop-as-alert";
+		}
 
 		$start_snort_iface_start[] = <<<EOE
 
 	# Start snort for {$value['descr']}
-	if [ ! -f {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid ]; then
-		pid=`/bin/pgrep -fn "snort -R {$snort_uuid} "`
+	if [ ! -f {$g['varrun_path']}/snort_{$if_real}.pid ]; then
+		pid=`/bin/pgrep -fn "snort -R {$if_real} "`
 	else
-		pid=`/bin/pgrep -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid`
+		pid=`/bin/pgrep -F {$g['varrun_path']}/snort_{$if_real}.pid`
 	fi
 
 	if [ -z \$pid ]; then
-		/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort START for {$value['descr']}({$snort_uuid}_{$if_real})..."
-		{$snortbindir}snort -R {$snort_uuid} -D {$quiet} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$if_real} > /dev/null 2>&1
+		/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort START for {$value['descr']}({$if_real})..."
+		{$snortbindir}snort -R _{$if_real} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface} > /dev/null 2>&1
 	fi
 
 EOE;
@@ -2851,10 +3227,10 @@ EOE;
 		$start_snort_iface_stop[] = <<<EOE
 
 	# Stop snort for {$value['descr']}
-	if [ -f {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid ]; then
-		pid=`/bin/pgrep -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid`
-		/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort STOP for {$value['descr']}({$snort_uuid}_{$if_real})..."
-		/bin/pkill -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid -a
+	if [ -f {$g['varrun_path']}/snort_{$if_real}.pid ]; then
+		pid=`/bin/pgrep -F {$g['varrun_path']}/snort_{$if_real}.pid`
+		/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort STOP for {$value['descr']}({$if_real})..."
+		/bin/pkill -F {$g['varrun_path']}/snort_{$if_real}.pid -a
 		time=0 timeout=30
 		while kill -0 \$pid 2>/dev/null; do
 			sleep 1
@@ -2863,14 +3239,14 @@ EOE;
 				break
 			fi
 		done
-		if [ -f {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid ]; then
-			/bin/rm {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid
+		if [ -f {$g['varrun_path']}/snort_{$if_real}.pid ]; then
+			/bin/rm {$g['varrun_path']}/snort_{$if_real}.pid
 		fi
 	else
-		pid=`/bin/pgrep -fn "snort -R {$snort_uuid} "`
+		pid=`/bin/pgrep -fn "snort -R {$if_real} "`
 		if [ ! -z \$pid ]; then
 			/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort STOP for {$value['descr']}({$snort_uuid}_{$if_real})..."
-			/bin/pkill -fn "snort -R {$snort_uuid} "
+			/bin/pkill -fn "snort -R {$if_real} "
 			time=0 timeout=30
 			while kill -0 \$pid 2>/dev/null; do
 				sleep 1
@@ -2941,67 +3317,6 @@ EOD;
 	@chmod("{$rcdir}snort.sh", 0755);
 }
 
-function snort_get_filtered_rules($rules, $filter) {
-
-	/************************************************/
-	/* This function returns a rules_map array of   */
-	/* of rules filtered using the GID:SID pairs    */
-	/* found in the passed filter criteria array.   */
-	/*                                              */
-	/*   $rules --> file, a directory or an array   */
-	/*              containing rules files to scan  */
-	/*                                              */
-	/*  $filter --> array of GID:SID pairs to use   */
-	/*              for filtering returned rules    */
-	/*              map array.                      */
-	/*                                              */
-	/*  Returns --> rules_map array                 */
-	/************************************************/
-
-	$tmp_map = array();
-	$filtered_map = array();
-
-	// If the filter array is empty, just
-	// return an empty result to save time
-	// since nothing would match.
-	if (empty($filter)) {
-		return $filtered_map;
-	}
-
-	// Load up all the rules from the location passed
-	$tmp_map = snort_load_rules_map($rules);
-
-	// Now walk the loaded filter list and copy
-	// matching GID:SID rules from the target list
-	// over to the filtered array.
-	foreach ($filter as $k1 => $rulem) {
-		foreach($rulem as $k2 => $v) {
-			if (isset($tmp_map[$k1][$k2])) {
-				if (!is_array($filtered_map[$k1])) {
-					$filtered_map[$k1] = array();
-				}
-				if (!is_array($filtered_map[$k1][$k2])) {
-					$filtered_map[$k1][$k2] = array();
-				}
-				$filtered_map[$k1][$k2]['rule'] = $tmp_map[$k1][$k2]['rule'];
-				$filtered_map[$k1][$k2]['category'] = $tmp_map[$k1][$k2]['category'];
-				$filtered_map[$k1][$k2]['action'] = $tmp_map[$k1][$k2]['action'];
-				$filtered_map[$k1][$k2]['modified'] = $tmp_map[$k1][$k2]['modified'];
-				$filtered_map[$k1][$k2]['disabled'] = $tmp_map[$k1][$k2]['disabled'];
-				$filtered_map[$k1][$k2]['flowbits'] = $tmp_map[$k1][$k2]['flowbits'];
-				$filtered_map[$k1][$k2]['managed'] = $tmp_map[$k1][$k2]['managed'];
-				$filtered_map[$k1][$k2]['state_toggled'] = $tmp_map[$k1][$k2]['state_toggled'];
-				$filtered_map[$k1][$k2]['default_state'] = $tmp_map[$k1][$k2]['default_state'];
-				$filtered_map[$k1][$k2]['default_action'] = $tmp_map[$k1][$k2]['default_action'];
-			}
-		}
-	}
-
-	// Clean up and return the filtered list of rules
-	unset($tmp_map);
-	return $filtered_map;
-}
-
 function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 
 	/***********************************************************/
@@ -3033,7 +3348,7 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 		return;
 
 	/* Log a message for rules rebuild in progress */
-	log_error(gettext("[Snort] Updating rules configuration for: " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . " ..."));
+	syslog(LOG_NOTICE, gettext("[Snort] Updating rules configuration for: " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . " ..."));
 
 	// Get any automatic rule category enable/disable modifications
 	// if auto-SID Mgmt is enabled and conf files exist for the interface.
@@ -3063,9 +3378,8 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 	/* into the $enabled_rules array.                     */
 	$enabled_rules = snort_load_rules_map("{$snortcfgdir}/preproc_rules/");
 
-	/* Only rebuild rules if some are selected or an IPS Policy is enabled  */
+	/* Process CATEGORIES rules if some are selected or an IPS Policy is enabled  */
 	if (!empty($snortcfg['rulesets']) || $snortcfg['ips_policy_enable'] == 'on') {
-		$no_rules_defined = false;
 
 		/* Load up all the text rules into a Rules Map array. */
 		$all_rules = snort_load_rules_map("{$snortdir}/rules/");
@@ -3129,8 +3443,14 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 
 		/* Check if a pre-defined Snort Subscriber rules policy is selected. */
 		/* If so, add all the VRT policy rules to our enforcing rule set.    */
-		if (!empty($snortcfg['ips_policy'])) {
-			$policy_rules = snort_load_vrt_policy($snortcfg['ips_policy'], $all_rules);
+		if ($snortcfg['ips_policy_enable'] == 'on' && !empty($snortcfg['ips_policy'])) {
+			if ($snortcfg['blockoffenders7'] == 'on' && $snortcfg['ips_mode'] == 'ips_mode_inline') {
+				$policy_mode = $snortcfg['ips_policy_mode'];
+			}
+			else {
+				$policy_mode = 'alert';
+			}
+			$policy_rules = snort_load_vrt_policy($snortcfg['ips_policy'], $policy_mode, $all_rules);
 			foreach ($policy_rules as $k1 => $policy) {
 				foreach ($policy as $k2 => $p) {
 					if (!is_array($enabled_rules[$k1]))
@@ -3151,11 +3471,12 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 		// Do the auto-SID managment first, if enabled, then do any manual SID state changes.
 		snort_auto_sid_mgmt($enabled_rules, $snortcfg, TRUE);
 		snort_modify_sids($enabled_rules, $snortcfg);
+		snort_modify_sids_action($enabled_rules, $snortcfg);
 
 		/* Check for and disable any rules dependent upon disabled preprocessors if  */
 		/* this option is enabled for the interface.                                 */
 		if ($snortcfg['preproc_auto_rule_disable'] == "on") {
-			log_error('[Snort] Checking for rules dependent on disabled preprocessors for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
+			syslog(LOG_NOTICE, '[Snort] Checking for rules dependent on disabled preprocessors for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
 			snort_filter_preproc_rules($snortcfg, $enabled_rules);
 		}
 
@@ -3164,7 +3485,7 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 
 		/* If auto-flowbit resolution is enabled, generate the dependent flowbits rules file. */
 		if ($snortcfg['autoflowbitrules'] == 'on') {
-			log_error('[Snort] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
+			syslog(LOG_NOTICE, '[Snort] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
 			$fbits = snort_resolve_flowbits($all_rules, $enabled_rules);
 
 			/* Check for and disable any flowbit-required rules the user has  */
@@ -3174,7 +3495,7 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 			/* Check for and disable any flowbit-required rules dependent upon     */
 			/* disabled preprocessors if this option is enabled for the interface. */
 			if ($snortcfg['preproc_auto_rule_disable'] == "on") {
-				log_error('[Snort] Checking flowbit rules dependent on disabled preprocessors for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
+				syslog(LOG_NOTICE, '[Snort] Checking flowbit rules dependent on disabled preprocessors for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
 				snort_filter_preproc_rules($snortcfg, $fbits, true);
 			}
 			snort_write_flowbit_rules_file($fbits, "{$snortcfgdir}/rules/{$flowbit_rules_file}");
@@ -3184,62 +3505,49 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 			snort_write_flowbit_rules_file(array(), "{$snortcfgdir}/rules/{$flowbit_rules_file}");
 		unset($all_rules);
 	}
-	// If no rule categories were enabled, then use auto-SID management if enabled, since it may enable some rules
-	elseif ($config['installedpackages']['snortglobal']['auto_manage_sids'] == 'on' &&
-		(!empty($snortcfg['disable_sid_file']) || !empty($snortcfg['enable_sid_file']) || 
-		!empty($snortcfg['modify_sid_file']))) {
 
-		snort_auto_sid_mgmt($enabled_rules, $snortcfg, TRUE);
-		if (!empty($enabled_rules)) {
-			// Auto-SID management generated some rules, so use them
-			$no_rules_defined = false;
-			snort_modify_sids($enabled_rules, $snortcfg);
+	// Process SID Management directives if enabled
+	snort_auto_sid_mgmt($enabled_rules, $snortcfg, TRUE);
+	if (!empty($enabled_rules)) {
+		// Auto-SID management generated some rules, so use them
+		snort_modify_sids($enabled_rules, $snortcfg);
+		snort_modify_sids_action($enabled_rules, $snortcfg);
 
-			// Write the enforcing rules file to the Snort interface's "rules" directory.
-			snort_write_enforcing_rules_file($enabled_rules, "{$snortcfgdir}/rules/{$snort_enforcing_rules_file}");
+		// Write the enforcing rules file to the Snort interface's "rules" directory.
+		snort_write_enforcing_rules_file($enabled_rules, "{$snortcfgdir}/rules/{$snort_enforcing_rules_file}");
 
-			// If auto-flowbit resolution is enabled, generate the dependent flowbits rules file.
-			if ($snortcfg['autoflowbitrules'] == 'on') {
-				log_error('[Snort] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
+		// If auto-flowbit resolution is enabled, generate the dependent flowbits rules file.
+		if ($snortcfg['autoflowbitrules'] == 'on') {
+			syslog(LOG_NOTICE, '[Snort] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
 
-				// Load up all rules into a Rules Map array for flowbits assessment
-				$all_rules = snort_load_rules_map("{$snortdir}/rules/");
-				$fbits = snort_resolve_flowbits($all_rules, $enabled_rules);
+			// Load up all rules into a Rules Map array for flowbits assessment
+			$all_rules = snort_load_rules_map("{$snortdir}/rules/");
+			$fbits = snort_resolve_flowbits($all_rules, $enabled_rules);
 
-				// Check for and disable any flowbit-required rules the
-				// user has manually forced to a disabled state.
-				snort_modify_sids($fbits, $snortcfg);
-				snort_write_flowbit_rules_file($fbits, "{$snortcfgdir}/rules/{$flowbit_rules_file}");
-				unset($all_rules, $fbits);
-			} else
-				// Just put an empty file to always have the file present
-			snort_write_flowbit_rules_file(array(), "{$snortcfgdir}/rules/{$flowbit_rules_file}");
-		}
-		else {
-			snort_write_enforcing_rules_file(array(), "{$snortcfgdir}/rules/{$snort_enforcing_rules_file}");
-			snort_write_flowbit_rules_file(array(), "{$snortcfgdir}/rules/{$flowbit_rules_file}");
-		}
+			// Check for and disable any flowbit-required rules the
+			// user has manually forced to a disabled state.
+			snort_modify_sids($fbits, $snortcfg);
+			snort_write_flowbit_rules_file($fbits, "{$snortcfgdir}/rules/{$flowbit_rules_file}");
+			unset($all_rules, $fbits);
+		} else
+			// Just put an empty file to always have the file present
+		snort_write_flowbit_rules_file(array(), "{$snortcfgdir}/rules/{$flowbit_rules_file}");
 	}
 	else {
-		/* No regular rules or policy were selected, so just use the decoder and preproc rules */
-		snort_write_enforcing_rules_file($enabled_rules, "{$snortcfgdir}/rules/{$snort_enforcing_rules_file}");
+		snort_write_enforcing_rules_file(array(), "{$snortcfgdir}/rules/{$snort_enforcing_rules_file}");
 		snort_write_flowbit_rules_file(array(), "{$snortcfgdir}/rules/{$flowbit_rules_file}");
 	}
 
 	if (!empty($snortcfg['customrules'])) {
 		@file_put_contents("{$snortcfgdir}/rules/custom.rules", base64_decode($snortcfg['customrules']));
-		$no_rules_defined = false;
 	}
-	else
+	else {
 		@file_put_contents("{$snortcfgdir}/rules/custom.rules", "");
-
-	/* Log a warning if the interface has no rules defined or enabled */
-	if ($no_rules_defined)
-		log_error(gettext("[Snort] Warning - no text rules or IPS-Policy selected for: " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . " ..."));
+	}
 
 	/* Build a new sid-msg.map file from the enabled */
 	/* rules and copy it to the interface directory. */
-	log_error(gettext("[Snort] Building new sid-msg.map file for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . "..."));
+	syslog(LOG_NOTICE, gettext("[Snort] Building new sid-msg.map file for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . "..."));
 	snort_build_sid_msg_map("{$snortcfgdir}/rules/", "{$snortcfgdir}/sid-msg.map");
 }
 
@@ -3377,7 +3685,7 @@ function snort_filter_preproc_rules($snortcfg, &$active_rules, $persist_log = fa
 	/* than optimal with the preprocessors disabled.   */
 	/***************************************************/
 	if ($disabled_count > 0) {
-		log_error(gettext("[Snort] Warning: auto-disabled {$disabled_count} rules due to disabled preprocessor dependencies."));
+		syslog(LOG_WARNING, gettext("[Snort] Warning: auto-disabled {$disabled_count} rules due to disabled preprocessor dependencies."));
 		natcasesort($log_msg);
 		if ($fp) {
 			/* Only write the header when not persisting the log */
@@ -3402,7 +3710,7 @@ function snort_filter_preproc_rules($snortcfg, &$active_rules, $persist_log = fa
 				@fwrite($fp, sprintf("%-30s  %-10s  %-20s  %s", $tmp[0], $tmp[1], $tmp[2], $tmp[3]) . "\n");
 			}
 		}
-		log_error(gettext("[Snort] See '{$file}' for list of auto-disabled rules."));
+		syslog(LOG_NOTICE, gettext("[Snort] See '{$file}' for list of auto-disabled rules."));
 		unset($log_msg);
 	}
 	if ($fp)
@@ -3424,7 +3732,7 @@ function snort_generate_conf($snortcfg) {
 		return;
 
 	$snortdir = SNORTDIR;
-	$snortlibdir = SNORT_PBI_BASEDIR . "lib";
+	$snortlibdir = SNORT_BASEDIR . "lib";
 	$snortlogdir = SNORTLOGDIR;
 	$flowbit_rules_file = FLOWBITS_FILENAME;
 	$snort_enforcing_rules_file = SNORT_ENFORCING_RULES_FILENAME;
@@ -3500,7 +3808,7 @@ function snort_remove_dead_rules() {
 	}
 
 	// Log how many obsoleted files were removed
-	log_error(gettext("[Snort] Removed {$count} obsoleted rules category files."));
+	syslog(LOG_NOTICE, gettext("[Snort] Removed {$count} obsoleted rules category files."));
 
 	// Now remove any dead rules files from the interface configurations
 	if (!empty($cats) && is_array($config['installedpackages']['snortglobal']['rule'])) {
@@ -3526,7 +3834,7 @@ function snort_sync_on_changes() {
 
 	/* Do not attempt a package sync while booting up or installing package */
 	if ($g['booting'] || $g['snort_postinstall']) {
-		log_error("[snort] Skipping XMLRPC sync when booting up or during package reinstallation.");
+		syslog(LOG_NOTICE, "[snort] Skipping XMLRPC sync when booting up or during package reinstallation.");
 		return;
 	}
 
@@ -3540,7 +3848,7 @@ function snort_sync_on_changes() {
 				if (is_array($snort_sync['row'])){
 					$rs=$snort_sync['row'];
 				} else {
-					log_error("[snort] XMLRPC sync is enabled but there are no hosts configured as replication targets.");
+					syslog(LOG_NOTICE, "[snort] XMLRPC sync is enabled but there are no hosts configured as replication targets.");
 					return;
 				}
 				break;
@@ -3561,13 +3869,13 @@ function snort_sync_on_changes() {
 						$rs[0]['varsyncport'] = $config['system']['webgui']['port'] ?: '443';
 					}
 					if ($system_carp['synchronizetoip'] == "") {
-						log_error("[snort] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+						syslog(LOG_NOTICE, "[snort] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
 						return;
 					} else {
 						$rs[0]['varsyncdestinenable'] = TRUE;
 					}
 				} else {
-					log_error("[snort] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+					syslog(LOG_NOTICE, "[snort] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
 					return;
 				}
 				break;			
@@ -3576,7 +3884,7 @@ function snort_sync_on_changes() {
 				break;
 		}
 		if (is_array($rs)){
-			log_error("[snort] XMLRPC sync is starting.");
+			syslog(LOG_NOTICE, "[snort] XMLRPC sync is starting.");
 			foreach ($rs as $sh){
 				// Only sync enabled replication targets
 				if ($sh['varsyncdestinenable']) {
@@ -3607,11 +3915,11 @@ function snort_sync_on_changes() {
 					if ($success) {
 						snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol, $username, $password, $synctimeout, $syncstartsnort);
 					} else {
-						log_error("[snort] XMLRPC sync with '{$sync_to_ip}' aborted due to the following error(s): {$error}");
+						syslog(LOG_ERR, "[snort] XMLRPC sync with '{$sync_to_ip}' aborted due to the following error(s): {$error}");
 					}
 				}
 			}
-			log_error("[snort] XMLRPC sync completed.");
+			syslog(LOG_NOTICE, "[snort] XMLRPC sync completed.");
 		}
  	}
 }
@@ -3628,12 +3936,12 @@ function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol,
 
 	/* Do not attempt a package sync while booting up or installing package */
 	if ($g['booting'] || isset($g['snort_postinstall'])) {
-		log_error("[snort] Skipping XMLRPC sync when booting up or during package reinstallation.");
+		syslog(LOG_NOTICE, "[snort] Skipping XMLRPC sync when booting up or during package reinstallation.");
 		return;
 	}
 
 	if ($username == "" || $password == "" || $sync_to_ip == "" || $port == "" || $protocol == "") {
-		log_error("[snort] A required XMLRPC sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
+		syslog(LOG_ERR, "[snort] A required XMLRPC sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
 		return;
 	}
 
@@ -3646,17 +3954,17 @@ function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol,
 	
 	$downloadrulescmd = "";
 	if ($syncdownloadrules == "yes") {
-		$downloadrulescmd = "log_error(gettext(\"[snort] XMLRPC pkg sync: Update of downloaded rule sets requested...\"));\n";
+		$downloadrulescmd = "syslog(LOG_NOTICE, gettext(\"[snort] XMLRPC pkg sync: Update of downloaded rule sets requested...\"));\n";
 		$downloadrulescmd .= "\tinclude_once(\"/usr/local/pkg/snort/snort_check_for_rule_updates.php\");\n";
 	}
 	$snortstart = "";
 	if ($syncstartsnort == "ON") {
-		$snortstart = "log_error(gettext(\"[snort] XMLRPC pkg sync: Checking Snort status...\"));\n";
+		$snortstart = "syslog(LOG_NOTICE, gettext(\"[snort] XMLRPC pkg sync: Checking Snort status...\"));\n";
 		$snortstart .= "\tif (!is_process_running(\"snort\")) {\n";
-		$snortstart .= "\t\tlog_error(gettext(\"[snort] XMLRPC pkg sync: Snort not running. Sending a start command...\"));\n";
+		$snortstart .= "\t\tsyslog(LOG_NOTICE, gettext(\"[snort] XMLRPC pkg sync: Snort not running. Sending a start command...\"));\n";
 		$snortstart .= "\t\t\$sh_script = RCFILEPREFIX . \"snort.sh\";\n";
 		$snortstart .= "\t\tmwexec_bg(\"{\$sh_script} start\");\n\t}\n";
-		$snortstart .= "\telse {\n\t\tlog_error(gettext(\"[snort] XMLRPC pkg sync: Snort is running...\"));\n\t}\n";
+		$snortstart .= "\telse {\n\t\tsyslog(LOG_NOTICE, gettext(\"[snort] XMLRPC pkg sync: Snort is running...\"));\n\t}\n";
 	}
 
 	/*************************************************/
@@ -3676,12 +3984,12 @@ function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol,
 	\$pkg_interface = "console";
 	{$downloadrulescmd}
 	unset(\$g["snort_postinstall"]);
-	log_error(gettext("[snort] XMLRPC pkg sync: Generating snort.conf file using Master Host settings..."));
+	syslog(LOG_NOTICE, gettext("[snort] XMLRPC pkg sync: Generating snort.conf file using Master Host settings..."));
 	\$rebuild_rules = true;
 	sync_snort_package_config();
 	\$rebuild_rules = false;
 	{$snortstart}
-	log_error(gettext("[snort] XMLRPC pkg sync process on this host is complete..."));
+	syslog(LOG_NOTICE, gettext("[snort] XMLRPC pkg sync process on this host is complete..."));
 	\$pkg_interface = \$orig_pkg_interface;
 	unset(\$g["snort_sync_in_progress"]);
 	return true;
@@ -3757,7 +4065,7 @@ EOD;
 			$method = 'pfsense.exec_php';
 			$params = array( XML_RPC_encode($password), XML_RPC_encode($payload) );
 
-			log_error("[snort] XMLRPC sync sending auto-SID conf files to {$url}:{$port}.");
+			syslog(LOG_NOTICE, "[snort] XMLRPC sync sending auto-SID conf files to {$url}:{$port}.");
 			$msg = new XML_RPC_Message($method, $params);
 			$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 			$cli->setCredentials($username, $password);
@@ -3765,17 +4073,17 @@ EOD;
 			$error = "";
 			if (!$resp) {
 				$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
-				log_error($error);
+				syslog(LOG_ERR, $error);
 				file_notice("sync_settings", $error, "Snort Settings Sync", "");
 			} elseif ($resp->faultCode()) {
 				$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
-				log_error($error);
+				syslog(LOG_ERR, $error);
 				file_notice("sync_settings", $error, "Snort Settings Sync", "");
 			}
 		}
 
 		if (!empty($sid_files) && $error == "") {
-			log_error("[snort] XMLRPC sync auto-SID conf files success with {$url}:{$port} (pfsense.exec_php).");
+			syslog(LOG_NOTICE, "[snort] XMLRPC sync auto-SID conf files success with {$url}:{$port} (pfsense.exec_php).");
 		}
 
 		/*************************************************/
@@ -3790,7 +4098,7 @@ EOD;
 			$method = 'pfsense.exec_php';
 			$params = array( XML_RPC_encode($password), XML_RPC_encode($payload) );
 
-			log_error("[snort] Snort XMLRPC sync sending IPREP files to {$url}:{$port}.");
+			syslog(LOG_NOTICE, "[snort] Snort XMLRPC sync sending IPREP files to {$url}:{$port}.");
 			$msg = new XML_RPC_Message($method, $params);
 			$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 			$cli->setCredentials($username, $password);
@@ -3798,17 +4106,17 @@ EOD;
 			$error = "";
 			if (!$resp) {
 				$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
-				log_error($error);
+				syslog(LOG_ERR, $error);
 				file_notice("sync_settings", $error, "Snort Settings Sync", "");
 			} elseif ($resp->faultCode()) {
 				$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
-				log_error($error);
+				syslog(LOG_ERR, $error);
 				file_notice("sync_settings", $error, "Snort Settings Sync", "");
 			}
 		}
 
 		if (!empty($iprep_files) && $error == "") {
-			log_error("[snort] XMLRPC sync IPREP files success with {$url}:{$port} (pfsense.exec_php).");
+			syslog(LOG_ERR, "[snort] XMLRPC sync IPREP files success with {$url}:{$port} (pfsense.exec_php).");
 		}
 
 		/* assemble xmlrpc payload */
@@ -3817,7 +4125,7 @@ EOD;
 			XML_RPC_encode($xml)
 		);
 
-		log_error("[snort] Beginning package configuration XMLRPC sync to {$url}:{$port}.");
+		syslog(LOG_NOTICE, "[snort] Beginning package configuration XMLRPC sync to {$url}:{$port}.");
 		$method = 'pfsense.merge_installedpackages_section_xmlrpc';
 		$msg = new XML_RPC_Message($method, $params);
 		$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
@@ -3827,14 +4135,14 @@ EOD;
 		$resp = $cli->send($msg, $synctimeout);
 		if (!$resp) {
 			$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port}.";
-			log_error($error);
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Snort Settings Sync", "");
 		} elseif ($resp->faultCode()) {
 			$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-			log_error($error);
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Snort Settings Sync", "");
 		} else {
-			log_error("[snort] Package configuration XMLRPC sync successfully completed with {$url}:{$port}.");
+			syslog(LOG_NOTICE, "[snort] Package configuration XMLRPC sync successfully completed with {$url}:{$port}.");
 		}
 
 		/* assemble xmlrpc payload */
@@ -3844,40 +4152,40 @@ EOD;
 			XML_RPC_encode($execcmd)
 		);
 
-		log_error("[snort] XMLRPC sync sending reload configuration cmd set as a file to {$url}:{$port}.");
+		syslog(LOG_NOTICE, "[snort] XMLRPC sync sending reload configuration cmd set as a file to {$url}:{$port}.");
 		$msg = new XML_RPC_Message($method, $params);
 		$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 		$cli->setCredentials($username, $password);
 		$resp = $cli->send($msg, $synctimeout);
 		if (!$resp) {
 			$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
-			log_error($error);
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Snort Settings Sync", "");
 		} elseif ($resp->faultCode()) {
 			$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-			log_error($error);
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Snort Settings Sync", "");
 		} else {
-			log_error("[snort] XMLRPC sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
+			syslog(LOG_NOTICE, "[snort] XMLRPC sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
 		}
 
 		$params2 = array(
 			XML_RPC_encode($password),
 			XML_RPC_encode($execcmd2)
 		);
-		log_error("[snort] XMLRPC sync sending {$url}:{$port} cmd to execute configuration reload.");
+		syslog(LOG_NOTICE, "[snort] XMLRPC sync sending {$url}:{$port} cmd to execute configuration reload.");
 		$msg2 = new XML_RPC_Message($method, $params2);
 		$resp = $cli->send($msg2, $synctimeout);
 		if (!$resp) {
 			$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
-			log_error($error);
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Snort Settings Sync", "");
 		} elseif ($resp->faultCode()) {
 			$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-			log_error($error);
+			syslog(LOG_ERR, $error);
 			file_notice("sync_settings", $error, "Snort Settings Sync", "");
 		} else {
-			log_error("[snort] XMLRPC sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
+			syslog(LOG_NOTICE, "[snort] XMLRPC sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
 		}
 	}
 }

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_conf_template.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_conf_template.inc
@@ -30,6 +30,7 @@ config snaplen: {$snaplen}
 config disable_decode_alerts
 config disable_tcpopt_experimental_alerts
 config disable_tcpopt_obsolete_alerts
+config disable_tcpopt_ttcp_alerts
 config disable_ttcp_alerts
 config disable_tcpopt_alerts
 config disable_ipopt_alerts
@@ -37,6 +38,9 @@ config disable_decode_drops
 
 # Enable the GTP decoder #
 config enable_gtp
+
+# Configure maximum number of flowbit references.
+config flowbits_size: 2048
 
 # Configure PCRE match limitations
 config pcre_match_limit: 3500
@@ -62,12 +66,12 @@ dynamicengine directory {$snort_dirs['dynamicengine']}
 dynamicdetection directory {$snort_dirs['dynamicrules']}
 
 # Inline packet normalization. For more information, see README.normalize
-# Disabled since we do not use "inline" mode with pfSense
-# preprocessor normalize_ip4
-# preprocessor normalize_tcp: ips ecn stream
-# preprocessor normalize_icmp4
-# preprocessor normalize_ip6
-# preprocessor normalize_icmp6
+# Does nothing in IDS mode (Legacy Mode blocking)
+preprocessor normalize_ip4
+preprocessor normalize_tcp: ips ecn stream
+preprocessor normalize_icmp4
+preprocessor normalize_ip6
+preprocessor normalize_icmp6
 
 # Flow and stream #
 {$frag3_global}
@@ -90,7 +94,7 @@ dynamicdetection directory {$snort_dirs['dynamicrules']}
 {$host_attrib_config}
 
 # Snort Output Logs #
-output alert_csv: alert timestamp,sig_generator,sig_id,sig_rev,msg,proto,src,srcport,dst,dstport,id,classification,priority {$alert_log_limit_size}
+output alert_csv: alert timestamp,sig_generator,sig_id,sig_rev,msg,proto,src,srcport,dst,dstport,id,classification,priority,action,disposition {$alert_log_limit_size}
 {$alertsystemlog_type}
 {$snortunifiedlog_type}
 {$spoink_type}

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -24,20 +24,20 @@
 global $g, $config;
 
 /* Define some useful constants for Snort */
-if (!defined("SNORT_PBI_BASEDIR")) {
-	define("SNORT_PBI_BASEDIR", "/usr/local/");
+if (!defined("SNORT_BASEDIR")) {
+	define("SNORT_BASEDIR", "/usr/local/");
 }
-if (!defined("SNORT_PBI_BINDIR"))
-	define("SNORT_PBI_BINDIR", SNORT_PBI_BASEDIR . "bin/");
+if (!defined("SNORT_BINDIR"))
+	define("SNORT_BINDIR", SNORT_BASEDIR . "bin/");
 if (!defined("SNORTDIR"))
-	define("SNORTDIR", SNORT_PBI_BASEDIR . "etc/snort");
+	define("SNORTDIR", SNORT_BASEDIR . "etc/snort");
 if (!defined("SNORTLOGDIR"))
 	define("SNORTLOGDIR", "{$g['varlog_path']}/snort");
 if (!defined("SNORT_BIN_VERSION")) {
 	// Grab the Snort binary version programmatically by
 	// running the binary with the command-line argument
 	// to display the version information.
-	$snortbindir = SNORT_PBI_BINDIR;
+	$snortbindir = SNORT_BINDIR;
 	$snortver = exec_command("{$snortbindir}/snort -V 2>&1 |/usr/bin/grep Version | /usr/bin/cut -c20-31");
 
 	// Extract just the numbers and decimal point
@@ -47,7 +47,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 		define("SNORT_BIN_VERSION", $matches[0]);
 	}
 	else {
-		define("SNORT_BIN_VERSION", "2.9.16");
+		define("SNORT_BIN_VERSION", "2.9.16.1");
 	}
 }
 
@@ -73,7 +73,7 @@ if (!defined("VRT_DNLD_URL"))
 if (!defined("ET_VERSION"))
 	define("ET_VERSION", "2.9.0");
 if (!defined("ET_BASE_DNLD_URL"))
-	define("ET_BASE_DNLD_URL", "http://rules.emergingthreats.net/"); 
+	define("ET_BASE_DNLD_URL", "https://rules.emergingthreats.net/"); 
 if (!defined("ETPRO_BASE_DNLD_URL"))
 	define("ETPRO_BASE_DNLD_URL", "https://rules.emergingthreatspro.com/"); 
 if (!defined("SNORT_ET_DNLD_FILENAME"))
@@ -89,7 +89,7 @@ if (!defined("SNORT_OPENAPPID_DNLD_URL"))
 if (!defined("SNORT_OPENAPPID_DNLD_FILENAME"))
 	define("SNORT_OPENAPPID_DNLD_FILENAME", "snort-openappid.tar.gz");
 if (!defined("SNORT_OPENAPPID_RULES_URL"))
-	define("SNORT_OPENAPPID_RULES_URL", "http://files.pfsense.org/openappid/");
+	define("SNORT_OPENAPPID_RULES_URL", "https://files.pfsense.org/openappid/");
 if (!defined("SNORT_OPENAPPID_RULES_FILENAME"))
 	define("SNORT_OPENAPPID_RULES_FILENAME", "appid_rules.tar.gz");
 if (!defined("SNORT_RULES_UPD_LOGFILE"))

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
@@ -54,7 +54,7 @@ if (empty($config['installedpackages']['snortglobal']['rule']))
 /****************************************************************************/
 
 $updated_cfg = false;
-log_error("[Snort] Checking configuration settings version...");
+syslog(LOG_NOTICE, "[Snort] Checking configuration settings version...");
 
 // Check the configuration version to see if XMLRPC Sync should
 // auto-disabled as part of the upgrade due to config format changes.
@@ -62,7 +62,7 @@ if (empty($config['installedpackages']['snortglobal']['snort_config_ver']) &&
     ($config['installedpackages']['snortsync']['config']['varsynconchanges'] == 'auto' ||
      $config['installedpackages']['snortsync']['config']['varsynconchanges'] == 'manual')) {
 	$config['installedpackages']['snortsync']['config']['varsynconchanges']	= "disabled";
-	log_error("[Snort] Turning off Snort Sync on this host due to configuration format changes in this update.  Upgrade all Snort Sync targets to this same Snort package version before re-enabling Snort Sync.");
+	syslog(LOG_NOTICE, "[Snort] Turning off Snort Sync on this host due to configuration format changes in this update.  Upgrade all Snort Sync targets to this same Snort package version before re-enabling Snort Sync.");
 	$updated_cfg = true;
 }
 
@@ -164,8 +164,37 @@ if (empty($config['installedpackages']['snortglobal']['sid_list_migration']) && 
 		}
 	}
 
-	// Set a flag to show one-time migration is completed
-	$config['installedpackages']['snortglobal']['sid_list_migration'] = "1";
+	// Set a flag to show one-time migration is completed.
+	// We can increment this flag in later versions if we
+	// need to import additional files as SID_MGMT_LISTS.
+	$config['installedpackages']['snortglobal']['sid_list_migration'] = "2";
+	$updated_cfg = true;
+	unset($a_list);
+}
+elseif ($config['installedpackages']['snortglobal']['sid_list_migration'] < "2") {
+
+	// Import dropsid-sample.conf and rejectsid-sample.conf
+	// files if missing from the SID_MGMT_LIST array.
+	if (!is_array($config['installedpackages']['snortglobal']['sid_mgmt_lists']['item'])) {
+		$config['installedpackages']['snortglobal']['sid_mgmt_lists']['item'] = array();
+	}
+	$sidmodfiles = array( "dropsid-sample.conf", "rejectsid-sample.conf" );
+	$a_list = &$config['installedpackages']['snortglobal']['sid_mgmt_lists']['item'];
+	foreach ($sidmodfiles as $sidfile) {
+		if (!in_array($sidfile, $a_list)) {
+			$data = file_get_contents("/var/db/snort/sidmods/" . $sidfile);
+			if ($data !== FALSE) {
+				$tmp = array();
+				$tmp['name'] = basename($sidfile);
+				$tmp['modtime'] = filemtime("/var/db/snort/sidmods/" . $sidfile);
+				$tmp['content'] = base64_encode($data);
+				$a_list[] = $tmp;
+			}
+		}		
+	}
+
+	// Set a flag to show this one-time migration is completed
+	$config['installedpackages']['snortglobal']['sid_list_migration'] = "2";
 	$updated_cfg = true;
 	unset($a_list);
 }
@@ -200,80 +229,77 @@ if (empty($config['installedpackages']['snortglobal']['rule_update_starttime']) 
 /**********************************************************/
 /* Migrate per interface settings if required.            */
 /**********************************************************/
-foreach ($config['installedpackages']['snortglobal']['rule'] as &$r) {
+foreach ($config['installedpackages']['snortglobal']['rule'] as &$rule) {
 	// Initialize arrays for supported preprocessors if necessary
-	if (!is_array($r['frag3_engine'])) {
-		$r['frag3_engine'] = array();
+	if (!is_array($rule['frag3_engine'])) {
+		$rule['frag3_engine'] = array();
 	}
-	if (!is_array($r['frag3_engine']['item'])) {
-		$r['frag3_engine']['item'] = array();
+	if (!is_array($rule['frag3_engine']['item'])) {
+		$rule['frag3_engine']['item'] = array();
 	}
-	if (!is_array($r['stream5_tcp_engine'])) {
-		$r['stream5_tcp_engine'] = array();
+	if (!is_array($rule['stream5_tcp_engine'])) {
+		$rule['stream5_tcp_engine'] = array();
 	}
-	if (!is_array($r['stream5_tcp_engine']['item'])) {
-		$r['stream5_tcp_engine']['item'] = array();
+	if (!is_array($rule['stream5_tcp_engine']['item'])) {
+		$rule['stream5_tcp_engine']['item'] = array();
 	}
-	if (!is_array($r['http_inspect_engine'])) {
-		$r['http_inspect_engine'] = array();
+	if (!is_array($rule['http_inspect_engine'])) {
+		$rule['http_inspect_engine'] = array();
 	}
-	if (!is_array($r['http_inspect_engine']['item'])) {
-		$r['http_inspect_engine']['item'] = array();
+	if (!is_array($rule['http_inspect_engine']['item'])) {
+		$rule['http_inspect_engine']['item'] = array();
 	}
-	if (!is_array($r['ftp_client_engine'])) {
-		$r['ftp_client_engine'] = array();
+	if (!is_array($rule['ftp_client_engine'])) {
+		$rule['ftp_client_engine'] = array();
 	}
-	if (!is_array($r['ftp_client_engine']['item'])) {
-		$r['ftp_client_engine']['item'] = array();
+	if (!is_array($rule['ftp_client_engine']['item'])) {
+		$rule['ftp_client_engine']['item'] = array();
 	}
-	if (!is_array($r['ftp_server_engine'])) {
-		$r['ftp_server_engine'] = array();
+	if (!is_array($rule['ftp_server_engine'])) {
+		$rule['ftp_server_engine'] = array();
 	}
-	if (!is_array($r['ftp_server_engine']['item'])) {
-		$r['ftp_server_engine']['item'] = array();
+	if (!is_array($rule['ftp_server_engine']['item'])) {
+		$rule['ftp_server_engine']['item'] = array();
 	}
-
-	$pconfig = array();
-	$pconfig = $r;
 
 	// Create a default "frag3_engine" if none are configured
-	if (empty($pconfig['frag3_engine']['item'])) {
+	if (empty($rule['frag3_engine']['item'])) {
 		$updated_cfg = true;
-		log_error("[Snort] Migrating Frag3 Engine configuration for interface {$pconfig['descr']}...");
+		syslog(LOG_NOTICE, "[Snort] Migrating Frag3 Engine configuration for interface {$rule['descr']}...");
 		$default = array( "name" => "default", "bind_to" => "all", "policy" => "bsd", 
 				"timeout" => 60, "min_ttl" => 1, "detect_anomalies" => "on", 
 				"overlap_limit" => 0, "min_frag_len" => 0 );
 
 		// Ensure sensible default values exist for global Frag3 parameters
-		if (empty($pconfig['frag3_max_frags']))
-			$pconfig['frag3_max_frags'] = '8192';
-		if (empty($pconfig['frag3_memcap']))
-			$pconfig['frag3_memcap'] = '4194304';
-		if (empty($pconfig['frag3_detection']))
-			$pconfig['frag3_detection'] = 'on';
+		if (empty($rule['frag3_max_frags']))
+			$rule['frag3_max_frags'] = '8192';
+		if (empty($rule['frag3_memcap']))
+			$rule['frag3_memcap'] = '4194304';
+		if (empty($rule['frag3_detection']))
+			$rule['frag3_detection'] = 'on';
 
 		// Put any old values in new default engine and remove old value
-		if (isset($pconfig['frag3_policy']))
-			$default['policy'] = $pconfig['frag3_policy'];
-		unset($pconfig['frag3_policy']);
-		if (isset($pconfig['frag3_timeout']) && is_numeric($pconfig['frag3_timeout']))
-			$default['timeout'] = $pconfig['frag3_timeout'];
-		unset($pconfig['frag3_timeout']);
-		if (isset($pconfig['frag3_overlap_limit']) && is_numeric($pconfig['frag3_overlap_limit']))
-			$default['overlap_limit'] = $pconfig['frag3_overlap_limit'];
-		unset($pconfig['frag3_overlap_limit']);
-		if (isset($pconfig['frag3_min_frag_len']) && is_numeric($pconfig['frag3_min_frag_len']))
-			$default['min_frag_len'] = $pconfig['frag3_min_frag_len'];
-		unset($pconfig['frag3_min_frag_len']);
+		if (isset($rule['frag3_policy']))
+			$default['policy'] = $rule['frag3_policy'];
+		unset($rule['frag3_policy']);
+		if (isset($rule['frag3_timeout']) && is_numeric($rule['frag3_timeout']))
+			$default['timeout'] = $rule['frag3_timeout'];
+		unset($rule['frag3_timeout']);
+		if (isset($rule['frag3_overlap_limit']) && is_numeric($rule['frag3_overlap_limit']))
+			$default['overlap_limit'] = $rule['frag3_overlap_limit'];
+		unset($rule['frag3_overlap_limit']);
+		if (isset($rule['frag3_min_frag_len']) && is_numeric($rule['frag3_min_frag_len']))
+			$default['min_frag_len'] = $rule['frag3_min_frag_len'];
+		unset($rule['frag3_min_frag_len']);
 
-		$pconfig['frag3_engine']['item'] = array();
-		$pconfig['frag3_engine']['item'][] = $default;
+		$rule['frag3_engine']['item'] = array();
+		$rule['frag3_engine']['item'][] = $default;
 	}
 
 	// Create a default Stream5 engine array if none are configured
-	if (empty($pconfig['stream5_tcp_engine']['item'])) {
+	if (empty($rule['stream5_tcp_engine']['item'])) {
 		$updated_cfg = true;
-		log_error("[Snort] Migrating Stream5 Engine configuration for interface {$pconfig['descr']}...");
+		syslog(LOG_NOTICE, "[Snort] Migrating Stream5 Engine configuration for interface {$rule['descr']}...");
 		$default = array( "name" => "default", "bind_to" => "all", "policy" => "bsd", "timeout" => 30, 
 				"max_queued_bytes" => 1048576, "detect_anomalies" => "off", "overlap_limit" => 0, 
 				"max_queued_segs" => 2621, "require_3whs" => "off", "startup_3whs_timeout" => 0, 
@@ -282,65 +308,65 @@ foreach ($config['installedpackages']['snortglobal']['rule'] as &$r) {
 				"ports_both" => "default", "ports_server" => "none" );
 
 		// Ensure sensible defaults exist for Stream5 global parameters
-		if (empty($pconfig['stream5_reassembly']))
-			$pconfig['stream5_reassembly'] = 'on';
-		if (empty($pconfig['stream5_flush_on_alert']))
-			$pconfig['stream5_flush_on_alert'] = 'off';
-		if (empty($pconfig['stream5_prune_log_max']))
-			$pconfig['stream5_prune_log_max'] = '1048576';
-		if (empty($pconfig['stream5_track_tcp']))
-			$pconfig['stream5_track_tcp'] = 'on';
-		if (empty($pconfig['stream5_max_tcp']))
-			$pconfig['stream5_max_tcp'] = '262144';
-		if (empty($pconfig['stream5_track_udp']))
-			$pconfig['stream5_track_udp'] = 'on';
-		if (empty($pconfig['stream5_max_udp']))
-			$pconfig['stream5_max_udp'] = '131072';
-		if (empty($pconfig['stream5_udp_timeout']))
-			$pconfig['stream5_udp_timeout'] = '30';
-		if (empty($pconfig['stream5_track_icmp']))
-			$pconfig['stream5_track_icmp'] = 'off';
-		if (empty($pconfig['stream5_max_icmp']))
-			$pconfig['stream5_max_icmp'] = '65536';
-		if (empty($pconfig['stream5_icmp_timeout']))
-			$pconfig['stream5_icmp_timeout'] = '30';
-		if (empty($pconfig['stream5_mem_cap']))
-			$pconfig['stream5_mem_cap']= '8388608';
+		if (empty($rule['stream5_reassembly']))
+			$rule['stream5_reassembly'] = 'on';
+		if (empty($rule['stream5_flush_on_alert']))
+			$rule['stream5_flush_on_alert'] = 'off';
+		if (empty($rule['stream5_prune_log_max']))
+			$rule['stream5_prune_log_max'] = '1048576';
+		if (empty($rule['stream5_track_tcp']))
+			$rule['stream5_track_tcp'] = 'on';
+		if (empty($rule['stream5_max_tcp']))
+			$rule['stream5_max_tcp'] = '262144';
+		if (empty($rule['stream5_track_udp']))
+			$rule['stream5_track_udp'] = 'on';
+		if (empty($rule['stream5_max_udp']))
+			$rule['stream5_max_udp'] = '131072';
+		if (empty($rule['stream5_udp_timeout']))
+			$rule['stream5_udp_timeout'] = '30';
+		if (empty($rule['stream5_track_icmp']))
+			$rule['stream5_track_icmp'] = 'off';
+		if (empty($rule['stream5_max_icmp']))
+			$rule['stream5_max_icmp'] = '65536';
+		if (empty($rule['stream5_icmp_timeout']))
+			$rule['stream5_icmp_timeout'] = '30';
+		if (empty($rule['stream5_mem_cap']))
+			$rule['stream5_mem_cap']= '8388608';
 
 		// Put any old values in new default engine and remove old value
-		if (isset($pconfig['stream5_policy']))
-			$default['policy'] = $pconfig['stream5_policy'];
-		unset($pconfig['stream5_policy']);
-		if (isset($pconfig['stream5_tcp_timeout']) && is_numeric($pconfig['stream5_tcp_timeout']))
-			$default['timeout'] = $pconfig['stream5_tcp_timeout'];
-		unset($pconfig['stream5_tcp_timeout']);
-		if (isset($pconfig['stream5_overlap_limit']) && is_numeric($pconfig['stream5_overlap_limit']))
-			$default['overlap_limit'] = $pconfig['stream5_overlap_limit'];
-		unset($pconfig['stream5_overlap_limit']);
-		if (isset($pconfig['stream5_require_3whs']))
-			$default['require_3whs'] = $pconfig['stream5_require_3whs'];
-		unset($pconfig['stream5_require_3whs']);
-		if (isset($pconfig['stream5_no_reassemble_async']))
-			$default['no_reassemble_async'] = $pconfig['stream5_no_reassemble_async'];
-		unset($pconfig['stream5_no_reassemble_async']);
-		if (isset($pconfig['stream5_dont_store_lg_pkts']))
-			$default['dont_store_lg_pkts'] = $pconfig['stream5_dont_store_lg_pkts'];
-		unset($pconfig['stream5_dont_store_lg_pkts']);
-		if (isset($pconfig['max_queued_bytes']) && is_numeric($pconfig['max_queued_bytes']))
-			$default['max_queued_bytes'] = $pconfig['max_queued_bytes'];
-		unset($pconfig['max_queued_bytes']);
-		if (isset($pconfig['max_queued_segs']) && is_numeric($pconfig['max_queued_segs']))
-			$default['max_queued_segs'] = $pconfig['max_queued_segs'];
-		unset($pconfig['max_queued_segs']);
+		if (isset($rule['stream5_policy']))
+			$default['policy'] = $rule['stream5_policy'];
+		unset($rule['stream5_policy']);
+		if (isset($rule['stream5_tcp_timeout']) && is_numeric($rule['stream5_tcp_timeout']))
+			$default['timeout'] = $rule['stream5_tcp_timeout'];
+		unset($rule['stream5_tcp_timeout']);
+		if (isset($rule['stream5_overlap_limit']) && is_numeric($rule['stream5_overlap_limit']))
+			$default['overlap_limit'] = $rule['stream5_overlap_limit'];
+		unset($rule['stream5_overlap_limit']);
+		if (isset($rule['stream5_require_3whs']))
+			$default['require_3whs'] = $rule['stream5_require_3whs'];
+		unset($rule['stream5_require_3whs']);
+		if (isset($rule['stream5_no_reassemble_async']))
+			$default['no_reassemble_async'] = $rule['stream5_no_reassemble_async'];
+		unset($rule['stream5_no_reassemble_async']);
+		if (isset($rule['stream5_dont_store_lg_pkts']))
+			$default['dont_store_lg_pkts'] = $rule['stream5_dont_store_lg_pkts'];
+		unset($rule['stream5_dont_store_lg_pkts']);
+		if (isset($rule['max_queued_bytes']) && is_numeric($rule['max_queued_bytes']))
+			$default['max_queued_bytes'] = $rule['max_queued_bytes'];
+		unset($rule['max_queued_bytes']);
+		if (isset($rule['max_queued_segs']) && is_numeric($rule['max_queued_segs']))
+			$default['max_queued_segs'] = $rule['max_queued_segs'];
+		unset($rule['max_queued_segs']);
 
-		$pconfig['stream5_tcp_engine']['item'] = array();
-		$pconfig['stream5_tcp_engine']['item'][] = $default;
+		$rule['stream5_tcp_engine']['item'] = array();
+		$rule['stream5_tcp_engine']['item'][] = $default;
 	}
 
 	// Create a default HTTP_INSPECT engine if none are configured
-	if (empty($pconfig['http_inspect_engine']['item'])) {
+	if (empty($rule['http_inspect_engine']['item'])) {
 		$updated_cfg = true;
-		log_error("[Snort] Migrating HTTP_Inspect Engine configuration for interface {$pconfig['descr']}...");
+		syslog(LOG_NOTICE, "[Snort] Migrating HTTP_Inspect Engine configuration for interface {$rule['descr']}...");
 		$default = array( "name" => "default", "bind_to" => "all", "server_profile" => "all", "enable_xff" => "off", 
 				"log_uri" => "off", "log_hostname" => "off", "server_flow_depth" => 65535, "enable_cookie" => "on", 
 				"client_flow_depth" => 1460, "extended_response_inspection" => "on", "no_alerts" => "off", 
@@ -351,97 +377,97 @@ foreach ($config['installedpackages']['snortglobal']['rule'] as &$r) {
 				"decompress_swf" => "off", "decompress_pdf" => "off" );
 
 		// Ensure sensible default values exist for global HTTP_INSPECT parameters
-		if (empty($pconfig['http_inspect']))
-			$pconfig['http_inspect'] = "on";
-		if (empty($pconfig['http_inspect_proxy_alert']))
-			$pconfig['http_inspect_proxy_alert'] = "off";
-		if (empty($pconfig['http_inspect_memcap']))
-			$pconfig['http_inspect_memcap'] = "150994944";
-		if (empty($pconfig['http_inspect_max_gzip_mem']))
-			$pconfig['http_inspect_max_gzip_mem'] = "838860";
+		if (empty($rule['http_inspect']))
+			$rule['http_inspect'] = "on";
+		if (empty($rule['http_inspect_proxy_alert']))
+			$rule['http_inspect_proxy_alert'] = "off";
+		if (empty($rule['http_inspect_memcap']))
+			$rule['http_inspect_memcap'] = "150994944";
+		if (empty($rule['http_inspect_max_gzip_mem']))
+			$rule['http_inspect_max_gzip_mem'] = "838860";
 
 		// Put any old values in new default engine and remove old value
-		if (isset($pconfig['server_flow_depth']) && is_numeric($pconfig['server_flow_depth']))
-			$default['server_flow_depth'] = $pconfig['server_flow_depth'];
-		unset($pconfig['server_flow_depth']);
-		if (isset($pconfig['client_flow_depth']) & is_numeric($pconfig['client_flow_depth']))
-			$default['client_flow_depth'] = $pconfig['client_flow_depth'];
-		unset($pconfig['client_flow_depth']);
-		if (isset($pconfig['http_server_profile']))
-			$default['server_profile'] = $pconfig['http_server_profile'];
-		unset($pconfig['http_server_profile']);
-		if (isset($pconfig['http_inspect_enable_xff']))
-			$default['enable_xff'] = $pconfig['http_inspect_enable_xff'];
-		unset($pconfig['http_inspect_enable_xff']);
-		if (isset($pconfig['http_inspect_log_uri']))
-			$default['log_uri'] = $pconfig['http_inspect_log_uri'];
-		unset($pconfig['http_inspect_log_uri']);
-		if (isset($pconfig['http_inspect_log_hostname']))
-			$default['log_hostname'] = $pconfig['http_inspect_log_hostname'];
-		unset($pconfig['http_inspect_log_hostname']);
-		if (isset($pconfig['noalert_http_inspect']))
-			$default['no_alerts'] = $pconfig['noalert_http_inspect'];
-		unset($pconfig['noalert_http_inspect']);
+		if (isset($rule['server_flow_depth']) && is_numeric($rule['server_flow_depth']))
+			$default['server_flow_depth'] = $rule['server_flow_depth'];
+		unset($rule['server_flow_depth']);
+		if (isset($rule['client_flow_depth']) & is_numeric($rule['client_flow_depth']))
+			$default['client_flow_depth'] = $rule['client_flow_depth'];
+		unset($rule['client_flow_depth']);
+		if (isset($rule['http_server_profile']))
+			$default['server_profile'] = $rule['http_server_profile'];
+		unset($rule['http_server_profile']);
+		if (isset($rule['http_inspect_enable_xff']))
+			$default['enable_xff'] = $rule['http_inspect_enable_xff'];
+		unset($rule['http_inspect_enable_xff']);
+		if (isset($rule['http_inspect_log_uri']))
+			$default['log_uri'] = $rule['http_inspect_log_uri'];
+		unset($rule['http_inspect_log_uri']);
+		if (isset($rule['http_inspect_log_hostname']))
+			$default['log_hostname'] = $rule['http_inspect_log_hostname'];
+		unset($rule['http_inspect_log_hostname']);
+		if (isset($rule['noalert_http_inspect']))
+			$default['no_alerts'] = $rule['noalert_http_inspect'];
+		unset($rule['noalert_http_inspect']);
 
-		$pconfig['http_inspect_engine']['item'] = array();
-		$pconfig['http_inspect_engine']['item'][] = $default;
+		$rule['http_inspect_engine']['item'] = array();
+		$rule['http_inspect_engine']['item'][] = $default;
 	}
 
 	// Create a default FTP_CLIENT engine if none are configured
-	if (empty($pconfig['ftp_client_engine']['item'])) {
+	if (empty($rule['ftp_client_engine']['item'])) {
 		$updated_cfg = true;
-		log_error("[Snort] Migrating FTP Client Engine configuration for interface {$pconfig['descr']}...");
+		syslog(LOG_NOTICE, "[Snort] Migrating FTP Client Engine configuration for interface {$rule['descr']}...");
 		$default = array( "name" => "default", "bind_to" => "all", "max_resp_len" => 256, 
 				  "telnet_cmds" => "no", "ignore_telnet_erase_cmds" => "yes", 
 				  "bounce" => "yes", "bounce_to_net" => "", "bounce_to_port" => "" );
 
 		// Set defaults for new FTP_Telnet preprocessor configurable parameters
-		if (empty($pconfig['ftp_telnet_inspection_type']))
-			$pconfig['ftp_telnet_inspection_type'] = 'stateful';
-		if (empty($pconfig['ftp_telnet_alert_encrypted']))
-			$pconfig['ftp_telnet_alert_encrypted'] = 'off';
-		if (empty($pconfig['ftp_telnet_check_encrypted']))
-			$pconfig['ftp_telnet_check_encrypted'] = 'on';
-		if (empty($pconfig['ftp_telnet_normalize']))
-			$pconfig['ftp_telnet_normalize'] = 'on';
-		if (empty($pconfig['ftp_telnet_detect_anomalies']))
-			$pconfig['ftp_telnet_detect_anomalies'] = 'on';
-		if (empty($pconfig['ftp_telnet_ayt_attack_threshold']))
-			$pconfig['ftp_telnet_ayt_attack_threshold'] = '20';
+		if (empty($rule['ftp_telnet_inspection_type']))
+			$rule['ftp_telnet_inspection_type'] = 'stateful';
+		if (empty($rule['ftp_telnet_alert_encrypted']))
+			$rule['ftp_telnet_alert_encrypted'] = 'off';
+		if (empty($rule['ftp_telnet_check_encrypted']))
+			$rule['ftp_telnet_check_encrypted'] = 'on';
+		if (empty($rule['ftp_telnet_normalize']))
+			$rule['ftp_telnet_normalize'] = 'on';
+		if (empty($rule['ftp_telnet_detect_anomalies']))
+			$rule['ftp_telnet_detect_anomalies'] = 'on';
+		if (empty($rule['ftp_telnet_ayt_attack_threshold']))
+			$rule['ftp_telnet_ayt_attack_threshold'] = '20';
 
 		// Add new FTP_Telnet Client default engine
-		$pconfig['ftp_client_engine']['item'] = array();
-		$pconfig['ftp_client_engine']['item'][] = $default;
+		$rule['ftp_client_engine']['item'] = array();
+		$rule['ftp_client_engine']['item'][] = $default;
 	}
 
 	// Create a default FTP_SERVER engine if none are configured
-	if (empty($pconfig['ftp_server_engine']['item'])) {
+	if (empty($rule['ftp_server_engine']['item'])) {
 		$updated_cfg = true;
-		log_error("[Snort] Migrating FTP Server Engine configuration for interface {$pconfig['descr']}...");
+		syslog(LOG_NOTICE, "[Snort] Migrating FTP Server Engine configuration for interface {$rule['descr']}...");
 		$default = array( "name" => "default", "bind_to" => "all", "ports" => "default", 
 				  "telnet_cmds" => "no", "ignore_telnet_erase_cmds" => "yes", 
 				  "ignore_data_chan" => "no", "def_max_param_len" => 100 );
 
 		// Add new FTP_Telnet Server default engine
-		$pconfig['ftp_server_engine']['item'] = array();
-		$pconfig['ftp_server_engine']['item'][] = $default;
+		$rule['ftp_server_engine']['item'] = array();
+		$rule['ftp_server_engine']['item'][] = $default;
 	}
 
 	// Set sensible defaults for new SDF options if SDF is enabled
-	if ($pconfig['sensitive_data'] == 'on') {
-		if (empty($pconfig['sdf_alert_threshold'])) {
-			$pconfig['sdf_alert_threshold'] = 25;
+	if ($rule['sensitive_data'] == 'on') {
+		if (empty($rule['sdf_alert_threshold'])) {
+			$rule['sdf_alert_threshold'] = 25;
 			$updated_cfg = true;
 		}
-		if (empty($pconfig['sdf_alert_data_type'])) {
-			$pconfig['sdf_alert_data_type'] = "Credit Card,Email Addresses,U.S. Phone Numbers,U.S. Social Security Numbers";
+		if (empty($rule['sdf_alert_data_type'])) {
+			$rule['sdf_alert_data_type'] = "Credit Card,Email Addresses,U.S. Phone Numbers,U.S. Social Security Numbers";
 			$updated_cfg = true;
 		}
 	}
 
 	// Change any ENABLE_SID settings to new format of GID:SID
-	if (!empty($pconfig['rule_sid_on'])) {
-		$tmp = explode("||", $pconfig['rule_sid_on']);
+	if (!empty($rule['rule_sid_on'])) {
+		$tmp = explode("||", $rule['rule_sid_on']);
 		$new_tmp = "";
 		foreach ($tmp as $v) {
 			if (strpos($v, ":") === false) {
@@ -451,14 +477,14 @@ foreach ($config['installedpackages']['snortglobal']['rule'] as &$r) {
 		}
 		$new_tmp = rtrim($new_tmp, " ||");
 		if (!empty($new_tmp)) {
-			$pconfig['rule_sid_on'] = $new_tmp;
+			$rule['rule_sid_on'] = $new_tmp;
 			$updated_cfg = true;
 		}
 	}
 
 	// Change any DISABLE_SID settings to new format of GID:SID
-	if (!empty($pconfig['rule_sid_off'])) {
-		$tmp = explode("||", $pconfig['rule_sid_off']);
+	if (!empty($rule['rule_sid_off'])) {
+		$tmp = explode("||", $rule['rule_sid_off']);
 		$new_tmp = "";
 		foreach ($tmp as $v) {
 			if (strpos($v, ":") === false) {
@@ -468,138 +494,138 @@ foreach ($config['installedpackages']['snortglobal']['rule'] as &$r) {
 		}
 		$new_tmp = rtrim($new_tmp, " ||");
 		if (!empty($new_tmp)) {
-			$pconfig['rule_sid_off'] = $new_tmp;
+			$rule['rule_sid_off'] = $new_tmp;
 			$updated_cfg = true;
 		}
 	}
 
 	// Migrate new POP3 preprocessor parameter settings
-	if (empty($pconfig['pop_memcap'])) {
-		$pconfig['pop_memcap'] = "838860";
+	if (empty($rule['pop_memcap'])) {
+		$rule['pop_memcap'] = "838860";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['pop_b64_decode_depth']) && $pconfig['pop_b64_decode_depth'] != '0') {
-		$pconfig['pop_b64_decode_depth'] = "0";
+	if (empty($rule['pop_b64_decode_depth']) && $rule['pop_b64_decode_depth'] != '0') {
+		$rule['pop_b64_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['pop_qp_decode_depth']) && $pconfig['pop_qp_decode_depth'] != '0') {
-		$pconfig['pop_qp_decode_depth'] = "0";
+	if (empty($rule['pop_qp_decode_depth']) && $rule['pop_qp_decode_depth'] != '0') {
+		$rule['pop_qp_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['pop_bitenc_decode_depth']) && $pconfig['pop_bitenc_decode_depth'] != '0') {
-		$pconfig['pop_bitenc_decode_depth'] = "0";
+	if (empty($rule['pop_bitenc_decode_depth']) && $rule['pop_bitenc_decode_depth'] != '0') {
+		$rule['pop_bitenc_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['pop_uu_decode_depth']) && $pconfig['pop_uu_decode_depth'] != '0') {
-		$pconfig['pop_uu_decode_depth'] = "0";
+	if (empty($rule['pop_uu_decode_depth']) && $rule['pop_uu_decode_depth'] != '0') {
+		$rule['pop_uu_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
 
 	// Migrate new IMAP preprocessor parameter settings
-	if (empty($pconfig['imap_memcap'])) {
-		$pconfig['imap_memcap'] = "838860";
+	if (empty($rule['imap_memcap'])) {
+		$rule['imap_memcap'] = "838860";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['imap_b64_decode_depth']) && $pconfig['imap_b64_decode_depth'] != '0') {
-		$pconfig['imap_b64_decode_depth'] = "0";
+	if (empty($rule['imap_b64_decode_depth']) && $rule['imap_b64_decode_depth'] != '0') {
+		$rule['imap_b64_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['imap_qp_decode_depth']) && $pconfig['imap_qp_decode_depth'] != '0') {
-		$pconfig['imap_qp_decode_depth'] = "0";
+	if (empty($rule['imap_qp_decode_depth']) && $rule['imap_qp_decode_depth'] != '0') {
+		$rule['imap_qp_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['imap_bitenc_decode_depth']) && $pconfig['imap_bitenc_decode_depth'] != '0') {
-		$pconfig['imap_bitenc_decode_depth'] = "0";
+	if (empty($rule['imap_bitenc_decode_depth']) && $rule['imap_bitenc_decode_depth'] != '0') {
+		$rule['imap_bitenc_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['imap_uu_decode_depth']) && $pconfig['imap_uu_decode_depth'] != '0') {
-		$pconfig['imap_uu_decode_depth'] = "0";
+	if (empty($rule['imap_uu_decode_depth']) && $rule['imap_uu_decode_depth'] != '0') {
+		$rule['imap_uu_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
 
 	// Migrate new SMTP preprocessor parameter settings
-	if (empty($pconfig['smtp_memcap'])) {
-		$pconfig['smtp_memcap'] = "838860";
+	if (empty($rule['smtp_memcap'])) {
+		$rule['smtp_memcap'] = "838860";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_max_mime_mem'])) {
-		$pconfig['smtp_max_mime_mem'] = "838860";
+	if (empty($rule['smtp_max_mime_mem'])) {
+		$rule['smtp_max_mime_mem'] = "838860";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_b64_decode_depth']) && $pconfig['smtp_b64_decode_depth'] != "0") {
-		$pconfig['smtp_b64_decode_depth'] = "0";
+	if (empty($rule['smtp_b64_decode_depth']) && $rule['smtp_b64_decode_depth'] != "0") {
+		$rule['smtp_b64_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_qp_decode_depth']) && $pconfig['smtp_qp_decode_depth'] != "0") {
-		$pconfig['smtp_qp_decode_depth'] = "0";
+	if (empty($rule['smtp_qp_decode_depth']) && $rule['smtp_qp_decode_depth'] != "0") {
+		$rule['smtp_qp_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_bitenc_decode_depth']) && $pconfig['smtp_bitenc_decode_depth'] != "0") {
-		$pconfig['smtp_bitenc_decode_depth'] = "0";
+	if (empty($rule['smtp_bitenc_decode_depth']) && $rule['smtp_bitenc_decode_depth'] != "0") {
+		$rule['smtp_bitenc_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_uu_decode_depth']) && $pconfig['smtp_uu_decode_depth'] != "0") {
-		$pconfig['smtp_uu_decode_depth'] = "0";
+	if (empty($rule['smtp_uu_decode_depth']) && $rule['smtp_uu_decode_depth'] != "0") {
+		$rule['smtp_uu_decode_depth'] = "0";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_email_hdrs_log_depth'])) {
-		$pconfig['smtp_email_hdrs_log_depth'] = "1464";
+	if (empty($rule['smtp_email_hdrs_log_depth'])) {
+		$rule['smtp_email_hdrs_log_depth'] = "1464";
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_ignore_tls_data'])) {
-		$pconfig['smtp_ignore_tls_data'] = 'on';
+	if (empty($rule['smtp_ignore_tls_data'])) {
+		$rule['smtp_ignore_tls_data'] = 'on';
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_log_mail_from'])) {
-		$pconfig['smtp_log_mail_from'] = 'on';
+	if (empty($rule['smtp_log_mail_from'])) {
+		$rule['smtp_log_mail_from'] = 'on';
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_log_rcpt_to'])) {
-		$pconfig['smtp_log_rcpt_to'] = 'on';
+	if (empty($rule['smtp_log_rcpt_to'])) {
+		$rule['smtp_log_rcpt_to'] = 'on';
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_log_filename'])) {
-		$pconfig['smtp_log_filename'] = 'on';
+	if (empty($rule['smtp_log_filename'])) {
+		$rule['smtp_log_filename'] = 'on';
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smtp_log_email_hdrs'])) {
-		$pconfig['smtp_log_email_hdrs'] = 'on';
+	if (empty($rule['smtp_log_email_hdrs'])) {
+		$rule['smtp_log_email_hdrs'] = 'on';
 		$updated_cfg = true;
 	}
 
 	// Default any unconfigured AppID preprocessor settings
-	if (empty($pconfig['appid_preproc'])) {
-		$pconfig['appid_preproc'] = 'off';
+	if (empty($rule['appid_preproc'])) {
+		$rule['appid_preproc'] = 'off';
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['sf_appid_mem_cap'])) {
-		$pconfig['sf_appid_mem_cap'] = '256';
+	if (empty($rule['sf_appid_mem_cap'])) {
+		$rule['sf_appid_mem_cap'] = '256';
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['sf_appid_statslog'])) {
-		$pconfig['sf_appid_statslog'] = 'on';
+	if (empty($rule['sf_appid_statslog'])) {
+		$rule['sf_appid_statslog'] = 'on';
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['sf_appid_stats_period'])) {
-		$pconfig['sf_appid_stats_period'] = '300';
+	if (empty($rule['sf_appid_stats_period'])) {
+		$rule['sf_appid_stats_period'] = '300';
 		$updated_cfg = true;
 	}
 
 	// Check for and fix an incorrect value for <blockoffendersip>.
 	// The value should be a string and not the index of the string.
 	// This corrects for the impact of a Bootstrap conversion bug.
-	if ($pconfig['blockoffendersip'] == '0' || $pconfig['blockoffendersip'] == '1' || $pconfig['blockoffendersip'] == '2') {
-		switch ($pconfig['blockoffendersip']) {
+	if ($rule['blockoffendersip'] == '0' || $rule['blockoffendersip'] == '1' || $rule['blockoffendersip'] == '2') {
+		switch ($rule['blockoffendersip']) {
 			case '0':
-				$pconfig['blockoffendersip'] = 'src';
+				$rule['blockoffendersip'] = 'src';
 				break;
 
 			case '1':
-				$pconfig['blockoffendersip'] = 'dst';
+				$rule['blockoffendersip'] = 'dst';
 				break;
 
 			case '2':
-				$pconfig['blockoffendersip'] = 'both';
+				$rule['blockoffendersip'] = 'both';
 				break;
 
 			default:
@@ -609,45 +635,53 @@ foreach ($config['installedpackages']['snortglobal']['rule'] as &$r) {
 	}
 
 	// Configure a default interface snaplen if not previously configured
-	if (!isset($pconfig['snaplen'])) {
-		$pconfig['snaplen'] = '1518';
+	if (!isset($rule['snaplen'])) {
+		$rule['snaplen'] = '1518';
 		$updated_cfg = true;
 	}
 
 	// Configure new SSH preprocessor parameter defaults if not already set
-	if (!isset($pconfig['ssh_preproc_ports'])) {
-		$pconfig['ssh_preproc_ports'] = '22';
+	if (!isset($rule['ssh_preproc_ports'])) {
+		$rule['ssh_preproc_ports'] = '22';
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['ssh_preproc_max_encrypted_packets'])) {
-		$pconfig['ssh_preproc_max_encrypted_packets'] = 20;
+	if (!isset($rule['ssh_preproc_max_encrypted_packets'])) {
+		$rule['ssh_preproc_max_encrypted_packets'] = 20;
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['ssh_preproc_max_client_bytes'])) {
-		$pconfig['ssh_preproc_max_client_bytes'] = 19600;
+	if (!isset($rule['ssh_preproc_max_client_bytes'])) {
+		$rule['ssh_preproc_max_client_bytes'] = 19600;
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['ssh_preproc_max_server_version_len'])) {
-		$pconfig['ssh_preproc_max_server_version_len'] = 100;
+	if (!isset($rule['ssh_preproc_max_server_version_len'])) {
+		$rule['ssh_preproc_max_server_version_len'] = 100;
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['ssh_preproc_enable_respoverflow'])) {
-		$pconfig['ssh_preproc_enable_respoverflow'] = 'on';
+	if (!isset($rule['ssh_preproc_enable_respoverflow'])) {
+		$rule['ssh_preproc_enable_respoverflow'] = 'on';
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['ssh_preproc_enable_srvoverflow'])) {
-		$pconfig['ssh_preproc_enable_srvoverflow'] = 'on';
+	if (!isset($rule['ssh_preproc_enable_srvoverflow'])) {
+		$rule['ssh_preproc_enable_srvoverflow'] = 'on';
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['ssh_preproc_enable_ssh1crc32'])) {
-		$pconfig['ssh_preproc_enable_ssh1crc32'] = 'on';
+	if (!isset($rule['ssh_preproc_enable_ssh1crc32'])) {
+		$rule['ssh_preproc_enable_ssh1crc32'] = 'on';
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['ssh_preproc_enable_protomismatch'])) {
-		$pconfig['ssh_preproc_enable_protomismatch'] = 'on';
+	if (!isset($rule['ssh_preproc_enable_protomismatch'])) {
+		$rule['ssh_preproc_enable_protomismatch'] = 'on';
 		$updated_cfg = true;
 	}
 	// End new SSH parameters
+
+	/**********************************************************/
+	/* Create new interface IPS mode setting if not set       */
+	/**********************************************************/
+	if (empty($rule['ips_mode'])) {
+		$rule['ips_mode'] = 'ips_mode_legacy';
+		$updated_cfg = true;
+	}
 
 	/**********************************************************/
 	/* Migrate any enabled Unified logging from Barnyard2 to  */
@@ -804,19 +838,16 @@ foreach ($config['installedpackages']['snortglobal']['rule'] as &$r) {
 	/**********************************************************/
 	/* End Barnyard2 parameter removal                        */
 	/**********************************************************/
-
-	// Save the new configuration data into the $config array pointer
-	$r = $pconfig;
 }
-// Release reference to final array element
-unset($r);
+// Release reference to config array
+unset($rule);
 
 // Log a message if we changed anything
 if ($updated_cfg) {
-	log_error("[Snort] Settings successfully migrated to new configuration format...");
+	syslog(LOG_NOTICE, "[Snort] Settings successfully migrated to new configuration format...");
 }
 else {
-	log_error("[Snort] Configuration version is current...");
+	syslog(LOG_NOTICE, "[Snort] Configuration version is current...");
 }
 
 ?>

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_uninstall.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2020 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2020 Bill Meeks
+ * Copyright (c) 2013-2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,12 +37,12 @@ require("/usr/local/pkg/snort/snort_defs.inc");
 global $config, $g;
 
 $snortdir = SNORTDIR;
-$snortlibdir = SNORT_PBI_BASEDIR . "lib";
+$snortlibdir = SNORT_BASEDIR . "lib";
 $snortlogdir = SNORTLOGDIR;
 $rcdir = RCFILEPREFIX;
 $snort_rules_upd_log = SNORT_RULES_UPD_LOGFILE;
 
-log_error(gettext("[Snort] Snort package uninstall in progress..."));
+syslog(LOG_NOTICE, gettext("[Snort] Snort package uninstall in progress..."));
 
 // Remove our rc.d startup shell script
 unlink_if_exists("{$rcdir}snort.sh");
@@ -50,7 +50,7 @@ unlink_if_exists("{$rcdir}snort.sh");
 // Make sure all active Snort processes are terminated
 // Log a message only if a running process is detected
 if (is_process_running("snort")) {
-	log_error(gettext("[Snort] Snort STOP on all interfaces..."));
+	syslog(LOG_NOTICE, gettext("[Snort] Snort STOP on all interfaces..."));
 	snort_stop_all_interfaces();
 }
 sleep(2);
@@ -65,7 +65,7 @@ unlink_if_exists("{$g['varrun_path']}/snort_*.pid");
 // Make sure all active Barnyard2 processes are terminated
 // Log a message only if a running process is detected
 if (is_process_running("barnyard2")) {
-	log_error(gettext("[Snort] Barnyard2 STOP on all interfaces..."));
+	syslog(LOG_NOTICE, gettext("[Snort] Barnyard2 STOP on all interfaces..."));
 }
 mwexec('/usr/bin/killall -z barnyard2', true);
 sleep(2);
@@ -112,13 +112,13 @@ if (!empty($widgets)) {
 
 // See if we are to clear blocked hosts on uninstall
 if ($config['installedpackages']['snortglobal']['clearblocks'] == 'on') {
-	log_error(gettext("[Snort] Removing all blocked hosts from <snort2c> table..."));
+	syslog(LOG_NOTICE, gettext("[Snort] Removing all blocked hosts from <snort2c> table..."));
 	mwexec("/sbin/pfctl -t snort2c -T flush");
 }
 
 // See if we are to clear Snort log files on uninstall
 if ($config['installedpackages']['snortglobal']['clearlogs'] == 'on') {
-	log_error(gettext("[Snort] Clearing all Snort-related log files..."));
+	syslog(LOG_NOTICE, gettext("[Snort] Clearing all Snort-related log files..."));
 	unlink_if_exists("{$snort_rules_upd_log}");
 	rmdir_recursive($snortlogdir);
 }
@@ -178,17 +178,17 @@ if (($config['installedpackages']['snortglobal']['clearblocks'] != 'off') ||
 /* has elected to not retain the package configuration.   */
 /**********************************************************/
 if ($config['installedpackages']['snortglobal']['forcekeepsettings'] != 'on') {
-	log_error(gettext("[Snort] Not saving settings... all Snort configuration info and logs will be deleted..."));
+	syslog(LOG_NOTICE, gettext("[Snort] Not saving settings... all Snort configuration info and logs will be deleted..."));
 	unset($config['installedpackages']['snortglobal']);
 	unset($config['installedpackages']['snortsync']);
 	unlink_if_exists("{$snort_rules_upd_log}");
 	rmdir_recursive("{$snortlogdir}");
 	rmdir_recursive("{$g['vardb_path']}/snort");
 	write_config("Removing Snort configuration");
-	log_error(gettext("[Snort] The package has been completely removed from this system."));
+	syslog(LOG_NOTICE, gettext("[Snort] The package and its configuration has been completely removed from this system."));
 }
 else {
-	log_error(gettext("[Snort] Package files removed but all Snort configuration info has been retained."));
+	syslog(LOG_NOTICE, gettext("[Snort] Package files removed but all Snort configuration info has been retained."));
 }
 
 return true;

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -108,6 +108,9 @@ function snort_add_supplist_entry($suppress) {
 		}
 	}
 
+	// Release config array reference
+	unset($a_suppress);
+
 	/* If we created a new list or updated an existing one, save the change, */
 	/* tell Snort to load it, and return true; otherwise return false.       */
 	if ($found_list) {
@@ -178,6 +181,18 @@ $if_real = get_real_interface($a_instance[$instanceid]['interface']);
 // Load up the arrays of force-enabled and force-disabled SIDs
 $enablesid = snort_load_sid_mods($a_instance[$instanceid]['rule_sid_on']);
 $disablesid = snort_load_sid_mods($a_instance[$instanceid]['rule_sid_off']);
+
+// Load up the arrays of forced-alert, forced-drop or forced-reject
+// rules as applicable to the current IPS mode.
+if ($a_instance[$instanceid]['blockoffenders7'] == 'on' && $a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline') {
+	$alertsid = snort_load_sid_mods($a_instance[$instanceid]['rule_sid_force_alert']);
+	$dropsid = snort_load_sid_mods($a_instance[$instanceid]['rule_sid_force_drop']);
+
+	// REJECT forcing is only applicable to Inline IPS Mode
+	if ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' ) {
+		$rejectsid = snort_load_sid_mods($a_instance[$instanceid]['rule_sid_force_reject']);
+	}
+}
 
 $pconfig = array();
 $pconfig['instance'] = $instanceid;
@@ -252,6 +267,8 @@ if ($_POST['filterlogentries_submit']) {
 	$filterfieldsarray[10] = null;
 	$filterfieldsarray[11] = $_POST['filterlogentries_classification'] ? $_POST['filterlogentries_classification'] : null;
 	$filterfieldsarray[12] = $_POST['filterlogentries_priority'] ? $_POST['filterlogentries_priority'] : null;
+	$filterfieldsarray[13] = $_POST['filterlogentries_action'] ? $_POST['filterlogentries_action'] : null;
+	$filterfieldsarray[14] = null;
 }
 
 if ($_POST['filterlogentries_clear']) {
@@ -267,7 +284,7 @@ if ($_POST['save']) {
 	$config['installedpackages']['snortglobal']['alertsblocks']['alertnumber'] = $_POST['alertnumber'];
 
 	write_config("Snort pkg: updated ALERTS tab settings.");
-
+	unset($a_instance);
 	header("Location: /snort/snort_alerts.php?instance={$instanceid}");
 	exit;
 }
@@ -391,6 +408,143 @@ if ($_POST['mode'] == 'togglesid' && is_numeric($_POST['sidid']) && is_numeric($
 	$savemsg = gettext("The state for rule {$gid}:{$sid} has been modified.  Snort is 'live-reloading' the new rules list.  Please wait at least 15 secs for the process to complete before toggling additional rules.");
 }
 
+if (isset($_POST['rule_action_save']) && $_POST['mode'] == "toggle_action" && isset($_POST['ruleActionOptions']) && is_numeric($_POST['sidid']) && is_numeric($_POST['gen_id'])) {
+
+	// Get the GID:SID tags embedded in the clicked rule icon.
+	$gid = $_POST['gen_id'];
+	$sid = $_POST['sidid'];
+
+	// Get the posted rule action
+	$action = $_POST['ruleActionOptions'];
+
+	// Put the target SID in the appropriate lists of modified
+	// SID actions based on the requested action; if default
+	// action is requested, remove the SID from all SID modified
+	// action lists.
+	switch ($action) {
+		case "action_default":
+			if (isset($alertsid[$gid][$sid])) {
+				unset($alertsid[$gid][$sid]);
+			}
+			if (isset($dropsid[$gid][$sid])) {
+				unset($dropsid[$gid][$sid]);
+			}
+			if (isset($rejectsid[$gid][$sid])) {
+				unset($rejectsid[$gid][$sid]);
+			}
+			break;
+
+		case "action_alert":
+			if (!is_array($alertsid[$gid])) {
+				$alertsid[$gid] = array();
+			}
+			if (!is_array($alertsid[$gid][$sid])) {
+				$alertsid[$gid][$sid] = array();
+			}
+			$alertsid[$gid][$sid] = "alertsid";
+			if (isset($dropsid[$gid][$sid])) {
+				unset($dropsid[$gid][$sid]);
+			}
+			if (isset($rejectsid[$gid][$sid])) {
+				unset($rejectsid[$gid][$sid]);
+			}
+			break;
+
+		case "action_drop":
+			if (!is_array($dropsid[$gid])) {
+				$dropsid[$gid] = array();
+			}
+			if (!is_array($dropsid[$gid][$sid])) {
+				$dropsid[$gid][$sid] = array();
+			}
+			$dropsid[$gid][$sid] = "dropsid";
+			if (isset($alertsid[$gid][$sid])) {
+				unset($alertsid[$gid][$sid]);
+			}
+			if (isset($rejectsid[$gid][$sid])) {
+				unset($rejectsid[$gid][$sid]);
+			}
+			break;
+
+		case "action_reject":
+			if (!is_array($rejectsid[$gid])) {
+				$rejectsid[$gid] = array();
+			}
+			if (!is_array($rejectsid[$gid][$sid])) {
+				$rejectsid[$gid][$sid] = array();
+			}
+			$rejectsid[$gid][$sid] = "rejectsid";
+			if (isset($alertsid[$gid][$sid])) {
+				unset($alertsid[$gid][$sid]);
+			}
+			if (isset($dropsid[$gid][$sid])) {
+				unset($dropsid[$gid][$sid]);
+			}
+			break;
+
+		default:
+			$input_errors[] = gettext("WARNING - unknown rule action of '{$action}' passed in $_POST parameter.  No change made to rule action.");
+	}
+
+	if (!$input_errors) {
+		// Write the updated forced rule action values to the config file.
+		$tmp = "";
+		foreach (array_keys($alertsid) as $k1) {
+			foreach (array_keys($alertsid[$k1]) as $k2)
+				$tmp .= "{$k1}:{$k2}||";
+		}
+		$tmp = rtrim($tmp, "||");
+
+		if (!empty($tmp))
+			$a_instance[$instanceid]['rule_sid_force_alert'] = $tmp;
+		else
+			unset($a_instance[$instanceid]['rule_sid_force_alert']);
+
+		$tmp = "";
+		foreach (array_keys($dropsid) as $k1) {
+			foreach (array_keys($dropsid[$k1]) as $k2)
+				$tmp .= "{$k1}:{$k2}||";
+		}
+		$tmp = rtrim($tmp, "||");
+
+		if (!empty($tmp))
+			$a_instance[$instanceid]['rule_sid_force_drop'] = $tmp;
+		else
+			unset($a_instance[$instanceid]['rule_sid_force_drop']);
+
+		$tmp = "";
+		foreach (array_keys($rejectsid) as $k1) {
+			foreach (array_keys($rejectsid[$k1]) as $k2)
+				$tmp .= "{$k1}:{$k2}||";
+		}
+		$tmp = rtrim($tmp, "||");
+
+		if (!empty($tmp))
+			$a_instance[$instanceid]['rule_sid_force_reject'] = $tmp;
+		else
+			unset($a_instance[$instanceid]['rule_sid_force_reject']);
+
+		/* Update the config.xml file. */
+		write_config("Snort pkg: User-forced rule action override applied for rule {$gid}:{$sid} on ALERTS tab for interface {$a_instance[$instanceid]['interface']}.");
+
+		/*************************************************/
+		/* Update the snort.conf file and rebuild the    */
+		/* rules for this interface.                     */
+		/*************************************************/
+		$rebuild_rules = true;
+		snort_generate_conf($a_instance[$instanceid]);
+		$rebuild_rules = false;
+
+		/* Signal Snort to live-load the new rules */
+		snort_reload_config($a_instance[$instanceid]);
+
+		// Sync to configured CARP slaves if any are enabled
+		snort_sync_on_changes();
+
+		$savemsg = gettext("The action for rule {$gid}:{$sid} has been modified.  Snort is 'live-reloading' the new rules list.  Please wait at least 15 secs for the process to complete before toggling additional rule actions.");
+	}
+}
+
 if ($_POST['clear']) {
 	snort_post_delete_logs($snort_uuid);
 	file_put_contents("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/alert", "");
@@ -398,6 +552,7 @@ if ($_POST['clear']) {
 	mwexec("/bin/chmod 660 {$snortlogdir}/*", true);
 	if (file_exists("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid"))
 		mwexec("/bin/pkill -HUP -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid -a");
+	unset($a_instance);
 	header("Location: /snort/snort_alerts.php?instance={$instanceid}");
 	exit;
 }
@@ -589,6 +744,12 @@ $group->add(new Form_Input(
 	'text',
 	$filterfieldsarray[11]
 ))->setHelp('Classification');
+$group->add(new Form_Select(
+	'filterlogentries_action',
+	null,
+	$filterfieldsarray[13],
+	array( 0 => "", "alert" => "Alert", "drop" => "Drop", "log" => "Log", "pass" => "Pass", "reject" => "Reject", "sdrop" => "SDrop" )
+))->setHelp('Action');
 $group->add(new Form_Checkbox(
 	'filterlogentries_exact_match',
 	'Exact Match Only',
@@ -697,7 +858,7 @@ print ($form);
 
 <div class="panel panel-default">
 	<div class="panel-heading">
-		<h2 class="panel-title">
+		<h2 class="panel-title" id="alert_panel_title">
 			<?php
 				if (!$filterfieldsarray)
 					printf(gettext("Last %s Alert Log Entries"), $pconfig['alertnumber']);
@@ -712,6 +873,7 @@ print ($form);
 			<thead>
 			   <tr class="sortableHeaderRowIdentifier text-nowrap">
 				<th data-sortable-type="date"><?=gettext("Date"); ?></th>
+				<th><?=gettext("Action"); ?></th>
 				<th data-sortable-type="numeric"><?=gettext("Pri"); ?></th>
 				<th><?=gettext("Proto"); ?></th>
 				<th><?=gettext("Class"); ?></th>
@@ -719,7 +881,7 @@ print ($form);
 				<th data-sortable-type="numeric"><?=gettext("SPort"); ?></th>
 				<th><?=gettext("Destination IP"); ?></th>
 				<th data-sortable-type="numeric"><?=gettext("DPort"); ?></th>
-				<th data-sortable-type="numeric"><?=gettext("SID"); ?></th>
+				<th data-sortable-type="numeric"><?=gettext("GID:SID"); ?></th>
 				<th data-sortable-type="alpha"><?=gettext("Description"); ?></th>
 			   </tr>
 			</thead>
@@ -732,11 +894,11 @@ if (file_exists("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/alert")) {
 	if (file_exists("{$g['tmp_path']}/alert_{$snort_uuid}")) {
 		$tmpblocked = array_flip(snort_get_blocked_ips());
 		$counter = 0;
-		/*                 0         1           2      3      4    5    6    7      8     9    10    11             12    */
-		/* File format timestamp,sig_generator,sig_id,sig_rev,msg,proto,src,srcport,dst,dstport,id,classification,priority */
+		/*                 0         1           2      3      4    5    6    7      8     9    10        11         12      13       14      */
+		/* File format timestamp,sig_generator,sig_id,sig_rev,msg,proto,src,srcport,dst,dstport,id,classification,priority,action,disposition */
 		$fd = fopen("{$g['tmp_path']}/alert_{$snort_uuid}", "r");
 		while (($fields = fgetcsv($fd, 1000, ',', '"')) !== FALSE) {
-			if(count($fields) < 13)
+			if(count($fields) < 14 || count($fields) > 15)
 				continue;
 
 			if ($filterlogentries && !snort_match_filter_field($fields, $filterfieldsarray, $filterlogentries_exact_match)) {
@@ -757,6 +919,63 @@ if (file_exists("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/alert")) {
 			$alert_priority = $fields[12];
 			/* Protocol */
 			$alert_proto = $fields[5];
+			/* Action */
+			if (isset($fields[13]) && $a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' && $a_instance[$instanceid]['blockoffenders7'] == 'on') {
+
+				switch ($fields[13]) {
+
+					case "alert":
+						$alert_action = '<i class="fa fa-exclamation-triangle icon-pointer text-warning text-center" title="';
+						if (isset($alertsid[$fields[1]][$fields[2]])) {
+							$alert_action .= gettext("Rule action is User-Forced to ALERT. Click to force a different action for this rule.");
+						}
+						else {
+							$alert_action .= gettext("Rule action is ALERT. Click to force a different action for this rule.");
+						}
+						break;
+
+					case "drop":
+						$alert_action = '<i class="fa fa-thumbs-down icon-pointer text-danger text-center" title="';
+						if (isset($dropsid[$fields[1]][$fields[2]])) {
+							$alert_action .= gettext("Rule action is User-Forced to DROP. Click to force a different action for this rule.");
+						}
+						else {
+							$alert_action .=  gettext("Rule action is DROP. Click to force a different action for this rule.");
+						}
+						break;
+
+					case "reject":
+						$alert_action = '<i class="fa fa-hand-stop-o icon-pointer text-warning text-center" title="';
+						if (isset($rejectsid[$fields[1]][$fields[2]])) {
+							$alert_action .= gettext("Rule action is User-Forced to REJECT. Click to force a different action for this rule.");
+						}
+						else {
+							$alert_action .= gettext("Rule action is REJECT. Click to force a different action for this rule.");
+						}
+						break;
+
+					case "sdrop":
+						$alert_action = '<i class="fa fa-thumbs-o-down icon-pointer text-danger text-center" title="' . gettext("Rule action is SDROP. Click to force a different action for this rule.");
+						break;
+
+					case "log":
+						$alert_action = '<i class="fa fa-tasks icon-pointer text-center" title="' . gettext("Rule action is LOG. Click to force a different action for this rule.") . '"</i>';
+						break;
+
+					case "pass":
+						$alert_action = '<i class="fa fa-thumbs-up icon-pointer text-success text-center" title="' . gettext("Rule action is PASS. Click to force a different action for this rule.");
+						break;
+
+					default:
+						$alert_action = '<i class="fa fa-question-circle icon-pointer text-danger text-center" title="' . gettext("Rule action is unrecognized!. Click to force a different action for this rule.");
+				}
+				$alert_action .= '" onClick="toggleAction(\'' . $fields[1] . '\', \'' . $fields[2] . '\');"</i>';
+			}
+			else {
+				$alert_action = '<i class="fa fa-exclamation-triangle text-warning text-center" title="' . gettext("Rule action is ALERT.") . '"</i>';
+			}
+			/* Disposition (not currently used, so just set to "Allow") */
+			$alert_disposition = isset($fields[14])?$fields[14]:gettext("Allow");
 
 			/* IP SRC */
 			$alert_ip_src = $fields[6];
@@ -820,7 +1039,7 @@ if (file_exists("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/alert")) {
 			/* IP DST Port */
 			$alert_dst_p = $fields[9];
 
-			/* SID */
+			/* GID:SID */
 			$alert_sid_str = "{$fields[1]}:{$fields[2]}";
 			if (!snort_is_alert_globally_suppressed($supplist, $fields[1], $fields[2])) {
 				$sidsupplink = "<i class=\"fa fa-plus-square-o icon-pointer\" onClick=\"encRuleSig('{$fields[1]}','{$fields[2]}','','{$alert_descr}');$('#mode').val('addsuppress');$('#formalert').submit();\"";
@@ -840,6 +1059,15 @@ if (file_exists("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/alert")) {
 				$sid_dsbl_link .= ' title="' . gettext("Force-disable this rule and remove it from current rules set.") . '"></i>';
 			}
 
+			/* Add icon for toggling rule action if applicable to current mode */
+			if ($a_instance[$instanceid]['blockoffenders7'] == 'on' && $a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline') {
+				$sid_action_link = "<i class=\"fa fa-pencil-square-o icon-pointer text-info\" onClick=\"toggleAction('{$fields[1]}', '{$fields[2]}');\"";
+				$sid_action_link .= ' title="' . gettext("Click to force a different action for this rule.") . '"></i>';
+			}
+			else {
+				$sid_action_link = '';
+			}
+
 			/* DESCRIPTION */
 			$alert_class = $fields[11];
 
@@ -847,6 +1075,7 @@ if (file_exists("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/alert")) {
 ?>
 			<tr class="text-nowrap">
 				<td><?=$alert_date; ?><br/><?=$alert_time; ?></td>
+				<td><?=$alert_action; ?></td>
 				<td><?=$alert_priority; ?></td>
 				<td><?=$alert_proto; ?></td>
 				<td style="word-wrap:break-word; white-space:normal"><?=$alert_class; ?></td>
@@ -854,7 +1083,7 @@ if (file_exists("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/alert")) {
 				<td><?=$alert_src_p; ?></td>
 				<td style="word-wrap:break-word; white-space:normal"><?=$alert_ip_dst;?></td>
 				<td><?=$alert_dst_p; ?></td>
-				<td><?=$alert_sid_str; ?><br/><?=$sidsupplink; ?>&nbsp;&nbsp;<?=$sid_dsbl_link; ?></td>
+				<td><?=$alert_sid_str; ?><br/><?=$sidsupplink; ?>&nbsp;&nbsp;<?=$sid_dsbl_link; ?>&nbsp;&nbsp;<?=$sid_action_link; ?></td>
 				<td style="word-wrap:break-word; white-space:normal"><?=$alert_descr; ?></td>
 			</tr>
 <?php
@@ -871,6 +1100,52 @@ if (file_exists("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/alert")) {
 </div>
 </div>
 
+<?php if ($a_instance[$instanceid]['blockoffenders7'] == 'on') : ?>
+	<!-- Modal Rule SID action selector window -->
+	<div class="modal fade" role="dialog" id="sid_action_selector">
+		<div class="modal-dialog">
+			<div class="modal-content">
+				<div class="modal-header">
+					<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+						<span aria-hidden="true">&times;</span>
+					</button>
+					<h3 class="modal-title"><?=gettext("Rule Action Selection")?></h3>
+				</div>
+				<div class="modal-body">
+					<h4><?=gettext("Choose desired rule action from selections below: ");?></h4>
+					<label class="radio-inline">
+						<input type="radio" form="formalert" name="ruleActionOptions" id="action_default" value="action_default"> <span class = "label label-default">Default</span>
+					</label>
+					<label class="radio-inline">
+						<input type="radio" form="formalert" name="ruleActionOptions" id="action_alert" value="action_alert"> <span class = "label label-warning">ALERT</span>
+					</label>
+					<label class="radio-inline">
+						<input type="radio" form="formalert" name="ruleActionOptions" id="action_drop" value="action_drop"> <span class = "label label-danger">DROP</span>
+					</label>
+
+			<?php if ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' && $a_instance[$instanceid]['blockoffenders7'] == 'on') : ?>
+					<label class="radio-inline">
+						<input type="radio" form="formalert" name="ruleActionOptions" id="action_reject" value="action_reject"> <span class = "label label-warning">REJECT</span>
+					</label>
+			<?php endif; ?>
+					<br /><br />
+						<p><?=gettext("Choosing 'Default' will return the rule action to the original value specified by the rule author.  Note this is usually ALERT.");?></p>
+				</div>
+				<div class="modal-footer">
+					<button type="submit" form="formalert" class="btn btn-sm btn-primary" id="rule_action_save" name="rule_action_save" value="<?=gettext("Save");?>" title="<?=gettext("Save changes and close selector");?>" onClick="$('#sid_action_selector').modal('hide');">
+						<i class="fa fa-save icon-embed-btn"></i>
+						<?=gettext("Save");?>
+					</button>
+					<button type="button" class="btn btn-sm btn-warning" id="cancel" name="cancel" value="<?=gettext("Cancel");?>" data-dismiss="modal" title="<?=gettext("Abandon changes and quit selector");?>">
+						<?=gettext("Cancel");?>
+					</button>
+				</div>
+			</div>
+		</div>
+	</div>
+<?php endif; ?>
+<?php unset($a_instance); ?>
+
 <script type="text/javascript">
 //<![CDATA[
 
@@ -885,6 +1160,13 @@ if (file_exists("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/alert")) {
 		$('#gen_id').val(rulegid);
 		$('#ip').val(srcip);
 		$('#descr').val(ruledescr);
+	}
+
+	function toggleAction(gid, sid) {
+		$('#sidid').val(sid);
+		$('#gen_id').val(gid);
+		$('#mode').val('toggle_action');
+		$('#sid_action_selector').modal('show');
 	}
 
 	//-- The following AJAX code was borrowed from the diag_logs_filter.php --
@@ -923,6 +1205,14 @@ events.push(function() {
 		$('#formalert').submit();
 	});
 
+	<?php if ($filterlogentries && count($filterfieldsarray)): ?>
+	// Set the number of filter matches if filtering alerts view
+	$('#alert_panel_title').text("<?=$counter . ' ' . gettext('Matched Entries from Active Log (filtered view)') . ' '; ?>");
+	<?php elseif ($counter == $anentries): ?>
+	$('#alert_panel_title').text("<?=gettext('Most Recent') . ' ' . $counter . ' ' . gettext('Entries from Active Log') . ' '; ?>");
+	<?php else: ?>
+	$('#alert_panel_title').text("<?=$counter . ' ' . gettext('Entries in Active Log') . ' '; ?>");
+	<?php endif;?>
 });
 //]]>
 </script>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_blocked.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_blocked.php
@@ -249,7 +249,7 @@ print($form);
 ?>
 
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=sprintf(gettext("Last %s Hosts Blocked by Snort"), $bnentries)?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=sprintf(gettext("Last %s Hosts Blocked by Snort (only applicable to Legacy Blocking Mode interfaces)"), $bnentries)?></h2></div>
 	<div class="panel-body table-responsive">
 
 		<table class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>
@@ -348,12 +348,12 @@ print($form);
 					<td colspan="4" style="text-align:center;" class="alert-info">
 						<?php	if (!empty($blocked_ips_array)) {
 							if ($counter > 1)
-								print($counter . gettext(" host IP addresses are currently being blocked by Snort."));
+								print($counter . gettext(" host IP addresses are currently being blocked by Snort on Legacy Mode Blocking interfaces."));
 							else
-								print($counter . gettext(" host IP address is currently being blocked Snort."));
+								print($counter . gettext(" host IP address is currently being blocked Snort on Legacy Blocking Mode interfaces."));
 						}
 						else {
-							print(gettext("There are currently no hosts being blocked by Snort."));
+							print(gettext("There are currently no hosts being blocked by Snort on Legacy Mode Blocking interfaces."));
 						}
 						?>
 					</td>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_define_servers.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_define_servers.php
@@ -3,7 +3,7 @@
  * snort_define_servers.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2018-2020 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2019-2020 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2008-2009 Robert Zelaya.
  * Copyright (c) 2014-2020 Bill Meeks
@@ -139,6 +139,9 @@ if ($_POST['save']) {
 		/* Sync to configured CARP slaves if any are enabled */
 		snort_sync_on_changes();
 
+		/* Release config array reference */
+		unset($a_nat);
+
 		/* after click go to this page */
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
@@ -163,6 +166,9 @@ if ($input_errors)
 	print_input_errors($input_errors); // TODO: add checks
 if ($savemsg)
 	print_info_box($savemsg);
+
+// Finished with config array reference, so release it
+unset($a_nat);
 
 $tab_array = array();
 $tab_array[] = array(gettext("Snort Interfaces"), true, "/snort/snort_interfaces.php");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
@@ -168,15 +168,11 @@ if (isset($_POST['clear'])) {
 
 if (isset($_POST['mode'])) {
 	if ($_POST['mode'] == 'force') {
-		// Mount file system R/W since we need to remove files
-
 		// Remove the existing MD5 signature files to force a download
 		unlink_if_exists("{$snortdir}/{$emergingthreats_filename}.md5");
 		unlink_if_exists("{$snortdir}/{$snort_community_rules_filename}.md5");
 		unlink_if_exists("{$snortdir}/{$snort_rules_file}.md5");
 		unlink_if_exists("{$snortdir}/{$snort_openappid_filename}.md5");
-
-		// Revert file system to R/O.
 	}
 	
 	// Launch a background process to download the updates
@@ -248,7 +244,7 @@ display_top_tabs($tab_array, true);
 					<td><?=gettext($openappid_detectors_sig_date);?></td>
 				</tr>
 				<tr>
-                                        <td><?=gettext("Snort OpenAppID RULES Detectors");?></td>
+                                        <td><?=gettext("Snort AppID Open Text Rules");?></td>
                                         <td><?=trim($openappid_detectors_rules_sig_chk_local);?></td>
                                         <td><?=gettext($openappid_detectors_rules_sig_date);?></td>
                                 </tr>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interface_logs.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interface_logs.php
@@ -43,8 +43,8 @@ $if_real = get_real_interface($a_instance[$id]['interface']);
 // Construct a pointer to the instance's logging subdirectory
 $snortlogdir = SNORTLOGDIR . "/snort_{$if_real}{$snort_uuid}/";
 
-// Construct a pointer to the PBI_BIN directory
-$snortbindir = SNORT_PBI_BINDIR;
+// Construct a pointer to the Snort BIN directory
+$snortbindir = SNORT_BINDIR;
 
 // Limit all file access to just the currently selected interface's logging subdirectory
 $logfile = htmlspecialchars($snortlogdir . basename($_POST['file']));

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces.php
@@ -49,22 +49,47 @@ if ($_POST['status'] == 'check') {
 	// Iterate configured Snort interfaces and get status of each
 	// into an associative array.  Return the array to the Ajax
 	// caller as a JSON object.
-	foreach ($a_nat as $natent) {
-		$intf_key = "snort_" . get_real_interface($natent['interface']) . $natent['uuid'];
-		if ($natent['enable'] == "on") {
-			if (snort_is_running($natent['uuid'], get_real_interface($natent['interface']))) {
+	$i = 0;
+	foreach ($a_nat as $intf) {
+		// Skip status update for any missing real interface
+		if (($if_real = get_real_interface($intf['interface'])) == "") {
+			continue;
+		}
+		$intf_key = "snort_" . $if_real;
+		$stop_lck_file = "{$g['varrun_path']}/{$intf_key}_stopping.lck";
+		$start_lck_file = "{$g['varrun_path']}/{$intf_key}_starting.lck";
+
+		if (!snort_is_running(get_real_interface($intf['interface']))) {
+			unlink_if_exists($stop_lck_file);
+		}
+
+		if ($intf['enable'] == "on") {
+			if (snort_is_running(get_real_interface($intf['interface'])) && !file_exists($stop_lck_file)) {
 				$list[$intf_key] = "RUNNING";
+				unlink_if_exists($start_lck_file);
+				unset($snort_starting[$i]);
+			}
+			elseif (file_exists($stop_lck_file)) {
+				$list[$intf_key] = "STOPPING";
+				unlink_if_exists($start_lck_file);
+				unset($snort_starting[$i]);
 			}
 			elseif (file_exists("{$g['varrun_path']}/{$intf_key}_starting.lck") || file_exists("{$g['varrun_path']}/snort_pkg_starting.lck")) {
 				$list[$intf_key] = "STARTING";
+				unlink_if_exists($stop_lck_file);
+				$snort_starting[$i] = TRUE;
 			}
 			else {
 				$list[$intf_key] = "STOPPED";
+				unlink_if_exists($stop_lck_file);
+				unlink_if_exists($start_lck_file);
+				unset($snort_starting[$i]);
 			}
 		}
 		else {
 			$list[$intf_key] = "DISABLED";
 		}
+		$i++;
 	}
 
 	// Return a JSON encoded array as the page output
@@ -76,27 +101,39 @@ if (isset($_POST['del_x'])) {
 	/* Delete selected Snort interfaces */
 	if (is_array($_POST['rule']) && count($_POST['rule'])) {
 		foreach ($_POST['rule'] as $rulei) {
-			$if_real = get_real_interface($a_nat[$rulei]['interface']);
-			$if_friendly = convert_friendly_interface_to_friendly_descr($snortcfg['interface']);
 			$snort_uuid = $a_nat[$rulei]['uuid'];
-			log_error("Stopping Snort on {$if_friendly}({$if_real}) due to interface deletion...");
-			snort_stop($a_nat[$rulei], $if_real);
-			rmdir_recursive("{$snortlogdir}/snort_{$if_real}{$snort_uuid}");
-			rmdir_recursive("{$snortdir}/snort_{$snort_uuid}_{$if_real}");
+			$if_real = get_real_interface($a_nat[$rulei]['interface']);
+
+			// Check that we still have the real interface defined in pfSense.
+			// The real interface will return as an empty string if it has
+			// been removed in pfSense.
+			if ($if_real == "") {
+				rmdir_recursive("{$snortlogdir}/snort_*{$snort_uuid}");
+				rmdir_recursive("{$snortdir}/snort_{$snort_uuid}_*");
+				syslog(LOG_NOTICE, "Deleted the Snort instance on a previously removed pfSense interface per user request...");
+			}
+			else {
+				$if_friendly = convert_friendly_interface_to_friendly_descr($snortcfg['interface']);
+				syslog(LOG_NOTICE, "Stopping Snort on {$if_friendly}({$if_real}) due to Snort instance deletion...");
+				snort_stop($a_nat[$rulei], $if_real);
+				rmdir_recursive("{$snortlogdir}/snort_{$if_real}{$snort_uuid}");
+				rmdir_recursive("{$snortdir}/snort_{$snort_uuid}_{$if_real}");
+				syslog(LOG_NOTICE, "Deleted Snort instance on {$if_friendly}({$if_real}) per user request...");
+			}
 
 			// Finally delete the interface's config entry entirely
 			unset($a_nat[$rulei]);
-			log_error("Deleted Snort instance on {$if_friendly}({$if_real}) per user request...");
 		}
 	  
 		/* If all the Snort interfaces are removed, then unset the interfaces config array. */
 		if (empty($a_nat))
-			unset($a_nat);
+			unset($config['installedpackages']['snortglobal']['rule']);
 
 		// Save updated configuration
 		write_config("Snort pkg: deleted one or more Snort interfaces.");
 		sleep(2);
 		sync_snort_package_config();
+		unset($a_nat);
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
 		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
@@ -114,22 +151,34 @@ else {
 		}
 	}
 	if (is_numeric($delbtn_list) && $a_nat[$delbtn_list]) {
-		$if_real = get_real_interface($a_nat[$delbtn_list]['interface']);
-		$if_friendly = convert_friendly_interface_to_friendly_descr($snortcfg['interface']);
 		$snort_uuid = $a_nat[$delbtn_list]['uuid'];
-		log_error("Stopping Snort on {$if_friendly}({$if_real}) due to interface deletion...");
-		snort_stop($a_nat[$delbtn_list], $if_real);
-		rmdir_recursive("{$snortlogdir}/snort_{$if_real}{$snort_uuid}");
-		rmdir_recursive("{$snortdir}/snort_{$snort_uuid}_{$if_real}");
+		$if_real = get_real_interface($a_nat[$delbtn_list]['interface']);
+
+		// Check that we still have the real interface defined in pfSense.
+		// The real interface will return as an empty string if it has
+		// been removed in pfSense.
+		if ($if_real == "") {
+			rmdir_recursive("{$snortlogdir}/snort_*{$snort_uuid}");
+			rmdir_recursive("{$snortdir}/snort_{$snort_uuid}_*");
+			syslog(LOG_NOTICE, "Deleted the Snort instance on a previously removed pfSense interface per user request...");
+		}
+		else {
+			$if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$delbtn_list]['interface']);
+			syslog(LOG_NOTICE, "Stopping Snort on {$if_friendly}({$if_real}) due to interface deletion...");
+			snort_stop($a_nat[$delbtn_list], $if_real);
+			rmdir_recursive("{$snortlogdir}/snort_{$if_real}{$snort_uuid}");
+			rmdir_recursive("{$snortdir}/snort_{$snort_uuid}_{$if_real}");
+			syslog(LOG_NOTICE, "Deleted Snort instance on {$if_friendly}({$if_real}) per user request...");
+		}
 
 		// Finally delete the interface's config entry entirely
 		unset($a_nat[$delbtn_list]);
-		log_error("Deleted Snort instance on {$if_friendly}({$if_real}) per user request...");
 
 		// Save updated configuration
 		write_config("Snort pkg: deleted one or more Snort interfaces.");
 		sleep(2);
 		sync_snort_package_config();
+		unset($a_nat);
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
 		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
@@ -146,6 +195,8 @@ if ($_POST['toggle'] && is_numericint($_POST['id'])) {
 	$if_real = get_real_interface($snortcfg['interface']);
 	$if_friendly = convert_friendly_interface_to_friendly_descr($snortcfg['interface']);
 	$id = $_POST['id'];
+	$start_lck_file = "{$g['varrun_path']}/snort_{$if_real}_starting.lck";
+	$stop_lck_file = "{$g['varrun_path']}/snort_{$if_real}_stopping.lck";
 
 	// Snort can take several seconds to startup, so to
 	// make the GUI more responsive, startup commands are
@@ -156,8 +207,7 @@ if ($_POST['toggle'] && is_numericint($_POST['id'])) {
 
 	// Create steps for the background task to start Snort.
 	// These commands will be handed off to a CLI PHP session
-	// for background execution as self-deleting PHP file.
-	$start_lck_file = "{$g['varrun_path']}/snort_{$if_real}{$snortcfg['uuid']}_starting.lck";
+	// for background execution in a self-deleting PHP file.
 	$snort_start_cmd = <<<EOD
 	<?php
 	require_once('/usr/local/pkg/snort/snort.inc');
@@ -176,28 +226,32 @@ EOD;
 
 	switch ($_POST['toggle']) {
 		case 'start':
-			file_put_contents("{$g['tmp_path']}/snort_{$if_real}{$snortcfg['uuid']}_startcmd.php", $snort_start_cmd);
-			if (snort_is_running($snortcfg['uuid'], $if_real)) {
-				log_error("Restarting Snort on {$if_friendly}({$if_real}) per user request...");
+			unlink_if_exists($stop_lck_file);
+			file_put_contents("{$g['tmp_path']}/snort_{$if_real}_startcmd.php", $snort_start_cmd);
+			if (snort_is_running($if_real)) {
+				syslog(LOG_NOTICE, "Restarting Snort on {$if_friendly}({$if_real}) per user request...");
 				snort_stop($snortcfg, $if_real);
-				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/snort_{$if_real}{$snortcfg['uuid']}_startcmd.php");
+				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/snort_{$if_real}_startcmd.php");
 			}
 			else {
-				log_error("Starting Snort on {$if_friendly}({$if_real}) per user request...");
-				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/snort_{$if_real}{$snortcfg['uuid']}_startcmd.php");
+				syslog(LOG_NOTICE, "Starting Snort on {$if_friendly}({$if_real}) per user request...");
+				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/snort_{$if_real}_startcmd.php");
 			}
-			$snort_starting[$id] = 'TRUE';
+			$snort_starting[$id] = TRUE;
 			break;
 		case 'stop':
-			if (snort_is_running($snortcfg['uuid'], $if_real)) {
-				log_error("Stopping Snort on {$if_friendly}({$if_real}) per user request...");
+			if (snort_is_running($if_real)) {
+				touch($stop_lck_file);
+				syslog(LOG_NOTICE, "Stopping Snort on {$if_friendly}({$if_real}) per user request...");
 				snort_stop($snortcfg, $if_real);
 			}
 			unset($snort_starting[$id]);
 			unlink_if_exists($start_lck_file);
+			break;
 		default:
 			unset($snort_starting[$id]);
-			unlink_if_exists('{$start_lck_file}');
+			unlink_if_exists($start_lck_file);
+			unlink_if_exists($stop_lck_file);
 	}
 	unset($snort_start_cmd);
 }
@@ -244,7 +298,7 @@ if ($savemsg)
 					<th><?=gettext("Interface"); ?></th>
 					<th><?=gettext("Snort Status"); ?></th>
 					<th><?=gettext("Pattern Match"); ?></th>
-					<th><?=gettext("Blocking"); ?></th>
+					<th><?=gettext("Blocking Mode"); ?></th>
 					<th><?=gettext("Description"); ?></th>
 					<th><?=gettext("Actions"); ?></th>
 				</tr>
@@ -265,14 +319,21 @@ if ($savemsg)
 				else
 					$no_rules = true;
 
-				foreach ($a_nat as $natent): ?>
-				<tr id="fr<?=$nnats?>">
+				foreach ($a_nat as $i => $natent): ?>
+				<tr id="fr<?=$i?>">
 				<?php
-					/* convert fake interfaces to real and check if iface is up */
-					/* There has to be a smarter way to do this */
-					$if_real = get_real_interface($natent['interface']);
-					$natend_friendly = convert_friendly_interface_to_friendly_descr($natent['interface']) . " ({$if_real})";
+					/* Convert fake interfaces to real and check if iface is up. */
+					/* A null real interface indicates it has been removed from system. */
+					if (($if_real = get_real_interface($natent['interface'])) == "") {
+						$natent['enable'] = "off";
+						$natend_friendly = gettext("Missing (removed?)");
+					}
+					else {
+						$natend_friendly = convert_friendly_interface_to_friendly_descr($natent['interface']) . " ({$if_real})";
+					}
 					$snort_uuid = $natent['uuid'];
+					$start_lck_file = "{$g['varrun_path']}/snort_{$if_real}_starting.lck";
+					$stop_lck_file = "{$g['varrun_path']}/snort_{$if_real}_stopping.lck";
 
 					/* See if interface has any rules defined and set boolean flag */
 					$no_rules = true;
@@ -289,65 +350,67 @@ if ($savemsg)
 						$no_rules_footnote = true;
 				?>
 					<td>
-						<input type="checkbox" id="frc<?=$nnats?>" name="rule[]" value="<?=$i?>" onClick="fr_bgcolor('<?=$nnats?>')" style="margin: 0; padding: 0;">
+						<input type="checkbox" id="frc<?=$i?>" name="rule[]" value="<?=$i?>" onClick="fr_bgcolor('<?=$i?>')" style="margin: 0; padding: 0;">
 					</td>
-					<td id="frd<?=$nnats?>" ondblclick="document.location='snort_interfaces_edit.php?id=<?=$nnats?>';">
+					<td id="frd<?=$i?>" ondblclick="document.location='snort_interfaces_edit.php?id=<?=$i?>';">
 						<?php
 							echo $natend_friendly;
 						?>
 					</td>
-					<td id="frd<?=$nnats?>" ondblclick="document.location='snort_interfaces_edit.php?id=<?=$nnats?>';">
-						<?php if ($config['installedpackages']['snortglobal']['rule'][$nnats]['enable'] == 'on') : ?>
-							<?php if (snort_is_running($snort_uuid, $if_real)) : ?>
-								<i id="snort_<?=$if_real.$snort_uuid;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('snort is running on this interface');?>"></i>
+					<td id="frd<?=$i?>" ondblclick="document.location='snort_interfaces_edit.php?id=<?=$i?>';">
+						<?php if ($natent['enable'] == 'on') : ?>
+							<?php if (snort_is_running($if_real) && !file_exists($stop_lck_file)) : ?>
+								<i id="snort_<?=$if_real;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('snort is running on this interface');?>"></i>
 								&nbsp;
-								<i id="snort_<?=$if_real.$snort_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart snort on this interface');?>"></i>
-								<i id="snort_<?=$if_real.$snort_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start snort on this interface');?>"></i>
-								<i id="snort_<?=$if_real.$snort_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop snort on this interface');?>"></i>
-							<?php elseif ($snort_starting[$nnats] == 'TRUE' || file_exists("{$g['varrun_path']}/snort_pkg_starting.lck")) : ?>
-								<i id="snort_<?=$if_real.$snort_uuid;?>" class="fa fa-cog fa-spin text-info icon-primary" title="<?=gettext('snort is starting on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Restart snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Start snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle($(this), 'stop', '<?=$i?>');" title="<?=gettext('Stop snort on this interface');?>"></i>
+							<?php elseif ($snort_starting[$i] == TRUE || file_exists($start_lck_file) || file_exists("{$g['varrun_path']}/snort_pkg_starting.lck")) : ?>
+								<i id="snort_<?=$if_real;?>" class="fa fa-cog fa-spin text-info icon-primary" title="<?=gettext('snort is starting on this interface');?>"></i>
 								&nbsp;
-								<i id="snort_<?=$if_real.$snort_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart snort on this interface');?>"></i>
-								<i id="snort_<?=$if_real.$snort_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start snort on this interface');?>"></i>
-								<i id="snort_<?=$if_real.$snort_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Restart snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Start snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle($(this), 'stop', '<?=$i?>');" title="<?=gettext('Stop snort on this interface');?>"></i>
 							<?php else: ?>
-								<i class="fa fa-times-circle text-danger icon-primary" title="<?=gettext('snort is stopped on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>" class="fa fa-times-circle text-danger icon-primary" title="<?=gettext('snort is stopped on this interface');?>"></i>
 								&nbsp;
-								<i id="snort_<?=$if_real.$snort_uuid;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Restart snort on this interface');?>"></i>
-								<i id="snort_<?=$if_real.$snort_uuid;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle('start', '<?=$nnats?>');" title="<?=gettext('Start snort on this interface');?>"></i>
-								<i id="snort_<?=$if_real.$snort_uuid;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle('stop', '<?=$nnats?>');" title="<?=gettext('Stop snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Restart snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>_start" class="fa fa-play-circle icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Start snort on this interface');?>"></i>
+								<i id="snort_<?=$if_real;?>_stop" class="fa fa-stop-circle-o icon-pointer icon-primary text-info hidden" onclick="javascript:snort_iface_toggle($(this), 'stop', '<?=$i?>');" title="<?=gettext('Stop snort on this interface');?>"></i>
 							<?php endif; ?>
 						<?php else : ?>
 							<?=gettext('DISABLED');?>&nbsp;
 						<?php endif; ?>
 					</td>
-					<td id="frd<?=$nnats?>" ondblclick="document.location='snort_interfaces_edit.php?id=<?=$nnats?>';">
-						<?php if ($config['installedpackages']['snortglobal']['rule'][$nnats]['performance'] != "") : ?>
-							<?=gettext(strtoupper($config['installedpackages']['snortglobal']['rule'][$nnats]['performance']))?>
+					<td id="frd<?=$i?>" ondblclick="document.location='snort_interfaces_edit.php?id=<?=$i?>';">
+						<?php if ($natent['performance'] != "") : ?>
+							<?=gettext(strtoupper($natent['performance']))?>
 						<?php else: ?>
 							<?=gettext('UNKNOWN');?>
 						<?php endif; ?>
 					</td>
-					<td id="frd<?=$nnats?>" ondblclick="document.location='snort_interfaces_edit.php?id=<?=$nnats?>';">
-						<?php if ($config['installedpackages']['snortglobal']['rule'][$nnats]['blockoffenders7'] == 'on') : ?>
-							<?=gettext('ENABLED');?>
-						<?php else: ?>
+					<td id="frd<?=$i?>" ondblclick="document.location='snort_interfaces_edit.php?id=<?=$i?>';">
+						<?php if ($natent['blockoffenders7'] == 'on' && $config['installedpackages']['snortglobal']['rule'][$i]['ips_mode'] == 'ips_mode_legacy') : ?>
+							<?=gettext('LEGACY MODE');?>
+						<?php elseif ($natent['blockoffenders7'] == 'on' && $config['installedpackages']['snortglobal']['rule'][$i]['ips_mode'] == 'ips_mode_inline') : ?>
+							<?=gettext('INLINE IPS');?>
+						<?php else : ?>
 							<?=gettext('DISABLED');?>
 						<?php endif; ?>
 					</td>
-					<td class="bg-info" ondblclick="document.location='snort_interfaces_edit.php?id=<?=$nnats?>';">
+					<td class="text-info" ondblclick="document.location='snort_interfaces_edit.php?id=<?=$i?>';">
 						<?=htmlspecialchars($natent['descr'])?>
 					</td>
 					<td>
-						<a href="snort_interfaces_edit.php?id=<?=$nnats;?>" class="fa fa-pencil icon-primary" title="<?=gettext('Edit this Snort interface mapping');?>"></a>
+						<a href="snort_interfaces_edit.php?id=<?=$i;?>" class="fa fa-pencil icon-primary" title="<?=gettext('Edit this Snort interface mapping');?>"></a>
 						<?php if ($id_gen < count($ifaces)): ?>
-							<a href="snort_interfaces_edit.php?id=<?=$nnats?>&action=dup" class="fa fa-clone" title="<?=gettext('Clone this Snort instance to an available interface');?>"></a>
+							<a href="snort_interfaces_edit.php?id=<?=$i?>&action=dup" class="fa fa-clone" title="<?=gettext('Clone this Snort instance to an available interface');?>"></a>
 						<?php endif; ?>
-						<a style="cursor:pointer;" class="fa fa-trash no-confirm icon-primary" id="Xldel_<?=$nnats?>" title="<?=gettext('Delete this Snort interface mapping'); ?>"></a>
-						<button style="display: none;" class="btn btn-xs btn-warning" type="submit" id="ldel_<?=$nnats?>" name="ldel_<?=$nnats?>" value="ldel_<?=$nnats?>" title="<?=gettext('Delete this Snort interface mapping'); ?>">Delete this Snort interface mapping</button>
+						<a style="cursor:pointer;" class="fa fa-trash no-confirm icon-primary" id="Xldel_<?=$i?>" title="<?=gettext('Delete this Snort interface mapping'); ?>"></a>
+						<button style="display: none;" class="btn btn-xs btn-warning" type="submit" id="ldel_<?=$i?>" name="ldel_<?=$i?>" value="ldel_<?=$i?>" title="<?=gettext('Delete this Snort interface mapping'); ?>">Delete this Snort interface mapping</button>
 					</td>	
 				</tr>
-				<?php $i++; $nnats++; endforeach; ob_end_flush(); ?>
+				<?php endforeach; ob_end_flush(); ?>
 				</tbody>
 			</table>
 		</div>
@@ -425,16 +488,20 @@ if ($savemsg)
 
 		// The JSON object returned by check_status() is an associative array
 		// of interface unique IDs and corresponding service status.  The
-		// "key" is the service name followed by the physical interface and a UUID.
+		// "key" is the service name followed by the real physical interface name.
 		// The "value" of the key is either "DISABLED, STOPPED, STARTING, or RUNNING".
 		//
-		// Example key:  snort_em1998
+		// Example key:  snort_em1
 		//
 		// Within the HTML of this page, icon controls for displaying status
 		// and for starting/restarting/stopping the service are tagged with
 		// control IDs using "key" followed by the icon's function.  These
 		// control IDs are used in the code below to alter icon appearance
 		// depending on the service status.
+		//
+		// Because an interface name in FreeBSD can contain CSS special characters
+		// such as a period, any CSS special characters in an interface name are
+		// escaped by double-backslashes in the code below.
 
 		var data = jQuery.parseJSON(responseData);
 
@@ -443,34 +510,55 @@ if ($savemsg)
 			var service_name = key.substring(0, key.indexOf('_'));
 			if (data[key] != 'DISABLED') {
 				if (data[key] == 'STOPPED') {
-					$('#' + key).removeClass('fa-check-circle fa-cog fa-spin text-success text-info');
-					$('#' + key).addClass('fa-times-circle text-danger');
-					$('#' + key).prop('title', service_name + ' is stopped on this interface');
-					$('#' + key + '_restart').addClass('hidden');
-					$('#' + key + '_stop').addClass('hidden');
-					$('#' + key + '_start').removeClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).removeClass('fa-check-circle fa-cog fa-spin text-success text-info');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).addClass('fa-times-circle text-danger');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).prop('title', service_name + ' is stopped on this interface');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_restart').addClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_stop').addClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_start').removeClass('hidden');
+				}
+				if (data[key] == 'STOPPING') {
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).removeClass('fa-check-circle fa-times-circle text-success text-danger');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).addClass('fa-cog fa-spin text-info');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).prop('title', service_name + ' is stopping on this interface');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_restart').addClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_start').addClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_stop').removeClass('hidden');
 				}
 				if (data[key] == 'STARTING') {
-					$('#' + key).removeClass('fa-check-circle fa-times-circle text-success text-danger');
-					$('#' + key).addClass('fa-cog fa-spin text-info');
-					$('#' + key).prop('title', service_name + ' is starting on this interface');
-					$('#' + key + '_restart').addClass('hidden');
-					$('#' + key + '_start').addClass('hidden');
-					$('#' + key + '_stop').removeClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).removeClass('fa-check-circle fa-times-circle text-success text-danger');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).addClass('fa-cog fa-spin text-info');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).prop('title', service_name + ' is starting on this interface');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_restart').addClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_start').addClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_stop').removeClass('hidden');
 				}
 				if (data[key] == 'RUNNING') {
-					$('#' + key).addClass('fa-check-circle text-success');
-					$('#' + key).removeClass('fa-times-circle fa-cog fa-spin text-danger text-info');
-					$('#' + key).prop('title', service_name + ' is running on this interface');
-					$('#' + key + '_restart').removeClass('hidden');
-					$('#' + key + '_stop').removeClass('hidden');
-					$('#' + key + '_start').addClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).addClass('fa-check-circle text-success');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).removeClass('fa-times-circle fa-cog fa-spin text-danger text-info');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).prop('title', service_name + ' is running on this interface');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_restart').removeClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_stop').removeClass('hidden');
+					$('#' + key.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_start').addClass('hidden');
 				}
 			}
 		}
 	}	
 
-	function snort_iface_toggle(action, id) {
+	function snort_iface_toggle(elem, action, id) {
+		// Peel off the first part of the control name
+		// to identify the STATUS icon.
+		var fldName = $(elem).attr('id');
+		fldName = fldName.substring(0, fldName.lastIndexOf('_'));
+		var service_name = fldName.substring(0, fldName.indexOf('_'));
+
+		// If stopping the service, change STATUS to a spinning gear cog.
+		if (action == 'stop') {
+			$('#' + fldName.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).removeClass('fa-check-circle fa-times-circle text-success text-danger');
+			$('#' + fldName.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).addClass('fa-cog fa-spin text-info');
+			$('#' + fldName.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" )).prop('title', service_name + ' is stopping on this interface');
+			$('#' + fldName.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" ) + '_restart').addClass('hidden');
+		}
 		$('#toggle').val(action);
 		$('#id').val(id);
 		$('#iform').submit();
@@ -507,6 +595,9 @@ if ($savemsg)
 </script>
 
 <?php
+// Finished with config array reference, so release it
+unset($a_nat);
+
 include("foot.inc");
 ?>
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
@@ -5,8 +5,8 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2011-2020 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2006 Manuel Kasper <mk@neon1.net>.
- * Copyright (c) 2020 Bill Meeks
  * Copyright (c) 2008-2009 Robert Zelaya
+ * Copyright (c) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,13 +35,13 @@ if ($_POST['save'])
 	$pconfig = $_POST;
 else {
 	$pconfig['snortdownload'] = $config['installedpackages']['snortglobal']['snortdownload'] == "on" ? 'on' : 'off';
-	$pconfig['oinkmastercode'] = $config['installedpackages']['snortglobal']['oinkmastercode'];
-	$pconfig['etpro_code'] = $config['installedpackages']['snortglobal']['etpro_code'];
+	$pconfig['oinkmastercode'] = htmlentities($config['installedpackages']['snortglobal']['oinkmastercode']);
+	$pconfig['etpro_code'] = htmlentities($config['installedpackages']['snortglobal']['etpro_code']);
 	$pconfig['emergingthreats'] = $config['installedpackages']['snortglobal']['emergingthreats'] == "on" ? 'on' : 'off';
 	$pconfig['emergingthreats_pro'] = $config['installedpackages']['snortglobal']['emergingthreats_pro'] == "on" ? 'on' : 'off';
 	$pconfig['rm_blocked'] = $config['installedpackages']['snortglobal']['rm_blocked'];
 	$pconfig['autorulesupdate7'] = $config['installedpackages']['snortglobal']['autorulesupdate7'];
-	$pconfig['rule_update_starttime'] = $config['installedpackages']['snortglobal']['rule_update_starttime'];
+	$pconfig['rule_update_starttime'] = htmlentities($config['installedpackages']['snortglobal']['rule_update_starttime']);
 	$pconfig['forcekeepsettings'] = $config['installedpackages']['snortglobal']['forcekeepsettings'] == "on" ? 'on' : 'off';
 	$pconfig['snortcommunityrules'] = $config['installedpackages']['snortglobal']['snortcommunityrules'] == "on" ? 'on' : 'off';
 	$pconfig['clearblocks'] = $config['installedpackages']['snortglobal']['clearblocks'] == "on" ? 'on' : 'off';
@@ -57,6 +57,8 @@ if (!isset($pconfig['rule_update_starttime']))
 	$pconfig['rule_update_starttime'] = '00:' . str_pad(strval(random_int(0,59)), 2, "00", STR_PAD_LEFT);
 if (!isset($config['installedpackages']['snortglobal']['forcekeepsettings']))
 	$pconfig['forcekeepsettings'] = 'on';
+if (!isset($config['installedpackages']['snortglobal']['clearblocks']))
+	$pconfig['clearblocks'] = 'on';
 if (!isset($config['installedpackages']['snortglobal']['curl_no_verify_ssl_peer']))
 	$pconfig['curl_no_verify_ssl_peer'] = 'off';
 
@@ -135,12 +137,12 @@ if (!$input_errors) {
 
 		// If deprecated rules should be removed, then do it
 		if ($config['installedpackages']['snortglobal']['hide_deprecated_rules'] == "on") {
-			log_error(gettext("[Snort] Hide Deprecated Rules is enabled.  Removing obsoleted rules categories."));
+			syslog(LOG_NOTICE, gettext("[Snort] Hide Deprecated Rules is enabled.  Removing obsoleted rules categories."));
 			snort_remove_dead_rules();
 		}
 
-		$config['installedpackages']['snortglobal']['oinkmastercode'] = $_POST['oinkmastercode'];
-		$config['installedpackages']['snortglobal']['etpro_code'] = $_POST['etpro_code'];
+		$config['installedpackages']['snortglobal']['oinkmastercode'] = trim(html_entity_decode($_POST['oinkmastercode']));
+		$config['installedpackages']['snortglobal']['etpro_code'] = trim(html_entity_decode($_POST['etpro_code']));
 
 		$config['installedpackages']['snortglobal']['rm_blocked'] = $_POST['rm_blocked'];
 		$config['installedpackages']['snortglobal']['autorulesupdate7'] = $_POST['autorulesupdate7'];
@@ -152,7 +154,7 @@ if (!$input_errors) {
 				$tmp = str_pad($_POST['rule_update_starttime'], 4, "0", STR_PAD_LEFT);
 				$_POST['rule_update_starttime'] = substr($tmp, 0, 2) . ":" . substr($tmp, -2);
 			}
-			$config['installedpackages']['snortglobal']['rule_update_starttime'] = str_pad($_POST['rule_update_starttime'], 4, "0", STR_PAD_LEFT);
+			$config['installedpackages']['snortglobal']['rule_update_starttime'] = str_pad(html_entity_decode($_POST['rule_update_starttime']), 4, "0", STR_PAD_LEFT);
 		}
 
 		$config['installedpackages']['snortglobal']['forcekeepsettings'] = $_POST['forcekeepsettings'] ? 'on' : 'off';
@@ -270,21 +272,21 @@ $section->addInput(new Form_Checkbox(
 ));
 $section->addInput(new Form_StaticText(
 	null,
-	'The OpenAppID package contains the application signatures required by the AppID preprocessor.'
+	'The OpenAppID Detectors package contains the application signatures required by the AppID preprocessor and the OpenAppID text rules.'
 ));
 $section->addInput(new Form_StaticText(
 	'OpenAppID Version',
 	$openappid_ver
 ));
-$group = new Form_Group('Enable RULES OpenAppID');
+$group = new Form_Group('Enable AppID Open Text Rules');
 $group->add(new Form_Checkbox(
         'openappid_rules_detectors',
         'Enable RULES OpenAppID',
-        'Click to enable download of APPID Open rules',
+        'Click to enable download of the AppID Open Text Rules',
         $pconfig['openappid_rules_detectors'] == 'on' ? true:false,
         'on'
 ));
-$group->setHelp('Note - the AppID Open Rules file is maintained by a volunteer contributor and hosted by the pfSense team.  ' . 
+$group->setHelp('Note - the AppID Open Text Rules file is maintained by a volunteer contributor and hosted by the pfSense team.  ' . 
 'The URL for the file ' . 'is <a href="' . SNORT_OPENAPPID_RULES_URL . SNORT_OPENAPPID_RULES_FILENAME . '" target="_blank">' . 
 SNORT_OPENAPPID_RULES_URL . SNORT_OPENAPPID_RULES_FILENAME . '</a>.');
 $section->add($group);
@@ -340,7 +342,7 @@ $section->addInput(new Form_Select(
 $section->addInput(new Form_Checkbox(
 	'clearblocks',
 	'Remove Blocked Hosts After Deinstall',
-	'Click to clear all blocked hosts added by Snort when removing the package.',
+	'Click to clear all blocked hosts added by Snort when removing the package.  Default is checked.',
 	$pconfig['clearblocks'] == 'on' ? true:false,
 	'on'
 ));

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress.php
@@ -68,7 +68,7 @@ if (isset($_POST['del_btn'])) {
 		foreach ($_POST['del'] as $itemi) {
 			/* make sure list is not being referenced by any interface */
 			if (snort_suppresslist_used($a_suppress[$itemi]['name'])) {
-				$input_errors[] = gettext("Suppression List '{$a_suppress[$itemi]['name']}' is currently assigned to one or more Snort interfaces and cannot be deleted.  Unassign it from all Snort interfaces first.");
+				$input_errors[] = gettext("Suppression List '{$a_suppress[$itemi]['name']}' is currently assigned to one or more Snort interfaces and cannot be deleted. Unassign it from all Snort interfaces first.");
 			} else {
 				unset($a_suppress[$itemi]);
 				$need_save = true;
@@ -77,6 +77,7 @@ if (isset($_POST['del_btn'])) {
 		if ($need_save) {
 			write_config("Snort pkg: deleted SUPPRESSION LIST.");
 			sync_snort_package_config();
+			unset($a_suppress);
 			header("Location: /snort/snort_interfaces_suppress.php");
 			return;
 		}
@@ -93,12 +94,13 @@ else {
 	}
 	if (is_numeric($delbtn_list) && $a_suppress[$delbtn_list]) {
 		if (snort_suppresslist_used($a_suppress[$delbtn_list]['name'])) {
-			$input_errors[] = gettext("This Suppression List '{$a_suppress[$delbtn_list]['name']}' is currently assigned to one or more Snort interfaces and cannot be deleted.  Unassign it from all Snort interfaces first.");
+			$input_errors[] = gettext("This Suppression List '{$$a_suppress[$delbtn_list]['name']}' is currently assigned to one or more Snort interfaces and cannot be deleted. Unassign it from all Snort interfaces first.");
 		}
 		else {
 			unset($a_suppress[$delbtn_list]);
 			write_config("Snort pkg: deleted SUPPRESSION LIST.");
 			sync_snort_package_config();
+			unset($a_suppress);
 			header("Location: /snort/snort_interfaces_suppress.php");
 			return;
 		}
@@ -184,6 +186,8 @@ display_top_tabs($tab_array, true);
 		</div>
 	</div>
 </div>
+
+<?php unset($a_suppress); ?>
 
 <script type="text/javascript">
 //<![CDATA[

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress_edit.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2004-2020 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya.
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * originially part of m0n0wall (http://m0n0.ch/wall)
@@ -43,6 +43,7 @@ elseif (isset($_GET['id']) && is_numericint($_GET['id']))
 
 /* Should never be called without identifying list index, so bail */
 if (is_null($id)) {
+	unset($a_suppress);
 	header("Location: /snort/snort_interfaces_suppress.php");
 	exit;
 }
@@ -59,6 +60,7 @@ function is_validwhitelistname($name) {
 }
 
 if ($_POST['cancel']) {
+	unset($a_suppress);
 	header("Location: /snort/snort_interfaces_suppress.php");
 	exit;
 }
@@ -124,11 +126,14 @@ if ($_POST['save']) {
 
 		write_config("Snort pkg: modified Suppress List {$s_list['name']}.");
 		sync_snort_package_config();
-
+		unset($a_suppress);
 		header("Location: /snort/snort_interfaces_suppress.php");
 		exit;
 	}
 }
+
+// Finished with config array reference, so release it
+unset($a_suppress);
 
 $pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Suppression List Edit"));
 include_once("head.inc");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_iprep_list_browser.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_iprep_list_browser.php
@@ -3,8 +3,8 @@
  * snort_iprep_list_browser.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2016-2020 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2020 Bill Meeks
+ * Copyright (c) 2019-2020 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2004-2020 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * originially part of m0n0wall (http://m0n0.ch/wall)
@@ -80,6 +80,7 @@ if (isset($_POST['del_btn'])) {
 			}
 		}
 		if ($need_save) {
+			unset($a_passlist);
 			write_config("Snort pkg: deleted PASS LIST.");
 			sync_snort_package_config();
 			header("Location: /snort/snort_passlist.php");
@@ -102,6 +103,7 @@ else {
 		}
 		else {
 			unset($a_passlist[$delbtn_list]);
+			unset($a_passlist);
 			write_config("Snort pkg: deleted PASS LIST.");
 			sync_snort_package_config();
 			header("Location: /snort/snort_passlist.php");
@@ -217,5 +219,6 @@ events.push(function() {
 
 //]]>
 </script>
+<?php unset($a_passlist); ?>
 <?php include("foot.inc"); ?>
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist_edit.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2004-2020 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2019 Bill Meeks
  * All rights reserved.
  *
  * originially part of m0n0wall (http://m0n0.ch/wall)
@@ -49,6 +49,7 @@ elseif (isset($_GET['id']) && is_numericint($_GET['id'])) {
 
 /* Should never be called without identifying list index, so bail */
 if (is_null($id)) {
+	unset($a_passlist);
 	header("Location: /snort/snort_passlist.php");
 	exit;
 }
@@ -167,7 +168,7 @@ if ($_POST['save']) {
 
 		/* create pass list and homenet file, then sync files */
 		sync_snort_package_config();
-
+		unset($a_passlist);
 		header("Location: /snort/snort_passlist.php");
 		exit;
 	}
@@ -289,6 +290,7 @@ if (isset($id)) {
 }
 
 print($form);
+unset($a_passlist);
 ?>
 
 <script type="text/javascript">

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
@@ -367,6 +367,8 @@ if ($_POST['arp_spoof_save']) {
 			$a_nat[$id]['arp_spoof_engine']['item'][] = $engine;
 		}
 
+		unset($a_nat);
+
 		// Save the updates to the Snort configuration
 		write_config("Snort pkg: Updated ARP Spoofing engine address pairs for {$a_nat[$id]['interface']}.");
 		header("Location: snort_preprocessors.php?id=$id#preproc_arp_spoof_row");
@@ -384,6 +386,7 @@ if ($_POST['del_http_inspect']) {
 	if (isset($_POST['eng_id']) && isset($id) && isset($a_nat[$id])) {
 		unset($a_nat[$id]['http_inspect_engine']['item'][$_POST['eng_id']]);
 		write_config("Snort pkg: deleted http_inspect engine for {$a_nat[$id]['interface']}.");
+		unset($a_nat);
 		header("Location: snort_preprocessors.php?id=$id#httpinspect_row");
 		exit;
 	}
@@ -392,6 +395,7 @@ elseif ($_POST['del_frag3']) {
 	if (isset($_POST['eng_id']) && isset($id) && isset($a_nat[$id])) {
 		unset($a_nat[$id]['frag3_engine']['item'][$_POST['eng_id']]);
 		write_config("Snort pkg: deleted frag3 engine for {$a_nat[$id]['interface']}.");
+		unset($a_nat);
 		header("Location: snort_preprocessors.php?id=$id#frag3_row");
 		exit;
 	}
@@ -400,6 +404,7 @@ elseif ($_POST['del_stream5_tcp']) {
 	if (isset($_POST['eng_id']) && isset($id) && isset($a_nat[$id])) {
 		unset($a_nat[$id]['stream5_tcp_engine']['item'][$_POST['eng_id']]);
 		write_config("Snort pkg: deleted stream5 engine for {$a_nat[$id]['interface']}.");
+		unset($a_nat);
 		header("Location: snort_preprocessors.php?id=$id#stream5_row");
 		exit;
 	}
@@ -408,6 +413,7 @@ elseif ($_POST['del_ftp_client']) {
 	if (isset($_POST['eng_id']) && isset($id) && isset($a_nat[$id])) {
 		unset($a_nat[$id]['ftp_client_engine']['item'][$_POST['eng_id']]);
 		write_config("Snort pkg: deleted ftp_client engine for {$a_nat[$id]['interface']}.");
+		unset($a_nat);
 		header("Location: snort_preprocessors.php?id=$id#ftp_telnet_row");
 		exit;
 	}
@@ -416,6 +422,7 @@ elseif ($_POST['del_ftp_server']) {
 	if (isset($_POST['eng_id']) && isset($id) && isset($a_nat[$id])) {
 		unset($a_nat[$id]['ftp_server_engine']['item'][$_POST['eng_id']]);
 		write_config("Snort pkg: deleted ftp_server engine for {$a_nat[$id]['interface']}.");
+		unset($a_nat);
 		header("Location: snort_preprocessors.php?id=$id#ftp_telnet_row");
 		exit;
 	}
@@ -424,6 +431,7 @@ elseif ($_POST['del_arp_spoof_engine']) {
 	if (isset($_POST['eng_id']) && isset($id) && isset($a_nat[$id])) {
 		unset($a_nat[$id]['arp_spoof_engine']['item'][$_POST['eng_id']]);
 		write_config("Snort pkg: deleted ARP spoof host address pair for {$a_nat[$id]['interface']}.");
+		unset($a_nat);
 		header("Location: snort_preprocessors.php?id=$id#preproc_arp_spoof_row");
 		exit;
 	}
@@ -722,13 +730,18 @@ if ($_POST['save']) {
 		if ($natent['preproc_auto_rule_disable'] == 'off')
 			unlink_if_exists("{$snortlogdir}/{$disabled_rules_log}");
 
-		/*******************************************************/
-		/* Signal Snort to reload Host Attribute Table if one  */
-		/* is configured and saved.                            */
-		/*******************************************************/
-		if ($natent['host_attribute_table'] == "on" && 
-		    !empty($natent['host_attribute_data']))
-			snort_reload_config($natent, "SIGURG");
+		/* If Snort is running, a restart is required   */
+		/* in order to pick up any preprocessor setting */
+		/* changes.                                     */
+		$if_real = get_real_interface($a_nat[$id]['interface']);
+		if (snort_is_running($if_real)) {
+			syslog(LOG_NOTICE, gettext("Snort: restarting on interface " . convert_real_interface_to_friendly_descr($if_real) . " due to Preprocessor configuration change."));
+			snort_stop($a_nat[$id], $if_real);
+			snort_start($a_nat[$id], $if_real, TRUE);
+			$savemsg = gettext("Snort has been restarted on interface " . convert_real_interface_to_friendly_descr($if_real) . " because Preprocessor changes require a restart.");
+		}
+
+		unset($a_nat);
 
 		/* Sync to configured CARP slaves if any are enabled */
 		snort_sync_on_changes();
@@ -762,6 +775,7 @@ if ($_POST['btn_import']) {
 				$a_nat[$id]['max_attribute_services_per_host'] = $pconfig['max_attribute_services_per_host'];
 				write_config("Snort pkg: imported Host Attribute Table data for {$a_nat[$id]['interface']}.");
 			}
+			unset($a_nat);
 			header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 			header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
 			header( 'Cache-Control: no-store, no-cache, must-revalidate' );
@@ -783,6 +797,7 @@ if ($_POST['btn_edit_hat']) {
 		$a_nat[$id]['max_attribute_hosts'] = $pconfig['max_attribute_hosts'];
 		$a_nat[$id]['max_attribute_services_per_host'] = $pconfig['max_attribute_services_per_host'];
 		write_config("Snort pkg: modified Host Attribute Table data for {$a_nat[$id]['interface']}.");
+		unset($a_nat);
 		header("Location: snort_edit_hat_data.php?id=$id");
 		exit;
 	}
@@ -2222,6 +2237,7 @@ print($modal);
 print_callout('<p>' . gettext("Remember to save your changes before you exit this page.  Preprocessor changes will rebuild the rules file.  This ") . 
 		gettext("may take several seconds to complete.  Snort must also be restarted on the interface to activate any changes made on this screen.") . '</p>', 
 		'info', 'NOTE:');
+unset($a_nat);
 ?>
 
 <script type="text/javascript">

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
@@ -27,7 +27,7 @@ require_once("/usr/local/pkg/snort/snort.inc");
 global $g, $rebuild_rules;
 
 $snortdir = SNORTDIR;
-$snortbindir = SNORT_PBI_BINDIR;
+$snortbindir = SNORT_BINDIR;
 $rules_map = array();
 $categories = array();
 $pconfig = array();
@@ -54,8 +54,9 @@ if (is_null($id)) {
 		$_POST['openruleset'] = $response[1];
 	}
 	else {
-	header("Location: /snort/snort_interfaces.php");
-	exit;
+		unset($a_rule);
+		header("Location: /snort/snort_interfaces.php");
+		exit;
 	}
 }
 
@@ -154,6 +155,18 @@ if ($a_rule[$id]['autoflowbitrules'] == 'on')
 	$categories[] = "Auto-Flowbit Rules";
 natcasesort($categories);
 
+// Only add custom ALERT, DROP or REJECT Action Rules
+// option if blocking is enabled.
+if ($a_rule[$id]['blockoffenders7'] == 'on') {
+	$categories[] = "User Forced ALERT Action Rules";
+
+	// Show custom DROP  and REJECT rules only if using Inline IPS mode.
+	if ($a_rule[$id]['ips_mode'] == 'ips_mode_inline') {
+		$categories[] = "User Forced DROP Action Rules";
+		$categories[] = "User Forced REJECT Action Rules";
+	}
+}
+
 // Add custom Category to view all Active Rules
 // on the interface at the bottom of the list.
 $categories[] = "Active Rules";
@@ -183,7 +196,7 @@ if ($currentruleset != 'custom.rules') {
 
 	// Test for the special case of an IPS Policy file.
 	elseif (substr($currentruleset, 0, 10) == "IPS Policy")
-		$rules_map = snort_load_vrt_policy($a_rule[$id]['ips_policy']);
+		$rules_map = snort_load_vrt_policy($a_rule[$id]['ips_policy'], $a_rule[$id]['ips_policy_mode']);
 
 	// Test for preproc_rules file and set the full path.
 	elseif (file_exists("{$snortdir}/preproc_rules/{$currentruleset}"))
@@ -244,6 +257,15 @@ if ($currentruleset != 'custom.rules') {
 		// diabled GID:SID pairs.
 		$rules_map = snort_get_filtered_rules($rule_files, snort_load_sid_mods($a_rule[$id]['rule_sid_off']));
 	}
+	elseif ($currentruleset == "User Forced ALERT Action Rules") {
+		$rules_map = snort_get_filtered_rules("{$snortcfgdir}/rules/", snort_load_sid_mods($a_rule[$id]['rule_sid_force_alert']));
+	}
+	elseif ($currentruleset == "User Forced DROP Action Rules") {
+		$rules_map = snort_get_filtered_rules("{$snortcfgdir}/rules/", snort_load_sid_mods($a_rule[$id]['rule_sid_force_drop']));
+	}
+	elseif ($currentruleset == "User Forced REJECT Action Rules") {
+		$rules_map = snort_get_filtered_rules("{$snortcfgdir}/rules/", snort_load_sid_mods($a_rule[$id]['rule_sid_force_reject']));
+	}
 	// If it's not a special case, and we can't find
 	// the given rule file, then notify the user.
 	elseif (!file_exists($rulefile)) {
@@ -262,6 +284,12 @@ snort_auto_sid_mgmt($rules_map, $a_rule[$id], FALSE);
 // Load up our enablesid and disablesid arrays with enabled or disabled SIDs
 $enablesid = snort_load_sid_mods($a_rule[$id]['rule_sid_on']);
 $disablesid = snort_load_sid_mods($a_rule[$id]['rule_sid_off']);
+
+/* Load up our rule action arrays with manually changed SID actions */
+$alertsid = snort_load_sid_mods($a_rule[$id]['rule_sid_force_alert']);
+$dropsid = snort_load_sid_mods($a_rule[$id]['rule_sid_force_drop']);
+$rejectsid = snort_load_sid_mods($a_rule[$id]['rule_sid_force_reject']);
+snort_modify_sids_action($rules_map, $a_rule[$id]);
 
 /* Process AJAX request to view content of a specific rule */
 if ($_POST['action'] == 'loadRule') {
@@ -355,7 +383,7 @@ if (isset($_POST['rule_state_save']) && isset($_POST['ruleStateOptions']) && is_
 	write_config("Snort pkg: modified state for rule {$gid}:{$sid} on {$a_rule[$id]['interface']}.");
 
 	// We changed a rule state, remind user to apply the changes
-	mark_subsystem_dirty('snort_rules');
+	mark_subsystem_dirty('snort_rules_state');
 
 	// Update our in-memory rules map with the changes just saved
 	// to the Snort configuration file.
@@ -363,6 +391,140 @@ if (isset($_POST['rule_state_save']) && isset($_POST['ruleStateOptions']) && is_
 
 	// Set a scroll-to anchor location
 	$anchor = "rule_{$gid}_{$sid}";
+}
+elseif (isset($_POST['rule_action_save']) && isset($_POST['ruleActionOptions']) && is_numeric($_POST['sid']) && is_numeric($_POST['gid']) && !empty($rules_map)) {
+
+	// Get the GID:SID tags embedded in the clicked rule icon.
+	$gid = $_POST['gid'];
+	$sid = $_POST['sid'];
+
+	// Get the posted rule action
+	$action = $_POST['ruleActionOptions'];
+
+	// Put the target SID in the appropriate lists of modified
+	// SID actions based on the requested action; if default
+	// action is requested, remove the SID from all SID modified
+	// action lists.
+	switch ($action) {
+		case "action_default":
+			$rules_map[$gid][$sid]['action'] = $rules_map[$gid][$sid]['default_action'];
+			if (isset($alertsid[$gid][$sid])) {
+				unset($alertsid[$gid][$sid]);
+			}
+			if (isset($dropsid[$gid][$sid])) {
+				unset($dropsid[$gid][$sid]);
+			}
+			if (isset($rejectsid[$gid][$sid])) {
+				unset($rejectsid[$gid][$sid]);
+			}
+			break;
+
+		case "action_alert":
+			$rules_map[$gid][$sid]['action'] = $rules_map[$gid][$sid]['alert'];
+			if (!is_array($alertsid[$gid])) {
+				$alertsid[$gid] = array();
+			}
+			if (!is_array($alertsid[$gid][$sid])) {
+				$alertsid[$gid][$sid] = array();
+			}
+			$alertsid[$gid][$sid] = "alertsid";
+			if (isset($dropsid[$gid][$sid])) {
+				unset($dropsid[$gid][$sid]);
+			}
+			if (isset($rejectsid[$gid][$sid])) {
+				unset($rejectsid[$gid][$sid]);
+			}
+			break;
+
+		case "action_drop":
+			$rules_map[$gid][$sid]['action'] = $rules_map[$gid][$sid]['drop'];
+			if (!is_array($dropsid[$gid])) {
+				$dropsid[$gid] = array();
+			}
+			if (!is_array($dropsid[$gid][$sid])) {
+				$dropsid[$gid][$sid] = array();
+			}
+			$dropsid[$gid][$sid] = "dropsid";
+			if (isset($alertsid[$gid][$sid])) {
+				unset($alertsid[$gid][$sid]);
+			}
+			if (isset($rejectsid[$gid][$sid])) {
+				unset($rejectsid[$gid][$sid]);
+			}
+			break;
+
+		case "action_reject":
+			$rules_map[$gid][$sid]['action'] = $rules_map[$gid][$sid]['reject'];
+			if (!is_array($rejectsid[$gid])) {
+				$rejectsid[$gid] = array();
+			}
+			if (!is_array($rejectsid[$gid][$sid])) {
+				$rejectsid[$gid][$sid] = array();
+			}
+			$rejectsid[$gid][$sid] = "rejectsid";
+			if (isset($alertsid[$gid][$sid])) {
+				unset($alertsid[$gid][$sid]);
+			}
+			if (isset($dropsid[$gid][$sid])) {
+				unset($dropsid[$gid][$sid]);
+			}
+			break;
+
+		default:
+			$input_errors[] = gettext("WARNING - unknown rule action of '{$action}' passed in $_POST parameter.  No change made to rule action.");
+	}
+
+	if (!$input_errors) {
+		// Write the updated forced rule action values to the config file.
+		$tmp = "";
+		foreach (array_keys($alertsid) as $k1) {
+			foreach (array_keys($alertsid[$k1]) as $k2)
+				$tmp .= "{$k1}:{$k2}||";
+		}
+		$tmp = rtrim($tmp, "||");
+
+		if (!empty($tmp))
+			$a_rule[$id]['rule_sid_force_alert'] = $tmp;
+		else
+			unset($a_rule[$id]['rule_sid_force_alert']);
+
+		$tmp = "";
+		foreach (array_keys($dropsid) as $k1) {
+			foreach (array_keys($dropsid[$k1]) as $k2)
+				$tmp .= "{$k1}:{$k2}||";
+		}
+		$tmp = rtrim($tmp, "||");
+
+		if (!empty($tmp))
+			$a_rule[$id]['rule_sid_force_drop'] = $tmp;
+		else
+			unset($a_rule[$id]['rule_sid_force_drop']);
+
+		$tmp = "";
+		foreach (array_keys($rejectsid) as $k1) {
+			foreach (array_keys($rejectsid[$k1]) as $k2)
+				$tmp .= "{$k1}:{$k2}||";
+		}
+		$tmp = rtrim($tmp, "||");
+
+		if (!empty($tmp))
+			$a_rule[$id]['rule_sid_force_reject'] = $tmp;
+		else
+			unset($a_rule[$id]['rule_sid_force_reject']);
+
+		/* Update the config.xml file. */
+		write_config("Snort pkg: modified action for rule {$gid}:{$sid} on {$a_rule[$id]['interface']}.");
+
+		// We changed a rule action, remind user to apply the changes
+		mark_subsystem_dirty('snort_rules_action');
+
+		// Update our in-memory rules map with the changes just saved
+		// to the Snort configuration file.
+		snort_modify_sids_action($rules_map, $a_rule[$id]);
+
+		// Set a scroll-to anchor location
+		$anchor = "rule_{$gid}_{$sid}";
+	}
 }
 elseif ($_POST['disable_all'] && !empty($rules_map)) {
 
@@ -403,7 +565,7 @@ elseif ($_POST['disable_all'] && !empty($rules_map)) {
 	write_config("Snort pkg: disabled all rules in category {$currentruleset} for {$a_rule[$id]['interface']}.");
 
 	// We changed a rule state, remind user to apply the changes
-	mark_subsystem_dirty('snort_rules');
+	mark_subsystem_dirty('snort_rules_state');
 
 	// Update our in-memory rules map with the changes just saved
 	// to the Snort configuration file.
@@ -447,7 +609,7 @@ elseif ($_POST['enable_all'] && !empty($rules_map)) {
 	write_config("Snort pkg: enable all rules in category {$currentruleset} for {$a_rule[$id]['interface']}.");
 
 	// We changed a rule state, remind user to apply the changes
-	mark_subsystem_dirty('snort_rules');
+	mark_subsystem_dirty('snort_rules_state');
 
 	// Update our in-memory rules map with the changes just saved
 	// to the Snort configuration file.
@@ -462,6 +624,12 @@ elseif ($_POST['resetcategory'] && !empty($rules_map)) {
 				unset($enablesid[$k1][$k2]);
 			if (isset($disablesid[$k1][$k2]))
 				unset($disablesid[$k1][$k2]);
+			if (isset($alertsid[$k1][$k2]))
+				unset($alertsid[$k1][$k2]);
+			if (isset($dropsid[$k1][$k2]))
+				unset($dropsid[$k1][$k2]);
+			if (isset($rejectsid[$k1][$k2]))
+				unset($rejectsid[$k1][$k2]);
 		}
 	}
 
@@ -490,10 +658,47 @@ elseif ($_POST['resetcategory'] && !empty($rules_map)) {
 	else				
 		unset($a_rule[$id]['rule_sid_off']);
 
+	// Write the updated alertsid, dropsid and rejectsid values to the config file.
+	$tmp = "";
+	foreach (array_keys($alertsid) as $k1) {
+		foreach (array_keys($alertsid[$k1]) as $k2)
+			$tmp .= "{$k1}:{$k2}||";
+	}
+	$tmp = rtrim($tmp, "||");
+
+	if (!empty($tmp))
+		$a_rule[$id]['rule_sid_force_alert'] = $tmp;
+	else
+		unset($a_rule[$id]['rule_sid_force_alert']);
+
+	$tmp = "";
+	foreach (array_keys($dropsid) as $k1) {
+		foreach (array_keys($dropsid[$k1]) as $k2)
+			$tmp .= "{$k1}:{$k2}||";
+	}
+	$tmp = rtrim($tmp, "||");
+
+	if (!empty($tmp))
+		$a_rule[$id]['rule_sid_force_drop'] = $tmp;
+	else
+		unset($a_rule[$id]['rule_sid_force_drop']);
+
+	$tmp = "";
+	foreach (array_keys($rejectsid) as $k1) {
+		foreach (array_keys($rejectsid[$k1]) as $k2)
+			$tmp .= "{$k1}:{$k2}||";
+	}
+	$tmp = rtrim($tmp, "||");
+
+	if (!empty($tmp))
+		$a_rule[$id]['rule_sid_force_reject'] = $tmp;
+	else
+		unset($a_rule[$id]['rule_sid_force_reject']);
+
 	write_config("Snort pkg: remove enablesid/disablesid changes for category {$currentruleset} on {$a_rule[$id]['interface']}.");
 
 	// We changed a rule state, remind user to apply the changes
-	mark_subsystem_dirty('snort_rules');
+	mark_subsystem_dirty('snort_rules_reset');
 
 	// Reload the rules so we can accurately show content after
 	// resetting any user overrides.
@@ -539,6 +744,15 @@ elseif ($_POST['resetcategory'] && !empty($rules_map)) {
 		$rule_files[] = "{$snortcfgdir}/rules/" . FLOWBITS_FILENAME;
 		$rule_files[] = "{$snortcfgdir}/rules/custom.rules";
 		$rules_map = snort_get_filtered_rules($rule_files, snort_load_sid_mods($a_rule[$id]['rule_sid_off']));
+	}
+	elseif ($currentruleset == "User Forced ALERT Action Rules") {
+		$rules_map = snort_get_filtered_rules("{$snortcfgdir}/rules/", snort_load_sid_mods($a_rule[$id]['rule_sid_force_alert']));
+	}
+	elseif ($currentruleset == "User Forced DROP Action Rules") {
+		$rules_map = snort_get_filtered_rules("{$snortcfgdir}/rules/", snort_load_sid_mods($a_rule[$id]['rule_sid_force_drop']));
+	}
+	elseif ($currentruleset == "User Forced REJECT Action Rules") {
+		$rules_map = snort_get_filtered_rules("{$snortcfgdir}/rules/", snort_load_sid_mods($a_rule[$id]['rule_sid_force_reject']));
 	}
 	// If it's not a special case, and we can't find
 	// the given rule file, then notify the user.
@@ -556,12 +770,15 @@ elseif ($_POST['resetall'] && !empty($rules_map)) {
 	// Remove all modified SIDs from config.xml and save the changes.
 	unset($a_rule[$id]['rule_sid_on']);
 	unset($a_rule[$id]['rule_sid_off']);
+	unset($a_rule[$id]['rule_sid_force_alert']);
+	unset($a_rule[$id]['rule_sid_force_drop']);
+	unset($a_rule[$id]['rule_sid_force_reject']);
 
 	/* Update the config.xml file. */
 	write_config("Snort pkg: remove all enablesid/disablesid changes for {$a_rule[$id]['interface']}.");
 
 	// We changed a rule state, remind user to apply the changes
-	mark_subsystem_dirty('snort_rules');
+	mark_subsystem_dirty('snort_rules_reset');
 
 	// Reload the rules so we can accurately show content after
 	// resetting any user overrides.
@@ -608,6 +825,16 @@ elseif ($_POST['resetall'] && !empty($rules_map)) {
 		$rule_files[] = "{$snortcfgdir}/rules/custom.rules";
 		$rules_map = snort_get_filtered_rules($rule_files, snort_load_sid_mods($a_rule[$id]['rule_sid_off']));
 	}
+	elseif ($currentruleset == "User Forced ALERT Action Rules") {
+		$rules_map = snort_get_filtered_rules("{$snortcfgdir}/rules/", snort_load_sid_mods($a_rule[$id]['rule_sid_force_alert']));
+	}
+	elseif ($currentruleset == "User Forced DROP Action Rules") {
+		$rules_map = snort_get_filtered_rules("{$snortcfgdir}/rules/", snort_load_sid_mods($a_rule[$id]['rule_sid_force_drop']));
+	}
+	elseif ($currentruleset == "User Forced REJECT Action Rules") {
+		$rules_map = snort_get_filtered_rules("{$snortcfgdir}/rules/", snort_load_sid_mods($a_rule[$id]['rule_sid_force_reject']));
+	}
+
 	// If it's not a special case, and we can't find
 	// the given rule file, then notify the user.
 	elseif (!file_exists($rulefile)) {
@@ -621,7 +848,9 @@ elseif ($_POST['resetall'] && !empty($rules_map)) {
 }
 elseif (isset($_POST['cancel'])) {
 	$pconfig['customrules'] = base64_decode($a_rule[$id]['customrules']);
-	clear_subsystem_dirty('snort_rules');
+	clear_subsystem_dirty('snort_rules_reset');
+	clear_subsystem_dirty('snort_rules_state');
+	clear_subsystem_dirty('snort_rules_action');
 }
 elseif (isset($_POST['clear'])) {
 	unset($a_rule[$id]['customrules']);
@@ -658,10 +887,12 @@ elseif (isset($_POST['save'])) {
 	else {
 		// Soft-restart Snort to live-load new rules
 		snort_reload_config($a_rule[$id]);
-		$savemsg = gettext("Custom rules validated successfully and any active Snort process on this interface has been signalled to live-load the new rules.");
+		$savemsg = gettext("Custom rules validated successfully and any active Snort process on this interface has been signaled to live-load the new rules.");
 	}
 
-	clear_subsystem_dirty('snort_rules');
+	clear_subsystem_dirty('snort_rules_reset');
+	clear_subsystem_dirty('snort_rules_state');
+	clear_subsystem_dirty('snort_rules_action');
 
 	// Sync to configured CARP slaves if any are enabled
 	snort_sync_on_changes();
@@ -692,13 +923,15 @@ elseif ($_POST['apply']) {
 	// Soft-restart Snort to live-load new rules
 	snort_reload_config($a_rule[$id]);
 
-	// We have saved changes and done a soft restart, so clear "dirty" flag
-	clear_subsystem_dirty('snort_rules');
+	// We have saved changes and done a soft restart, so clear "dirty" flags
+	clear_subsystem_dirty('snort_rules_reset');
+	clear_subsystem_dirty('snort_rules_state');
+	clear_subsystem_dirty('snort_rules_action');
 
 	// Sync to configured CARP slaves if any are enabled
 	snort_sync_on_changes();
 
-	if (snort_is_running($snort_uuid, $if_real))
+	if (snort_is_running($if_real))
 		$savemsg = gettext("Snort is 'live-reloading' the new rule set.");
 }
 
@@ -727,9 +960,17 @@ if ($savemsg) {
 <input type='hidden' name='gid' id='gid' value=''/>
 
 <?php
-if (is_subsystem_dirty('snort_rules')) {
+if (is_subsystem_dirty('snort_rules_state')) {
 	$_POST['if'] = $id . "|" . $currentruleset;
 	print_info_box('<p>' . gettext("A change has been made to a rule state.") . '<br/>' . gettext("Click APPLY when finished to send the changes to the running configuration.") . '</p>');
+}
+if (is_subsystem_dirty('snort_rules_action')) {
+	$_POST['if'] = $id . "|" . $currentruleset;
+	print_info_box('<p>' . gettext("A change has been made to a rule action.") . '<br/>' . gettext("Click APPLY when finished to send the changes to the running configuration.") . '</p>');
+}
+if (is_subsystem_dirty('snort_rules_reset')) {
+	$_POST['if'] = $id . "|" . $currentruleset;
+	print_info_box('<p>' . gettext("A rule category has been reset to vendor defaults.") . '<br/>' . gettext("Click APPLY when finished to send the changes to the running configuration.") . '</p>');
 }
 
 $tab_array = array();
@@ -906,12 +1147,26 @@ print($section);
 						<td style="padding-left: 8px;"><i class="fa fa-check-circle-o text-success"></i></td><td style="padding-left: 4px;"><small><?=gettext('Default Enabled');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-check-circle text-success"></i></td><td style="padding-left: 4px;"><small><?=gettext('Enabled by user');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-adn text-success"></i></td><td style="padding-left: 4px;"><small><?=gettext('Auto-enabled by SID Mgmt');?></small></td>
+						<td style="padding-left: 8px;"><i class="fa fa-adn text-warning"></i></td><td style="padding-left: 4px;"><small><?=gettext('Action/content modified by SID Mgmt');?></small></td>
+						<td style="padding-left: 8px;"><i class="fa fa-exclamation-triangle text-warning"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is alert');?></small></td>
+				<?php if ($a_rule[$id]['ips_mode'] == 'ips_mode_inline' && $a_rule[$id]['blockoffenders7'] == 'on') : ?>
+						<td style="padding-left: 8px;"><i class="fa fa-hand-stop-o text-warning"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is reject');?></small></td>
+				<?php else : ?>
+						<td><td></td></td>
+				<?php endif; ?>
 					</tr>
 					<tr>
 						<td></td>
 						<td style="padding-left: 8px;"><i class="fa fa-times-circle-o text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Default Disabled');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-times-circle text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Disabled by user');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-adn text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Auto-disabled by SID Mgmt');?></small></td>
+						<td><td></td></td>
+				<?php if ($a_rule[$id]['blockoffenders7'] == 'on' && $a_rule[$id]['ips_mode'] == 'ips_mode_inline') : ?>
+						<td style="padding-left: 8px;"><i class="fa fa-thumbs-down text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is drop');?></small></td>
+				<?php else : ?>
+						<td><td></td></td>
+				<?php endif; ?>
+						<td><td></td></td>
 					</tr>
 				</tbody>
 			</table>
@@ -922,7 +1177,8 @@ print($section);
 
 					<table style="table-layout: fixed; width: 100%;" class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>
 						<colgroup>
-							<col width="3%">
+							<col width="5%">
+							<col width="5%">
 							<col width="4%">
 							<col width="9%">
 							<col width="5%">
@@ -934,7 +1190,8 @@ print($section);
 						</colgroup>
 						<thead>
 						   <tr class="sortableHeaderRowIdentifier">
-							<th data-sortable="false">&nbsp;</th>
+							<th data-sortable="false"><?=gettext("State");?></th>
+							<th data-sortable="false"><?=gettext("Action");?></th>
 							<th data-sortable="true" data-sortable-type="numeric"><?=gettext("GID"); ?></th>
 							<th data-sortable="true" data-sortable-type="numeric"><?=gettext("SID"); ?></th>
 							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Proto"); ?></th>
@@ -988,7 +1245,7 @@ print($section);
 									$disable_cnt++;
 									$user_disable_cnt++;
 									$iconb_class = 'class="fa fa-times-circle text-danger text-left"';
-									$title = gettext("Disabled by user. Click to change rule state");
+									$title = gettext("Forec-Disabled by user. Click to change rule state");
 								}
 								// See if the rule is in our list of user-enabled overrides
 								elseif (isset($enablesid[$gid][$sid])) {
@@ -996,7 +1253,7 @@ print($section);
 									$enable_cnt++;
 									$user_enable_cnt++;
 									$iconb_class = 'class="fa fa-check-circle text-success text-left"';
-									$title = gettext("Enabled by user. Click to change rule state");
+									$title = gettext("Force-Enabled by user. Click to change rule state");
 								}
 
 								// These last two checks handle normal cases of default-enabled or default disabled rules
@@ -1013,6 +1270,38 @@ print($section);
 									$enable_cnt++;
 									$iconb_class = 'class="fa fa-check-circle-o text-success text-left"';
 									$title = gettext("Enabled by default. Click to change rule state");
+								}
+
+								// Determine which icon to display in the second column for rule action.
+								// Default to ALERT icon.
+								$textss = $textse = "";
+								$iconact_class = 'class="fa fa-exclamation-triangle text-warning text-center"';
+								if (isset($alertsid[$gid][$sid]) && $a_rule[$id]['blockoffenders7'] == 'on' && $a_rule[$id]['ips_mode'] == 'ips_mode_inline') {
+									$title_act = gettext("Rule action is User-Forced to alert on traffic when triggered.");
+								}
+								else {
+									$title_act = gettext("Rule will alert on traffic when triggered.");
+								}
+								if ($v['action'] == 'drop' && $a_rule[$id]['blockoffenders7'] == 'on' && $a_rule[$id]['ips_mode'] == 'ips_mode_inline') {
+									$iconact_class = 'class="fa fa-thumbs-down text-danger text-center"';
+									if (isset($dropsid[$gid][$sid])) {
+										$title_act = gettext("Rule action is User-Forced to drop traffic when triggered.");
+									}
+									else {
+										$title_act = gettext("Rule will drop traffic when triggered.");
+									}
+								}
+								elseif ($v['action'] == 'reject' && $a_rule[$id]['ips_mode'] == 'ips_mode_inline' && $a_rule[$id]['blockoffenders7'] == 'on') {
+									$iconact_class = 'class="fa fa-hand-stop-o text-warning text-center"';
+									if (isset($rejectsid[$gid][$sid])) {
+										$title_act = gettext("Rule action is User-Forced to reject traffic when triggered.");
+									}
+									else {
+										$title_act = gettext("Rule will reject traffic when triggered.");
+									}
+								}
+								if ($a_rule[$id]['blockoffenders7'] == 'on' && $a_rule[$id]['ips_mode'] == 'ips_mode_inline') {
+									$title_act .= gettext("  Click to change rule action.");
 								}
 
 								// Pick off the first section of the rule (prior to the start of the MSG field),
@@ -1044,6 +1333,14 @@ print($section);
 									<i class="fa fa-adn text-warning text-left" title="<?=gettext('Action or content modified by settings on SID Mgmt tab'); ?>"></i><?=$textse; ?>
 							<?php endif; ?>
 								</td>
+							<?php if ($a_rule[$id]['blockoffenders7'] == 'on' && $a_rule[$id]['ips_mode'] == 'ips_mode_inline') : ?>
+								<td><?=$textss; ?><a id="rule_<?=$gid; ?>_<?=$sid; ?>_action" href="#" onClick="toggleAction('<?=$sid; ?>', '<?=$gid; ?>');" 
+									<?=$iconact_class; ?> title="<?=$title_act; ?>"></a><?=$textse; ?>
+								</td>
+							<?php else : ?>
+								<td><?=$textss; ?><i <?=$iconact_class; ?> title="<?=$title_act; ?>"></i><?=$textse; ?>
+								</td>
+							<?php endif; ?>
 							       <td ondblclick="showRuleContents('<?=$gid; ?>','<?=$sid; ?>');">
 									<?=$textss . $gid . $textse; ?>
 							       </td>
@@ -1084,7 +1381,8 @@ print($section);
 
 					<table style="table-layout: fixed; width: 100%;" class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>
 						<colgroup>
-							<col width="4%">
+							<col width="5%">
+							<col width="5%">
 							<col width="5%">
 							<col width="7%">
 							<col width="22%">
@@ -1093,7 +1391,8 @@ print($section);
 						</colgroup>
 						<thead>
 						   <tr class="sortableHeaderRowIdentifier">
-							<th data-sortable="false">&nbsp;</th>
+							<th data-sortable="false"><?=gettext("State"); ?></th>
+							<th data-sortable="false"><?=gettext("Action");?></th>
 							<th data-sortable="true" data-sortable-type="numeric"><?=gettext("GID"); ?></th>
 							<th data-sortable="true" data-sortable-type="numeric"><?=gettext("SID"); ?></th>
 							<th data-sortable="true" data-sortable-type="alpha"><?=gettext("Classification"); ?></th>
@@ -1144,7 +1443,7 @@ print($section);
 											$disable_cnt++;
 											$user_disable_cnt++;
 											$iconb_class = 'class="fa fa-times-circle text-danger text-left"';
-											$title = gettext("Disabled by user. Click to change rule state");
+											$title = gettext("Force-Disabled by user. Click to change rule state");
 										}
 										// See if the rule is in our list of user-enabled overrides
 										elseif (isset($enablesid[$gid][$sid])) {
@@ -1152,7 +1451,7 @@ print($section);
 											$enable_cnt++;
 											$user_enable_cnt++;
 											$iconb_class = 'class="fa fa-check-circle text-success text-left"';
-											$title = gettext("Enabled by user. Click to change rule state");
+											$title = gettext("Force-Enabled by user. Click to change rule state");
 										}
 
 										// These last two checks handle normal cases of default-enabled or default disabled rules
@@ -1170,6 +1469,39 @@ print($section);
 											$iconb_class = 'class="fa fa-check-circle-o text-success text-left"';
 											$title = gettext("Enabled by default. Click to change rule state");
 										}
+
+										// Determine which icon to display in the second column for rule action.
+										// Default to ALERT icon.
+										$textss = $textse = "";
+										$iconact_class = 'class="fa fa-exclamation-triangle text-warning text-center"';
+										if (isset($alertsid[$gid][$sid]) && $a_rule[$id]['blockoffenders7'] == 'on' && $a_rule[$id]['ips_mode'] == 'ips_mode_inline') {
+											$title_act = gettext("Rule action is User-Forced to alert on traffic when triggered.");
+										}
+										else {
+											$title_act = gettext("Rule will alert on traffic when triggered.");
+										}
+										if ($v['action'] == 'drop' && $a_rule[$id]['blockoffenders7'] == 'on' && $a_rule[$id]['ips_mode'] == 'ips_mode_inline') {
+											$iconact_class = 'class="fa fa-thumbs-down text-danger text-center"';
+											if (isset($dropsid[$gid][$sid])) {
+												$title_act = gettext("Rule action is User-Forced to drop traffic when triggered.");
+											}
+											else {
+												$title_act = gettext("Rule will drop traffic when triggered.");
+											}
+										}
+										elseif ($v['action'] == 'reject' && $a_rule[$id]['ips_mode'] == 'ips_mode_inline' && $a_rule[$id]['blockoffenders7'] == 'on') {
+											$iconact_class = 'class="fa fa-hand-stop-o text-warning text-center"';
+											if (isset($rejectsid[$gid][$sid])) {
+												$title_act = gettext("Rule action is User-Forced to reject traffic when triggered.");
+											}
+											else {
+												$title_act = gettext("Rule will reject traffic when triggered.");
+											}
+										}
+										if ($a_rule[$id]['blockoffenders7'] == 'on' && $a_rule[$id]['ips_mode'] == 'ips_mode_inline') {
+											$title_act .= gettext("  Click to change rule action.");
+										}
+
 										$message = snort_get_msg($v['rule']);
 										$matches = array();
 										if (preg_match('/(?:classtype\b\s*:)\s*(\S*\s*;)/iU', $v['rule'], $matches))
@@ -1190,6 +1522,15 @@ print($section);
 											<i class="fa fa-adn text-warning text-left" title="<?=gettext('Action or content modified by settings on SID Mgmt tab'); ?>"></i><?=$textse; ?>
 									<?php endif; ?>
 										</td>
+									<?php if ($a_rule[$id]['blockoffenders7'] == 'on' && $a_rule[$id]['ips_mode'] == 'ips_mode_inline') : ?>
+										<td><?=$textss; ?><a id="rule_<?=$gid; ?>_<?=$sid; ?>_action" href="#" onClick="toggleAction('<?=$sid; ?>', '<?=$gid; ?>');" 
+											<?=$iconact_class; ?> title="<?=$title_act; ?>"></a><?=$textse; ?>
+										</td>
+									<?php else : ?>
+										<td><?=$textss; ?><i <?=$iconact_class; ?> title="<?=$title_act; ?>"></i><?=$textse; ?>
+										</td>
+									<?php endif; ?>
+
 									       <td ondblclick="showRuleContents('<?=$gid; ?>','<?=$sid; ?>');">
 											<?=$textss . $gid . $textse; ?>
 									       </td>
@@ -1237,6 +1578,49 @@ print($section);
 </div>
 
 <?php endif;?>
+<!-- Modal Rule SID action selector window -->
+<div class="modal fade" role="dialog" id="sid_action_selector">
+	<div class="modal-dialog">
+		<div class="modal-content">
+			<div class="modal-header">
+				<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+					<span aria-hidden="true">&times;</span>
+				</button>
+				<h3 class="modal-title"><?=gettext("Rule Action Selection")?></h3>
+			</div>
+			<div class="modal-body">
+				<h4><?=gettext("Choose desired rule action from selections below: ");?></h4>
+				<label class="radio-inline">
+					<input type="radio" name="ruleActionOptions" id="action_default" value="action_default"> <span class = "label label-default">Default</span>
+				</label>
+				<label class="radio-inline">
+					<input type="radio" name="ruleActionOptions" id="action_alert" value="action_alert"> <span class = "label label-warning">ALERT</span>
+				</label>
+				<label class="radio-inline">
+					<input type="radio" name="ruleActionOptions" id="action_drop" value="action_drop"> <span class = "label label-danger">DROP</span>
+				</label>
+
+		<?php if ($a_rule[$id]['ips_mode'] == 'ips_mode_inline' && $a_rule[$id]['blockoffenders7'] == 'on') : ?>
+				<label class="radio-inline">
+					<input type="radio" name="ruleActionOptions" id="action_reject" value="action_reject"> <span class = "label label-warning">REJECT</span>
+				</label>
+		<?php endif; ?>
+				<br /><br />
+					<p><?=gettext("Choosing 'Default' will return the rule action to the original value specified by the rule author.  Note this is usually ALERT.");?></p>
+			</div>
+			<div class="modal-footer">
+				<button type="submit" class="btn btn-sm btn-primary" id="rule_action_save" name="rule_action_save" value="<?=gettext("Save");?>" title="<?=gettext("Save changes and close selector");?>">
+					<i class="fa fa-save icon-embed-btn"></i>
+					<?=gettext("Save");?>
+				</button>
+				<button type="button" class="btn btn-sm btn-warning" id="cancel" name="cancel" value="<?=gettext("Cancel");?>" data-dismiss="modal" title="<?=gettext("Abandon changes and quit selector");?>">
+					<?=gettext("Cancel");?>
+				</button>
+			</div>
+		</div>
+	</div>
+</div>
+
 <!-- Modal Rule SID state selector window -->
 <div class="modal fade" role="dialog" id="sid_state_selector">
 	<div class="modal-dialog">
@@ -1294,6 +1678,7 @@ $modal->addInput(new Form_Textarea (
 ))->removeClass('form-control')->addClass('row-fluid col-sm-10')->setAttribute('rows', '10')->setAttribute('wrap', 'soft');
 $form->add($modal);
 print($form);
+unset($a_rule);
 ?>
 
 <script type="text/javascript">
@@ -1304,6 +1689,18 @@ function toggleState(sid, gid) {
 	$('#gid').val(gid);
 	$('#openruleset').val($('#selectbox').val());
 	$('#sid_state_selector').modal('show');
+}
+
+function toggleAction(sid, gid) {
+	if ($('#rule_'+gid+'_'+sid).hasClass('text-success')) {
+		$('#sid').val(sid);
+		$('#gid').val(gid);
+		$('#openruleset').val($('#selectbox').val());
+		$('#sid_action_selector').modal('show');
+	}
+	else {
+		alert("Rule is disabled, so changing ACTION is meaningless and thus is disabled for this rule.");
+	}
 }
 
 function wopen(url, name)

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
@@ -54,6 +54,7 @@ if (isset($id) && $a_nat[$id]) {
 		$pconfig['autoflowbitrules'] = $a_nat[$id]['autoflowbitrules'] == 'on' ? 'on' : 'off';;
 	$pconfig['ips_policy_enable'] = $a_nat[$id]['ips_policy_enable'] == 'on' ? 'on' : 'off';;
 	$pconfig['ips_policy'] = $a_nat[$id]['ips_policy'];
+	$pconfig['ips_policy_mode'] = $a_nat[$id]['ips_policy_mode'];
 } else {
 	$pconfig['autoflowbitrules'] = 'on';
 }
@@ -121,10 +122,12 @@ if (isset($_POST["save"])) {
 	if ($_POST['ips_policy_enable'] == "on") {
 		$a_nat[$id]['ips_policy_enable'] = 'on';
 		$a_nat[$id]['ips_policy'] = $_POST['ips_policy'];
+		$a_nat[$id]['ips_policy_mode'] = $_POST['ips_policy_mode'];
 	}
 	else {
 		$a_nat[$id]['ips_policy_enable'] = 'off';
 		unset($a_nat[$id]['ips_policy']);
+		unset($a_nat[$id]['ips_policy_mode']);
 	}
 
 	$enabled_items = "";
@@ -158,7 +161,7 @@ if (isset($_POST["save"])) {
 
 	$pconfig = $_POST;
 	$enabled_rulesets_array = explode("||", $enabled_items);
-	if (snort_is_running($snort_uuid, $if_real))
+	if (snort_is_running($if_real))
 		$savemsg = gettext("Snort is 'live-reloading' the new rule set.");
 
 	// Sync to configured CARP slaves if any are enabled
@@ -171,15 +174,18 @@ if (isset($_POST['unselectall'])) {
 	if ($_POST['ips_policy_enable'] == "on") {
 		$a_nat[$id]['ips_policy_enable'] = 'on';
 		$a_nat[$id]['ips_policy'] = $_POST['ips_policy'];
+		$a_nat[$id]['ips_policy_mode'] = $_POST['ips_policy_mode'];
 	}
 	else {
 		$a_nat[$id]['ips_policy_enable'] = 'off';
 		unset($a_nat[$id]['ips_policy']);
+		unset($a_nat[$id]['ips_policy_mode']);
 	}
 
 	$pconfig['autoflowbits'] = $_POST['autoflowbits'];
 	$pconfig['ips_policy_enable'] = $_POST['ips_policy_enable'];
 	$pconfig['ips_policy'] = $_POST['ips_policy'];
+	$pconfig['ips_policy_mode'] = $_POST['ips_policy_mode'];
 	$enabled_rulesets_array = array();
 
 	$savemsg = gettext("All rule categories have been de-selected.  ");
@@ -193,10 +199,12 @@ if (isset($_POST['selectall'])) {
 	if ($_POST['ips_policy_enable'] == "on") {
 		$a_nat[$id]['ips_policy_enable'] = 'on';
 		$a_nat[$id]['ips_policy'] = $_POST['ips_policy'];
+		$a_nat[$id]['ips_policy_mode'] = $_POST['ips_policy_mode'];
 	}
 	else {
 		$a_nat[$id]['ips_policy_enable'] = 'off';
 		unset($a_nat[$id]['ips_policy']);
+		unset($a_nat[$id]['ips_policy_mode']);
 	}
 
 	$pconfig['autoflowbits'] = $_POST['autoflowbits'];
@@ -265,6 +273,9 @@ if ($input_errors) {
 if ($savemsg) {
 	print_info_box($savemsg);
 }
+
+// Finished with config array reference, so release it
+unset($a_nat);
 
 $tab_array = array();
 	$tab_array[] = array(gettext("Snort Interfaces"), true, "/snort/snort_interfaces.php");
@@ -380,6 +391,14 @@ if ($snortdownload == "on") {
 		'in an Excel file.  Max-Detect is a policy created for testing network traffic through your ' . 
 		'device.  This policy should be used with caution on production systems!</span>'
 	));
+	$section->addInput(new Form_Select(
+		'ips_policy_mode',
+		'IPS Policy Mode',
+		$pconfig['ips_policy_mode'],
+		array(  'alert' => 'Alert',
+			'policy'  => 'Policy')
+		))->setHelp('When Policy is selected, this will automatically change the action for rules in the selected IPS Policy from their default action of alert to the action specified ' .
+				'in the policy metadata (typically drop, but may be alert for some policy rules).');
 	print($section);
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/widgets/widgets/snort_alerts.widget.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/widgets/widgets/snort_alerts.widget.php
@@ -119,14 +119,14 @@ function snort_widget_get_alerts() {
 
 			if (file_exists("/tmp/alert_snort{$snort_uuid}")) {
 
-				/*              0         1            2      3       4   5     6   7       8   9       10 11             12       */
-				/* File format: timestamp,generator_id,sig_id,sig_rev,msg,proto,src,srcport,dst,dstport,id,classification,priority */
+				/*              0         1            2      3       4   5     6   7       8   9       10 11             12       13     14          */
+				/* File format: timestamp,generator_id,sig_id,sig_rev,msg,proto,src,srcport,dst,dstport,id,classification,priority,action,disposition */
 				if (!$fd = fopen("/tmp/alert_snort{$snort_uuid}", "r")) {
 					log_error(gettext("[Snort Widget] Failed to open file /tmp/alert_snort{$snort_uuid}"));
 					continue;
 				}
 				while (($fields = fgetcsv($fd, 1000, ',', '"')) !== FALSE) {
-					if(count($fields) < 13)
+					if(count($fields) < 14 || count($fields) > 15)
 						continue;
 
 					// Get the Snort interface this alert was received from

--- a/security/pfSense-pkg-snort/files/var/db/snort/sidmods/dropsid-sample.conf
+++ b/security/pfSense-pkg-snort/files/var/db/snort/sidmods/dropsid-sample.conf
@@ -1,0 +1,45 @@
+# Note: This file is used to specify what rules you wish to be set to have
+# an action of drop rather than alert.
+
+# Example of modifying action for individual rules
+# 1:1034,1:9837,1:1270,1:3390,1:710,1:1249,3:13010
+
+# Example of modifying action for rule ranges
+# 1:220-1:3264,3:13010-3:13013
+
+# Comments are allowed in this file, and can also be on the same line
+# as the modify action syntax, as long as it is a trailing comment
+# 1:1011 # I Modified this rule action because I could!
+
+# Example of modifying action for MS and cve rules, note the use of the : 
+# in cve. This will modify MS09-008, cve 2009-0233, bugtraq 21301,
+# and all MS00 and all cve 2000 related sids!  These support regular expression
+# matching only after you have specified what you are looking for, i.e. 
+# MS00-<regex> or cve:<regex>, the first section CANNOT contain a regular
+# expression (MS\d{2}-\d+) will NOT work, use the pcre: keyword (below)
+# for this.
+# MS09-008,cve:2009-0233,bugtraq:21301,MS00-\d+,cve:2000-\d+
+
+# Example of using the pcre: keyword to modify rule action.  the pcre keyword 
+# allows for full use of regular expression syntax, you do not need to designate
+# with / and all pcre searches are treated as case insensitive. For more information 
+# about regular expression syntax: http://www.regular-expressions.info/
+# The following example modifies action for all MS07 through MS10 
+# pcre:MS(0[7-9]|10)-\d+
+
+# The following example modifies action for Snort VRT rules tagged with IPS 
+# Policy Security and ips drop.  Note the better way to accomplish this is
+# by setting the option "IPS Policy Mode" to "policy" on the CATEGORIES tab.
+# -----------------
+# pcre:"pcre:security-ips\s*drop"
+
+# Example of modifying action for specific categories entirely
+# VRT-web-iis,ET-shellcode,ET-emergingthreats-smtp,Custom-shellcode,Custom-emergingthreats-smtp
+
+# Any of the above values can be on a single line or multiple lines, when 
+# on a single line they simply need to be separated by a ,
+# 1:9837,1:220-1:3264,3:13010-3:13013,pcre:MS(0[0-7])-\d+,MS09-008,cve:2009-0233
+
+# The modifications in this file are for sample/example purposes only and
+# should not actively be used, you need to modify this file to fit your 
+# environment.

--- a/security/pfSense-pkg-snort/files/var/db/snort/sidmods/rejectsid-sample.conf
+++ b/security/pfSense-pkg-snort/files/var/db/snort/sidmods/rejectsid-sample.conf
@@ -1,0 +1,44 @@
+# Note: This file is used to specify what rules you wish to be set to have
+# an action of reject rather than alert.
+
+# Example of modifying action for individual rules
+# 1:1034,1:9837,1:1270,1:3390,1:710,1:1249,3:13010
+
+# Example of modifying action for rule ranges
+# 1:220-1:3264,3:13010-3:13013
+
+# Comments are allowed in this file, and can also be on the same line
+# as the modify action syntax, as long as it is a trailing comment
+# 1:1011 # I Modified this rule action to reject because I could!
+
+# Example of modifying action for MS and cve rules, note the use of the : 
+# in cve. This will modify MS09-008, cve 2009-0233, bugtraq 21301,
+# and all MS00 and all cve 2000 related sids!  These support regular expression
+# matching only after you have specified what you are looking for, i.e. 
+# MS00-<regex> or cve:<regex>, the first section CANNOT contain a regular
+# expression (MS\d{2}-\d+) will NOT work, use the pcre: keyword (below)
+# for this.
+# MS09-008,cve:2009-0233,bugtraq:21301,MS00-\d+,cve:2000-\d+
+
+# Example of using the pcre: keyword to modify rule action.  the pcre keyword 
+# allows for full use of regular expression syntax, you do not need to designate
+# with / and all pcre searches are treated as case insensitive. For more information 
+# about regular expression syntax: http://www.regular-expressions.info/
+# The following example modifies action for all MS07 through MS10 
+# pcre:MS(0[7-9]|10)-\d+
+
+# The following example modifies action to reject for Snort VRT rules tagged with 
+# IPS Policy Security and ips drop.
+# -----------------
+# pcre:"pcre:security-ips\s*drop"
+
+# Example of modifying action for specific categories entirely
+# VRT-web-iis,ET-shellcode,ET-emergingthreats-smtp,Custom-shellcode,Custom-emergingthreats-smtp
+
+# Any of the above values can be on a single line or multiple lines, when 
+# on a single line they simply need to be separated by a ,
+# 1:9837,1:220-1:3264,3:13010-3:13013,pcre:MS(0[0-7])-\d+,MS09-008,cve:2009-0233
+
+# The modifications in this file are for sample/example purposes only and
+# should not actively be used, you need to modify this file to fit your 
+# environment.

--- a/security/pfSense-pkg-snort/pkg-plist
+++ b/security/pfSense-pkg-snort/pkg-plist
@@ -48,6 +48,8 @@ www/widgets/include/widget-snort.inc
 /var/db/snort/sidmods/disablesid-sample.conf
 /var/db/snort/sidmods/enablesid-sample.conf
 /var/db/snort/sidmods/modifysid-sample.conf
+/var/db/snort/sidmods/dropsid-sample.conf
+/var/db/snort/sidmods/rejectsid-sample.conf
 %%DATADIR%%/info.xml
 @dir /etc/inc/priv
 @dir /etc/inc


### PR DESCRIPTION
### pfSense-pkg-snort-4.1.2
This updates the Snort GUI package on pfSense-2.4.5 RELEASE to the same code base used in pfSense-2.5 DEVEL. This new version supports an Inline IPS Mode of operation using the netmap device via the improved DAQ library (version 2.2.2_2).

**New Features:**
1. Inline IPS Mode blocking option now available for all interfaces.

2. Improvements to logging ported in from the DEVEL package by using the PHP `syslog()` function to steer messages based on Priority.

3. Update Emerging Threats and OpenAppID rules download URLs to use HTTPS instead of HTTP.