### PR TITLE
pfBlockerNG proxy fix. Issue #11128

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -166,7 +166,6 @@ $pfb['curl_defaults'] = array(  CURLOPT_USERAGENT	=> 'pfSense/pfBlockerNG cURL d
 				CURLOPT_SSL_VERIFYHOST	=> true,
 				CURLOPT_FRESH_CONNECT	=> true,
 				CURLOPT_FILETIME	=> true,
-				CURLOPT_TCP_FASTOPEN	=> true,
 				CURLOPT_TCP_NODELAY	=> true,
 				CURLOPT_CONNECTTIMEOUT	=> 15
 				);
@@ -332,6 +331,8 @@ function pfb_global() {
 			$pfb['curl_defaults'][CURLOPT_PROXYAUTH]	= 'CURLAUTH_ANY | CURLAUTH_ANYSAFE';
 			$pfb['curl_defaults'][CURLOPT_PROXYUSERPWD]	= "{$config['system']['proxyuser']}:{$config['system']['proxypass']}";
 		}
+	} else {
+		$pfb['curl_defaults'][CURLOPT_TCP_FASTOPEN]		= true;
 	}
 
 	// Set pfBlockerNG to disabled on 're-install'


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/11128
- [X] Ready for review

If `CURLOPT_TCP_FASTOPEN` is set, curl ignores `CURLOPT_PROXY` settings