### PR TITLE
BandwidthD frame resize fix. Issue #10911

### DIFF
--- a/net-mgmt/pfSense-pkg-bandwidthd/Makefile
+++ b/net-mgmt/pfSense-pkg-bandwidthd/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-bandwidthd
 PORTVERSION=	0.7.4
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-bandwidthd/files/usr/local/www/diag_bandwidthd.php
+++ b/net-mgmt/pfSense-pkg-bandwidthd/files/usr/local/www/diag_bandwidthd.php
@@ -40,7 +40,7 @@ display_top_tabs($tab_array);
 
 <?php include("foot.inc"); ?>
 <script>
-$('#bandwidthd').load(function() {
+$('#bandwidthd').on('load', function() {
 	/* Find height of iframe contnet and then add 20px for padding */
 	$(this).height( $(this).contents().find("body").height() + 20 );
 });


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10911
- [X] Ready for review

from https://api.jquery.com/load-event/:
> Note: This API has been removed in jQuery 3.0; please use .on( "load", handler ) instead of .load( handler ) and .trigger( "load" ) instead of .load().