### PR TITLE
Update frr_ospf_interfaces.xml

### DIFF
--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf_interfaces.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf_interfaces.xml
@@ -100,7 +100,7 @@
 			<fieldname>interface</fieldname>
 			<description>Enter the desired participating interface here.</description>
 			<type>select_source</type>
-			<source><![CDATA[frr_get_interfaces(false, false)]]></source>
+			<source><![CDATA[frr_get_interfaces(false, false, true)]]></source>
 			<source_name>name</source_name>
 			<source_value>value</source_value>
 			<required/>


### PR DESCRIPTION
Allow lo0 to be used as an OSPF interface for loopback purposes.

Loopbacks can be assigned as IP Alias VIPs on lo0 via Firewall>Virtual IPs