### PR TITLE
pfBlockerNG check dnsvl_vip. Fixes #11108

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG-devel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-pfBlockerNG-devel
 PORTVERSION=	3.0.0
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1708,7 +1708,8 @@ function pfb_unbound_dnsbl($mode) {
 			}
 
 			// Remove any DNSBL VIPs added to unbound.conf on 'disable'
-			elseif (strpos($line, 'interface:') !== FALSE && $mode == 'disabled' && strpos($line, $pfb['dnsbl_vip']) !== FALSE) { 
+			elseif ((strpos($line, 'interface:') !== FALSE) && ($mode == 'disabled') &&
+			    !empty($pfb['dnsbl_vip']) && (strpos($line, $pfb['dnsbl_vip']) !== FALSE)) { 
 				$u_update = TRUE;
 				$u_msg .= "  Removed DNSBL VIP from Unbound Interface settings\n";
 				unset($conf[$key]);


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/11108
- [X] Ready for review

check that `$pfb['dnsbl_vip']` is not empty before `strpos()`