### PR TITLE
pfSense-pkg-suricata-6.0.0_1 - Revert runtime binary to 5.0.4, add Action column to ALERTS tab.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.0
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -12,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=6.0.0:security/suricata
+RUN_DEPENDS=	suricata>=5.0.4:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -930,6 +930,7 @@ if ($filterlogentries && count($filterfieldsarray)) {
 			<thead>
 			   <tr class="sortableHeaderRowIdentifier text-nowrap">
 				<th data-sortable-type="date"><?=gettext("Date"); ?></th>
+				<th><?=gettext("Action"); ?></th>
 				<th data-sortable-type="numeric"><?=gettext("Pri"); ?></th>
 				<th><?=gettext("Proto"); ?></th>
 				<th><?=gettext("Class"); ?></th>
@@ -1053,6 +1054,42 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 			/* Protocol */
 			$alert_proto = $fields['proto'];
 
+			/* Action */
+			if (isset($fields['action']) && $a_instance[$instanceid]['blockoffenders'] == 'on' && ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' || $a_instance[$instanceid]['block_drops_only'] == 'on')) {
+
+				switch ($fields['action']) {
+
+					case "Drop":
+					case "wDrop":
+						if (isset($dropsid[$fields['gid']][$fields['sid']])) {
+							$alert_action = '<i class="fa fa-thumbs-down icon-pointer text-danger text-center" title="';
+							$alert_action .= gettext("Rule action is User-Forced to DROP. Click to force a different action for this rule.");
+						}
+						elseif ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' && isset($rejectsid[$fields['gid']][$fields['sid']])) {
+							$alert_action = '<i class="fa fa-hand-stop-o icon-pointer text-warning text-center" title="';
+							$alert_action .= gettext("Rule action is User-Forced to REJECT. Click to force a different action for this rule.");
+						}
+						else {
+							$alert_action = '<i class="fa fa-thumbs-down icon-pointer text-danger text-center" title="';
+							$alert_action .=  gettext("Rule action is DROP. Click to force a different action for this rule.");
+						}
+						break;
+
+					default:
+						$alert_action = '<i class="fa fa-question-circle icon-pointer text-danger text-center" title="' . gettext("Rule action is unrecognized!. Click to force a different action for this rule.");
+				}
+				$alert_action .= '" onClick="toggleAction(\'' . $fields['gid'] . '\', \'' . $fields['sid'] . '\');"</i>';
+			}
+			else {
+				if ($a_instance[$instanceid]['blockoffenders'] == 'on' && ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' || $a_instance[$instanceid]['block_drops_only'] == 'on')) {
+					$alert_action = '<i class="fa fa-exclamation-triangle icon-pointer text-warning text-center" title="' . gettext("Rule action is ALERT.");
+					$alert_action .= '" onClick="toggleAction(\'' . $fields['gid'] . '\', \'' . $fields['sid'] . '\');"</i>';
+				}
+				else {
+					$alert_action = '<i class="fa fa-exclamation-triangle text-warning text-center" title="' . gettext("Rule action is ALERT.") . '"</i>';
+				}
+			}
+
 			/* IP SRC */
 			if ($decoder_event == FALSE) {
 				$alert_ip_src = $fields['src'];
@@ -1174,6 +1211,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 			<tr>
 	<?php endif; ?>
 				<td><?=$alert_date;?><br/><?=$alert_time;?></td>
+				<td><?=$alert_action; ?></td>
 				<td><?=$alert_priority;?></td>
 				<td style="word-wrap:break-word; white-space:normal"><?=$alert_proto;?></td>
 				<td style="word-wrap:break-word; white-space:normal"><?=$alert_class;?></td>


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.0_1
This update reverts the Suricata binary to the latest 5.0.4 version from the upstream 5.x branch. It also includes one new feature.

**New Features:**
1. Added a rule **Action** column with appropriate icons to the ALERTS tab to show the action set for the triggered rule. Note that for Reject actions, the DROP icon will be shown unless the user forced the rule action to reject by clicking a "change action" icon on the ALERTS or RULES tab. Due to logging limitations in the Suricata binary, a rule whose action is changed to Reject via SID MGMT functions will not show the Reject icon under this column.

**Bug Fixes:**
None