### PR TITLE
suricata - Update Suricata binary to the latest 6.0.0 version from upstream.

### DIFF
--- a/security/suricata/Makefile
+++ b/security/suricata/Makefile
@@ -2,7 +2,7 @@
 # $FreeBSD$
 
 PORTNAME=	suricata
-DISTVERSION=	5.0.3
+DISTVERSION=	6.0.0
 CATEGORIES=	security
 MASTER_SITES=	https://www.openinfosecfoundation.org/download/
 

--- a/security/suricata/distinfo
+++ b/security/suricata/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1593532636
-SHA256 (suricata-5.0.3.tar.gz) = 34413ecdad2ff2452526dbcd22f1279afd0935151916c0ff9cface4b0b5665db
-SIZE (suricata-5.0.3.tar.gz) = 23744731
+TIMESTAMP = 1603981496
+SHA256 (suricata-6.0.0.tar.gz) = 3c175a6dee9071141391f64828502cfb6e48dc1a20833e1411fb45be5368923b
+SIZE (suricata-6.0.0.tar.gz) = 30832555

--- a/security/suricata/files/patch-alert-pf.diff
+++ b/security/suricata/files/patch-alert-pf.diff
@@ -1,38 +1,38 @@
-diff -ruN ./suricata-5.0.3.orig/src/Makefile.am ./suricata-5.0.3/src/Makefile.am
---- ./suricata-5.0.3.orig/src/Makefile.am	2020-04-28 06:06:20.000000000 -0400
-+++ ./src/Makefile.am	2020-06-30 12:23:55.000000000 -0400
-@@ -10,6 +10,7 @@
- suricata_SOURCES = \
+diff -ruN ./suricata-6.0.0.orig/src/Makefile.am ./suricata-6.0.0/src/Makefile.am
+--- ./suricata-6.0.0.orig/src/Makefile.am	2020-10-07 12:53:53.000000000 -0400
++++ ./src/Makefile.am	2020-10-29 10:50:01.000000000 -0400
+@@ -16,6 +16,7 @@
+ COMMON_SOURCES = \
  alert-debuglog.c alert-debuglog.h \
  alert-fastlog.c alert-fastlog.h \
 +alert-pf.c alert-pf.h \
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
- alert-unified2-alert.c alert-unified2-alert.h \
-diff -ruN ./suricata-5.0.3.orig/src/Makefile.in ./suricata-5.0.3/src/Makefile.in
---- ./suricata-5.0.3.orig/src/Makefile.in	2020-04-28 06:06:35.000000000 -0400
-+++ ./src/Makefile.in	2020-06-30 12:25:12.000000000 -0400
-@@ -110,7 +110,7 @@
- am__installdirs = "$(DESTDIR)$(bindir)"
+ app-layer.c app-layer.h \
+diff -ruN ./suricata-6.0.0.orig/src/Makefile.in ./suricata-6.0.0/src/Makefile.in
+--- ./suricata-6.0.0.orig/src/Makefile.in	2020-10-07 12:54:18.000000000 -0400
++++ ./src/Makefile.in	2020-10-29 10:51:45.000000000 -0400
+@@ -137,7 +137,7 @@
  PROGRAMS = $(bin_PROGRAMS)
- am_suricata_OBJECTS = alert-debuglog.$(OBJEXT) alert-fastlog.$(OBJEXT) \
+ am__dirstamp = $(am__leading_dot)dirstamp
+ am__objects_1 = alert-debuglog.$(OBJEXT) alert-fastlog.$(OBJEXT) \
 -	alert-prelude.$(OBJEXT) alert-syslog.$(OBJEXT) \
 +	alert-pf.$(OBJEXT) alert-prelude.$(OBJEXT) alert-syslog.$(OBJEXT) \
- 	alert-unified2-alert.$(OBJEXT) app-layer.$(OBJEXT) \
- 	app-layer-dcerpc.$(OBJEXT) app-layer-dcerpc-udp.$(OBJEXT) \
+ 	app-layer.$(OBJEXT) app-layer-dcerpc.$(OBJEXT) \
+ 	app-layer-dcerpc-udp.$(OBJEXT) \
  	app-layer-detect-proto.$(OBJEXT) app-layer-dnp3.$(OBJEXT) \
-@@ -661,6 +661,7 @@
- suricata_SOURCES = \
+@@ -868,6 +868,7 @@
+ COMMON_SOURCES = \
  alert-debuglog.c alert-debuglog.h \
  alert-fastlog.c alert-fastlog.h \
 +alert-pf.c alert-pf.h \
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
- alert-unified2-alert.c alert-unified2-alert.h \
-diff -ruN ./suricata-5.0.3.orig/src/alert-pf.c ./suricata-5.0.3/src/alert-pf.c
---- ./suricata-5.0.3.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/alert-pf.c	2020-01-06 14:22:20.000000000 -0500
-@@ -0,0 +1,1151 @@
+ app-layer.c app-layer.h \
+diff -ruN ./suricata-6.0.0.orig/src/alert-pf.c ./suricata-6.0.0/src/alert-pf.c
+--- ./suricata-6.0.0.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
++++ ./src/alert-pf.c	2020-10-29 11:43:20.000000000 -0400
+@@ -0,0 +1,1148 @@
 +/* Copyright (C) 2007-2020 Open Information Security Foundation
 + *
 + * You can copy, redistribute or modify this Program under the terms of
@@ -694,9 +694,6 @@ diff -ruN ./suricata-5.0.3.orig/src/alert-pf.c ./suricata-5.0.3/src/alert-pf.c
 +        SCLogInfo("alert-pf output processed %" PRIu64 " alert", alerts);
 +    else
 +        SCLogInfo("alert-pf output processed %" PRIu64 " alerts", alerts);
-+
-+    SC_ATOMIC_DESTROY(alert_pf_blocks);
-+    SC_ATOMIC_DESTROY(alert_pf_alerts);
 +}
 +
 +/** \brief Thread for monitoring firewall interface IP address changes.
@@ -1184,8 +1181,8 @@ diff -ruN ./suricata-5.0.3.orig/src/alert-pf.c ./suricata-5.0.3/src/alert-pf.c
 +    return TM_ECODE_OK;
 +}
 +
-diff -ruN ./suricata-5.0.3.orig/src/alert-pf.h ./suricata-5.0.3/src/alert-pf.h
---- ./suricata-5.0.3.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
+diff -ruN ./suricata-6.0.0.orig/src/alert-pf.h ./suricata-6.0.0/src/alert-pf.h
+--- ./suricata-6.0.0.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
 +++ ./src/alert-pf.h	2020-02-29 10:25:58.000000000 -0500
 @@ -0,0 +1,59 @@
 +/* Copyright (C) 2007-2020 Open Information Security Foundation
@@ -1247,32 +1244,30 @@ diff -ruN ./suricata-5.0.3.orig/src/alert-pf.h ./suricata-5.0.3/src/alert-pf.h
 +
 +#endif /* __ALERT_PF_H__ */
 +
-diff -ruN ./suricata-5.0.3.orig/src/output.c ./suricata-5.0.3/src/output.c
---- ./suricata-5.0.3.orig/src/output.c	2020-04-28 06:06:20.000000000 -0400
-+++ ./src/output.c	2020-06-30 12:26:27.000000000 -0400
-@@ -43,6 +43,7 @@
+diff -ruN ./suricata-6.0.0.orig/src/output.c ./suricata-6.0.0/src/output.c
+--- ./suricata-6.0.0.orig/src/output.c	2020-10-07 12:53:53.000000000 -0400
++++ ./src/output.c	2020-10-29 10:53:44.000000000 -0400
+@@ -42,6 +42,7 @@
+ 
  #include "alert-fastlog.h"
- #include "alert-unified2-alert.h"
  #include "alert-debuglog.h"
 +#include "alert-pf.h"
  #include "alert-prelude.h"
  #include "alert-syslog.h"
- #include "output-json-alert.h"
-@@ -1048,6 +1049,10 @@
+ #include "output-json.h"
+@@ -1045,6 +1046,8 @@
      AlertFastLogRegister();
      /* debug log */
      AlertDebugLogRegister();
 +    /* alerf pf */
 +    AlertPfRegister();
-+    /* alerf pf */
-+    AlertPfRegister();
      /* prelue log */
      AlertPreludeRegister();
      /* syslog log */
-diff -ruN ./suricata-5.0.3.orig/src/suricata-common.h ./suricata-5.0.3/src/suricata-common.h
---- ./suricata-5.0.3.orig/src/suricata-common.h	2020-04-28 06:06:20.000000000 -0400
-+++ ./src/suricata-common.h	2020-06-30 12:26:59.000000000 -0400
-@@ -461,6 +461,7 @@
+diff -ruN ./suricata-6.0.0.orig/src/suricata-common.h ./suricata-6.0.0/src/suricata-common.h
+--- ./suricata-6.0.0.orig/src/suricata-common.h	2020-10-07 12:53:53.000000000 -0400
++++ ./src/suricata-common.h	2020-10-29 10:54:25.000000000 -0400
+@@ -488,6 +488,7 @@
      LOGGER_PRELUDE,
      LOGGER_PCAP,
      LOGGER_JSON_METADATA,

--- a/security/suricata/pkg-plist
+++ b/security/suricata/pkg-plist
@@ -72,8 +72,6 @@ man/man1/suricata.1.gz
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/commands/disablesource.pyc
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/commands/enablesource.py
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/commands/enablesource.pyc
-%%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/commands/listenabledsources.py
-%%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/commands/listenabledsources.pyc
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/commands/listsources.py
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/commands/listsources.pyc
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/commands/removesource.py
@@ -128,7 +126,7 @@ man/man1/suricata.1.gz
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/util.pyc
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/version.py
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/version.pyc
-%%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata_update-1.1.2-py%%PYTHON_VER%%.egg-info
+%%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata_update-1.2.0-py%%PYTHON_VER%%.egg-info
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricatasc/__init__.py
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricatasc/__init__.pyc
 %%DATADIR%%/rules/app-layer-events.rules


### PR DESCRIPTION
### Suricata v6.0.0
This updates the Suricata binary on pfSense AMD64 platforms to the latest 6.0.0 version from upstream. Release Notes for this version can be found here:  [https://suricata-ids.org/2020/10/08/suricata-6-0-0-released/](https://suricata-ids.org/2020/10/08/suricata-6-0-0-released/).