### PR TITLE
Suricata - Update RELENG_2_4_5 branch to latest 5.0.4 version from upstream 5.x branch.

### DIFF
--- a/security/suricata/Makefile
+++ b/security/suricata/Makefile
@@ -2,7 +2,7 @@
 # $FreeBSD$
 
 PORTNAME=	suricata
-DISTVERSION=	5.0.3
+DISTVERSION=	5.0.4
 CATEGORIES=	security
 MASTER_SITES=	https://www.openinfosecfoundation.org/download/
 
@@ -21,7 +21,7 @@ LIB_DEPENDS=	libpcre.so:devel/pcre \
 
 USES=		autoreconf cpe gmake iconv:translit libtool pathfix pkgconfig
 
-CONFLICTS_INSTALL=	libhtp suricata5
+CONFLICTS_INSTALL=	libhtp
 
 USE_LDCONFIG=	yes
 USE_RC_SUBR=	${PORTNAME}

--- a/security/suricata/distinfo
+++ b/security/suricata/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1593532636
-SHA256 (suricata-5.0.3.tar.gz) = 34413ecdad2ff2452526dbcd22f1279afd0935151916c0ff9cface4b0b5665db
-SIZE (suricata-5.0.3.tar.gz) = 23744731
+TIMESTAMP = 1604674593
+SHA256 (suricata-5.0.4.tar.gz) = b4398036fd36086d088668a4d2b0759a1a22ea9b8ce066a542cf9b27278f988b
+SIZE (suricata-5.0.4.tar.gz) = 29091046

--- a/security/suricata/files/patch-alert-pf.diff
+++ b/security/suricata/files/patch-alert-pf.diff
@@ -1,6 +1,6 @@
-diff -ruN ./suricata-5.0.3.orig/src/Makefile.am ./suricata-5.0.3/src/Makefile.am
---- ./suricata-5.0.3.orig/src/Makefile.am	2020-04-28 06:06:20.000000000 -0400
-+++ ./src/Makefile.am	2020-06-30 12:23:55.000000000 -0400
+diff -ruN ./suricata-5.0.4.orig/src/Makefile.am ./suricata-5.0.4/src/Makefile.am
+--- ./suricata-5.0.4.orig/src/Makefile.am	2020-10-07 17:01:44.000000000 -0400
++++ ./src/Makefile.am	2020-11-06 10:13:19.000000000 -0500
 @@ -10,6 +10,7 @@
  suricata_SOURCES = \
  alert-debuglog.c alert-debuglog.h \
@@ -9,9 +9,9 @@ diff -ruN ./suricata-5.0.3.orig/src/Makefile.am ./suricata-5.0.3/src/Makefile.am
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
  alert-unified2-alert.c alert-unified2-alert.h \
-diff -ruN ./suricata-5.0.3.orig/src/Makefile.in ./suricata-5.0.3/src/Makefile.in
---- ./suricata-5.0.3.orig/src/Makefile.in	2020-04-28 06:06:35.000000000 -0400
-+++ ./src/Makefile.in	2020-06-30 12:25:12.000000000 -0400
+diff -ruN ./suricata-5.0.4.orig/src/Makefile.in ./suricata-5.0.4/src/Makefile.in
+--- ./suricata-5.0.4.orig/src/Makefile.in	2020-10-07 17:02:07.000000000 -0400
++++ ./src/Makefile.in	2020-11-06 10:14:35.000000000 -0500
 @@ -110,7 +110,7 @@
  am__installdirs = "$(DESTDIR)$(bindir)"
  PROGRAMS = $(bin_PROGRAMS)
@@ -29,8 +29,8 @@ diff -ruN ./suricata-5.0.3.orig/src/Makefile.in ./suricata-5.0.3/src/Makefile.in
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
  alert-unified2-alert.c alert-unified2-alert.h \
-diff -ruN ./suricata-5.0.3.orig/src/alert-pf.c ./suricata-5.0.3/src/alert-pf.c
---- ./suricata-5.0.3.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
+diff -ruN ./suricata-5.0.4.orig/src/alert-pf.c ./suricata-5.0.4/src/alert-pf.c
+--- ./suricata-5.0.4.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
 +++ ./src/alert-pf.c	2020-01-06 14:22:20.000000000 -0500
 @@ -0,0 +1,1151 @@
 +/* Copyright (C) 2007-2020 Open Information Security Foundation
@@ -1184,8 +1184,8 @@ diff -ruN ./suricata-5.0.3.orig/src/alert-pf.c ./suricata-5.0.3/src/alert-pf.c
 +    return TM_ECODE_OK;
 +}
 +
-diff -ruN ./suricata-5.0.3.orig/src/alert-pf.h ./suricata-5.0.3/src/alert-pf.h
---- ./suricata-5.0.3.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
+diff -ruN ./suricata-5.0.4.orig/src/alert-pf.h ./suricata-5.0.4/src/alert-pf.h
+--- ./suricata-5.0.4.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
 +++ ./src/alert-pf.h	2020-02-29 10:25:58.000000000 -0500
 @@ -0,0 +1,59 @@
 +/* Copyright (C) 2007-2020 Open Information Security Foundation
@@ -1247,9 +1247,9 @@ diff -ruN ./suricata-5.0.3.orig/src/alert-pf.h ./suricata-5.0.3/src/alert-pf.h
 +
 +#endif /* __ALERT_PF_H__ */
 +
-diff -ruN ./suricata-5.0.3.orig/src/output.c ./suricata-5.0.3/src/output.c
---- ./suricata-5.0.3.orig/src/output.c	2020-04-28 06:06:20.000000000 -0400
-+++ ./src/output.c	2020-06-30 12:26:27.000000000 -0400
+diff -ruN ./suricata-5.0.4.orig/src/output.c ./suricata-5.0.4/src/output.c
+--- ./suricata-5.0.4.orig/src/output.c	2020-10-07 17:01:44.000000000 -0400
++++ ./src/output.c	2020-11-06 10:15:54.000000000 -0500
 @@ -43,6 +43,7 @@
  #include "alert-fastlog.h"
  #include "alert-unified2-alert.h"
@@ -1269,9 +1269,9 @@ diff -ruN ./suricata-5.0.3.orig/src/output.c ./suricata-5.0.3/src/output.c
      /* prelue log */
      AlertPreludeRegister();
      /* syslog log */
-diff -ruN ./suricata-5.0.3.orig/src/suricata-common.h ./suricata-5.0.3/src/suricata-common.h
---- ./suricata-5.0.3.orig/src/suricata-common.h	2020-04-28 06:06:20.000000000 -0400
-+++ ./src/suricata-common.h	2020-06-30 12:26:59.000000000 -0400
+diff -ruN ./suricata-5.0.4.orig/src/suricata-common.h ./suricata-5.0.4/src/suricata-common.h
+--- ./suricata-5.0.4.orig/src/suricata-common.h	2020-10-07 17:01:44.000000000 -0400
++++ ./src/suricata-common.h	2020-11-06 10:16:37.000000000 -0500
 @@ -461,6 +461,7 @@
      LOGGER_PRELUDE,
      LOGGER_PCAP,

--- a/security/suricata/files/patch-src_suricata-common.h
+++ b/security/suricata/files/patch-src_suricata-common.h
@@ -1,0 +1,11 @@
+--- src/suricata-common.h-orig	2020-10-25 16:56:49.454317000 +0100
++++ src/suricata-common.h	2020-10-25 16:57:06.035153000 +0100
+@@ -36,6 +36,8 @@
+ #define _GNU_SOURCE
+ #define __USE_GNU
+ 
++#include "queue.h"
++
+ #if HAVE_CONFIG_H
+ #include <config.h>
+ #endif

--- a/security/suricata/pkg-plist
+++ b/security/suricata/pkg-plist
@@ -128,7 +128,7 @@ man/man1/suricata.1.gz
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/util.pyc
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/version.py
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata/update/version.pyc
-%%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata_update-1.1.2-py%%PYTHON_VER%%.egg-info
+%%PYTHON%%%%PYTHON_SITELIBDIR%%/suricata_update-1.1.3-py%%PYTHON_VER%%.egg-info
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricatasc/__init__.py
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/suricatasc/__init__.pyc
 %%DATADIR%%/rules/app-layer-events.rules


### PR DESCRIPTION
### Suricata-5.0.4
This updates the Suricata binary to the latest 5.0.4 version from the upstream 5.x branch. [Release Note](https://suricata-ids.org/2020/10/08/suricata-4-1-9-and-5-0-4-released/)s can be found here: [https://suricata-ids.org/2020/10/08/suricata-4-1-9-and-5-0-4-released/](https://suricata-ids.org/2020/10/08/suricata-4-1-9-and-5-0-4-released/).