### PR TITLE
Fix net-snmp logging to syslog

### DIFF
--- a/net-mgmt/pfSense-pkg-net-snmp/Makefile
+++ b/net-mgmt/pfSense-pkg-net-snmp/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-net-snmp
 PORTVERSION=	0.1.5
-PORTREVISION=	6
+PORTREVISION=	7
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-net-snmp/files/usr/local/pkg/net-snmp.inc
+++ b/net-mgmt/pfSense-pkg-net-snmp/files/usr/local/pkg/net-snmp.inc
@@ -630,7 +630,7 @@ echo "Starting net-snmpd..."
 /usr/bin/killall -9 snmpd 2>/dev/null
 sleep 1
 
-/usr/local/sbin/snmpd -LF 0-4 d \
+/usr/local/sbin/snmpd -LS 0-6 d \
 			-p /var/run/net_snmpd.pid \
 			-M /usr/share/snmp/mibs/:/usr/local/share/snmp/mibs \
 			-C \


### PR DESCRIPTION
The net-snmp service command currently is set to log to a file rather than to syslog so log output ends up in file `/usr/local/www/d` rather than syslog.
Also, increase logging level to info as net-snmpd is very un-chatty.

Redmine: https://redmine.pfsense.org/issues/11204