### PR TITLE
pfSense-pkg-suricata-5.0.4-RELENG_2_4_5 - GUI update for 5.0.4 binary support and bug fixes.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	5.0.3
+PORTVERSION=	5.0.4
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -12,7 +12,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=5.0.3:security/suricata
+RUN_DEPENDS=	suricata>=5.0.4:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -763,7 +763,7 @@ if (!is_array($suricatacfg['libhtp_policy']))
 if (!is_array($suricatacfg['libhtp_policy']['item']))
 	$suricatacfg['libhtp_policy']['item'] = array();
 if (count($suricatacfg['libhtp_policy']['item']) < 1) {
-	$http_hosts_default_policy = "     personality: IDS\n     request-body-limit: 4096\n     response-body-limit: 4096\n";
+	$http_hosts_default_policy = "personality: IDS\n     request-body-limit: 4096\n     response-body-limit: 4096\n";
 	$http_hosts_default_policy .= "     double-decode-path: no\n     double-decode-query: no\n     uri-include-all: no\n";
 }
 else {
@@ -801,7 +801,7 @@ else {
 			}
 		}
 		else {
-			$http_hosts_default_policy = "     personality: {$v['personality']}\n     request-body-limit: {$v['request-body-limit']}\n";
+			$http_hosts_default_policy = "personality: {$v['personality']}\n     request-body-limit: {$v['request-body-limit']}\n";
 			$http_hosts_default_policy .= "     response-body-limit: {$v['response-body-limit']}\n";
 			$http_hosts_default_policy .= "     meta-field-limit: " . (isset($v['meta-field-limit']) ? $v['meta-field-limit'] : "18432") . "\n";
 			$http_hosts_default_policy .= "     double-decode-path: {$v['double-decode-path']}\n";
@@ -809,7 +809,7 @@ else {
 			$http_hosts_default_policy .= "     uri-include-all: {$v['uri-include-all']}\n";
 		}
 	}
-	// Remove trailing newline
+	// Remove any leading or trailing spaces and newline
 	$http_hosts_default_policy = trim($http_hosts_default_policy);
 	$http_hosts_policy = trim($http_hosts_policy);
 }

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -930,6 +930,7 @@ if ($filterlogentries && count($filterfieldsarray)) {
 			<thead>
 			   <tr class="sortableHeaderRowIdentifier text-nowrap">
 				<th data-sortable-type="date"><?=gettext("Date"); ?></th>
+				<th><?=gettext("Action"); ?></th>
 				<th data-sortable-type="numeric"><?=gettext("Pri"); ?></th>
 				<th><?=gettext("Proto"); ?></th>
 				<th><?=gettext("Class"); ?></th>
@@ -1053,6 +1054,42 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 			/* Protocol */
 			$alert_proto = $fields['proto'];
 
+			/* Action */
+			if (isset($fields['action']) && $a_instance[$instanceid]['blockoffenders'] == 'on' && ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' || $a_instance[$instanceid]['block_drops_only'] == 'on')) {
+
+				switch ($fields['action']) {
+
+					case "Drop":
+					case "wDrop":
+						if (isset($dropsid[$fields['gid']][$fields['sid']])) {
+							$alert_action = '<i class="fa fa-thumbs-down icon-pointer text-danger text-center" title="';
+							$alert_action .= gettext("Rule action is User-Forced to DROP. Click to force a different action for this rule.");
+						}
+						elseif ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' && isset($rejectsid[$fields['gid']][$fields['sid']])) {
+							$alert_action = '<i class="fa fa-hand-stop-o icon-pointer text-warning text-center" title="';
+							$alert_action .= gettext("Rule action is User-Forced to REJECT. Click to force a different action for this rule.");
+						}
+						else {
+							$alert_action = '<i class="fa fa-thumbs-down icon-pointer text-danger text-center" title="';
+							$alert_action .=  gettext("Rule action is DROP. Click to force a different action for this rule.");
+						}
+						break;
+
+					default:
+						$alert_action = '<i class="fa fa-question-circle icon-pointer text-danger text-center" title="' . gettext("Rule action is unrecognized!. Click to force a different action for this rule.");
+				}
+				$alert_action .= '" onClick="toggleAction(\'' . $fields['gid'] . '\', \'' . $fields['sid'] . '\');"</i>';
+			}
+			else {
+				if ($a_instance[$instanceid]['blockoffenders'] == 'on' && ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' || $a_instance[$instanceid]['block_drops_only'] == 'on')) {
+					$alert_action = '<i class="fa fa-exclamation-triangle icon-pointer text-warning text-center" title="' . gettext("Rule action is ALERT.");
+					$alert_action .= '" onClick="toggleAction(\'' . $fields['gid'] . '\', \'' . $fields['sid'] . '\');"</i>';
+				}
+				else {
+					$alert_action = '<i class="fa fa-exclamation-triangle text-warning text-center" title="' . gettext("Rule action is ALERT.") . '"</i>';
+				}
+			}
+
 			/* IP SRC */
 			if ($decoder_event == FALSE) {
 				$alert_ip_src = $fields['src'];
@@ -1174,6 +1211,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 			<tr>
 	<?php endif; ?>
 				<td><?=$alert_date;?><br/><?=$alert_time;?></td>
+				<td><?=$alert_action; ?></td>
 				<td><?=$alert_priority;?></td>
 				<td style="word-wrap:break-word; white-space:normal"><?=$alert_proto;?></td>
 				<td style="word-wrap:break-word; white-space:normal"><?=$alert_class;?></td>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -55,9 +55,26 @@ if (isset($_POST['del_x'])) {
 			$if_real = get_real_interface($a_nat[$rulei]['interface']);
 			$if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$rulei]['interface']);
 			$suricata_uuid = $a_nat[$rulei]['uuid'];
-			suricata_stop($a_nat[$rulei], $if_real);
-			rmdir_recursive("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}");
-			rmdir_recursive("{$suricatadir}suricata_{$suricata_uuid}_{$if_real}");
+
+			// Check that we still have the real interface defined in pfSense.
+			// The real interface will return as an empty string if it has
+			// been removed in pfSense.
+			if ($if_real == "") {
+				rmdir_recursive("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}");
+				rmdir_recursive("{$suricatadir}suricata_{$suricata_uuid}_*");
+				syslog(LOG_NOTICE, "Deleted the Suricata instance on a previously removed pfSense interface per user request...");
+			}
+			else {
+				// Delete the interface sub-directories and then the instance itself
+				$if_friendly = convert_friendly_interface_to_friendly_descr($snortcfg['interface']);
+				syslog(LOG_NOTICE, "Stopping Suricata on {$if_friendly}({$if_real}) due to Suricata instance deletion...");
+				suricata_stop($a_nat[$rulei], $if_real);
+				rmdir_recursive("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}");
+				rmdir_recursive("{$suricatadir}suricata_{$suricata_uuid}_{$if_real}");
+				syslog(LOG_NOTICE, "Deleted Suricata instance on {$if_friendly}({$if_real}) per user request...");
+			}
+
+			// Finally, delete the interface's config entry entirely
 			unset($a_nat[$rulei]);
 		}
 
@@ -90,14 +107,27 @@ if (isset($_POST['del_x'])) {
 		$if_real = get_real_interface($a_nat[$delbtn_list]['interface']);
 		$if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$delbtn_list]['interface']);
 		$suricata_uuid = $a_nat[$delbtn_list]['uuid'];
-		syslog(LOG_NOTICE, "Stopping Suricata on {$if_friendly}({$if_real}) due to interface deletion...");
-		suricata_stop($a_nat[$delbtn_list], $if_real);
-		rmdir_recursive("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}");
-		rmdir_recursive("{$suricatadir}suricata_{$suricata_uuid}_{$if_real}");
 
-		// Finally delete the interface's config entry entirely
-		unset($a_nat[$delbtn_list]);
-		syslog(LOG_NOTICE, "Deleted Suricata instance on {$if_friendly}({$if_real}) per user request...");
+		// Check that we still have the real interface defined in pfSense.
+		// The real interface will return as an empty string if it has
+		// been removed in pfSense.
+		if ($if_real == "") {
+			rmdir_recursive("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}");
+			rmdir_recursive("{$suricatadir}suricata_{$suricata_uuid}_*");
+			syslog(LOG_NOTICE, "Deleted the Suricata instance on a previously removed pfSense interface per user request...");
+		}
+		else {
+			// Delete the interface sub-directories and then the instance itself
+			$if_friendly = convert_friendly_interface_to_friendly_descr($snortcfg['interface']);
+			syslog(LOG_NOTICE, "Stopping Suricata on {$if_friendly}({$if_real}) due to Suricata instance deletion...");
+			suricata_stop($a_nat[$rulei], $if_real);
+			rmdir_recursive("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}");
+			rmdir_recursive("{$suricatadir}suricata_{$suricata_uuid}_{$if_real}");
+			syslog(LOG_NOTICE, "Deleted Suricata instance on {$if_friendly}({$if_real}) per user request...");
+		}
+
+		// Finally, delete the interface's config entry entirely
+		unset($a_nat[$rulei]);
 
 		// Save updated configuration
 		write_config("Suricata pkg: deleted one or more Suricata interfaces.");
@@ -185,6 +215,10 @@ if ($_POST['status'] == 'check') {
 	// into an associative array.  Return the array to the Ajax
 	// caller as a JSON object.
 	foreach ($a_nat as $intf) {
+		// Skip status update for any missing real interface
+		if (($if_real = get_real_interface($intf['interface'])) == "") {
+			continue;
+		}
 		$intf_key = "suricata_" . get_real_interface($intf['interface']) . $intf['uuid'];
 		if ($intf['enable'] == "on") {
 			if (suricata_is_running($intf['uuid'], get_real_interface($intf['interface']))) {
@@ -283,10 +317,17 @@ include_once("head.inc"); ?>
 ?>
 				<tr id="fr<?=$nnats?>">
 <?php
-					/* convert fake interfaces to real and check if iface is up */
-					/* There has to be a smarter way to do this */
+					/* Convert fake interfaces to real and check if iface is up. */
+					/* A null real interface indicates it has been removed from system. */
 					$if_real = get_real_interface($natent['interface']);
-					$natend_friendly= convert_friendly_interface_to_friendly_descr($natent['interface']);
+					if (($if_real = get_real_interface($natent['interface'])) == "") {
+						$natent['enable'] = "off";
+						$natend_friendly = gettext("Missing (removed?)");
+					}
+					else {
+						$natend_friendly = convert_friendly_interface_to_friendly_descr($natent['interface']) . " ({$if_real})";
+					}
+
 					$suricata_uuid = $natent['uuid'];
 
 					/* See if interface has any rules defined and set boolean flag */


### PR DESCRIPTION
### pfSense-pkg-suricata-5.0.4_RELENG_2_4_5
This package update provides support for the latest 5.0.4 Suricata binary from the upstream 5.x branch and fixes four bugs. One new feature is also added.

**New Features:**
1. Added a rule Action column with appropriate icons to the ALERTS tab to show the action set for the triggered rule. Note that for Reject actions, the DROP icon will be shown unless the user forced the rule action to reject by clicking a "change action" icon on the ALERTS or RULES tab. Due to logging limitations in the Suricata binary, a rule whose action is changed to Reject via SID MGMT functions will not show the Reject icon under this column.

**Bug Fixes:**
1. Check that LRO, TSO and all Hardware Checksumming is disabled in pfSense config.xml when user enables and saves "IPS Inline" mode configuration.

2. Potential YAML key indentation issue with libhtp policy settings in suricata.yaml conf file.

3. Add input validation to prevent users from choosing Netmap Inline IPS Mode with incompatible physical NICs. See Redmine Issue #10950 from Snort for details. Suricata needs the same input validation.

4. Complete implementation of fix for Redmine Issue 9789 (from Snort) since Suricata is susceptible to the same issues.