### PR TITLE
pfSense-pkg-suricata-6.0.0 -- Fix Redmine Issues 10950 and 9789, update to support version 6.0.0 binary.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	5.0.3
+PORTVERSION=	6.0.0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -12,7 +12,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=5.0.3:security/suricata
+RUN_DEPENDS=	suricata>=6.0.0:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -763,7 +763,7 @@ if (!is_array($suricatacfg['libhtp_policy']))
 if (!is_array($suricatacfg['libhtp_policy']['item']))
 	$suricatacfg['libhtp_policy']['item'] = array();
 if (count($suricatacfg['libhtp_policy']['item']) < 1) {
-	$http_hosts_default_policy = "     personality: IDS\n     request-body-limit: 4096\n     response-body-limit: 4096\n";
+	$http_hosts_default_policy = "personality: IDS\n     request-body-limit: 4096\n     response-body-limit: 4096\n";
 	$http_hosts_default_policy .= "     double-decode-path: no\n     double-decode-query: no\n     uri-include-all: no\n";
 }
 else {
@@ -801,7 +801,7 @@ else {
 			}
 		}
 		else {
-			$http_hosts_default_policy = "     personality: {$v['personality']}\n     request-body-limit: {$v['request-body-limit']}\n";
+			$http_hosts_default_policy = "personality: {$v['personality']}\n     request-body-limit: {$v['request-body-limit']}\n";
 			$http_hosts_default_policy .= "     response-body-limit: {$v['response-body-limit']}\n";
 			$http_hosts_default_policy .= "     meta-field-limit: " . (isset($v['meta-field-limit']) ? $v['meta-field-limit'] : "18432") . "\n";
 			$http_hosts_default_policy .= "     double-decode-path: {$v['double-decode-path']}\n";
@@ -809,7 +809,7 @@ else {
 			$http_hosts_default_policy .= "     uri-include-all: {$v['uri-include-all']}\n";
 		}
 	}
-	// Remove trailing newline
+	// Remove any leading or trailing spaces and newline
 	$http_hosts_default_policy = trim($http_hosts_default_policy);
 	$http_hosts_policy = trim($http_hosts_policy);
 }

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -55,9 +55,26 @@ if (isset($_POST['del_x'])) {
 			$if_real = get_real_interface($a_nat[$rulei]['interface']);
 			$if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$rulei]['interface']);
 			$suricata_uuid = $a_nat[$rulei]['uuid'];
-			suricata_stop($a_nat[$rulei], $if_real);
-			rmdir_recursive("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}");
-			rmdir_recursive("{$suricatadir}suricata_{$suricata_uuid}_{$if_real}");
+
+			// Check that we still have the real interface defined in pfSense.
+			// The real interface will return as an empty string if it has
+			// been removed in pfSense.
+			if ($if_real == "") {
+				rmdir_recursive("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}");
+				rmdir_recursive("{$suricatadir}suricata_{$suricata_uuid}_*");
+				syslog(LOG_NOTICE, "Deleted the Suricata instance on a previously removed pfSense interface per user request...");
+			}
+			else {
+				// Delete the interface sub-directories and then the instance itself
+				$if_friendly = convert_friendly_interface_to_friendly_descr($snortcfg['interface']);
+				syslog(LOG_NOTICE, "Stopping Suricata on {$if_friendly}({$if_real}) due to Suricata instance deletion...");
+				suricata_stop($a_nat[$rulei], $if_real);
+				rmdir_recursive("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}");
+				rmdir_recursive("{$suricatadir}suricata_{$suricata_uuid}_{$if_real}");
+				syslog(LOG_NOTICE, "Deleted Suricata instance on {$if_friendly}({$if_real}) per user request...");
+			}
+
+			// Finally, delete the interface's config entry entirely
 			unset($a_nat[$rulei]);
 		}
 
@@ -90,14 +107,27 @@ if (isset($_POST['del_x'])) {
 		$if_real = get_real_interface($a_nat[$delbtn_list]['interface']);
 		$if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$delbtn_list]['interface']);
 		$suricata_uuid = $a_nat[$delbtn_list]['uuid'];
-		syslog(LOG_NOTICE, "Stopping Suricata on {$if_friendly}({$if_real}) due to interface deletion...");
-		suricata_stop($a_nat[$delbtn_list], $if_real);
-		rmdir_recursive("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}");
-		rmdir_recursive("{$suricatadir}suricata_{$suricata_uuid}_{$if_real}");
 
-		// Finally delete the interface's config entry entirely
-		unset($a_nat[$delbtn_list]);
-		syslog(LOG_NOTICE, "Deleted Suricata instance on {$if_friendly}({$if_real}) per user request...");
+		// Check that we still have the real interface defined in pfSense.
+		// The real interface will return as an empty string if it has
+		// been removed in pfSense.
+		if ($if_real == "") {
+			rmdir_recursive("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}");
+			rmdir_recursive("{$suricatadir}suricata_{$suricata_uuid}_*");
+			syslog(LOG_NOTICE, "Deleted the Suricata instance on a previously removed pfSense interface per user request...");
+		}
+		else {
+			// Delete the interface sub-directories and then the instance itself
+			$if_friendly = convert_friendly_interface_to_friendly_descr($snortcfg['interface']);
+			syslog(LOG_NOTICE, "Stopping Suricata on {$if_friendly}({$if_real}) due to Suricata instance deletion...");
+			suricata_stop($a_nat[$rulei], $if_real);
+			rmdir_recursive("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}");
+			rmdir_recursive("{$suricatadir}suricata_{$suricata_uuid}_{$if_real}");
+			syslog(LOG_NOTICE, "Deleted Suricata instance on {$if_friendly}({$if_real}) per user request...");
+		}
+
+		// Finally, delete the interface's config entry entirely
+		unset($a_nat[$rulei]);
 
 		// Save updated configuration
 		write_config("Suricata pkg: deleted one or more Suricata interfaces.");
@@ -185,6 +215,10 @@ if ($_POST['status'] == 'check') {
 	// into an associative array.  Return the array to the Ajax
 	// caller as a JSON object.
 	foreach ($a_nat as $intf) {
+		// Skip status update for any missing real interface
+		if (($if_real = get_real_interface($intf['interface'])) == "") {
+			continue;
+		}
 		$intf_key = "suricata_" . get_real_interface($intf['interface']) . $intf['uuid'];
 		if ($intf['enable'] == "on") {
 			if (suricata_is_running($intf['uuid'], get_real_interface($intf['interface']))) {
@@ -283,10 +317,17 @@ include_once("head.inc"); ?>
 ?>
 				<tr id="fr<?=$nnats?>">
 <?php
-					/* convert fake interfaces to real and check if iface is up */
-					/* There has to be a smarter way to do this */
+					/* Convert fake interfaces to real and check if iface is up. */
+					/* A null real interface indicates it has been removed from system. */
 					$if_real = get_real_interface($natent['interface']);
-					$natend_friendly= convert_friendly_interface_to_friendly_descr($natent['interface']);
+					if (($if_real = get_real_interface($natent['interface'])) == "") {
+						$natent['enable'] = "off";
+						$natend_friendly = gettext("Missing (removed?)");
+					}
+					else {
+						$natend_friendly = convert_friendly_interface_to_friendly_descr($natent['interface']) . " ({$if_real})";
+					}
+
 					$suricata_uuid = $natent['uuid'];
 
 					/* See if interface has any rules defined and set boolean flag */

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -31,6 +31,14 @@ global $g, $rebuild_rules;
 $suricatadir = SURICATADIR;
 $suricatalogdir = SURICATALOGDIR;
 
+// Define an array of native-mode netmap compatible NIC drivers
+$netmapifs = array('cc', 'cxl', 'cxgbe', 'em', 'igb', 'em', 'lem', 'ix', 'ixgbe', 'ixl', 're', 'vtnet');
+if (pfs_version_compare(false, 2.4, $g['product_version'])) {
+	/* add FreeBSD 12 iflib(4) supported devices */
+	$netmapifs = array_merge($netmapifs, array('ice', 'bnxt', 'vmx'));
+	sort($netmapifs);
+}
+
 init_config_arr(array('installedpackages', 'suricata', 'rule'));
 $suricataglob = $config['installedpackages']['suricata'];
 $a_rule = &$config['installedpackages']['suricata']['rule'];
@@ -302,6 +310,20 @@ if (isset($_POST["save"]) && !$input_errors) {
 				$input_errors[] = gettext("The '{$_POST['interface']}' interface is already assigned to another Suricata instance.");
 				break;
 			}
+		}
+	}
+
+	if ($_POST['ips_mode'] == 'ips_mode_inline') {
+		$is_netmap = false;
+		$realint = get_real_interface($_POST['interface']);
+		foreach ($netmapifs as $if) {
+			if (substr($realint, 0, strlen($if)) == $if) {
+				$is_netmap = true;
+				break;
+			}
+		}
+		if (!$is_netmap) {
+			$input_errors[] = gettext("The '{$_POST['interface']}' interface does not support Inline IPS Mode with native netmap.");
 		}
 	}
 
@@ -653,9 +675,11 @@ if ($savemsg2) {
 	print_info_box($savemsg2);
 }
 
+// If using Inline IPS, check that CSO, TSO and LRO are all disabled
 if ($pconfig['enable'] == 'on' && $pconfig['ips_mode'] == 'ips_mode_inline' && (!isset($config['system']['disablechecksumoffloading']) || !isset($config['system']['disablesegmentationoffloading']) || !isset($config['system']['disablelargereceiveoffloading']))) {
-	print_info_box(gettext('IPS inline mode requires that Hardware Checksum, Hardware TCP Segmentation and Hardware Large Receive Offloading ' .
-				'all be disabled on the ') . '<b>' . gettext('System > Advanced > Networking ') . '</b>' . gettext('tab.'));
+	print_info_box(gettext('WARNING! IPS inline mode requires that Hardware Checksum Offloading, Hardware TCP Segmentation Offloading and Hardware Large Receive Offloading ' .
+				'all be disabled for proper operation. This firewall currently has one or more of these Offloading settings NOT disabled. Visit the ') . '<a href="/system_advanced_network.php">' . 
+			        gettext('System > Advanced > Networking') . '</a>' . gettext(' tab and ensure all three of these Offloading settings are disabled.'));
 }
 
 $tab_array = array();

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -76,6 +76,14 @@ $suricata_uuid = $pconfig['uuid'];
 // Get the physical configured interfaces on the firewall
 $interfaces = get_configured_interface_with_descr();
 
+// Footnote real interface associated with each configured interface
+foreach ($interfaces as $if => $desc) {
+	$interfaces[$if] = $interfaces[$if] . " (" . get_real_interface($if) . ")";
+}
+
+// Add a special "Unassigned" interface selection at end of list
+$interfaces["Unassigned"] = gettext("Unassigned");
+
 // See if interface is already configured, and use its values
 if (isset($id) && isset($a_rule[$id])) {
 	/* old options */
@@ -84,6 +92,10 @@ if (isset($id) && isset($a_rule[$id])) {
 		$pconfig['configpassthru'] = base64_decode($pconfig['configpassthru']);
 	if (empty($pconfig['uuid']))
 		$pconfig['uuid'] = $suricata_uuid;
+	if (get_real_interface($pconfig['interface']) == "") {
+		$pconfig['interface'] = gettext("Unassigned");
+		$pconfig['enable'] = "off";
+	}
 }
 
 // Must be a new interface, so try to pick next available physical interface to use


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.0
This package update provides support for the latest 6.0.0 Suricata binary and fixes four bugs. No new features are added.

**New Features:**
None

**Bug Fixes:**
1. Check that LRO, TSO and all Hardware Checksumming is disabled in pfSense _config.xml_ when user enables and saves "IPS Inline" mode configuration.

2. Potential YAML key indentation issue with libhtp policy settings in _suricata.yaml_ conf file.

3. Add input validation to prevent users from choosing Netmap Inline IPS Mode with incompatible physical NICs. See [Redmine Issue #10950](https://redmine.pfsense.org/issues/10950) from Snort for details. Suricata needs the same input validation.

4. Complete implementation of fix for [Redmine Issue 9789](https://redmine.pfsense.org/issues/9789) (from Snort) since Suricata is susceptible to the same issues.