### PR TITLE
pfBlockerNG DuckDuckGo safesearch fix. Issue #11155

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfb_dnsbl.safesearch.conf
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfb_dnsbl.safesearch.conf
@@ -1,9 +1,7 @@
-local-data: "www.duckduckgo.com A 54.229.105.151"
-local-data: "duckduckgo.com A 54.229.105.151"
-local-data: "pixabay.com A 104.18.21.183"
-local-data: "pixabay.com A 104.18.20.183"
-local-data: "pixabay.com AAAA 2606:4700::6812:14b7"
-local-data: "pixabay.com AAAA 2606:4700::6812:15b7"
+local-zone: "duckduckgo.com" redirect
+local-data: "duckduckgo.com 300 CNAME safe.duckduckgo.com"
+local-zone: "pixabay.com" redirect
+local-data: "pixabay.com 300 CNAME safesearch.pixabay.com"
 local-data: "yandex.ru A 213.180.193.56"
 local-data: "yandex.ua A 213.180.193.56"
 local-data: "yandex.by A 213.180.193.56"


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/11155
- [X] Ready for review

duckduckgo safesearch redirection must use CNAME instead of A entry,
see https://www.reddit.com/r/pfBlockerNG/comments/inat95/new_ip_address_for_safeduckduckgocom_old_ip/
and https://help.duckduckgo.com/duckduckgo-help-pages/features/safe-search/