### PR TITLE
Suricata4 - Update Suricata4 to latest 4.1.9 version from upstream.

### DIFF
--- a/security/suricata4/Makefile
+++ b/security/suricata4/Makefile
@@ -2,7 +2,7 @@
 # $FreeBSD$
 
 PORTNAME=	suricata
-DISTVERSION=	4.1.8
+DISTVERSION=	4.1.9
 CATEGORIES=	security
 MASTER_SITES=	https://www.openinfosecfoundation.org/download/
 PKGNAMESUFFIX=	4

--- a/security/suricata4/distinfo
+++ b/security/suricata4/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1593532725
-SHA256 (suricata-4.1.8.tar.gz) = c8a83a05f57cedc0ef81d833ddcfdbbfdcdb6f459a91b1b15dc2d5671f1aecbb
-SIZE (suricata-4.1.8.tar.gz) = 15786311
+TIMESTAMP = 1603981565
+SHA256 (suricata-4.1.9.tar.gz) = 3440cd1065b1b3999dc101a37c49321fab2791b38f16e2f7fe27369dd007eea7
+SIZE (suricata-4.1.9.tar.gz) = 21019238

--- a/security/suricata4/files/patch-alert-pf.diff
+++ b/security/suricata4/files/patch-alert-pf.diff
@@ -1,6 +1,6 @@
-diff -ruN ./suricata-4.1.8.orig/src/Makefile.am ./suricata-4.1.8/src/Makefile.am
---- ./suricata-4.1.8.orig/src/Makefile.am	2020-04-27 14:59:47.000000000 -0400
-+++ ./src/Makefile.am	2020-06-30 12:10:25.000000000 -0400
+diff -ruN ./suricata-4.1.9.orig/src/Makefile.am ./suricata-4.1.9/src/Makefile.am
+--- ./suricata-4.1.9.orig/src/Makefile.am	2020-10-07 13:14:59.000000000 -0400
++++ ./src/Makefile.am	2020-10-29 10:38:04.000000000 -0400
 @@ -10,6 +10,7 @@
  suricata_SOURCES = \
  alert-debuglog.c alert-debuglog.h \
@@ -9,9 +9,9 @@ diff -ruN ./suricata-4.1.8.orig/src/Makefile.am ./suricata-4.1.8/src/Makefile.am
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
  alert-unified2-alert.c alert-unified2-alert.h \
-diff -ruN ./suricata-4.1.8.orig/src/Makefile.in ./suricata-4.1.8/src/Makefile.in
---- ./suricata-4.1.8.orig/src/Makefile.in	2020-04-27 15:00:03.000000000 -0400
-+++ ./src/Makefile.in	2020-06-30 12:12:19.000000000 -0400
+diff -ruN ./suricata-4.1.9.orig/src/Makefile.in ./suricata-4.1.9/src/Makefile.in
+--- ./suricata-4.1.9.orig/src/Makefile.in	2020-10-07 13:15:23.000000000 -0400
++++ ./src/Makefile.in	2020-10-29 10:39:57.000000000 -0400
 @@ -112,7 +112,7 @@
  am__installdirs = "$(DESTDIR)$(bindir)"
  PROGRAMS = $(bin_PROGRAMS)
@@ -29,8 +29,8 @@ diff -ruN ./suricata-4.1.8.orig/src/Makefile.in ./suricata-4.1.8/src/Makefile.in
  alert-prelude.c alert-prelude.h \
  alert-syslog.c alert-syslog.h \
  alert-unified2-alert.c alert-unified2-alert.h \
-diff -ruN ./suricata-4.1.8.orig/src/alert-pf.c ./suricata-4.1.8/src/alert-pf.c
---- ./suricata-4.1.8.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
+diff -ruN ./suricata-4.1.9.orig/src/alert-pf.c ./suricata-4.1.9/src/alert-pf.c
+--- ./suricata-4.1.9.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
 +++ ./src/alert-pf.c	2020-02-29 10:29:27.000000000 -0500
 @@ -0,0 +1,1151 @@
 +/* Copyright (C) 2007-2020 Open Information Security Foundation
@@ -1184,8 +1184,8 @@ diff -ruN ./suricata-4.1.8.orig/src/alert-pf.c ./suricata-4.1.8/src/alert-pf.c
 +    return TM_ECODE_OK;
 +}
 +
-diff -ruN ./suricata-4.1.8.orig/src/alert-pf.h ./suricata-4.1.8/src/alert-pf.h
---- ./suricata-4.1.8.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
+diff -ruN ./suricata-4.1.9.orig/src/alert-pf.h ./suricata-4.1.9/src/alert-pf.h
+--- ./suricata-4.1.9.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
 +++ ./src/alert-pf.h	2020-02-29 10:02:39.000000000 -0500
 @@ -0,0 +1,59 @@
 +/* Copyright (C) 2007-2020 Open Information Security Foundation
@@ -1247,9 +1247,9 @@ diff -ruN ./suricata-4.1.8.orig/src/alert-pf.h ./suricata-4.1.8/src/alert-pf.h
 +
 +#endif /* __ALERT_PF_H__ */
 +
-diff -ruN ./suricata-4.1.8.orig/src/output.c ./suricata-4.1.8/src/output.c
---- ./suricata-4.1.8.orig/src/output.c	2020-04-27 14:59:47.000000000 -0400
-+++ ./src/output.c	2020-06-30 12:14:54.000000000 -0400
+diff -ruN ./suricata-4.1.9.orig/src/output.c ./suricata-4.1.9/src/output.c
+--- ./suricata-4.1.9.orig/src/output.c	2020-10-07 13:14:59.000000000 -0400
++++ ./src/output.c	2020-10-29 10:41:46.000000000 -0400
 @@ -43,6 +43,7 @@
  #include "alert-fastlog.h"
  #include "alert-unified2-alert.h"
@@ -1267,9 +1267,9 @@ diff -ruN ./suricata-4.1.8.orig/src/output.c ./suricata-4.1.8/src/output.c
      /* prelue log */
      AlertPreludeRegister();
      /* syslog log */
-diff -ruN ./suricata-4.1.8.orig/src/suricata-common.h ./suricata-4.1.8/src/suricata-common.h
---- ./suricata-4.1.8.orig/src/suricata-common.h	2020-04-27 14:59:48.000000000 -0400
-+++ ./src/suricata-common.h	2020-06-30 12:15:52.000000000 -0400
+diff -ruN ./suricata-4.1.9.orig/src/suricata-common.h ./suricata-4.1.9/src/suricata-common.h
+--- ./suricata-4.1.9.orig/src/suricata-common.h	2020-10-07 13:14:59.000000000 -0400
++++ ./src/suricata-common.h	2020-10-29 10:42:42.000000000 -0400
 @@ -440,6 +440,7 @@
      LOGGER_PRELUDE,
      LOGGER_PCAP,

--- a/security/suricata4/files/patch-pfSense-ARMv6_ARMv7.diff
+++ b/security/suricata4/files/patch-pfSense-ARMv6_ARMv7.diff
@@ -1,10 +1,11 @@
-diff -ruN ./suricata-4.1.8.orig/configure.ac ./suricata-4.1.8/configure.ac
---- ./suricata-4.1.8.orig/configure.ac	2020-04-27 14:59:48.000000000 -0400
-+++ ./configure.ac	2020-06-30 12:06:02.000000000 -0400
-@@ -272,6 +272,23 @@
+diff -ruN ./suricata-4.1.9.orig/configure.ac ./suricata-4.1.9/configure.ac
+--- ./suricata-4.1.9.orig/configure.ac	2020-10-07 13:14:59.000000000 -0400
++++ ./configure.ac	2020-10-29 10:33:28.000000000 -0400
+@@ -272,7 +272,24 @@
      esac
      AC_MSG_RESULT(ok)
  
+-    # enable modifications for AFL fuzzing
 +    # armv6/7 platform needs compiler optimization disabled for now.
 +	NO_OPTIMIZE="no"
 +    AC_MSG_CHECKING([for armv6/armv7 platform])
@@ -22,9 +23,10 @@ diff -ruN ./suricata-4.1.8.orig/configure.ac ./suricata-4.1.8/configure.ac
 +			NO_OPTIMIZE="no"
 +	esac
 +
-     # enable modifications for AFL fuzzing
++   # enable modifications for AFL fuzzing
      AC_ARG_ENABLE(afl,
             AS_HELP_STRING([--enable-afl], Enable AFL fuzzing logic[])], [enable_afl="$enableval"],[enable_afl=no])
+ 
 @@ -2451,6 +2468,15 @@
              fi
          fi

--- a/security/suricata4/files/patch-src_suricata-common.h
+++ b/security/suricata4/files/patch-src_suricata-common.h
@@ -1,0 +1,12 @@
+diff -ruN ./suricata-4.1.9.orig/src/suricata-common.h ./suricata-4.1.9/src/suricata-common.h
+--- ./suricata-4.1.9.orig/src/suricata-common.h	2020-10-07 13:14:59.000000000 -0400
++++ ./src/suricata-common.h	2020-11-11 13:49:44.000000000 -0500
+@@ -36,6 +36,8 @@
+ #define _GNU_SOURCE
+ #define __USE_GNU
+ 
++#include "queue.h"
++
+ #if HAVE_CONFIG_H
+ #include <config.h>
+ #endif


### PR DESCRIPTION
### Suricata4-4.1.9
This updates the Suricata4 binary to the latest 4.1.9 version from upstream. [Release Notes](https://suricata-ids.org/2020/10/08/suricata-4-1-9-and-5-0-4-released/) for this version can be found here:  [https://suricata-ids.org/2020/10/08/suricata-4-1-9-and-5-0-4-released/](https://suricata-ids.org/2020/10/08/suricata-4-1-9-and-5-0-4-released/).