### PR TITLE
Wrap net-snmp IPv6 listen address in square brackets

### DIFF
--- a/net-mgmt/pfSense-pkg-net-snmp/Makefile
+++ b/net-mgmt/pfSense-pkg-net-snmp/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-net-snmp
 PORTVERSION=	0.1.5
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-net-snmp/files/usr/local/pkg/net-snmp.inc
+++ b/net-mgmt/pfSense-pkg-net-snmp/files/usr/local/pkg/net-snmp.inc
@@ -200,7 +200,11 @@ function netsnmp_resync() {
 		}
 		/* An address or hostname is optional but needs to be before the port */
 		if (!empty($agent['ipaddress'])) {
-			$aa = "{$agent['ipaddress']}:{$aa}";
+			if (is_ipaddrv6($agent['ipaddress'])) {
+				$aa = "[{$agent['ipaddress']}]:{$aa}";
+			} else {
+				$aa = "{$agent['ipaddress']}:{$aa}";
+			}
 		}
 		/* Transport is optional (UDP is assumed) */
 		if (!empty($agent['transport'])) {


### PR DESCRIPTION
With net-snmp v5.7 (current 2.4.5) snmpd will accept an IPv6 listen address without square brackets, with v5.9 (2.5.0 dev) it requires them to be wrapped in square brackets and will silently fail to start without them. Running in debug to stdout will show a failed to bind error for the v6 address.

Both versions will accept the address in square brackets so do it regardless.

Redmine: https://redmine.pfsense.org/issues/10990