### PR TITLE
pfSense-pkg-snort-4.1.2_1 -- Address Redmine Issue #10917, Snort start failure due to PID file suffix limit.

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.1.2
-PORTREVISION=	0
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -500,30 +500,31 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
 	return $valresult;
 }
 
-/* checks to see if service is running */
-function snort_is_running($if_real, $type = 'snort') {
+/* Checks to see if service is running by looking for PID filename matching the UUID */
+function snort_is_running($uuid) {
 	global $config, $g;
 
-	return isvalidpid("{$g['varrun_path']}/{$type}_{$if_real}.pid");
+	return isvalidpid("{$g['varrun_path']}/snort_{$uuid}.pid");
 }
 
 function snort_stop($snortcfg, $if_real) {
 	global $config, $g;
+	$snort_uuid = $snortcfg['uuid'];
 
-	if (isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid")) {
+	if (isvalidpid("{$g['varrun_path']}/snort_{$snort_uuid}.pid")) {
 		syslog(LOG_NOTICE, "[Snort] Snort STOP for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
-		killbypid("{$g['varrun_path']}/snort_{$if_real}.pid");
+		killbypid("{$g['varrun_path']}/snort_{$snort_uuid}.pid");
 
 		// Now wait up to 10 seconds for Snort to actually stop and clear its PID file
 		$count = 0;
 		do {
-			if (!isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid"))
+			if (!isvalidpid("{$g['varrun_path']}/snort_{$snort_uuid}.pid"))
 				break;
 			sleep(1);
 			$count++;
 		} while ($count < 10);
 	}
-	unlink_if_exists("{$g['varrun_path']}/snort_{$if_real}.pid");
+	unlink_if_exists("{$g['varrun_path']}/snort_{$snort_uuid}.pid");
 }
 
 function snort_start($snortcfg, $if_real, $background=FALSE) {
@@ -540,11 +541,11 @@ function snort_start($snortcfg, $if_real, $background=FALSE) {
 		$quiet = "-q --suppress-config-log";
 
 	// If Snort is already running on this interface, stop it before restarting
-	if (snort_is_running($if_real)) {
+	if (snort_is_running($snort_uuid)) {
 		snort_stop($snortcfg, $if_real);
 	}
 
-	if ($snortcfg['enable'] == 'on' && $if_real <> "" && !isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid")) {
+	if ($snortcfg['enable'] == 'on' && $if_real <> "" && !isvalidpid("{$g['varrun_path']}/snort_{$snort_uuid}.pid")) {
 
 		// Adjust the interface specification and DAQ type according to operating mode
 		if ($snortcfg['ips_mode'] == "ips_mode_inline" && $snortcfg['blockoffenders7'] == "on") {
@@ -558,9 +559,9 @@ function snort_start($snortcfg, $if_real, $background=FALSE) {
 
 		syslog(LOG_NOTICE, "[Snort] Snort START for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
 		if ($background)
-			mwexec_bg("{$snortbindir}snort -R _{$if_real} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface}");
+			mwexec_bg("{$snortbindir}snort -R _{$snort_uuid} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface}");
 		else
-			mwexec("{$snortbindir}snort -R _{$if_real} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface}");
+			mwexec("{$snortbindir}snort -R _{$snort_uuid} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface}");
 	}
 }
 
@@ -642,9 +643,9 @@ function snort_reload_config($snortcfg, $signal="SIGHUP") {
 	/* Only send the SIGHUP if Snort is running and we    */
 	/* can find a valid PID for the process.              */
 	/******************************************************/
-	if (isvalidpid("{$g['varrun_path']}/snort_{$if_real}.pid")) {
+	if (isvalidpid("{$g['varrun_path']}/snort_{$snort_uuid}.pid")) {
 		syslog(LOG_NOTICE, "[Snort] Snort RELOAD CONFIG for " . convert_real_interface_to_friendly_descr($if_real) . "({$if_real})...");
-		mwexec_bg("/bin/pkill -{$signal} -F {$g['varrun_path']}/snort_{$if_real}.pid");
+		mwexec_bg("/bin/pkill -{$signal} -F {$g['varrun_path']}/snort_{$snort_uuid}.pid");
 	}
 }
 
@@ -3211,15 +3212,15 @@ function snort_create_rc() {
 		$start_snort_iface_start[] = <<<EOE
 
 	# Start snort for {$value['descr']}
-	if [ ! -f {$g['varrun_path']}/snort_{$if_real}.pid ]; then
-		pid=`/bin/pgrep -fn "snort -R {$if_real} "`
+	if [ ! -f {$g['varrun_path']}/snort_{$snort_uuid}.pid ]; then
+		pid=`/bin/pgrep -fn "snort -R {$snort_uuid} "`
 	else
-		pid=`/bin/pgrep -F {$g['varrun_path']}/snort_{$if_real}.pid`
+		pid=`/bin/pgrep -F {$g['varrun_path']}/snort_{$snort_uuid}.pid`
 	fi
 
 	if [ -z \$pid ]; then
 		/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort START for {$value['descr']}({$if_real})..."
-		{$snortbindir}snort -R _{$if_real} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface} > /dev/null 2>&1
+		{$snortbindir}snort -R _{$snort_uuid} -D {$quiet} {$daq_type} -l {$snortlogdir}/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile --no-interface-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$iface} > /dev/null 2>&1
 	fi
 
 EOE;
@@ -3227,10 +3228,10 @@ EOE;
 		$start_snort_iface_stop[] = <<<EOE
 
 	# Stop snort for {$value['descr']}
-	if [ -f {$g['varrun_path']}/snort_{$if_real}.pid ]; then
-		pid=`/bin/pgrep -F {$g['varrun_path']}/snort_{$if_real}.pid`
+	if [ -f {$g['varrun_path']}/snort_{$snort_uuid}.pid ]; then
+		pid=`/bin/pgrep -F {$g['varrun_path']}/snort_{$snort_uuid}.pid`
 		/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort STOP for {$value['descr']}({$if_real})..."
-		/bin/pkill -F {$g['varrun_path']}/snort_{$if_real}.pid -a
+		/bin/pkill -F {$g['varrun_path']}/snort_{$snort_uuid}.pid -a
 		time=0 timeout=30
 		while kill -0 \$pid 2>/dev/null; do
 			sleep 1
@@ -3239,11 +3240,11 @@ EOE;
 				break
 			fi
 		done
-		if [ -f {$g['varrun_path']}/snort_{$if_real}.pid ]; then
-			/bin/rm {$g['varrun_path']}/snort_{$if_real}.pid
+		if [ -f {$g['varrun_path']}/snort_{$snort_uuid}.pid ]; then
+			/bin/rm {$g['varrun_path']}/snort_{$snort_uuid}.pid
 		fi
 	else
-		pid=`/bin/pgrep -fn "snort -R {$if_real} "`
+		pid=`/bin/pgrep -fn "snort -R {$snort_uuid} "`
 		if [ ! -z \$pid ]; then
 			/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort STOP for {$value['descr']}({$snort_uuid}_{$if_real})..."
 			/bin/pkill -fn "snort -R {$if_real} "

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_cron_misc.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_cron_misc.inc
@@ -111,9 +111,9 @@ function snort_check_dir_size_limit($snortloglimitsize) {
 			mwexec('/bin/chmod 660 {$snort_log_dir}/*', true);
 
 			// Soft-restart Snort process to resync logging
-			if (file_exists("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid")) {
+			if (file_exists("{$g['varrun_path']}/snort_{$snort_uuid}.pid")) {
 				syslog(LOG_NOTICE, gettext("[Snort] Restarting logging on {$value['descr']} ({$if_real})..."));
-				mwexec("/bin/pkill -HUP -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid -a");
+				mwexec("/bin/pkill -HUP -F {$g['varrun_path']}/snort_{$snort_uuid}.pid -a");
 			}
 		}
 		syslog(LOG_NOTICE, gettext("[Snort] Automatic clean-up of Snort logs completed."));

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -500,8 +500,13 @@ if ($snortdownload == 'on') {
 	if (file_exists("{$tmpfname}/{$snort_filename}")) {
 		snort_update_status(gettext("Installing Snort Subscriber ruleset..."));
 
-		/* Default to FreeBSD-11 for now as that is highest available version of SO rules */
+		/* Determine the platform FreeBSD major version so we can unpack  */
+		/* the corresponding SO rules. Default to FreeBSD-11.             */
 		$freebsd_version_so = 'FreeBSD-11';
+		$major_os_ver = strcspn(php_uname('r'), ".-");
+		if ($major_os_ver > 0) {
+			$freebsd_version_so = 'FreeBSD-' . substr(php_uname('r'), 0, $major_os_ver);
+		}
 
 		/* Remove the old Snort rules files */
 		$vrt_prefix = VRT_FILE_PREFIX;

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_post_install.php
@@ -162,12 +162,14 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 	/* End of duplicate UUID bug fix.                               */
 	/****************************************************************/
 
-	/* Do one-time settings migration for new multi-engine configurations */
+	/* Do any required settings migration for new configurations */
 	update_status(gettext("Migrating settings to new configuration..."));
 	include('/usr/local/pkg/snort/snort_migrate_config.php');
 	update_status(gettext(" done.") . "\n");
 	syslog(LOG_NOTICE, gettext("[Snort] Downloading and updating configured rule sets."));
+	update_status(gettext("Downloading configured rule sets. This may take some time...") . "\n");
 	include('/usr/local/pkg/snort/snort_check_for_rule_updates.php');
+	update_status(gettext("Finished downloading and installing configured rules.") . "\n");
 	update_status(gettext("Generating snort.conf configuration file from saved settings.") . "\n");
 	$rebuild_rules = true;
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -550,8 +550,8 @@ if ($_POST['clear']) {
 	file_put_contents("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/alert", "");
 	/* XXX: This is needed if snort is run as snort user */
 	mwexec("/bin/chmod 660 {$snortlogdir}/*", true);
-	if (file_exists("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid"))
-		mwexec("/bin/pkill -HUP -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid -a");
+	if (file_exists("{$g['varrun_path']}/snort_{$snort_uuid}.pid"))
+		mwexec("/bin/pkill -HUP -F {$g['varrun_path']}/snort_{$snort_uuid}.pid -a");
 	unset($a_instance);
 	header("Location: /snort/snort_alerts.php?instance={$instanceid}");
 	exit;

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces.php
@@ -59,12 +59,12 @@ if ($_POST['status'] == 'check') {
 		$stop_lck_file = "{$g['varrun_path']}/{$intf_key}_stopping.lck";
 		$start_lck_file = "{$g['varrun_path']}/{$intf_key}_starting.lck";
 
-		if (!snort_is_running(get_real_interface($intf['interface']))) {
+		if (!snort_is_running($intf['uuid'])) {
 			unlink_if_exists($stop_lck_file);
 		}
 
 		if ($intf['enable'] == "on") {
-			if (snort_is_running(get_real_interface($intf['interface'])) && !file_exists($stop_lck_file)) {
+			if (snort_is_running($intf['uuid']) && !file_exists($stop_lck_file)) {
 				$list[$intf_key] = "RUNNING";
 				unlink_if_exists($start_lck_file);
 				unset($snort_starting[$i]);
@@ -228,7 +228,7 @@ EOD;
 		case 'start':
 			unlink_if_exists($stop_lck_file);
 			file_put_contents("{$g['tmp_path']}/snort_{$if_real}_startcmd.php", $snort_start_cmd);
-			if (snort_is_running($if_real)) {
+			if (snort_is_running($snortcfg['uuid'])) {
 				syslog(LOG_NOTICE, "Restarting Snort on {$if_friendly}({$if_real}) per user request...");
 				snort_stop($snortcfg, $if_real);
 				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/snort_{$if_real}_startcmd.php");
@@ -240,7 +240,7 @@ EOD;
 			$snort_starting[$id] = TRUE;
 			break;
 		case 'stop':
-			if (snort_is_running($if_real)) {
+			if (snort_is_running($snortcfg['uuid'])) {
 				touch($stop_lck_file);
 				syslog(LOG_NOTICE, "Stopping Snort on {$if_friendly}({$if_real}) per user request...");
 				snort_stop($snortcfg, $if_real);
@@ -359,7 +359,7 @@ if ($savemsg)
 					</td>
 					<td id="frd<?=$i?>" ondblclick="document.location='snort_interfaces_edit.php?id=<?=$i?>';">
 						<?php if ($natent['enable'] == 'on') : ?>
-							<?php if (snort_is_running($if_real) && !file_exists($stop_lck_file)) : ?>
+							<?php if (snort_is_running($snort_uuid) && !file_exists($stop_lck_file)) : ?>
 								<i id="snort_<?=$if_real;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('snort is running on this interface');?>"></i>
 								&nbsp;
 								<i id="snort_<?=$if_real;?>_restart" class="fa fa-repeat icon-pointer icon-primary text-info" onclick="javascript:snort_iface_toggle($(this), 'start', '<?=$i?>');" title="<?=gettext('Restart snort on this interface');?>"></i>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
@@ -326,7 +326,7 @@ if ($_POST['save'] && !$input_errors) {
 			// See if moving an existing Snort instance to another physical interface
 			if ($natent['interface'] != $a_rule[$id]['interface']) {
 				$oif_real = get_real_interface($a_rule[$id]['interface']);
-				if (snort_is_running($a_rule[$id]['uuid'], $oif_real)) {
+				if (snort_is_running($a_rule[$id]['uuid'])) {
 					snort_stop($a_rule[$id], $oif_real);
 					$snort_start = true;
 				}
@@ -503,14 +503,14 @@ if ($_POST['save'] && !$input_errors) {
 		}
 
 		/* See if we need to restart Snort to activate changes made */
-		if ($snort_restart && !$snort_start && snort_is_running($if_real)) {
+		if ($snort_restart && !$snort_start && snort_is_running($natent['uuid'])) {
 			snort_start($natent, $if_real, TRUE);
 			$savemsg = gettext('Restarted Snort on this interface to activate new saved configuration settings.');
 		}
 
 		/* See if we need to restart Snort after a Pass List re-assignment, */
 		/* but only if we did not restart for any other reason.             */
-		if ($snort_new_passlist && !$snort_start && !$snort_restart && snort_is_running($if_real)) {
+		if ($snort_new_passlist && !$snort_start && !$snort_restart && snort_is_running($natent['uuid'])) {
 			snort_start($natent, $if_real, TRUE);
 			$savemsg = gettext('Restarted Snort on this interface due to a Pass List change.');
 		}
@@ -522,7 +522,7 @@ if ($_POST['save'] && !$input_errors) {
 		/* function only signals a running Snort instance to   */
 		/* safely reload these parameters.                     */
 		/*******************************************************/
-		if ($snort_reload && !$snort_start && !$snort_restart && snort_is_running($if_real)) {
+		if ($snort_reload && !$snort_start && !$snort_restart && snort_is_running($natent['uuid'])) {
 			snort_reload_config($natent, "SIGHUP");
 			$savemsg = gettext('Signaled Snort to reload configuration due to change in HOME_NET, EXTERNAL_NET or Suppress List assignments.');
 		}

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ip_reputation.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ip_reputation.php
@@ -140,7 +140,7 @@ if ($_POST['apply']) {
 	snort_generate_conf($a_nat[$id]);
 
 	// If Snort is already running, must restart to change IP REP preprocessor configuration.
-	if (snort_is_running($if_real)) {
+	if (snort_is_running($a_nat[$id]['uuid'])) {
 		syslog(LOG_NOTICE, gettext("Snort: restarting on interface " . convert_real_interface_to_friendly_descr($if_real) . " due to IP REP preprocessor configuration change."));
 		snort_stop($a_nat[$id], $if_real);
 		snort_start($a_nat[$id], $if_real, TRUE);
@@ -183,7 +183,7 @@ if ($_POST['save']) {
 		snort_generate_conf($a_nat[$id]);
 
 		// If Snort is already running, must restart to change IP REP preprocessor configuration.
-		if (snort_is_running($if_real)) {
+		if (snort_is_running($a_nat[$id]['uuid'])) {
 			syslog(LOG_NOTICE, gettext("Snort: restarting on interface " . convert_real_interface_to_friendly_descr($if_real) . " due to IP REP preprocessor configuration change."));
 			snort_stop($a_nat[$id], $if_real);
 			snort_start($a_nat[$id], $if_real, TRUE);

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
@@ -734,7 +734,7 @@ if ($_POST['save']) {
 		/* in order to pick up any preprocessor setting */
 		/* changes.                                     */
 		$if_real = get_real_interface($a_nat[$id]['interface']);
-		if (snort_is_running($if_real)) {
+		if (snort_is_running($a_nat[$id]['uuid'])) {
 			syslog(LOG_NOTICE, gettext("Snort: restarting on interface " . convert_real_interface_to_friendly_descr($if_real) . " due to Preprocessor configuration change."));
 			snort_stop($a_nat[$id], $if_real);
 			snort_start($a_nat[$id], $if_real, TRUE);

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
@@ -931,7 +931,7 @@ elseif ($_POST['apply']) {
 	// Sync to configured CARP slaves if any are enabled
 	snort_sync_on_changes();
 
-	if (snort_is_running($if_real))
+	if (snort_is_running($a_rule[$id]['uuid']))
 		$savemsg = gettext("Snort is 'live-reloading' the new rule set.");
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
@@ -161,7 +161,7 @@ if (isset($_POST["save"])) {
 
 	$pconfig = $_POST;
 	$enabled_rulesets_array = explode("||", $enabled_items);
-	if (snort_is_running($if_real))
+	if (snort_is_running($a_nat[$id]['uuid']))
 		$savemsg = gettext("Snort is 'live-reloading' the new rule set.");
 
 	// Sync to configured CARP slaves if any are enabled


### PR DESCRIPTION
### pfSense-pkg-snort-4.1.2_1
This update to the Snort GUI package corrects the bug reported in [Redmine Issue #10917](https://redmine.pfsense.org/issues/10917). The Snort binary would fail to start in instances where the physical real interface name plus any associated VLAN ID exceeded 10 characters in length. This could occur with certain physical interfaces (e.g., _mvneta1_) when VLAN IDs longer than 2 characters were added. Other interface naming scenarios could also trigger the problem.

There is an 11-character limit (including the terminating NULL) on PID filename suffixes supported by the Snort binary.

**New Features:**
1. When unpacking the Snort Subscriber Rules, the code now queries the firewall host OS for the correct version (FreeBSD-11 or FreeBSD-12) and unpacks the appropriate Shared Object (SO) rules for the platform.

**Bug Fixes:**
1. Under specific conditions, with long physical interface names combined with VLAN IDs or other characters, the Snort binary would throw a fatal startup error due to the passed PID filename suffix exceeding 10 characters. See [Redmine Issue #10917](https://redmine.pfsense.org/issues/10917).