### PR TITLE
haproxy-devel fixes dnsstats lbagent hostnameprefix

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/Makefile
+++ b/net/pfSense-pkg-haproxy-devel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-haproxy-devel
 PORTVERSION=	0.61
-PORTREVISION=	0
+PORTREVISION=	1
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -1224,14 +1224,21 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 
 			$unix_socket = false;
 			$servers = array();
+			$serverprefix = haproxy_utils::haproxy_hostname_get_prefix($be['address']);
+			$serveraddress = haproxy_utils::haproxy_hostname_strip_prefix($be['address']);
+			if ($addrprefix && $serverprefix && $serverprefix !== $addrprefix) {
+				continue; // skip the server if its not 'usable' in this transparent-backend
+			}
 			if ($be['forwardto'] && $be['forwardto'] != "") {
 				$unix_socket = true;
 				$servers[] = "/{$be['forwardto']}.socket send-proxy-v2-ssl-cn";
 			} else {
-				if (is_ipaddr($be['address']) || $use_haproxyresolvers) {
-					$servers[] = $be['address'];
-				} elseif (is_hostname($be['address'])) {
-					$dnsresult_servers = haproxy_utils::query_dns($be['address'], $dnsquerytype);
+				if (in_array($serverprefix, array('unix@'))) {
+					$servers[] = $serveraddress;
+				} elseif (is_ipaddr($serveraddress) || $use_haproxyresolvers) {
+					$servers[] = $serveraddress;
+				} elseif (is_hostname($serveraddress)) {
+					$dnsresult_servers = haproxy_utils::query_dns($serveraddress, $dnsquerytype);
 					foreach($dnsresult_servers as $dnsresult_server){
 						$servers[] = $dnsresult_server['data'];
 					}
@@ -1248,14 +1255,16 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 						continue;
 					}
 				} else {
-					if (!$unix_socket) {
+					if (!$unix_socket && !$serverprefix) {
 						// place the ipv4@ or ipv6@ before the address, but not when using a unix socket
+						// or a prefix was already specified by the user.
 						$server = $addrprefix . $server;
 					}
 				}
 				if (!empty($be['port'])) {
 					$server = $server . ":" . $be['port'];
 				}
+				$server = $serverprefix . $server;
 				$servername = $be['name'];
 				$id = "";
 				if (count($servers) > 1) {

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy_utils.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy_utils.inc
@@ -516,9 +516,12 @@ function echo_html_select($name, $keyvaluelist, $selected, $listEmptyMessage="",
 	return $result;
 }
 
-function haproxy_keyvalue_array($hap_array) {
+function haproxy_keyvalue_array($hap_array, $includedeprecatedkey = null) {
 	$result = array();
 	foreach($hap_array as $key => $item) {
+		if ($item['deprecated'] && $key != $includedeprecatedkey){
+			continue;
+		}
 		$result[$key] = $item['name'];
 	}
 	return $result;

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy_utils.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy_utils.inc
@@ -30,6 +30,43 @@ require_once("config.inc");
 class haproxy_utils {
 	public static $pf_version;
 
+	public function is_valid_haproxy_hostname($hostname){
+		global $input_errors;
+		$parts = explode('@', $hostname);
+		if (count($parts) > 2) {
+			$input_errors[] = "The hostname '$hostname' contains multiple prefixes.";
+			return false;
+		}
+		if (count($parts) == 2) {
+			$hostnameprefix = $parts[0];
+			if ($hostnameprefix == "unix") {
+				// is there any way to further validate this.?.
+				return true; 
+			}
+			$hostnamename = $parts[1];
+			if (!in_array($hostnameprefix, array("ipv4","ipv6","upd","udp4","udp6","unix"))) {
+				$input_errors[] = "The hostname '$hostname' has a invalid prefix: $hostnameprefix@";
+				return false; // invalid prefix?
+			}
+		} else {
+			$hostnamename = $hostname;
+		}
+		return is_hostname($hostnamename);
+	}
+	public function haproxy_hostname_strip_prefix($hostname){
+		$i = stripos($hostname, '@');
+		if ($i !== false) {
+			$hostname = substr($hostname, $i + 1);
+		}
+		return $hostname;
+	}
+	public function haproxy_hostname_get_prefix($hostname){
+		$i = stripos($hostname, '@');
+		if ($i !== false) {
+			return substr($hostname, 0, $i + 1);
+		}
+		return false;
+	}
 	public function query_dns($host, $querytype="A,AAAA") {
 		$result = array();
 		$types = explode(',',$querytype);

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pool_edit.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pool_edit.php
@@ -431,8 +431,8 @@ if ($_POST) {
 		}
 
 		if (!isset($server['forwardto']) || $server['forwardto'] == "") {
-			if (!is_ipaddr($server_address) && !is_hostname($server_address) && !haproxy_is_frontendname($server_address)) {
-				$input_errors[] = "The field 'Address' for server $server_name is not a valid ip address or hostname." . $server_address;
+			if (!is_ipaddr($server_address) && !haproxy_utils::is_valid_haproxy_hostname($server_address) && !haproxy_is_frontendname($server_address)) {
+				$input_errors[] = "The field 'Address' for server '$server_name' is not a valid ip address or hostname '" . $server_address . "'.";
 			}
 		} else {
 			if ((!empty($server_address)) || ($server_port && !is_numeric($server_port))) {

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pool_edit.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pool_edit.php
@@ -827,7 +827,7 @@ $section->addInput(new Form_Select(
 	'check_type',
 	'Health check method',
 	$pconfig['check_type']?$pconfig['check_type']:"HTTP",
-	haproxy_keyvalue_array($a_checktypes)
+	haproxy_keyvalue_array($a_checktypes, $pconfig['check_type'])
 ))->setHelp('<textarea readonly="yes" cols="60" rows="2" id="check_type_description" name="check_type_description" style="padding:5px; border:1px dashed #990000; background-color: #ffffff; color: #000000; font-size: 8pt;"></textarea>');
 
 //TODO milliseconds behind field.

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_stats.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_stats.php
@@ -127,7 +127,7 @@ if (isset($_GET['showstatresolvers'])){
 	$showstatresolversname = $_GET['showstatresolvers'];
 	echo "<td colspan='2'>";
 	echo "Resolver statistics: $sticktablename<br/>";
-	$res = haproxy_socket_command("show stat resolvers $showstatresolversname");
+	$res = haproxy_socket_command("show resolvers $showstatresolversname");
 	foreach($res as $line){
 		echo "<br/>".print_r($line,true);
 	}


### PR DESCRIPTION
- fix dns-statistics page showing the proper stats
fixes: https://redmine.pfsense.org/issues/10885

- hide deprecated agent-check from available health check options, unless chosen..
fixes: https://redmine.pfsense.org/issues/10936

- allow prefixing server names with supported options like ipv6@ and unix@

and bump version to 0.61.1