### PR TITLE
pfSense-pkg-suricata-6.0.0_1 -- Add reason text to write_config() calls to address Redmine Issue 204.

### DIFF
--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -113,7 +113,7 @@ function suricata_add_supplist_entry($suppress) {
 	/* If we created a new list or updated an existing one, save the change */
 	/* and return true; otherwise return false.                             */
 	if ($found_list) {
-		write_config();
+		write_config("Suricata pkg: saved change to Suppress List " . $s_list['name'] . " from ALERTS tab.");
 		sync_suricata_package_config();
 		return true;
 	}
@@ -287,7 +287,7 @@ if ($_POST['save']) {
 	$config['installedpackages']['suricata']['alertsblocks']['arefresh'] = $_POST['arefresh'] ? 'on' : 'off';
 	$config['installedpackages']['suricata']['alertsblocks']['alertnumber'] = $_POST['alertnumber'];
 
-	write_config();
+	write_config("Suricata pkg: saved change to ALERTS tab configuration.");
 
 	header("Location: /suricata/suricata_alerts.php?instance={$instanceid}");
 	exit;
@@ -527,7 +527,7 @@ if ($_POST['mode'] == 'togglesid' && is_numeric($_POST['sidid']) && is_numeric($
 		unset($a_instance[$instanceid]['rule_sid_off']);
 
 	/* Update the config.xml file. */
-	write_config();
+	write_config("Suricata pkg: User-forced rule state override applied for rule {$gid}:{$sid} on ALERTS tab for interface {$a_instance[$instanceid]['interface']}.");
 
 	/*************************************************/
 	/* Update the suricata.yaml file and rebuild the */

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_define_vars.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_define_vars.php
@@ -115,7 +115,7 @@ if ($_POST) {
 
 		$a_nat[$id] = $natent;
 
-		write_config();
+		write_config("Suricata pkg: saved changes for PORT or IP variables.");
 
 		/* Update the suricata.yaml file for this interface. */
 		$rebuild_rules = false;

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
@@ -76,7 +76,7 @@ if (isset($id) && $a_nat[$id]) {
 		if (!is_array($a_nat[$id]['host_os_policy']['item']))
 			$a_nat[$id]['host_os_policy']['item'] = array();
 		$a_nat[$id]['host_os_policy']['item'][] = $default;
-		write_config();
+		write_config("Suricata pkg: saved new default Host_OS_Policy engine.");
 		$host_os_policy_engine_next_id++;
 	}
 	else
@@ -173,7 +173,7 @@ if ($_POST['save_os_policy']) {
 			}
 
 			// Now write the new engine array to conf
-			write_config();
+			write_config("Suricata pkg: saved new Host_OS_Policy engine.");
 			header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 			header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
 			header( 'Cache-Control: no-store, no-cache, must-revalidate' );
@@ -206,7 +206,7 @@ elseif ($_POST['del_os_policy']) {
 	}
 	if (isset($id) && $a_nat[$id]) {
 		$a_nat[$id] = $natent;
-		write_config();
+		write_config("Suricata pkg: deleted a Host_OS_Policy engine.");
 	}
 	header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 	header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
@@ -320,7 +320,7 @@ elseif ($_POST['save'] || $_POST['apply']) {
 		/**************************************************/
 		if (isset($id) && $a_nat[$id]) {
 			$a_nat[$id] = $natent;
-			write_config();
+			write_config("Suricata pkg: saved flow or stream configuration changes.");
 			$rebuild_rules = false;
 			suricata_generate_yaml($natent);
 
@@ -408,7 +408,7 @@ elseif ($_POST['save_import_alias']) {
 			}
 
 			// Write the new engine array to config file
-			write_config();
+			write_config("Suricata pkg: saved Host_OS_Policy engine created from a defined firewall alias.");
 			$importalias = false;
 			$selectalias = false;
 			header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules_flowbits.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules_flowbits.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -126,7 +126,7 @@ if ($_POST['addsuppress'] && is_numeric($_POST['sid']) && is_numeric($_POST['gid
 	}
 
 	if ($found_list) {
-		write_config();
+		write_config("Suricata pkg: added suppress entry for rule {$_POST['gid']}:{$_POST['sid']} to Suppress List {$a_nat[$id]['suppresslistname']}.");
 		$rebuild_rules = false;
 		sync_suricata_package_config();
 		suricata_reload_config($a_nat[$id]);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2014 Bill Meeks
+ * Copyright (c) 2020 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -112,7 +112,7 @@ if ($_POST['save']) {
 		else
 			$a_suppress[] = $s_list;
 
-		write_config();
+		write_config("Suricata pkg: saved changes to Suppress List {$s_list['name']}.");
 		sync_suricata_package_config();
 
 		header("Location: /suricata/suricata_suppress.php");


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.0_1
This change adds missing description text to calls to the _write_config()_ function to address [Redmine Issue #204](https://redmine.pfsense.org/issues/204). The package version is not incremented.