### PR TITLE
pfBlockerNG v3.0.0_6

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG-devel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-pfBlockerNG-devel
 PORTVERSION=	3.0.0
-PORTREVISION=	5
+PORTREVISION=	6
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -286,6 +286,9 @@ function pfb_global() {
 	$pfb['dnsbl_noaaaa']	= $pfb['dnsblconfig']['pfb_noaaaa'];		// DNSBL Resolver python no AAAA
 	$pfb['dnsbl_noaaaa_list']=$pfb['dnsblconfig']['pfb_noaaaa_list'];	// DNSBL Resolver python no AAAA list
 
+	$pfb['dnsbl_gp']		= $pfb['dnsblconfig']['pfb_gp'];		// DNSBL Resolver python - DNSBL Bypass
+	$pfb['dnsbl_gp_bypass_list']	= $pfb['dnsblconfig']['pfb_gp_bypass_list'];	// DNSBL Resolver python - List of Local IPs to bypass DNSBL
+
 	// DNSBL Resolver mode (Unbound/Python)
 	$pfb['dnsbl_py_blacklist'] = FALSE;
 	if ($pfb['dnsbl_mode'] == 'dnsbl_python' && $pfb['dnsbl_py_block'] == 'on') {
@@ -1307,7 +1310,7 @@ function pfb_create_dnsbl($mode) {
 					if ($pfb['dnsbl_v6'] == 'on') {
 						$dnsbl_new_nat[] = array (	'source'		=> array('any'  => ''),
 										'destination'		=> array('address' => "::{$pfb['dnsbl_vip']}",
-										'port' => "{$lport}"),
+														'port' => "{$lport}"),
 										'protocol'		=> 'tcp',
 										'target'		=> '::1',
 										'local-port'		=> "{$port}",
@@ -1987,6 +1990,21 @@ EOF;
 
 [noAAAA]
 {$noaaaa}
+EOF;
+			}
+		}
+
+		if ($pfb['dnsbl_gp'] == 'on' && isset($pfb['dnsbl_gp_bypass_list']) && !empty($pfb['dnsbl_gp_bypass_list'])) {
+			$gp_bypass = '';
+			$gp_bypass_list = pfbng_text_area_decode($pfb['dnsbl_gp_bypass_list'], TRUE, TRUE);
+			if (!empty($gp_bypass_list)) {
+				foreach ($gp_bypass_list as $key => $list) {
+					$gp_bypass .= "{$key} = {$list[0]}\n";
+				}
+				$pfb_py_conf .= <<<EOF
+
+[GP_Bypass_List]
+{$gp_bypass}
 EOF;
 			}
 		}

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1285,34 +1285,38 @@ function pfb_create_dnsbl($mode) {
 		}
 
 		if ($mode == 'enabled') {
-			// Generate new DNSBL NAT per DNSBL listening ports
-			$selected_ports = array("{$pfb['dnsbl_port']}" => '80', "{$pfb['dnsbl_port_ssl']}" => '443');
-			foreach ($selected_ports as $port => $lport) {
 
-				$dnsbl_new_nat[] =	array ( 'source'		=> array('any'  => ''),
-								'destination'		=> array('address' => "{$pfb['dnsbl_vip']}", 'port' => "{$lport}"),
-								'protocol'		=> 'tcp',
-								'target'		=> '127.0.0.1',
-								'local-port'		=> "{$port}",
-								'interface'		=> "{$pfb['dnsbl_iface']}",
-								'descr'			=> 'pfB DNSBL - DO NOT EDIT',
-								'associated-rule-id'	=> 'pass',
-								'natreflection'		=> 'purenat'
-								);
+			// Generate new DNSBL NAT per DNSBL listening ports except for 'localhost' interface setting.
+			$dnsbl_new_nat = array();
+			if ($pfb['dnsbl_iface'] != 'lo0') {
+				$selected_ports = array("{$pfb['dnsbl_port']}" => '80', "{$pfb['dnsbl_port_ssl']}" => '443');
+				foreach ($selected_ports as $port => $lport) {
 
-				// Add DNSBL IPv6 NAT Rules
-				if ($pfb['dnsbl_v6'] == 'on') {
-					$dnsbl_new_nat[] = array (	'source'		=> array('any'  => ''),
-									'destination'		=> array('address' => "::{$pfb['dnsbl_vip']}",
-													'port' => "{$lport}"),
+					$dnsbl_new_nat[] =	array ( 'source'		=> array('any'  => ''),
+									'destination'		=> array('address' => "{$pfb['dnsbl_vip']}", 'port' => "{$lport}"),
 									'protocol'		=> 'tcp',
-									'target'		=> '::1',
+									'target'		=> '127.0.0.1',
 									'local-port'		=> "{$port}",
 									'interface'		=> "{$pfb['dnsbl_iface']}",
 									'descr'			=> 'pfB DNSBL - DO NOT EDIT',
 									'associated-rule-id'	=> 'pass',
 									'natreflection'		=> 'purenat'
 									);
+
+					// Add DNSBL IPv6 NAT Rules
+					if ($pfb['dnsbl_v6'] == 'on') {
+						$dnsbl_new_nat[] = array (	'source'		=> array('any'  => ''),
+										'destination'		=> array('address' => "::{$pfb['dnsbl_vip']}",
+										'port' => "{$lport}"),
+										'protocol'		=> 'tcp',
+										'target'		=> '::1',
+										'local-port'		=> "{$port}",
+										'interface'		=> "{$pfb['dnsbl_iface']}",
+										'descr'			=> 'pfB DNSBL - DO NOT EDIT',
+										'associated-rule-id'	=> 'pass',
+										'natreflection'		=> 'purenat'
+										);
+					}
 				}
 			}
 
@@ -8512,7 +8516,7 @@ function sync_package_pfblockerng($cron='') {
 
 		$new_aliases_list[] = 'pfB_DNSBL_Ports';
 		$new_aliases[] = array( 'name'		=> 'pfB_DNSBL_Ports',
-					'address'	=> "{$pfb['dnsbl_port']} {$pfb['dnsbl_port_ssl']}",
+					'address'	=> $pfb['dnsbl_iface'] != 'lo0' ? "{$pfb['dnsbl_port']} {$pfb['dnsbl_port_ssl']}" : '80, 443',
 					'descr'		=> 'pfBlockerNG DNSBL VIP Ports',
 					'type'		=> 'port',
 					'detail'	=> 'DO NOT EDIT THIS PORT||DO NOT EDIT THIS PORT'

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -333,7 +333,8 @@ function pfb_global() {
 			$pfb['curl_defaults'][CURLOPT_PROXYAUTH]	= 'CURLAUTH_ANY | CURLAUTH_ANYSAFE';
 			$pfb['curl_defaults'][CURLOPT_PROXYUSERPWD]	= "{$config['system']['proxyuser']}:{$config['system']['proxypass']}";
 		}
-	} else {
+	}
+	else {
 		$pfb['curl_defaults'][CURLOPT_TCP_FASTOPEN]		= true;
 	}
 
@@ -6126,6 +6127,22 @@ function sync_package_pfblockerng($cron='') {
 		@file_put_contents('/var/log/pfblockerng/py_error.log', $log, FILE_APPEND);
 	}
 
+	// Force DNSBL Mode to DNSBL Unbound mode until the DNS Resolver DHCP OpenVPN Client Registration option has been disabled in pfSense < 2.5.
+	if ($pfb['dnsbl_mode'] == 'dnsbl_python' && substr(trim(file_get_contents('/etc/version')), 0, 3) < '2.5' &&
+	    isset($config['unbound']['regovpnclients'])) {
+
+		$pfb['dnsbl_mode']		= 'dnsbl_unbound';
+		$pfb['dnsbl_py_blacklist']	= FALSE;
+
+		$log = "\n [ ALERT ]\n"
+			. " DNSBL Python mode is not compatable with the DNS Resolver OpenVPN Client Registration option enabled!\n"
+			. " The DNS Resolver DHCP Registration option must be disabled to utilize the DNSBL Python feature!\n"
+			. " DNSBL has been automatically downgraded to the DNSBL Unbound mode!\n\n";
+		pfb_logger("{$log}", 1);
+
+		$log = "[pfBlockerNG]: Terminating DNSBL Python mode due to DNS Resolver OpenVPN Client Registration option enabled!\n";
+		@file_put_contents('/var/log/pfblockerng/py_error.log', $log, FILE_APPEND);
+	}
 
 /*
 

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng.php
@@ -32,7 +32,7 @@ if ($_SERVER['REMOTE_ADDR'] == '127.0.0.1' && $_REQUEST && $_REQUEST['pfb']) {
 
 	$query = htmlspecialchars($_REQUEST['pfb']);
 	if (file_exists("/var/db/aliastables/{$query}_v4.txt")) {
-        	$type = '_v4';
+		$type = '_v4';
 	} elseif (file_exists("/var/db/aliastables/{$query}_v6.txt")) {
 		$type = '_v6';
 	}
@@ -63,7 +63,7 @@ if (isset($argv[1])) {
 		exit;
 	}
 	elseif ($argv[1] == 'cleardnsbl') {
-		pfBlockerNG_clearsqlite('clearall');
+		pfBlockerNG_clearsqlite('cleardnsbl');
 		exit;
 	}
 }
@@ -1537,7 +1537,7 @@ $section->addInput(new Form_StaticText(
 
 // Maxmind License Key verification
 if (empty($pfb['maxmind_key'])) {
-        print_callout('<br /><br /><p><strong>'
+	print_callout('<br /><br /><p><strong>'
 			. 'MaxMind now requires a License Key! Review the IP tab: MaxMind settings for more information.'
 			. '</strong></p><br />', 'danger', '');
 }

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng.php
@@ -59,10 +59,11 @@ global $config, $g, $pfb;
 if (isset($argv[1])) {
 	if ($argv[1] == 'clearip') {
 		pfBlockerNG_clearip();
+		pfBlockerNG_clearsqlite('clearip');
 		exit;
 	}
 	elseif ($argv[1] == 'cleardnsbl') {
-		pfBlockerNG_cleardnsbl('clearall');
+		pfBlockerNG_clearsqlite('clearall');
 		exit;
 	}
 }

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -126,6 +126,12 @@ if ($type != 'GeoIP') {
 	}
 }
 
+// Remove any empty '<config></config>' XML tags
+if (isset($rowdata[0]) && empty($rowdata[0])) {
+	unset($rowdata[0]);
+	$rowdata = array_values($rowdata);
+}
+
 if (!empty($action) && isset($gtype) && isset($rowid)) {
 
 	switch ($action) {

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -316,6 +316,13 @@ if ($_POST) {
 			$input_errors[] = 'In order to utilize the DNSBL Python feature, first disable the DNS Resolver DHCP Registration option.';
 		}
 
+		// DNSBL Python mode is not compatable with the DNS Resolver OpenVPN Client Registration option (pfSense < 2.5)
+		if ($_POST['dnsbl_mode'] == 'dnsbl_python' && substr(trim(file_get_contents('/etc/version')), 0, 3) < '2.5' &&
+		    isset($config['unbound']['regovpnclients'])) {
+			$input_errors[] = 'DNSBL Python mode is not compatable with the DNS Resolver \'OpenVPN Client Registration option\'!';
+			$input_errors[] = 'In order to utilize the DNSBL Python feature, first disable the DNS Resolver OpenVPN Client Registration option.';
+		}
+
 		// DNSBL Python mode is only available for pfSense 2.4.5 and above
 		if ($_POST['dnsbl_mode'] == 'dnsbl_python' && substr(trim(file_get_contents('/etc/version')), 0, 5) < '2.4.5') {
 			$input_errors[] = 'DNSBL Python mode is compatable with pfSense versions 2.4.5 and above.';
@@ -477,6 +484,7 @@ $section->addInput(new Form_Select(
 		. '<strong>Unbound Python Mode</strong>:<br />'
 		. '&emsp;&emsp;&emsp;&emsp;This mode is only available for pfSense version 2.4.5 and above.<br />'
 		. '&emsp;&emsp;&emsp;&emsp;Python DNSBL mode is <strong>not</strong> compatable with the DNS Resolver DHCP Registration option (Unbound will Crash)!<br />'
+		. '&emsp;&emsp;&emsp;&emsp;Python DNSBL mode is <strong>not</strong> compatable with the DNS Resolver OpenVPN Client Registration (pfSense < 2.5)!<br />'
 		. '&emsp;&emsp;&emsp;&emsp;This mode will utilize the python integration of Unbound for DNSBL.<br />'
 		. '&emsp;&emsp;&emsp;&emsp;This mode will allow logging of DNS Replies, and more advanced DNSBL Blocking features.<br />'
 		. '&emsp;&emsp;&emsp;&emsp;This mode requires substantially less memory </div>'

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.json
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.json
@@ -462,7 +462,7 @@
 					"header":	"ISC_Shadowserver"
 				},
 				{
-					"feed":		"Internet Storm Center",
+					"feed":		"Internet Storm Center - Onyphe",
 					"website":	"https://isc.sans.edu/",
 					"url":		"https://isc.sans.edu/api/threatlist/onyphe",
 					"header":	"ISC_Onyphe"
@@ -1108,7 +1108,7 @@
 		"Email": {
 			"info":		"List of email providers. If not filtered by 'TOP1M Whitelist' may block many websites.",
 			"description":	"Email - List of email providers domains.",
-			"action":	"block",
+			"action":	"",
 			"cron":		"Weekly",
 			"feeds": [
 				{
@@ -1647,6 +1647,12 @@
 					"website":	"https://phishing.army/",
 					"url":		"https://phishing.army/download/phishing_army_blocklist.txt",
 					"header":	"PhishingArmy",
+					"alternate": [
+							{
+							"url":		"https://phishing.army/download/phishing_army_blocklist_extended.txt",
+							"header":	"PhishingArmy_agr"
+							}
+						],
 					"info":		"Generated every 6 hours from PhishTank, OpenPhish, Cert.pl and PhishFindR reports. Each domain is analyzed to eliminate false positives, through the Whitelist of Anudeep and the Alexa Rank."
 				}
 			]

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.json
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.json
@@ -1108,7 +1108,7 @@
 		"Email": {
 			"info":		"List of email providers. If not filtered by 'TOP1M Whitelist' may block many websites.",
 			"description":	"Email - List of email providers domains.",
-			"action":	"",
+			"action":	"block",
 			"cron":		"Weekly",
 			"feeds": [
 				{

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/var/unbound/pfb_unbound_include.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/var/unbound/pfb_unbound_include.inc
@@ -40,15 +40,30 @@ if (isset($config['unbound']['python']) && !empty($config['unbound']['python_scr
 	// DNSBL Python mode is not compatable with dhcpleases binary code,
 	// as it attempts to HUP the Unbound PID and will cause DNSBL Python mode to crash Unbound
 
+	$config = parse_config(true);
+
 	// Force DNSBL Mode to DNSBL Unbound mode until the DNS Resolver DHCP Registration option has been disabled.
 	if (isset($config['unbound']['regdhcp'])) {
 		$python_mode = FALSE;
 
-		$config = parse_config(true);
 		unset($config['unbound']['python']);
 		write_config('pfBlockerNG: Disable DNSBL python due to DNS Resolver DHCP Registration enabled');
 		$log = "[pfBlockerNG]: Terminating DNSBL Python mode due to DNS Resolver DHCP Registration option enabled!\n";
 		@file_put_contents('/var/log/pfblockerng/py_error.log', $log, FILE_APPEND); 
+	} else {
+		$python_mode = TRUE;		// This variable to remain in future
+	}
+
+	// Force DNSBL Mode to DNSBL Unbound mode until the DNS Resolver OpenVPN Client Registration option has been disabled.
+	if (substr(trim(file_get_contents('/etc/version')), 0, 3) < '2.5' && isset($config['unbound']['regovpnclients'])) {
+		$python_mode = FALSE;
+
+		if (isset($config['unbound']['python'])) {
+			unset($config['unbound']['python']);
+			write_config('pfBlockerNG: Disable DNSBL python due to DNS Resolver OpenVPN Client Registration option enabled');
+		}
+		$log = "[pfBlockerNG]: Terminating DNSBL Python mode due to DNS Resolver OpenVPN Client Registration option enabled!\n";
+		@file_put_contents('/var/log/pfblockerng/py_error.log', $log, FILE_APPEND);
 	} else {
 		$python_mode = TRUE;		// This variable to remain in future
 	}


### PR DESCRIPTION
- Fix incorrect function name call
- Add safety belt for DNS Python mode and the DNS Resolver OpenVPN Client Registration option.
- Add a Phishing Army alternative feed.
- Remove any empty < config >< /config > config.xml entries
- DNSBL - NAT / Floating rule modifications when Localhost interface is selected
- Preliminary DNSBL Group Policy configuration