### PR TITLE
pfSense-pkg-frr v1.0.0

### DIFF
--- a/net/pfSense-pkg-frr/Makefile
+++ b/net/pfSense-pkg-frr/Makefile
@@ -1,8 +1,8 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-frr
-PORTVERSION=	0.6.8
-PORTREVISION=	9
+PORTVERSION=	1.0.0
+PORTREVISION=	0
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -76,6 +76,8 @@ do-install:
 	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/frr/frr_bfd.xml \
 		${STAGEDIR}${PREFIX}/pkg/frr
 	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/frr/frr_bfd_peers.xml \
+		${STAGEDIR}${PREFIX}/pkg/frr
+	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/frr/frr_bfd_profiles.xml \
 		${STAGEDIR}${PREFIX}/pkg/frr
 	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/frr/inc/frr_ospf6.inc \
 		${STAGEDIR}${PREFIX}/pkg/frr/inc

--- a/net/pfSense-pkg-frr/files/usr/local/bin/frrctl
+++ b/net/pfSense-pkg-frr/files/usr/local/bin/frrctl
@@ -146,7 +146,7 @@ bgp6*)
 	fi
 	case $2 in
 	rou*)
-		daemon_command "show bgp"
+		daemon_command "show bgp ipv6"
 		;;
 	esac ;;
 bgp*)
@@ -156,15 +156,15 @@ bgp*)
 	fi
 	case $2 in
 	rou*)
-		daemon_command "show ip bgp"
+		daemon_command "show bgp ipv4"
 		;;
 	nei*)
 		shift; shift;
-		daemon_command "show ip bgp neighbors $*"
+		daemon_command "show bgp neighbors $*"
 		;;
 	peer*)
 		shift; shift;
-		daemon_command "show ip bgp peer-group $*"
+		daemon_command "show bgp peer-group $*"
 		;;
 	sum*)
 		shift; shift;
@@ -172,11 +172,16 @@ bgp*)
 		;;
 	nexth*)
 		shift; shift;
-		daemon_command "show ip bgp nexthop detail $*"
+		daemon_command "show bgp nexthop detail $*"
 		;;
 	mem*)
 		shift; shift;
 		daemon_command "show bgp memory $*"
+		;;
+	cycleneighbor)
+		daemon_command "config terminal" "router bgp $3"  "neighbor $4 shutdown"
+		sleep 1;
+		daemon_command "config terminal" "router bgp $3"  "no neighbor $4 shutdown"
 		;;
 	esac ;;
 bfd*)

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr.inc
@@ -26,6 +26,8 @@ require_once("service-utils.inc");
 require_once("util.inc");
 
 define('PKG_FRR_CONFIG_BASE', '/var/etc/frr');
+define('PKG_FRR_LIST_NONE_VALUE', array('name' => 'None', 'value' => 'none'));
+
 /* Since we need to embed this in strings & HERE Docs, copy to a var. Can't embed constants. */
 global $frr_config_base;
 $frr_config_base = PKG_FRR_CONFIG_BASE;
@@ -57,7 +59,7 @@ require_once("frr/inc/frr_ospf6.inc");
 /* Build a list of only CARP VIPs, formatted for use in a selection list */
 function frr_get_carp_list() {
 	$list = array();
-	$list[] = array("name" => "none", "value" => "none");
+	$list[] = PKG_FRR_LIST_NONE_VALUE;
 	$carplist = get_configured_vip_list("all", VIP_CARP);
 	foreach ($carplist as $vid => $vaddr) {
 		$vip = get_configured_vip($vid);
@@ -205,7 +207,7 @@ function frr_get_route_destinations() {
 	global $config;
 	$list = array();
 
-	$list[] = array("name" => "None", "value" => "none");
+	$list[] = PKG_FRR_LIST_NONE_VALUE;
 
 	/* Add non-disabled gateways to the list */
 	$gateways = return_gateways_array();
@@ -260,6 +262,11 @@ function frr_array_seq_sort(&$arr) {
 	}
 }
 
+/* Sort an array by its 'name' and 'seq' value. */
+function frr_array_name_seq_sort(&$arr) {
+	usort($arr, "frr_array_name_seq_compare");
+}
+
 /* Convert a CIDR prefix to wildcard bits */
 function frr_cidr_to_wildcard_bits($cidr) {
 	return long2ip(~gen_subnet_mask_long($cidr));
@@ -297,6 +304,7 @@ function frr_generate_config_rcfile() {
 
 	/* Get FRR daemon modules to append to daemon commands */
 	$frrmodules = array();
+
 	/* SNMP */
 	foreach ($daemons as $config_key => $daemon) {
 		$frrmodules[$daemon[0]] = '';
@@ -746,6 +754,8 @@ function frr_package_config_upgrade() {
 	$ospf6d_conf = &$config['installedpackages']['frrospf6d']['config'][0];
 	init_config_arr(array('installedpackages', 'frrglobalacls', 'config'));
 	$frr_acls_conf = &$config['installedpackages']['frrglobalacls']['config'];
+	init_config_arr(array('installedpackages', 'frrglobalprefixes', 'config'));
+	$frr_prefixes_conf = &$config['installedpackages']['frrglobalprefixes']['config'];
 	init_config_arr(array('installedpackages', 'frrglobalroutemaps', 'config'));
 	$frr_routemap_conf = &$config['installedpackages']['frrglobalroutemaps']['config'];
 	init_config_arr(array('installedpackages', 'frrospfdinterfaces', 'config'));
@@ -888,6 +898,28 @@ function frr_package_config_upgrade() {
 		$need_write = true;
 	}
 
+	/* ACL and Prefix List add IP Type*/
+	foreach ($frr_acls_conf as $aclconf) {
+		if (empty($aclconf['iptype']) && !empty($aclconf['row'])) {
+			if (is_subnetv4($aclconf['row'][0]['source'])) {
+				$aclconf['iptype'] = 'IPv4';
+			} else {
+				$aclconf['iptype'] = 'IPv6';
+			}
+			$need_write = true;
+		}
+	}
+	foreach ($frr_prefixes_conf as $prefixconf) {
+		if (empty($prefixconf['iptype']) && !empty($prefixconf['row'])) {
+			if (is_subnetv4($aclconf['row'][0]['source'])) {
+				$aclconf['iptype'] = 'IPv4';
+			} else {
+				$aclconf['iptype'] = 'IPv6';
+			}
+			$need_write = true;
+		}
+	}
+
 	/* Save Changes */
 	if ($need_write) {
 		update_status("Saving changes ... ");
@@ -896,7 +928,6 @@ function frr_package_config_upgrade() {
 	} else {
 		update_status("Nothing to do.\n");
 	}
-
 }
 
 /* Install-time functions */

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr.inc
@@ -447,20 +447,20 @@ EOF;
 			// Assume it's up if the status can't be determined.
 			default:
 				if ($frr_restart_needed) {
-					log_error("FRR: Restarting services.");
+					frr_package_log("FRR: Restarting services.");
 					mwexec_bg("/usr/local/etc/rc.d/frr.sh restart");
 				} else {
-					log_error("FRR: Reloading configuration.");
+					frr_package_log("FRR: Reloading configuration.");
 					mwexec_bg("/usr/local/sbin/frr-reload");
 				}
 				break;
 		}
 	} else {
 		if ($frr_restart_needed) {
-			log_error("FRR: Restarting services.");
+			frr_package_log("FRR: Restarting services.");
 			mwexec_bg("/usr/local/etc/rc.d/frr.sh restart");
 		} else {
-			log_error("FRR: Reloading configuration.");
+			frr_package_log("FRR: Reloading configuration.");
 			mwexec_bg("/usr/local/sbin/frr-reload");
 		}
 	}
@@ -571,6 +571,24 @@ function frr_setkey() {
 	}
 }
 
+/* Write a message to the syslog conditionally on package log level setting*/
+function frr_package_log($string, $priority = LOG_INFO) {
+	global $config;
+
+	/* Populate FRR Global Settings */
+	if (is_array($config['installedpackages']['frr']['config'])) {
+		$frr_conf = &$config['installedpackages']['frr']['config'][0];
+	}
+
+	/* Check if extended package logging is enabled */
+	if (is_null($frr_conf['pkgloglevel']) || ($frr_conf['pkgloglevel'] < 1)) {
+		// Extended logging is disabled
+		return;
+	}
+
+	syslog($priority, "FRR Package: {$string}");
+}
+
 /* Main function to generate all of the configuration files and make general
  * preparations */
 function frr_generate_config() {
@@ -612,7 +630,7 @@ function frr_generate_config() {
 
 	/* Create the rc.d service control script and trigger restart/reload */
 	if (!empty($_POST['service_force_restart'])) {
-		log_error("FRR: Service restart forced.");
+		frr_package_log("FRR: Service restart forced.");
 		$force_restart = true;
 	} else {
 		$force_restart = false;
@@ -632,11 +650,11 @@ function frr_generate_config_vtysh() {
 
 	/* If there is no raw configuration and no GUI configuration, stop. */
 	if (empty($frr_conf)) {
-		log_error("FRR vtysh: No config data found.");
+		frr_package_log("FRR vtysh: No config data found.");
 		return;
 	}
 	if (empty($frr_conf['enable'])) {
-		log_error("FRR vtysh: FRR master switch is off.");
+		frr_package_log("FRR vtysh: FRR master switch is off.");
 		return;
 	}
 
@@ -690,15 +708,15 @@ function frr_generate_config_integrated() {
 
 	/* If there is no raw configuration and no GUI configuration, stop. */
 	if (empty($frr_conf)) {
-		log_error("FRR Integrated: No config data found.");
+		frr_package_log("FRR Integrated: No config data found.");
 		return;
 	}
 	if (empty($frr_conf['enable'])) {
-		log_error("FRR Integrated: FRR master switch is off.");
+		frr_package_log("FRR Integrated: FRR master switch is off.");
 		return;
 	}
 
-	log_error("FRR Integrated: Rebuild configuration.");
+	frr_package_log("FRR Integrated: Rebuild configuration.");
 
 	$integratedconffile = $frr_auto_config_warning;
 	$integratedconffile .= "frr defaults traditional\n";

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr.inc
@@ -273,7 +273,7 @@ function frr_cidr_to_wildcard_bits($cidr) {
 }
 
 /* Create the rc.d service control script for FRR */
-function frr_generate_config_rcfile($force_restart = false) {
+function frr_generate_config_rcfile() {
 	global $config, $frr_config_base, $frr_modules;
 	/* If frr is not configured, then stop */
 	if (is_array($config['installedpackages']['frr']['config'])) {
@@ -333,11 +333,6 @@ function frr_generate_config_rcfile($force_restart = false) {
 			$frr_daemons_start_cmd .= $frrmodules[$daemon];
 		}
 		$frr_daemons_start_cmd .= "\n";
-	}
-
-	/* If force_restart is set, delete the previously generated start command file to force a service restart */
-	if ($force_restart) {
-		unlink_if_exists("/tmp/frr_start_command_last.txt");
 	}
 
 	/* Check/Record the generated start command so that it can be compared to decide
@@ -432,37 +427,53 @@ EOF;
 		}
 	}
 
-	/* Start/Restart FRR, if a CARP VIP is set, check its status and act
-	 * appropriately. */
-	if (isset($frr_conf['carpstatusvid']) && $frr_conf['carpstatusvid'] != "none") {
-		$status = get_carp_interface_status($frr_conf['carpstatusvid']);
-		switch (strtoupper($status)) {
-			// Stop the service if the VIP is in BACKUP or INIT state.
-			case "BACKUP":
-			case "INIT":
-				mwexec_bg("/usr/local/etc/rc.d/frr.sh stop");
-				break;
-			// Start the service if the VIP is MASTER state.
-			case "MASTER":
-			// Assume it's up if the status can't be determined.
-			default:
-				if ($frr_restart_needed) {
-					frr_package_log("FRR: Restarting services.");
-					mwexec_bg("/usr/local/etc/rc.d/frr.sh restart");
-				} else {
-					frr_package_log("FRR: Reloading configuration.");
-					mwexec_bg("/usr/local/sbin/frr-reload");
-				}
-				break;
+	return $frr_restart_needed;
+}
+
+function frr_service_action($restart_needed) {
+	global $config, $frr_config_base, $frr_modules;
+	/* If frr is not configured, then stop */
+	if (is_array($config['installedpackages']['frr']['config'])) {
+		$frr_conf = &$config['installedpackages']['frr']['config'][0];
+	} else {
+		return null;
+	}
+
+	if ($frr_conf['enable']) {
+		/* Start/Restart FRR, if a CARP VIP is set, check its status and appropriately. */
+		if (isset($frr_conf['carpstatusvid']) && $frr_conf['carpstatusvid'] != "none") {
+			$status = get_carp_interface_status($frr_conf['carpstatusvid']);
+			switch (strtoupper($status)) {
+				// Stop the service if the VIP is in BACKUP or INIT state.
+				case "BACKUP":
+				case "INIT":
+					mwexec_bg("/usr/local/etc/rc.d/frr.sh stop");
+					break;
+				// Start the service if the VIP is MASTER state.
+				case "MASTER":
+				// Assume it's up if the status can't be determined.
+				default:
+					if ($restart_needed) {
+						frr_package_log("FRR: Restarting services.");
+						mwexec_bg("/usr/local/etc/rc.d/frr.sh restart");
+					} else {
+						frr_package_log("FRR: Reloading configuration.");
+						mwexec_bg("/usr/local/sbin/frr-reload");
+					}
+					break;
+			}
+		} else {
+			if ($restart_needed) {
+				frr_package_log("FRR: Restarting services.");
+				mwexec_bg("/usr/local/etc/rc.d/frr.sh restart");
+			} else {
+				frr_package_log("FRR: Reloading configuration.");
+				mwexec_bg("/usr/local/sbin/frr-reload");
+			}
 		}
 	} else {
-		if ($frr_restart_needed) {
-			frr_package_log("FRR: Restarting services.");
-			mwexec_bg("/usr/local/etc/rc.d/frr.sh restart");
-		} else {
-			frr_package_log("FRR: Reloading configuration.");
-			mwexec_bg("/usr/local/sbin/frr-reload");
-		}
+		frr_package_log("FRR: Stopping services.");
+		mwexec_bg("/usr/local/etc/rc.d/frr.sh stop");
 	}
 }
 
@@ -631,11 +642,11 @@ function frr_generate_config() {
 	/* Create the rc.d service control script and trigger restart/reload */
 	if (!empty($_POST['service_force_restart'])) {
 		frr_package_log("FRR: Service restart forced.");
-		$force_restart = true;
-	} else {
-		$force_restart = false;
+		/* If force_restart is set, delete the previously generated start command file to force a service restart */
+		unlink_if_exists("/tmp/frr_start_command_last.txt");
 	}
-	frr_generate_config_rcfile($force_restart);
+	$restart_needed = frr_generate_config_rcfile();
+	frr_service_action($restart_needed);
 }
 
 function frr_generate_config_vtysh() {
@@ -659,7 +670,7 @@ function frr_generate_config_vtysh() {
 	}
 
 	$vtyshconffile = $frr_auto_config_warning;
-	$vtyshconffile = "service integrated-vtysh-config\n\n";
+	$vtyshconffile .= "service integrated-vtysh-config\n\n";
 	file_put_contents("{$frr_config_base}/vtysh.conf", $vtyshconffile);
 	chown("{$frr_config_base}/vtysh.conf", 'frr');
 	chgrp("{$frr_config_base}/vtysh.conf", 'frr');
@@ -760,6 +771,9 @@ function frr_generate_config_integrated() {
 	$integratedconffile .= "line vty\n";
 	$integratedconffile .= "!\n";
 	$integratedconffile .= "end\n";
+
+	/* Remove sample configuration files */
+	array_map('unlink', glob("{$frr_config_base}/*.sample*"));
 
 	file_put_contents("{$frr_config_base}/frr.conf", $integratedconffile, LOCK_EX);
 	chown("{$frr_config_base}/frr.conf", 'frr');

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr.inc
@@ -273,7 +273,7 @@ function frr_cidr_to_wildcard_bits($cidr) {
 }
 
 /* Create the rc.d service control script for FRR */
-function frr_generate_config_rcfile() {
+function frr_generate_config_rcfile($force_restart = false) {
 	global $config, $frr_config_base, $frr_modules;
 	/* If frr is not configured, then stop */
 	if (is_array($config['installedpackages']['frr']['config'])) {
@@ -333,6 +333,11 @@ function frr_generate_config_rcfile() {
 			$frr_daemons_start_cmd .= $frrmodules[$daemon];
 		}
 		$frr_daemons_start_cmd .= "\n";
+	}
+
+	/* If force_restart is set, delete the previously generated start command file to force a service restart */
+	if ($force_restart) {
+		unlink_if_exists("/tmp/frr_start_command_last.txt");
 	}
 
 	/* Check/Record the generated start command so that it can be compared to decide
@@ -442,20 +447,20 @@ EOF;
 			// Assume it's up if the status can't be determined.
 			default:
 				if ($frr_restart_needed) {
-					log_error("FRR Restarting");
+					log_error("FRR: Restarting services.");
 					mwexec_bg("/usr/local/etc/rc.d/frr.sh restart");
 				} else {
-					log_error("FRR Reloading Configuration");
+					log_error("FRR: Reloading configuration.");
 					mwexec_bg("/usr/local/sbin/frr-reload");
 				}
 				break;
 		}
 	} else {
 		if ($frr_restart_needed) {
-			log_error("FRR Restarting");
+			log_error("FRR: Restarting services.");
 			mwexec_bg("/usr/local/etc/rc.d/frr.sh restart");
 		} else {
-			log_error("FRR Reloading Configuration");
+			log_error("FRR: Reloading configuration.");
 			mwexec_bg("/usr/local/sbin/frr-reload");
 		}
 	}
@@ -599,14 +604,20 @@ function frr_generate_config() {
 	/* BFD Configuration */
 	frr_generate_config_bfd();
 
-	/* Create the rc.d service control script */
-	frr_generate_config_rcfile();
-
 	/* Setup TCP MD5 authentication */
 	frr_setkey();
 
 	/* Integrated configuration */
 	frr_generate_config_integrated();
+
+	/* Create the rc.d service control script and trigger restart/reload */
+	if (!empty($_POST['service_force_restart'])) {
+		log_error("FRR: Service restart forced.");
+		$force_restart = true;
+	} else {
+		$force_restart = false;
+	}
+	frr_generate_config_rcfile($force_restart);
 }
 
 function frr_generate_config_vtysh() {
@@ -625,10 +636,11 @@ function frr_generate_config_vtysh() {
 		return;
 	}
 	if (empty($frr_conf['enable'])) {
-		/* FRR master switch is off. */
+		log_error("FRR vtysh: FRR master switch is off.");
 		return;
 	}
 
+	$vtyshconffile = $frr_auto_config_warning;
 	$vtyshconffile = "service integrated-vtysh-config\n\n";
 	file_put_contents("{$frr_config_base}/vtysh.conf", $vtyshconffile);
 	chown("{$frr_config_base}/vtysh.conf", 'frr');
@@ -682,9 +694,11 @@ function frr_generate_config_integrated() {
 		return;
 	}
 	if (empty($frr_conf['enable'])) {
-		/* FRR master switch is off. */
+		log_error("FRR Integrated: FRR master switch is off.");
 		return;
 	}
+
+	log_error("FRR Integrated: Rebuild configuration.");
 
 	$integratedconffile = $frr_auto_config_warning;
 	$integratedconffile .= "frr defaults traditional\n";

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr.inc
@@ -754,6 +754,11 @@ function frr_generate_config_integrated() {
 	$integratedconffile .= "!\n";
 
 	if (!empty($frr_conf['routerid'])) {
+		if (is_ipaddrv4($frr_conf['routerid'])) {
+			$integratedconffile .= "ip ";
+		} elseif (is_ipaddrv6($frr_conf['routerid'])) {
+			$integratedconffile .= "ipv6 ";
+		}
 		$integratedconffile .= "router-id {$frr_conf['routerid']}\n";
 		$integratedconffile .= "!\n";
 	}

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr.inc
@@ -260,11 +260,13 @@ function frr_array_seq_sort(&$arr) {
 	if ($need_sort) {
 		usort($arr, "frr_array_seq_compare");
 	}
+
+	return $need_sort;
 }
 
 /* Sort an array by its 'name' and 'seq' value. */
 function frr_array_name_seq_sort(&$arr) {
-	usort($arr, "frr_array_name_seq_compare");
+	return usort($arr, "frr_array_name_seq_compare");
 }
 
 /* Convert a CIDR prefix to wildcard bits */
@@ -783,6 +785,24 @@ function frr_generate_config_integrated() {
 	file_put_contents("{$frr_config_base}/frr.conf", $integratedconffile, LOCK_EX);
 	chown("{$frr_config_base}/frr.conf", 'frr');
 	chgrp("{$frr_config_base}/frr.conf", 'frr');
+}
+
+/* Upgrade the FRR configuration to the latest format */
+function frr_config_sort_route_map() {
+	global $config;
+
+	update_status("Sorting route-map configuration items");
+
+	init_config_arr(array('installedpackages', 'frrglobalroutemaps', 'config'));
+	$frr_routemap_conf = &$config['installedpackages']['frrglobalroutemaps']['config'];
+
+	$need_write = frr_array_name_seq_sort($frr_routemap_conf);
+
+	if ($need_write) {
+		update_status("Saving sorted route-map configuration items");
+		write_config('FRR: Sorted route-map configuration items');
+		update_status("Done.\n");
+	}
 }
 
 /* Upgrade the FRR configuration to the latest format */

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr.inc
@@ -990,6 +990,7 @@ function frr_package_config_upgrade() {
 			$need_write = true;
 		}
 	}
+	update_status("Done.\n");
 
 	/* Save Changes */
 	if ($need_write) {
@@ -1001,8 +1002,28 @@ function frr_package_config_upgrade() {
 	}
 }
 
+function frr_set_tunables() {
+	global $config;
+
+	init_config_arr(array('sysctl', 'item'));
+	$sysctl_conf = &$config['sysctl']['item'];
+	$sysctl_maxsockbuff = array('tunable' => 'kern.ipc.maxsockbuf', 'value' => 16777216, 'descr' => "Maximum socket buffer size - set by FRR package");
+
+	if (!in_array($sysctl_maxsockbuff, $sysctl_conf)) {
+		update_status("Installing maxsockbuf tunable ... ");
+		$sysctl_conf[] = $sysctl_maxsockbuff;
+		write_config('FRR: Installed maxsockbuf tunable.');
+		system_setup_sysctl();
+		update_status("Done.\n");
+	}
+}
+
 /* Install-time functions */
 function frr_package_install() {
 	/* Upgrade the configuration */
 	frr_package_config_upgrade();
+
+	/* Set tunable kern.ipc.maxsockbuf to FRR recommended */
+	/* OSPF and OSPF6 most likely won't work without this */
+	frr_set_tunables();
 }

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr.xml
@@ -284,6 +284,25 @@
 				</rowhelperfield>
 			</rowhelper>
 		</field>
+
+		<field>
+			<name>Force Service Restart</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>Force Service Restart</fielddescr>
+			<fieldname>service_force_restart</fieldname>
+			<type>button</type>
+			<buttonicon>fa-cog</buttonicon>
+			<buttonclass>btn-danger</buttonclass>
+			<description>
+				<![CDATA[
+				Click to force a service restart.<br />
+				<b>This will cause a reconvergance of any enabled routing protocols!</b>
+				]]>
+			</description>
+			<placeonbottom/>
+		</field>
 	</fields>
 	<custom_php_resync_config_command>
 		frr_generate_config();

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr.xml
@@ -212,7 +212,6 @@
 			<source_name>name</source_name>
 			<source_value>value</source_value>
 		</field>
-
 		<field>
 			<name>Logging</name>
 			<type>listtopic</type>
@@ -244,7 +243,6 @@
 			<description>Enable agentx support for accessing FRR Zebra data via SNMP with the net-snmp package.</description>
 			<type>checkbox</type>
 		</field>
-
 		<field>
 			<name>Route Handling</name>
 			<type>listtopic</type>
@@ -300,7 +298,6 @@
 				</rowhelperfield>
 			</rowhelper>
 		</field>
-
 		<field>
 			<name>Force Service Restart</name>
 			<type>listtopic</type>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr.xml
@@ -163,6 +163,18 @@
 			<type>checkbox</type>
 		</field>
 		<field>
+			<fielddescr>Default Router ID</fielddescr>
+			<fieldname>routerid</fieldname>
+			<description>
+				<![CDATA[
+				Specify the default Router ID. RID is the highest logical (loopback) IP address configured on a router.<br />
+				For more information on router identifiers see <a href='http://en.wikipedia.org/wiki/Open_Shortest_Path_First'>wikipedia</a>.<br />
+				Per-daemon configuration will take precedence over this setting.
+				]]>
+			</description>
+			<type>input</type>
+		</field>
+		<field>
 			<fielddescr>Master Password</fielddescr>
 			<fieldname>password</fieldname>
 			<description>Password to access the management daemons. Required.</description>
@@ -174,23 +186,6 @@
 			<fieldname>passwordencrypt</fieldname>
 			<description>Enable password encryption service.</description>
 			<type>checkbox</type>
-		</field>
-		<field>
-			<fielddescr>Logging</fielddescr>
-			<fieldname>logging</fieldname>
-			<description>If set to yes, Logs will be written via syslog.</description>
-			<type>checkbox</type>
-		</field>
-		<field>
-			<fielddescr>Router ID</fielddescr>
-			<fieldname>routerid</fieldname>
-			<description>
-				<![CDATA[
-				Specify the default Router ID. RID is the highest logical (loopback) IP address configured on a router.<br />
-				For more information on router identifiers see <a href='http://en.wikipedia.org/wiki/Open_Shortest_Path_First'>wikipedia</a>.
-				]]>
-			</description>
-			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Ignore IPsec Restart</fielddescr>
@@ -209,7 +204,7 @@
 			<fieldname>carpstatusvid</fieldname>
 			<description>
 				<![CDATA[
-				Used to determine the CARP status. When the CARP vhid is in BACKUP status, frr will not be started.<br />
+				Used to determine the CARP status. When the CARP vhid is in BACKUP status, FRR will not be started.<br />
 				]]>
 			</description>
 			<type>select_source</type>
@@ -218,6 +213,27 @@
 			<source_value>value</source_value>
 		</field>
 
+		<field>
+			<name>Logging</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>Syslog Logging</fielddescr>
+			<fieldname>logging</fieldname>
+			<description>If set to yes, FRR daemon Logs will be written via syslog.</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Package Logging Level</fielddescr>
+			<fieldname>pkgloglevel</fieldname>
+			<description>Set the log level for package scripts</description>
+			<type>select</type>
+			<default_value>none</default_value>
+			<options>
+				<option><name>Normal</name><value>0</value></option>
+				<option><name>Extended</name><value>1</value></option>
+			</options>
+		</field>
 		<field>
 			<name>Modules</name>
 			<type>listtopic</type>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bfd.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bfd.xml
@@ -40,6 +40,10 @@
 			<url>pkg.php?xml=frr/frr_bfd_peers.xml</url>
 		</tab>
 		<tab>
+			<text>Profiles</text>
+			<url>pkg.php?xml=frr/frr_bfd_profiles.xml</url>
+		</tab>
+		<tab>
 			<text>[Global Settings]</text>
 			<url>pkg_edit.php?xml=frr.xml</url>
 		</tab>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bfd_peers.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bfd_peers.xml
@@ -220,6 +220,9 @@
 			<type>checkbox</type>
 		</field>
 	</fields>
+	<custom_delete_php_command>
+		frr_generate_config();
+	</custom_delete_php_command>
 	<custom_php_resync_config_command>
 		frr_generate_config();
 	</custom_php_resync_config_command>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bfd_profiles.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bfd_profiles.xml
@@ -5,7 +5,7 @@
 	<copyright>
 	<![CDATA[
 /*
- * frr_bfd_peers.xml
+ * frr_bfd_profiles.xml
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2012-2020 Rubicon Communications, LLC (Netgate)
@@ -25,10 +25,10 @@
  */
 	]]>
 	</copyright>
-	<name>frr_bfd_peers</name>
+	<name>frr_bfd_profiles</name>
 	<title>Services/FRR/BFD</title>
 	<include_file>/usr/local/pkg/frr.inc</include_file>
-	<aftersaveredirect>pkg.php?xml=frr/frr_bfd_peers.xml</aftersaveredirect>
+	<aftersaveredirect>pkg.php?xml=frr/frr_bfd_profiles.xml</aftersaveredirect>
 	<tabs>
 		<tab>
 			<text>BFD</text>
@@ -37,11 +37,11 @@
 		<tab>
 			<text>Peers</text>
 			<url>pkg.php?xml=frr/frr_bfd_peers.xml</url>
-			<active/>
 		</tab>
 		<tab>
 			<text>Profiles</text>
 			<url>pkg.php?xml=frr/frr_bfd_profiles.xml</url>
+			<active/>
 		</tab>
 		<tab>
 			<text>[Global Settings]</text>
@@ -66,33 +66,22 @@
 	</tabs>
 	<adddeleteeditpagefields>
 		<columnitem>
-			<fielddescr>Peer Address</fielddescr>
-			<fieldname>peer</fieldname>
+			<fielddescr>Name</fielddescr>
+			<fieldname>name</fieldname>
 		</columnitem>
 		<columnitem>
 			<fielddescr>Description</fielddescr>
 			<fieldname>descr</fieldname>
 		</columnitem>
-		<columnitem>
-			<fielddescr>Label</fielddescr>
-			<fieldname>label</fieldname>
-		</columnitem>
-		<columnitem>
-			<fielddescr>Shutdown</fielddescr>
-			<fieldname>shutdown</fieldname>
-		</columnitem>
 	</adddeleteeditpagefields>
 	<fields>
 		<field>
-			<name>Peer Configurations</name>
+			<name>Profile Configuration</name>
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>Peer Address</fielddescr>
-			<fieldname>peer</fieldname>
-			<description>
-				<![CDATA[IP address of a peer]]>
-			</description>
+			<fielddescr>Name</fielddescr>
+			<fieldname>name</fieldname>
 			<type>input</type>
 			<size>20</size>
 			<required/>
@@ -102,45 +91,6 @@
 			<fieldname>descr</fieldname>
 			<size>50</size>
 			<type>input</type>
-		</field>
-		<field>
-			<fielddescr>Label</fielddescr>
-			<fieldname>label</fieldname>
-			<description>
-				<![CDATA[
-				Label a peer with the provided word. This word can be referenced later on other daemons to refer to a specific peer.
-				]]>
-			</description>
-			<size>50</size>
-			<type>input</type>
-		</field>
-		<field>
-			<fielddescr>Profile</fielddescr>
-			<fieldname>Profile</fieldname>
-			<description>
-				<![CDATA[
-				Select the profile for peer take configuration from.
-				]]>
-			</description>
-			<type>select_source</type>
-			<source><![CDATA[frr_get_bfd_profiles()]]></source>
-			<source_name>name</source_name>
-			<source_value>value</source_value>
-		</field>
-		<field>
-			<name>Options</name>
-			<type>listtopic</type>
-		</field>
-		<field>
-			<fielddescr>Multihop</fielddescr>
-			<fieldname>multihop</fieldname>
-			<description>
-				<![CDATA[
-				 Expect packets with TTL less than 254 due to more than one hop between peer addresses and listen on the multihop port 4784.
-				 When using multi-hop mode echo-mode will not work, see RFC 5883 section 3.
-				]]>
-			</description>
-			<type>checkbox</type>
 		</field>
 		<field>
 			<fielddescr>Shutdown</fielddescr>
@@ -154,34 +104,18 @@
 			<type>checkbox</type>
 		</field>
 		<field>
-			<name>Source Address/Interface</name>
-			<type>listtopic</type>
-		</field>
-		<field>
-			<fielddescr>Interface</fielddescr>
-			<fieldname>interface</fieldname>
-			<description>Select the interface which BFD will use as a packet source.</description>
-			<type>select_source</type>
-			<source><![CDATA[frr_get_interfaces()]]></source>
-			<source_name>name</source_name>
-			<source_value>value</source_value>
-		</field>
-		<field>
-			<fielddescr>Local Source Address</fielddescr>
-			<fieldname>local_address</fieldname>
+			<fielddescr>Passive</fielddescr>
+			<fieldname>passive</fieldname>
 			<description>
 				<![CDATA[
-				Provide a local address to bind the BFD peer listener to for participating in a BFD session.<br />
-				This option is mandatory for IPv6.
+				Mark session as passive.
+				A passive session will not attempt to start the connection and will wait for control packets from peer before it begins replying.
 				]]>
 			</description>
-			<type>select_source</type>
-			<source><![CDATA[frr_get_bfd_source_addresses()]]></source>
-			<source_name>name</source_name>
-			<source_value>value</source_value>
+			<type>checkbox</type>
 		</field>
 		<field>
-			<name>Advanced Options</name>
+			<name>Profile Options</name>
 			<type>listtopic</type>
 		</field>
 		<field>
@@ -227,13 +161,25 @@
 			<size>20</size>
 		</field>
 		<field>
+			<fielddescr>Minimum TTL</fielddescr>
+			<fieldname>minimumttl</fieldname>
+			<description>
+				<![CDATA[
+				    For multi hop sessions only, configure the minimum expected TTL for an incoming BFD control packet.<br />
+    				This feature serves the purpose of tightening the packet validation requirements to avoid receiving BFD control packets from other sessions.<br />
+    				The default value is 254 (which means we only expect one hop between this system and the peer).
+				]]>
+			</description>
+			<type>input</type>
+		</field>
+		<field>
 			<fielddescr>Echo Mode</fielddescr>
 			<fieldname>echomode</fieldname>
 			<description>
 				<![CDATA[
-				Enables or disables the echo transmission mode. This mode is disabled by default.
-				FRR documentation recommendeds that the transmission interval of control packets to be increased after enabling echo-mode to reduce bandwidth usage. For example: transmission-interval 2000.
-				Echo mode is not supported on multi-hop setups, see RFC 5883 section 3.
+					Enables or disables the echo transmission mode. This mode is disabled by default.
+					FRR documentation recommendeds that the transmission interval of control packets to be increased after enabling echo-mode to reduce bandwidth usage. For example: transmission-interval 2000.
+					Echo mode is not supported on multi-hop setups, see RFC 5883 section 3.
 				]]>
 			</description>
 			<type>checkbox</type>
@@ -246,6 +192,6 @@
 		frr_generate_config();
 	</custom_php_resync_config_command>
 	<custom_php_validation_command>
-		frr_bfd_peer_validate_input();
+		frr_bfd_profile_validate_input();
 	</custom_php_validation_command>
 </packagegui>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bgp.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bgp.xml
@@ -145,7 +145,6 @@
 			<description>If checked, BGP will not assume IPv4 unicast by default.</description>
 			<type>checkbox</type>
 		</field>
-
 		<field>
 			<name>Modules</name>
 			<type>listtopic</type>
@@ -162,7 +161,22 @@
 			<description>Enable BGP Resource Public Key Infrastructure.</description>
 			<type>checkbox</type>
 		</field>
-
+		<field>
+			<name>Global Neighbor Shutdown</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>Global Neighbor Shutdown</fielddescr>
+			<fieldname>shutdown</fieldname>
+			<description>Administratively shutdown ALL neighbors</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Message</fielddescr>
+			<fieldname>shutdownmessage</fieldname>
+			<description>Shutdown message (optional)</description>
+			<type>input</type>
+		</field>
 		<field>
 			<name>Graceful Restart/Shutdown</name>
 			<type>listtopic</type>
@@ -211,7 +225,6 @@
 			<description>If checked, enable BGP graceful shutdown.</description>
 			<type>checkbox</type>
 		</field>
-
 		<field>
 			<name>RPKI Timers</name>
 			<type>listtopic</type>
@@ -236,7 +249,6 @@
 			<type>input</type>
 			<combinefields>end</combinefields>
 		</field>
-
 		<field>
 			<name>Network Distribution</name>
 			<type>listtopic</type>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bgp_advanced.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bgp_advanced.xml
@@ -96,7 +96,6 @@
 			<source_name>name</source_name>
 			<source_value>value</source_value>
 		</field>
-
 		<field>
 			<name>Advanced Timers</name>
 			<type>listtopic</type>
@@ -139,7 +138,6 @@
 			<type>input</type>
 			<combinefields>end</combinefields>
 		</field>
-
 		<field>
 			<name>Advanced Routing Behavior</name>
 			<type>listtopic</type>
@@ -162,7 +160,6 @@
 			<description>Reject incoming and outgoing routes with AS_SET or AS_CONFED_SET type</description>
 			<type>checkbox</type>
 		</field>
-
 		<field>
 			<name>Route Reflecting</name>
 			<type>listtopic</type>
@@ -395,7 +392,6 @@
 			<description>Disable the requirement to apply incoming and outgoing filter to eBGP sessions</description>
 			<type>checkbox</type>
 		</field>
-
 		<field>
 			<name>Networking Behavior</name>
 			<type>listtopic</type>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bgp_aspaths.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bgp_aspaths.xml
@@ -149,6 +149,9 @@
 			</rowhelper>
 		</field>
 	</fields>
+	<custom_delete_php_command>
+		frr_generate_config();
+	</custom_delete_php_command>
 	<custom_php_resync_config_command>
 		frr_generate_config();
 	</custom_php_resync_config_command>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bgp_communities.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bgp_communities.xml
@@ -167,6 +167,9 @@
 			</rowhelper>
 		</field>
 	</fields>
+	<custom_delete_php_command>
+		frr_generate_config();
+	</custom_delete_php_command>
 	<custom_php_resync_config_command>
 		frr_generate_config();
 	</custom_php_resync_config_command>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bgp_neighbors.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bgp_neighbors.xml
@@ -708,8 +708,10 @@
 			<description>Neighbor is part of its own update group</description>
 			<type>checkbox</type>
 		</field>
-
 	</fields>
+	<custom_delete_php_command>
+		frr_generate_config();
+	</custom_delete_php_command>
 	<custom_php_resync_config_command>
 		frr_generate_config();
 	</custom_php_resync_config_command>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bgp_neighbors.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bgp_neighbors.xml
@@ -153,10 +153,34 @@
 			<combinefields>end</combinefields>
 		</field>
 		<field>
+			<name>Shutdown</name>
+			<type>listtopic</type>
+		</field>
+		<field>
 			<fielddescr>Shutdown</fielddescr>
 			<fieldname>shutdown</fieldname>
-			<description>Administratively shutdown the neighbor</description>
+			<description>Neighbor administrative shutdown</description>
 			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Shutdown Message</fielddescr>
+			<fieldname>shutdownmessage</fieldname>
+			<description>Shutdown message (optional)</description>
+			<type>input</type>
+		</field>
+		<field>
+			<fielddescr>Auto-Shutdown</fielddescr>
+			<fieldname>shutdownautortt</fieldname>
+			<description>RTT in milliseconds to automatically shutdown the peer if exceeded.</description>
+			<type>input</type>
+			<combinefields>begin</combinefields>
+		</field>
+		<field>
+			<fielddescr>Auto-Shutdown Keepalive Count</fielddescr>
+			<fieldname>shutdownautortt</fieldname>
+			<description>Number of keepalive messages to count before shutting down the peer when round-trip-time exceeds the set threshold.</description>
+			<type>input</type>
+			<combinefields>end</combinefields>
 		</field>
 		<field>
 			<name>Basic Options</name>
@@ -264,7 +288,6 @@
 			<type>input</type>
 			<combinefields>end</combinefields>
 		</field>
-
 		<field>
 			<name>Peer Filtering</name>
 			<type>listtopic</type>
@@ -394,7 +417,6 @@
 			<source_name>name</source_name>
 			<source_value>value</source_value>
 		</field>
-
 		<field>
 			<name>BFD</name>
 			<type>listtopic</type>
@@ -435,7 +457,6 @@
 			<source_name>name</source_name>
 			<source_value>value</source_value>
 		</field>
-
 		<field>
 			<name>Graceful Restart</name>
 			<type>listtopic</type>
@@ -453,7 +474,6 @@
 				<option><name>Disable</name><value>disable</value></option>
 			</options>
 		</field>
-
 		<field>
 			<name>Advanced Options</name>
 			<type>listtopic</type>
@@ -668,6 +688,12 @@
 			<type>input</type>
 		</field>
 		<field>
+			<fielddescr>Maximum Prefix Out</fielddescr>
+			<fieldname>maximumprefixout_num</fieldname>
+			<description>Maximum Prefix to Send (1-4294967295)</description>
+			<type>input</type>
+		</field>
+		<field>
 			<fielddescr>Remove Private AS</fielddescr>
 			<fieldname>removeprivateas</fieldname>
 			<description>Remove private ASNs in outbound updates</description>
@@ -687,7 +713,6 @@
 			<type>checkbox</type>
 			<combinefields>end</combinefields>
 		</field>
-
 		<field>
 			<fielddescr>Route Client</fielddescr>
 			<fieldname>routeclient_reflector</fieldname>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bgp_rpki_cache_servers.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_bgp_rpki_cache_servers.xml
@@ -140,6 +140,9 @@
 			<type>input</type>
 		</field>
 	</fields>
+	<custom_delete_php_command>
+		frr_generate_config();
+	</custom_delete_php_command>
 	<custom_php_resync_config_command>
 		frr_generate_config();
 	</custom_php_resync_config_command>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_global_acls.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_global_acls.xml
@@ -165,6 +165,9 @@
 			</rowhelper>
 		</field>
 	</fields>
+	<custom_delete_php_command>
+		frr_generate_config();
+	</custom_delete_php_command>
 	<custom_php_resync_config_command>
 		frr_generate_config();
 	</custom_php_resync_config_command>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_global_acls.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_global_acls.xml
@@ -74,6 +74,10 @@
 	</tabs>
 	<adddeleteeditpagefields>
 		<columnitem>
+			<fielddescr>IP Type</fielddescr>
+			<fieldname>iptype</fieldname>
+		</columnitem>
+		<columnitem>
 			<fielddescr>Name</fielddescr>
 			<fieldname>name</fieldname>
 		</columnitem>
@@ -84,15 +88,42 @@
 	</adddeleteeditpagefields>
 	<fields>
 		<field>
+			<fielddescr>Type</fielddescr>
+			<fieldname>type</fieldname>
+			<description>Access list type.</description>
+			<type>select</type>
+			<default_value>zebra</default_value>
+			<options>
+				<option><name>Standard</name><value>standard</value></option>
+				<option><name>Extended</name><value>extended</value></option>
+				<option><name>Zebra</name><value>zebra</value></option>
+			</options>
+			<required/>
+			<combinefields>begin</combinefields>
+		</field>
+		<field>
+			<fielddescr>IP Type</fielddescr>
+			<fieldname>iptype</fieldname>
+			<description>Access list IP version.</description>
+			<type>select</type>
+			<default_value>IPv4</default_value>
+			<options>
+				<option><name>IPv4</name><value>IPv4</value></option>
+				<option><name>IPv6</name><value>IPv6</value></option>
+			</options>
+			<required/>
+			<combinefields>end</combinefields>
+		</field>
+		<field>
 			<fielddescr>Name</fielddescr>
 			<fieldname>name</fieldname>
 			<description>
 				<![CDATA[
 				The name of this Access List entry.
-				<br />
-				Use 1-99 or 1300-1999 for a standard access list (source only),
-				100-199 or 2000-2699 for an extended access list (source and destination),
-				or enter a text name for a zebra access list
+				<br /><br />
+				- 1-99 or 1300-1999 for a standard access list (source only).<br />
+				- 100-199 or 2000-2699 for an extended access list (source and destination).<br />
+				- Enter a text name for a zebra access list.
 				]]>
 			</description>
 			<type>input</type>
@@ -110,13 +141,12 @@
 			<description>
 				<![CDATA[
 				Access List entries determine if networks are allowed or denied in specific contexts used in various routing daemons.
-				<br />
-				Order is important. Use the sequence field to reorder entries after saving. The networks may be a host, network, or "any".
-				Exact only applies to zebra type access lists.
-				<br />
-				Leave the Destination Network blank when using a standard or zebra access list instead of an extended access list.
-				<br />
-				Only Zebra Access Lists support IPv6. The type is detected automatically based on the address given. To specify 'any' for IPv6, use 'any6'.
+				<br /><br />
+				<b>Notes:</b><br />
+				- Entries are evaluated in order, use the sequence field to reorder entries after saving. The networks may be a host, network, or "any".<br />
+				- Exact only applies to zebra type access lists.<br />
+				- Leave the Destination Network blank when using a standard or zebra access list instead of an extended access list.<br />
+				- Only Zebra Access Lists support IPv6
 				]]>
 			</description>
 			<type>info</type>
@@ -150,10 +180,20 @@
 					<size>25</size>
 				</rowhelperfield>
 				<rowhelperfield>
+					<fielddescr>Source Any</fielddescr>
+					<fieldname>sourceany</fieldname>
+					<type>checkbox</type>
+				</rowhelperfield>
+				<rowhelperfield>
 					<fielddescr>Destination Network</fielddescr>
 					<fieldname>destination</fieldname>
 					<type>input</type>
 					<size>25</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Destination Any</fielddescr>
+					<fieldname>destinationany</fieldname>
+					<type>checkbox</type>
 				</rowhelperfield>
 				<rowhelperfield>
 					<fielddescr>Exact</fielddescr>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_global_prefixes.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_global_prefixes.xml
@@ -157,6 +157,9 @@
 			</rowhelper>
 		</field>
 	</fields>
+	<custom_delete_php_command>
+		frr_generate_config();
+	</custom_delete_php_command>
 	<custom_php_resync_config_command>
 		frr_generate_config();
 	</custom_php_resync_config_command>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_global_prefixes.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_global_prefixes.xml
@@ -74,6 +74,10 @@
 	</tabs>
 	<adddeleteeditpagefields>
 		<columnitem>
+			<fielddescr>IP Type</fielddescr>
+			<fieldname>iptype</fieldname>
+		</columnitem>
+		<columnitem>
 			<fielddescr>Name</fielddescr>
 			<fieldname>name</fieldname>
 		</columnitem>
@@ -83,6 +87,18 @@
 		</columnitem>
 	</adddeleteeditpagefields>
 	<fields>
+		<field>
+			<fielddescr>IP Type</fielddescr>
+			<fieldname>iptype</fieldname>
+			<description>Prefix list IP version.</description>
+			<type>select</type>
+			<default_value>IPv4</default_value>
+			<options>
+				<option><name>IPv4</name><value>IPv4</value></option>
+				<option><name>IPv6</name><value>IPv6</value></option>
+			</options>
+			<required/>
+		</field>
 		<field>
 			<fielddescr>Name</fielddescr>
 			<fieldname>name</fieldname>
@@ -141,6 +157,11 @@
 					<fieldname>source</fieldname>
 					<type>input</type>
 					<size>25</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Any</fielddescr>
+					<fieldname>any</fieldname>
+					<type>checkbox</type>
 				</rowhelperfield>
 				<rowhelperfield>
 					<fielddescr>Minimum Prefix</fielddescr>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_global_raw.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_global_raw.xml
@@ -116,7 +116,6 @@
 				</rowhelperfield>
 			</rowhelper>
 		</field>
-
 		<field>
 			<name>RAW Configuration Management</name>
 			<type>listtopic</type>
@@ -131,7 +130,6 @@
 			</description>
 			<type>info</type>
 		</field>
-
 		<field>
 			<name>RAW Configuration Files</name>
 			<type>listtopic</type>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_global_routemaps.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_global_routemaps.xml
@@ -503,6 +503,7 @@
 		</field>
 	</fields>
 	<custom_php_resync_config_command>
+		frr_config_sort_route_map();
 		frr_generate_config();
 	</custom_php_resync_config_command>
 	<custom_php_validation_command>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf.xml
@@ -115,7 +115,6 @@
 			</description>
 			<type>input</type>
 		</field>
-
 		<field>
 			<name>Modules</name>
 			<type>listtopic</type>
@@ -126,7 +125,6 @@
 			<description>Enable agentx support for accessing FRR Zebra data via SNMP with the net-snmp package.</description>
 			<type>checkbox</type>
 		</field>
-
 		<field>
 			<name>Default Area</name>
 			<type>listtopic</type>
@@ -167,7 +165,6 @@
 				<option><name>Not so Totally Stub Area (nssa no-summary)</name><value>nssanosum</value></option>
 			</options>
 		</field>
-
 		<field>
 			<name>OSPF Networks</name>
 			<type>listtopic</type>
@@ -211,7 +208,6 @@
 				</rowhelperfield>
 			</rowhelper>
 		</field>
-
 		<field>
 			<name>Route Redistribution</name>
 			<type>listtopic</type>
@@ -276,7 +272,6 @@
 			</description>
 			<type>info</type>
 		</field>
-
 		<field>
 			<fielddescr>pfSense Kernel Routes</fielddescr>
 			<fieldname>redistributekernel</fieldname>
@@ -326,7 +321,6 @@
 			</description>
 			<type>info</type>
 		</field>
-
 		<field>
 			<fielddescr>BGP Routes</fielddescr>
 			<fieldname>redistributebgp</fieldname>
@@ -376,7 +370,6 @@
 			</description>
 			<type>info</type>
 		</field>
-
 		<field>
 			<fielddescr>FRR Static Routes</fielddescr>
 			<fieldname>redistributestatic</fieldname>
@@ -426,7 +419,6 @@
 			</description>
 			<type>info</type>
 		</field>
-
 		<field>
 			<name>Default Route Redistribution</name>
 			<type>listtopic</type>
@@ -464,7 +456,6 @@
 			<source_name>name</source_name>
 			<source_value>value</source_value>
 		</field>
-
 		<field>
 			<name>Advanced</name>
 			<type>listtopic</type>
@@ -487,7 +478,6 @@
 			<description>Base value, in Mbit/s, used to calculate automatic interface costs. Must be set the same on all OSPF routers (1-4294967, default 100).</description>
 			<type>input</type>
 		</field>
-
 		<field>
 			<fielddescr>Max Metric</fielddescr>
 			<fieldname>max_metric_administrative</fieldname>
@@ -527,7 +517,6 @@
 				<option><name>Standard (RFC2328)</name><value>standard</value></option>
 			</options>
 		</field>
-
 	</fields>
 	<custom_php_resync_config_command>
 		frr_generate_config();

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf6.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf6.xml
@@ -121,7 +121,6 @@
 			</description>
 			<type>input</type>
 		</field>
-
 		<field>
 			<name>Modules</name>
 			<type>listtopic</type>
@@ -132,7 +131,6 @@
 			<description>Enable agentx support for accessing FRR OSPF6 data via SNMP with the net-snmp package.</description>
 			<type>checkbox</type>
 		</field>
-
 		<field>
 			<name>Default Area</name>
 			<type>listtopic</type>
@@ -175,7 +173,6 @@
 				<!-- <option><name>Not so Totally Stub Area (nssa no-summary)</name><value>nssanosum</value></option> -->
 			</options>
 		</field>
-
 		<field>
 			<name>Route Distribution</name>
 			<type>listtopic</type>
@@ -214,7 +211,6 @@
 			</description>
 			<type>info</type>
 		</field>
-
 		<field>
 			<name>Route Redistribution</name>
 			<type>listtopic</type>
@@ -256,7 +252,6 @@
 			</description>
 			<type>info</type>
 		</field>
-
 		<field>
 			<fielddescr>pfSense Kernel Routes</fielddescr>
 			<fieldname>redistributekernel</fieldname>
@@ -283,7 +278,6 @@
 			</description>
 			<type>info</type>
 		</field>
-
 		<field>
 			<fielddescr>BGP Routes</fielddescr>
 			<fieldname>redistributebgp</fieldname>
@@ -310,7 +304,6 @@
 			</description>
 			<type>info</type>
 		</field>
-
 		<field>
 			<fielddescr>FRR Static Routes</fielddescr>
 			<fieldname>redistributestatic</fieldname>
@@ -337,7 +330,6 @@
 			</description>
 			<type>info</type>
 		</field>
-
 		<field>
 			<name>Route Filtering</name>
 			<type>listtopic</type>
@@ -378,7 +370,6 @@
 			<source_name>name</source_name>
 			<source_value>value</source_value>
 		</field>
-
 		<field>
 			<name>Advanced</name>
 			<type>listtopic</type>
@@ -413,7 +404,6 @@
 			<description>Intra-area route distance (1-255).</description>
 			<type>input</type>
 		</field>
-
 	</fields>
 	<custom_php_resync_config_command>
 		frr_generate_config();

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf6_areas.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf6_areas.xml
@@ -112,7 +112,6 @@
 				<!-- <option><name>Not so Totally Stub Area (nssa no-summary)</name><value>nssanosum</value></option> -->
 			</options>
 		</field>
-
 		<field>
 			<name>Range Overrides</name>
 			<type>listtopic</type>
@@ -149,7 +148,6 @@
 				</rowhelperfield>
 			</rowhelper>
 		</field>
-
 		<field>
 			<name>ABR Summary Route Filtering</name>
 			<type>listtopic</type>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf6_areas.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf6_areas.xml
@@ -191,7 +191,9 @@
 			<source_value>value</source_value>
 		</field>
 	</fields>
-
+	<custom_delete_php_command>
+		frr_generate_config();
+	</custom_delete_php_command>
 	<custom_php_resync_config_command>
 		frr_generate_config();
 	</custom_php_resync_config_command>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf6_interfaces.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf6_interfaces.xml
@@ -135,7 +135,6 @@
 			<description>Ignore MTU values for OSPF6 peers on this interface. Allows OSPF6 to form full adjacencies even when there is an MTU mismatch.</description>
 			<type>checkbox</type>
 		</field>
-
 		<field>
 			<name>OSPF6 Interface Handling</name>
 			<type>listtopic</type>
@@ -158,7 +157,6 @@
 			<description>Metric (cost) for this OSPF6 interface (leave blank for default).</description>
 			<type>input</type>
 		</field>
-
 		<field>
 			<name>Advanced</name>
 			<type>listtopic</type>
@@ -192,7 +190,6 @@
 			<description>Retransmit Interval this OSPF6 interface in seconds (Default 5).</description>
 			<type>input</type>
 		</field>
-
 		<field>
 			<name>BFD</name>
 			<type>listtopic</type>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf6_interfaces.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf6_interfaces.xml
@@ -209,6 +209,9 @@
 			<type>checkbox</type>
 		</field>
 	</fields>
+	<custom_delete_php_command>
+		frr_generate_config();
+	</custom_delete_php_command>
 	<custom_php_resync_config_command>
 		frr_generate_config();
 	</custom_php_resync_config_command>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf_areas.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf_areas.xml
@@ -136,7 +136,6 @@
 				<option><name>Disable</name><value>disable</value></option>
 			</options>
 		</field>
-
 		<field>
 			<name>Authentication</name>
 			<type>listtopic</type>
@@ -160,7 +159,6 @@
 				<option><value>simple</value><name>Simple Password</name></option>
 			</options>
 		</field>
-
 		<field>
 			<name>Route Summarization</name>
 			<type>listtopic</type>
@@ -207,7 +205,6 @@
 				</rowhelperfield>
 			</rowhelper>
 		</field>
-
 		<field>
 			<name>ABR Summary Route Filtering</name>
 			<type>listtopic</type>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf_areas.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf_areas.xml
@@ -249,7 +249,9 @@
 			<source_value>value</source_value>
 		</field>
 	</fields>
-
+	<custom_delete_php_command>
+		frr_generate_config();
+	</custom_delete_php_command>
 	<custom_php_resync_config_command>
 		frr_generate_config();
 	</custom_php_resync_config_command>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf_interfaces.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf_interfaces.xml
@@ -258,6 +258,9 @@
 			<type>checkbox</type>
 		</field>
 	</fields>
+	<custom_delete_php_command>
+		frr_generate_config();
+	</custom_delete_php_command>
 	<custom_php_resync_config_command>
 		frr_generate_config();
 	</custom_php_resync_config_command>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf_interfaces.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf_interfaces.xml
@@ -137,7 +137,6 @@
 			<description>Ignore MTU values for OSPF peers on this interface. Allows OSPF to form full adjacencies even when there is an MTU mismatch.</description>
 			<type>checkbox</type>
 		</field>
-
 		<field>
 			<name>OSPF Interface Handling</name>
 			<type>listtopic</type>
@@ -160,7 +159,6 @@
 			<description>Prevent routes for this interface subnet or IP address from being distributed by OSPF (Suggested for Multi-WAN environments).</description>
 			<type>checkbox</type>
 		</field>
-
 		<field>
 			<name>Authentication</name>
 			<type>listtopic</type>
@@ -198,7 +196,6 @@
 			</description>
 			<type>input</type>
 		</field>
-
 		<field>
 			<name>Advanced</name>
 			<type>listtopic</type>
@@ -241,7 +238,6 @@
 			</description>
 			<type>input</type>
 		</field>
-
 		<field>
 			<name>BFD</name>
 			<type>listtopic</type>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf_neighbors.xml
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/frr_ospf_neighbors.xml
@@ -128,6 +128,9 @@
 			<type>input</type>
 		</field>
 	</fields>
+	<custom_delete_php_command>
+		frr_generate_config();
+	</custom_delete_php_command>
 	<custom_php_resync_config_command>
 		frr_generate_config();
 	</custom_php_resync_config_command>

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_bfd.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_bfd.inc
@@ -139,14 +139,12 @@ function frr_generate_config_bfd() {
 		$frr_conf = &$config['installedpackages']['frr']['config'][0];
 	} else {
 		/* If FRR is not configured, stop. */
+		frr_package_log("FRR BFDd: No FRR global config data found.");
 		return null;
 	}
 	/* Populate FRR BFD Settings */
 	if (is_array($config['installedpackages']['frrbfd']['config'])) {
 		$frr_bfd_conf = &$config['installedpackages']['frrbfd']['config'][0];
-	} else {
-		/* No BFD config, stop. */
-		return null;
 	}
 
 	if (isset($config['installedpackages']['frrglobalraw']['config'][0]['bfdd']) &&
@@ -155,12 +153,16 @@ function frr_generate_config_bfd() {
 		$frr_integrated_config['bfdd'] = str_replace("\r","",base64_decode($config['installedpackages']['frrglobalraw']['config'][0]['bfdd']));
 	} else {
 		/* If there is no raw configuration and no GUI configuration, stop. */
-		if (empty($frr_conf['enable']) || empty($frr_bfd_conf['enable'])) {
-			/* FRR is disabled or BFD Daemon is not enabled. */
-			return;
-		}
 		if (empty($frr_bfd_conf)) {
-			log_error("FRR BFDd: No config data found.");
+			frr_package_log("FRR BFDd: No config data found.");
+			return;
+		} elseif (empty($frr_bfd_conf['enable'])) {
+			/* BFD Daemon is not enabled. */
+			frr_package_log("FRR BFDd: BFD disabled.");
+			return;
+		} elseif (empty($frr_conf['enable'])) {
+			/* FRR is disabled or BFD Daemon is not enabled. */
+			frr_package_log("FRR BFDd: FRR master disabled.");
 			return;
 		}
 

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_bfd.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_bfd.inc
@@ -69,6 +69,76 @@ function frr_get_bfd_source_addresses($includedefault = true) {
 	return $addresses;
 }
 
+/* Fetch a list of BFD profiles for use in selection lists */
+function frr_get_bfd_profiles() {
+	global $config;
+
+	$list = array();
+	$list[] = PKG_FRR_LIST_NONE_VALUE;
+
+	if (is_array($config['installedpackages']['frrbfdprofiles']['config'])) {
+		$frr_bfd_profiles = &$config['installedpackages']['frrbfdprofiles']['config'];
+		foreach ($frr_bfd_profiles as $profile) {
+			$name = empty($profile['descr']) ? $profile['name'] : "{$profile['name']} - {$profile['descr']}";
+			$list[] = array("name" => $name, "value" => $profile['name']);
+			unset($name);
+		}
+	}
+
+	return ($list);
+}
+
+/* Generate BFD Profiles configuration lines */
+function frr_bfd_generate_profiles() {
+	global $config;
+
+	/* Populate FRR BFD profiles definitions */
+	if (is_array($config['installedpackages']['frrbfdprofiles']['config'])) {
+		$frr_bfd_profiles = &$config['installedpackages']['frrbfdprofiles']['config'];
+	} else {
+		/* No BFD profiles config, stop. */
+		return null;
+	}
+
+	$bfdprofileconf = "";
+	/* Loop through Profiles and process */
+	foreach ($frr_bfd_profiles as $profile) {
+		/* Profile Definition */
+		$bfdprofileconf .= " profile {$profile['name']}\n";
+
+		/* Profile Options */
+		if (frr_validate_intrange($profile['detectmultiplier'], 2, 255)) {
+			$bfdprofileconf .= "  detect-multiplier {$profile['detectmultiplier']}\n";
+		}
+		if (frr_validate_intrange($profile['receiveinterval'], 10, 60000)) {
+			$bfdprofileconf .= "  receive-interval {$profile['receiveinterval']}\n";
+		}
+		if (frr_validate_intrange($profile['transmitinterval'], 10, 60000)) {
+			$bfdprofileconf .= "  transmit-interval {$profile['transmitinterval']}\n";
+		}
+		if (frr_validate_intrange($profile['echointerval'], 10, 60000)) {
+			$bfdprofileconf .= "  echo-interval {$profile['echointerval']}\n";
+		}
+		if (!empty($profile['passive'])) {
+			$bfdprofileconf .= "  passive-mode\n";
+		}
+		if (!empty($profile['shutdown'])) {
+			$bfdprofileconf .= "  shutdown\n";
+		} else {
+			$bfdprofileconf .= "  no shutdown\n";
+		}
+		if (!empty($profile['echomode'])) {
+			$bfdprofileconf .= "  echo-mode\n";
+		}
+		if (frr_validate_intrange($profile['minimumttl'], 1, 254)) {
+			$bfdprofileconf .= "  minimum-ttl {$profile['minimumttl']}\n";
+		}
+		$bfdprofileconf .= " !\n";
+	}
+
+	return $bfdprofileconf;
+}
+
 /* Generate BFD Peers configuration lines */
 function frr_bfd_generate_peers() {
 	global $config;
@@ -100,28 +170,32 @@ function frr_bfd_generate_peers() {
 			$bfdpeerconf .= "\n";
 
 			/* Peer Options */
-			if (!empty($peer['label'])) {
-				$bfdpeerconf .= "  label {$peer['label']}\n";
-			}
-			if (frr_validate_intrange($peer['detectmultiplier'], 2, 255)) {
-				$bfdpeerconf .= "  detect-multiplier {$peer['detectmultiplier']}\n";
-			}
-			if (frr_validate_intrange($peer['receiveinterval'], 10, 60000)) {
-				$bfdpeerconf .= "  receive-interval {$peer['receiveinterval']}\n";
-			}
-			if (frr_validate_intrange($peer['transmitinterval'], 10, 60000)) {
-				$bfdpeerconf .= "  transmit-interval {$peer['transmitinterval']}\n";
-			}
-			if (frr_validate_intrange($peer['echointerval'], 10, 60000)) {
-				$bfdpeerconf .= "  transmit-interval {$peer['echointerval']}\n";
-			}
-			if (!empty($peer['shutdown'])) {
-				$bfdpeerconf .= "  shutdown\n";
+			if ((empty($peer['profile'])) || ($peer['profile'] == 'none')) {
+				if (!empty($peer['label'])) {
+					$bfdpeerconf .= "  label {$peer['label']}\n";
+				}
+				if (frr_validate_intrange($peer['detectmultiplier'], 2, 255)) {
+					$bfdpeerconf .= "  detect-multiplier {$peer['detectmultiplier']}\n";
+				}
+				if (frr_validate_intrange($peer['receiveinterval'], 10, 60000)) {
+					$bfdpeerconf .= "  receive-interval {$peer['receiveinterval']}\n";
+				}
+				if (frr_validate_intrange($peer['transmitinterval'], 10, 60000)) {
+					$bfdpeerconf .= "  transmit-interval {$peer['transmitinterval']}\n";
+				}
+				if (frr_validate_intrange($peer['echointerval'], 10, 60000)) {
+					$bfdpeerconf .= "  echo-interval {$peer['echointerval']}\n";
+				}
+				if (!empty($peer['shutdown'])) {
+					$bfdpeerconf .= "  shutdown\n";
+				} else {
+					$bfdpeerconf .= "  no shutdown\n";
+				}
+				if (!empty($peer['echomode'])) {
+					$bfdpeerconf .= "  echo-mode\n";
+				}
 			} else {
-				$bfdpeerconf .= "  no shutdown\n";
-			}
-			if (!empty($peer['echomode'])) {
-				$bfdpeerconf .= "  echo-mode\n";
+				$bfdpeerconf .= "  profile {$peer['profile']}\n";
 			}
 			$bfdpeerconf .= " !\n";
 		}
@@ -168,6 +242,9 @@ function frr_generate_config_bfd() {
 
 		$frr_integrated_config['bfdd'] = "";
 		$frr_integrated_config['bfdd'] .= "bfd\n";
+
+		/* BFD Profiles */
+		$frr_integrated_config['bfdd'] .= frr_bfd_generate_profiles();
 
 		/* BFD Peers */
 		$frr_integrated_config['bfdd'] .= frr_bfd_generate_peers();

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_bgp.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_bgp.inc
@@ -19,14 +19,13 @@
  * limitations under the License.
  */
 
-/* Supported address famililes constant */
-define("FRR_BGP_ADDRESS_FAMILIES", array("ipv4 unicast", "ipv6 unicast"));
+define('PKG_FRR_BGP_ADDRESS_FAMILIES', array('ipv4 unicast', 'ipv6 unicast'));
 
 /* Fetch the list of BGP AS Paths for use in selection lists */
 function frr_get_bgp_aspath_list() {
 	global $config;
 	$list = array();
-	$list[] = array("name" => "None", "value" => "none");
+	$list[] = PKG_FRR_LIST_NONE_VALUE;
 	if (is_array($config['installedpackages']['frrbgpaspaths']['config'])) {
 		foreach ($config['installedpackages']['frrbgpaspaths']['config'] as $asp) {
 			$list[] = array("name" => "{$asp['name']} - {$asp['descr']}", "value" => $asp['name']);
@@ -39,7 +38,7 @@ function frr_get_bgp_aspath_list() {
 function frr_get_bgp_community_list() {
 	global $config, $frr_well_known_communities;
 	$list = array();
-	$list[] = array("name" => "None", "value" => "none");
+	$list[] = PKG_FRR_LIST_NONE_VALUE;
 
 	foreach ($frr_well_known_communities as $wkc) {
 		$tmp["name"] = $wkc;
@@ -208,7 +207,7 @@ function frr_bgp_generate_router() {
 		$bgpconf .= "\n";
 	}
 	/* Address-family options */
-	foreach (FRR_BGP_ADDRESS_FAMILIES as $af) {
+	foreach (PKG_FRR_BGP_ADDRESS_FAMILIES as $af) {
 		$ipfamily = explode(" ", $af)[0];
 		$af_pre = $af . "-pre";
 
@@ -454,7 +453,7 @@ function frr_bgp_generate_neighbors() {
 	foreach ($frr_neighbor_conf as $neighbor) {
 		/* Per-neighbor address family enabled flag */
 		$nei_af_flag = array();
-		foreach (FRR_BGP_ADDRESS_FAMILIES as $af) {
+		foreach (PKG_FRR_BGP_ADDRESS_FAMILIES as $af) {
 			$nei_af_flag[$af] = false;
 		}
 
@@ -620,7 +619,7 @@ function frr_bgp_generate_neighbors() {
 		}
 
 		/* Address family neighbor configuration items */
-		foreach(FRR_BGP_ADDRESS_FAMILIES as $af) {
+		foreach(PKG_FRR_BGP_ADDRESS_FAMILIES as $af) {
 			/* Check if neighbor is enabled for the current address family */
 			if (!($nei_af_flag[$af])) {
 				continue;
@@ -904,7 +903,7 @@ function frr_bgp_generate_address_families() {
 
 	$afconf = "";
 
-	foreach (FRR_BGP_ADDRESS_FAMILIES as $af) {
+	foreach (PKG_FRR_BGP_ADDRESS_FAMILIES as $af) {
 		if (empty($frr_bgp_config_address_family["{$af}-pre"])) {
 			continue;
 		}
@@ -945,7 +944,7 @@ function frr_generate_config_bgp() {
 		$frr_integrated_config['bgpd'] = "";
 
 		$frr_bgp_config_address_family = array();
-		foreach (FRR_BGP_ADDRESS_FAMILIES as $af) {
+		foreach (PKG_FRR_BGP_ADDRESS_FAMILIES as $af) {
 			$frr_bgp_config_address_family[$af] = "";
 			$frr_bgp_config_address_family["{$af}-pre"] = "";
 		}

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_bgp.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_bgp.inc
@@ -188,6 +188,15 @@ function frr_bgp_generate_router() {
 		$bgpconf .= " bgp graceful-shutdown\n";
 	}
 
+	/* Global neighbors administrative shutdown */
+	if (!empty($frr_bgp_conf['shutdown'])) {
+		$bgpconf .= " bgp shutdown";
+		if (!empty($frr_bgp_conf['shutdownmessage'])) {
+			$bgpconf .= " message \"{$frr_bgp_conf['shutdownmessage']}\"";
+		}
+		$bgpconf .= "\n";
+	}
+
 	/* Timers */
 	/* Set keep-alive and holdtime, both MUST be set together */
 	if ((frr_validate_intrange($frr_bgp_conf['timers_keepalive'], 0, 65535)) &&
@@ -495,8 +504,23 @@ function frr_bgp_generate_neighbors() {
 			$nconf .= " neighbor {$neighbor['peer']} description {$neighbor['descr']}\n";
 		}
 
+		/* Neighbor administrative/automatic shutdown */
 		if (!empty($neighbor['shutdown'])) {
-			$nconf .= " neighbor {$neighbor['peer']} shutdown\n";
+			$nconf .= " neighbor {$neighbor['peer']} shutdown";
+			if (!empty($neighbor['shutdownmessage'])) {
+				$nconf .= " message \"{$neighbor['shutdownmessage']}\"";
+			}
+			$nconf .= "\n";
+		}
+
+		if (!empty($neighbor['shutdownautortt'])) {
+			$nconf .= " neighbor {$neighbor['peer']} shutdown rtt {$neighbor['shutdownautortt']}";
+			if (!empty($neighbor['shutdownautokeepalive'])) {
+				$nconf .= " count {$neighbor['shutdownautokeepalive']}";
+			} else {
+				$nconf .= " count 1";
+			}
+			$nconf .= "\n";
 		}
 
 		switch ($neighbor['grmode']) {
@@ -601,19 +625,6 @@ function frr_bgp_generate_neighbors() {
 			$nconf .= "\n";
 		}
 
-		if (frr_validate_ulong($neighbor['maximumprefix_num'], 1)) {
-			$nconf .= " neighbor {$neighbor['peer']} maximum-prefix {$neighbor['maximumprefix_num']}";
-			if (frr_validate_intrange($neighbor['maximumprefix_threshold'], 1, 100)) {
-				$nconf .= " {$neighbor['maximumprefix_threshold']}";
-			}
-			if (!empty($neighbor['maximumprefix_warnonly'])) {
-				$nconf .= " warning-only";
-			} elseif (frr_validate_intrange($neighbor['maximumprefix_restart'], 1, 65535)) {
-				$nconf .= " {$neighbor['maximumprefix_restart']}";
-			}
-			$nconf .= "\n";
-		}
-
 		if (!empty($neighbor['solo'])) {
 			$nconf .= " neighbor {$neighbor['peer']} solo\n";
 		}
@@ -647,6 +658,26 @@ function frr_bgp_generate_neighbors() {
 					$frr_bgp_config_address_family[$af] .= "  neighbor {$neighbor['peer']} send-community {$neighbor['sendcommunity']}\n";
 					break;
 				default:
+			}
+
+			if (frr_validate_ulong($neighbor['maximumprefix_num'], 1)) {
+				$frr_bgp_config_address_family[$af] .= " neighbor {$neighbor['peer']} maximum-prefix {$neighbor['maximumprefix_num']}";
+				if (frr_validate_intrange($neighbor['maximumprefix_threshold'], 1, 100)) {
+					$frr_bgp_config_address_family[$af] .= " {$neighbor['maximumprefix_threshold']}";
+				}
+				if (!empty($neighbor['maximumprefix_warnonly'])) {
+					$frr_bgp_config_address_family[$af] .= " warning-only";
+				} elseif (frr_validate_intrange($neighbor['maximumprefix_restart'], 1, 65535)) {
+					$frr_bgp_config_address_family[$af] .= " restart {$neighbor['maximumprefix_restart']}";
+				}
+				if (!empty($neighbor['maximumprefix_force'])) {
+					$frr_bgp_config_address_family[$af] .= " force";
+				}
+				$frr_bgp_config_address_family[$af] .= "\n";
+			}
+
+			if (frr_validate_ulong($neighbor['maximumprefixout_num'], 1)) {
+				$frr_bgp_config_address_family[$af] .= " neighbor {$neighbor['peer']} maximum-prefix-out {$neighbor['maximumprefixout_num']}\n";
 			}
 
 			if ($neighbor['nexthopself'] == "enabled") {

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_bgp.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_bgp.inc
@@ -921,6 +921,7 @@ function frr_generate_config_bgp() {
 		$frr_conf = &$config['installedpackages']['frr']['config'][0];
 	} else {
 		/* If FRR is not configured, stop. */
+		frr_package_log("FRR BGPd: No FRR global config data found.");
 		return null;
 	}
 	/* Populate FRR BGP Settings */
@@ -935,12 +936,18 @@ function frr_generate_config_bgp() {
 	} else {
 		/* If there is no raw configuration and no GUI configuration, stop. */
 		if (empty($frr_bgp_conf)) {
-			log_error("FRR BGPd: No config data found.");
+			frr_package_log("FRR BGPd: No config data found.");
 			return;
-		} elseif (empty($frr_conf['enable']) || empty($frr_bgp_conf['enable'])) {
-			/* FRR is disabled or BGP is not enabled. */
+		} elseif (empty($frr_bgp_conf['enable'])) {
+			/* BGP daemon is not enabled. */
+			frr_package_log("FRR BGPd: BGP disabled.");
+			return;
+		} elseif (empty($frr_conf['enable'])) {
+			/* FRR is disabled or BFD Daemon is not enabled. */
+			frr_package_log("FRR BGPd: FRR master disabled.");
 			return;
 		}
+
 		$frr_integrated_config['bgpd'] = "";
 
 		$frr_bgp_config_address_family = array();

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_ospf.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_ospf.inc
@@ -27,7 +27,7 @@ function frr_generate_config_ospf_areas() {
 
 	$defined_areas = array();
 	$auto_areas = array();
-	$conffile = "";
+	$aconf = "";
 
 	/* Automatic Area: Default */
 	if (!isset($auto_areas[$frr_ospfd_conf['defaultarea']]) || !is_array($auto_areas[$frr_ospfd_conf['defaultarea']])) {
@@ -100,26 +100,26 @@ function frr_generate_config_ospf_areas() {
 				$areatype = "";
 		}
 		if (!empty($areatype)) {
-			$conffile .= " area {$conf['area']} {$areatype}\n";
+			$aconf .= " area {$conf['area']} {$areatype}\n";
 		}
 
 		/* defaultcost */
 		if (!empty($conf['defaultcost'])) {
-			$conffile .= " area {$conf['area']} default-cost {$conf['defaultcost']}\n";
+			$aconf .= " area {$conf['area']} default-cost {$conf['defaultcost']}\n";
 		}
 
 		/* shortcut */
 		if (!empty($conf['shortcut'])) {
-			$conffile .= " area {$conf['area']} shortcut {$conf['shortcut']}\n";
+			$aconf .= " area {$conf['area']} shortcut {$conf['shortcut']}\n";
 		}
 
 		/* authentication */
 		switch ($conf['authtype']) {
 			case "digest":
-				$conffile .= " area {$conf['area']} authentication message-digest\n";
+				$aconf .= " area {$conf['area']} authentication message-digest\n";
 				break;
 			case "simple":
-				$conffile .= " area {$conf['area']} authentication\n";
+				$aconf .= " area {$conf['area']} authentication\n";
 				break;
 			default:
 				break;
@@ -131,40 +131,40 @@ function frr_generate_config_ospf_areas() {
 				if (empty($range['rangeprefix'])) {
 					continue;
 				}
-				$conffile .= " area {$conf['area']} range {$range['rangeprefix']}";
+				$aconf .= " area {$conf['area']} range {$range['rangeprefix']}";
 				if (!empty($range['rangenotadvertise'])) {
-					$conffile .= " not-advertise";
+					$aconf .= " not-advertise";
 				} elseif (!empty($range['rangecost'])) {
-					$conffile .= " cost {$range['rangecost']}";
+					$aconf .= " cost {$range['rangecost']}";
 				} elseif (!empty($range['subprefix'])) {
-					$conffile .= " substitute {$range['subprefix']}";
+					$aconf .= " substitute {$range['subprefix']}";
 				}
-				$conffile .= "\n";
+				$aconf .= "\n";
 			}
 		}
 
 		/* exportlist */
 		if (!empty($conf['exportlist']) && ($conf['exportlist'] != "none")) {
-			$conffile .= " area {$conf['area']} export-list {$conf['exportlist']}\n";
+			$aconf .= " area {$conf['area']} export-list {$conf['exportlist']}\n";
 		}
 
 		/* filterlist_out */
 		if (!empty($conf['filterlist_out']) && ($conf['filterlist_out'] != "none")) {
-			$conffile .= " area {$conf['area']} filter-list prefix {$conf['filterlist_out']} out\n";
+			$aconf .= " area {$conf['area']} filter-list prefix {$conf['filterlist_out']} out\n";
 		}
 
 		/* filterlist_in */
 		if (!empty($conf['filterlist_in']) && ($conf['filterlist_in'] != "none")) {
-			$conffile .= " area {$conf['area']} filter-list prefix {$conf['filterlist_in']} in\n";
+			$aconf .= " area {$conf['area']} filter-list prefix {$conf['filterlist_in']} in\n";
 		}
 
 		/* importlist */
 		if (!empty($conf['importlist']) && ($conf['importlist'] != "none")) {
-			$conffile .= " area {$conf['area']} import-list {$conf['importlist']}\n";
+			$aconf .= " area {$conf['area']} import-list {$conf['importlist']}\n";
 		}
 	}
 
-	return $conffile;
+	return $aconf;
 }
 
 function frr_generate_config_ospf_interfaces() {
@@ -250,20 +250,20 @@ function frr_generate_config_ospf_interfaces() {
 
 function frr_generate_config_ospf_neighbors() {
 	global $config;
-	$conffile = "";
+	$neiconf= "";
 
 	init_config_arr(array('installedpackages', 'frrospfdneighbors', 'config'));
 	foreach ($config['installedpackages']['frrospfdneighbors']['config'] as $conf) {
-		$conffile .= " neighbor {$conf['neighbor']}" ;
+		$neiconf .= " neighbor {$conf['neighbor']}" ;
 		if (!empty($conf['priority'])) {
-			$conffile .= " priority {$conf['priority']}";
+			$neiconf .= " priority {$conf['priority']}";
 		}
 		if (!empty($conf['pollinginterval'])) {
-			$conffile .= " poll-interval {$conf['pollinginterval']}";
+			$neiconf .= " poll-interval {$conf['pollinginterval']}";
 		}
-		$conffile .= "\n" ;
+		$neiconf .= "\n" ;
 	}
-	return $conffile;
+	return $neiconf;
 }
 
 function frr_generate_config_ospf_redistribute($frr_ospfd_conf, $variablename, $sourcename) {
@@ -422,6 +422,7 @@ function frr_generate_config_ospf() {
 		$frr_integrated_config['ospfd'] .= frr_generate_config_ospf_neighbors();
 
 		/* Interface Settings */
+		/* Interface settings do not return a string as they are an accumulation of all protocols */
 		$passive_interfaces = array();
 		global $passive_interfaces;
 		frr_generate_config_ospf_interfaces();

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_ospf.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_ospf.inc
@@ -22,7 +22,7 @@
 function frr_generate_config_ospf_areas() {
 	global $config, $frr_config_base, $frr_auto_config_warning;
 	if (is_array($config['installedpackages']['frrospfd']['config'])) {
-		$ospfd_conf = &$config['installedpackages']['frrospfd']['config'][0];
+		$frr_ospfd_conf = &$config['installedpackages']['frrospfd']['config'][0];
 	}
 
 	$defined_areas = array();
@@ -30,11 +30,11 @@ function frr_generate_config_ospf_areas() {
 	$conffile = "";
 
 	/* Automatic Area: Default */
-	if (!isset($auto_areas[$ospfd_conf['defaultarea']]) || !is_array($auto_areas[$ospfd_conf['defaultarea']])) {
-		$auto_areas[$ospfd_conf['defaultarea']] = array();
+	if (!isset($auto_areas[$frr_ospfd_conf['defaultarea']]) || !is_array($auto_areas[$frr_ospfd_conf['defaultarea']])) {
+		$auto_areas[$frr_ospfd_conf['defaultarea']] = array();
 	}
-	$auto_areas[$ospfd_conf['defaultarea']]['area'] = $ospfd_conf['defaultarea'];
-	$auto_areas[$ospfd_conf['defaultarea']]['type'] = $ospfd_conf['defaultareatype'];
+	$auto_areas[$frr_ospfd_conf['defaultarea']]['area'] = $frr_ospfd_conf['defaultarea'];
+	$auto_areas[$frr_ospfd_conf['defaultarea']]['type'] = $frr_ospfd_conf['defaultareatype'];
 
 	/* Automatic Areas: Interfaces with Authentication */
 	init_config_arr(array('installedpackages', 'frrospfdinterfaces', 'config'));
@@ -45,7 +45,7 @@ function frr_generate_config_ospf_areas() {
 		}
 
 		/* Use default area if the interface area is empty */
-		$ifarea = (isset($conf['interfacearea']) && (strlen($conf['interfacearea']) > 0)) ? $conf['interfacearea'] : $ospfd_conf['defaultarea'];
+		$ifarea = (isset($conf['interfacearea']) && (strlen($conf['interfacearea']) > 0)) ? $conf['interfacearea'] : $frr_ospfd_conf['defaultarea'];
 
 		if (!isset($auto_areas[$ifarea]) || !is_array($auto_areas[$ifarea])) {
 			$auto_areas[$ifarea] = array();
@@ -170,7 +170,7 @@ function frr_generate_config_ospf_areas() {
 function frr_generate_config_ospf_interfaces() {
 	global $config, $passive_interfaces, $frr_integrated_config;
 	init_config_arr(array('installedpackages', 'frrospfd', 'config'));
-	$ospfd_conf = &$config['installedpackages']['frrospfd']['config'][0];
+	$frr_ospfd_conf = &$config['installedpackages']['frrospfd']['config'][0];
 
 	/* Setup interface entries to define network types, costs, etc. */
 	init_config_arr(array('installedpackages', 'frrospfdinterfaces', 'config'));
@@ -243,7 +243,7 @@ function frr_generate_config_ospf_interfaces() {
 		if (empty($interface_ip)) {
 			continue;
 		}
-		$area = (strlen($conf['interfacearea']) > 0) ? $conf['interfacearea'] : $ospfd_conf['defaultarea'];
+		$area = (strlen($conf['interfacearea']) > 0) ? $conf['interfacearea'] : $frr_ospfd_conf['defaultarea'];
 		$frr_integrated_config['interfaces'][$realif] .= " ip ospf area {$area}\n";
 	}
 }
@@ -266,26 +266,26 @@ function frr_generate_config_ospf_neighbors() {
 	return $conffile;
 }
 
-function frr_generate_config_ospf_redistribute($ospfd_conf, $variablename, $sourcename) {
+function frr_generate_config_ospf_redistribute($frr_ospfd_conf, $variablename, $sourcename) {
 	$redistconf = "";
-	if ($ospfd_conf[$variablename]) {
+	if ($frr_ospfd_conf[$variablename]) {
 		$redistconf .= " redistribute {$sourcename}";
-		if (!empty($ospfd_conf[$variablename . '_routemap']) &&
-			($ospfd_conf[$variablename . '_routemap'] != 'none')) {
-			$redistconf .= " route-map {$ospfd_conf[$variablename . '_routemap']}";
+		if (!empty($frr_ospfd_conf[$variablename . '_routemap']) &&
+			($frr_ospfd_conf[$variablename . '_routemap'] != 'none')) {
+			$redistconf .= " route-map {$frr_ospfd_conf[$variablename . '_routemap']}";
 		}
-		if (!empty($ospfd_conf[$variablename . '_metric']) &&
-			($ospfd_conf[$variablename . '_metric'] != 'none')) {
-			$redistconf .= " metric {$ospfd_conf[$variablename . '_metric']}";
+		if (!empty($frr_ospfd_conf[$variablename . '_metric']) &&
+			($frr_ospfd_conf[$variablename . '_metric'] != 'none')) {
+			$redistconf .= " metric {$frr_ospfd_conf[$variablename . '_metric']}";
 		}
-		if (!empty($ospfd_conf[$variablename . '_metrictype']) &&
-			($ospfd_conf[$variablename . '_metrictype'] != 'none')) {
-			$redistconf .= " metric-type {$ospfd_conf[$variablename . '_metrictype']}";
+		if (!empty($frr_ospfd_conf[$variablename . '_metrictype']) &&
+			($frr_ospfd_conf[$variablename . '_metrictype'] != 'none')) {
+			$redistconf .= " metric-type {$frr_ospfd_conf[$variablename . '_metrictype']}";
 		}
 		$redistconf .= "\n";
-		if (!empty($ospfd_conf[$variablename . '_distlist']) &&
-			($ospfd_conf[$variablename . '_distlist'] != 'none')) {
-			$redistconf .= " distribute-list {$ospfd_conf[$variablename . '_distlist']} out {$sourcename}\n";
+		if (!empty($frr_ospfd_conf[$variablename . '_distlist']) &&
+			($frr_ospfd_conf[$variablename . '_distlist'] != 'none')) {
+			$redistconf .= " distribute-list {$frr_ospfd_conf[$variablename . '_distlist']} out {$sourcename}\n";
 		}
 	}
 	return $redistconf;
@@ -299,11 +299,12 @@ function frr_generate_config_ospf() {
 		$frr_conf = &$config['installedpackages']['frr']['config'][0];
 	} else {
 		/* If FRR is not configured, stop. */
+		frr_package_log("FRR OSPFd: No FRR global config data found.");
 		return null;
 	}
 	/* Populate FRR OSPF Settings */
 	if (is_array($config['installedpackages']['frrospfd']['config'])) {
-		$ospfd_conf = &$config['installedpackages']['frrospfd']['config'][0];
+		$frr_ospfd_conf = &$config['installedpackages']['frrospfd']['config'][0];
 	}
 
 	if (isset($config['installedpackages']['frrglobalraw']['config'][0]['ospfd']) &&
@@ -312,11 +313,16 @@ function frr_generate_config_ospf() {
 		$frr_integrated_config['ospfd'] = str_replace("\r", "", base64_decode($config['installedpackages']['frrglobalraw']['config'][0]['ospfd']));
 	} else {
 		/* If there is no raw configuration and no GUI configuration, stop. */
-		if (empty($ospfd_conf)) {
-			log_error("FRR OSPFd: No config data found.");
+		if (empty($frr_ospfd_conf)) {
+			frr_package_log("FRR OSPFd: No config data found.");
 			return;
-		} elseif (empty($frr_conf['enable']) || empty($ospfd_conf['enable'])) {
-			/* FRR is disabled or OSPF is not enabled. */
+		} elseif (empty($frr_ospfd_conf['enable'])) {
+			/* OSPF daemon is not enabled. */
+			frr_package_log("FRR OSPFd: OSPF disabled.");
+			return;
+		} elseif (empty($frr_conf['enable'])) {
+			/* FRR is disabled or BFD Daemon is not enabled. */
+			frr_package_log("FRR OSPFd: FRR master disabled.");
 			return;
 		}
 		$frr_integrated_config['ospfd'] = "";
@@ -324,12 +330,12 @@ function frr_generate_config_ospf() {
 		$redist = "";
 		$noredist = "";
 		/* Add entries for manually-defined networks */
-		if (is_array($ospfd_conf['row'])) {
-			foreach ($ospfd_conf['row'] as $redistr) {
+		if (is_array($frr_ospfd_conf['row'])) {
+			foreach ($frr_ospfd_conf['row'] as $redistr) {
 				if (empty($redistr['routevalue'])) {
 					continue;
 				}
-				$area = ($redistr['routearea'] == "") ? $ospfd_conf['defaultarea'] : $redistr['routearea'];
+				$area = ($redistr['routearea'] == "") ? $frr_ospfd_conf['defaultarea'] : $redistr['routearea'];
 				$redist .= " network {$redistr['routevalue']} area {$area}\n";
 			}
 		}
@@ -337,67 +343,67 @@ function frr_generate_config_ospf() {
 		$frr_integrated_config['ospfd'] .= "router ospf\n";
 		/* If the router ID is defined in BGP, use that, otherwise try to use
 		 * the global router ID, if one is set. */
-		if (is_ipaddrv4($ospfd_conf['routerid'])) {
-			$frr_integrated_config['ospfd'] .= " ospf router-id {$ospfd_conf['routerid']}\n";
+		if (is_ipaddrv4($frr_ospfd_conf['routerid'])) {
+			$frr_integrated_config['ospfd'] .= " ospf router-id {$frr_ospfd_conf['routerid']}\n";
 		} elseif (is_ipaddrv4($frr_conf['routerid'])) {
 			$frr_integrated_config['ospfd'] .= " ospf router-id {$frr_conf['routerid']}\n";
 		}
 
-		if ($frr_conf['logging'] && $ospfd_conf['adjacencylog']) {
+		if ($frr_conf['logging'] && $frr_ospfd_conf['adjacencylog']) {
 			$frr_integrated_config['ospfd'] .= " log-adjacency-changes detail\n";
 		}
 
 		/* Route Redistribution */
-		$frr_integrated_config['ospfd'] .= frr_generate_config_ospf_redistribute($ospfd_conf, 'redistributeconnectedsubnets', 'connected');
-		$frr_integrated_config['ospfd'] .= frr_generate_config_ospf_redistribute($ospfd_conf, 'redistributekernel', 'kernel');
-		$frr_integrated_config['ospfd'] .= frr_generate_config_ospf_redistribute($ospfd_conf, 'redistributebgp', 'bgp');
-		$frr_integrated_config['ospfd'] .= frr_generate_config_ospf_redistribute($ospfd_conf, 'redistributestatic', 'static');
-		if ($ospfd_conf['redistributedefaultroute']) {
+		$frr_integrated_config['ospfd'] .= frr_generate_config_ospf_redistribute($frr_ospfd_conf, 'redistributeconnectedsubnets', 'connected');
+		$frr_integrated_config['ospfd'] .= frr_generate_config_ospf_redistribute($frr_ospfd_conf, 'redistributekernel', 'kernel');
+		$frr_integrated_config['ospfd'] .= frr_generate_config_ospf_redistribute($frr_ospfd_conf, 'redistributebgp', 'bgp');
+		$frr_integrated_config['ospfd'] .= frr_generate_config_ospf_redistribute($frr_ospfd_conf, 'redistributestatic', 'static');
+		if ($frr_ospfd_conf['redistributedefaultroute']) {
 			$frr_integrated_config['ospfd'] .= " default-information originate";
-			if (!empty($ospfd_conf['redistributedefaultroute_routemap']) &&
-				($ospfd_conf['redistributedefaultroute_routemap'] != 'none')) {
-				$frr_integrated_config['ospfd'] .= " route-map {$ospfd_conf['redistributedefaultroute_routemap']}";
+			if (!empty($frr_ospfd_conf['redistributedefaultroute_routemap']) &&
+				($frr_ospfd_conf['redistributedefaultroute_routemap'] != 'none')) {
+				$frr_integrated_config['ospfd'] .= " route-map {$frr_ospfd_conf['redistributedefaultroute_routemap']}";
 			}
-			if (!empty($ospfd_conf['redistributedefaultroute_metric']) &&
-				($ospfd_conf['redistributedefaultroute_metric'] != 'none')) {
-				$frr_integrated_config['ospfd'] .= " metric {$ospfd_conf['redistributedefaultroute_metric']}";
+			if (!empty($frr_ospfd_conf['redistributedefaultroute_metric']) &&
+				($frr_ospfd_conf['redistributedefaultroute_metric'] != 'none')) {
+				$frr_integrated_config['ospfd'] .= " metric {$frr_ospfd_conf['redistributedefaultroute_metric']}";
 			}
-			if (!empty($ospfd_conf['redistributedefaultroute_metrictype']) &&
-				($ospfd_conf['redistributedefaultroute_metrictype'] != 'none')) {
-				$frr_integrated_config['ospfd'] .= " metric-type {$ospfd_conf['redistributedefaultroute_metrictype']}";
+			if (!empty($frr_ospfd_conf['redistributedefaultroute_metrictype']) &&
+				($frr_ospfd_conf['redistributedefaultroute_metrictype'] != 'none')) {
+				$frr_integrated_config['ospfd'] .= " metric-type {$frr_ospfd_conf['redistributedefaultroute_metrictype']}";
 			}
 			$frr_integrated_config['ospfd'] .= "\n";
 		}
 
-		if ($ospfd_conf['spfholdtime'] || $ospfd_conf['spfdelay']) {
-			$spf_minhold = ($ospfd_conf['spfholdtime']) ? $ospfd_conf['spfholdtime'] : 1000;
+		if ($frr_ospfd_conf['spfholdtime'] || $frr_ospfd_conf['spfdelay']) {
+			$spf_minhold = ($frr_ospfd_conf['spfholdtime']) ? $frr_ospfd_conf['spfholdtime'] : 1000;
 			$spf_maxhold = $spf_minhold * 10;
-			$spf_delay = ($ospfd_conf['spfdelay']) ? $ospfd_conf['spfdelay'] : 200;
+			$spf_delay = ($frr_ospfd_conf['spfdelay']) ? $frr_ospfd_conf['spfdelay'] : 200;
 			$frr_integrated_config['ospfd'] .= " timers throttle spf {$spf_delay} {$spf_minhold} {$spf_maxhold}\n";
 		}
-		if ($ospfd_conf['rfc1583']) {
+		if ($frr_ospfd_conf['rfc1583']) {
 			$frr_integrated_config['ospfd'] .= " ospf rfc1583compatibility\n";
 		}
-		if ($ospfd_conf['opaquelsa']) {
+		if ($frr_ospfd_conf['opaquelsa']) {
 			$frr_integrated_config['ospfd'] .= " capability opaque\n";
 		}
-		if (!empty($ospfd_conf['writemultiplier'])) {
-			$frr_integrated_config['ospfd'] .= " ospf write-multiplier {$ospfd_conf['writemultiplier']}\n";
+		if (!empty($frr_ospfd_conf['writemultiplier'])) {
+			$frr_integrated_config['ospfd'] .= " ospf write-multiplier {$frr_ospfd_conf['writemultiplier']}\n";
 		}
-		if (!empty($ospfd_conf['referencebandwidth'])) {
-			$frr_integrated_config['ospfd'] .= " auto-cost reference-bandwidth {$ospfd_conf['referencebandwidth']}\n";
+		if (!empty($frr_ospfd_conf['referencebandwidth'])) {
+			$frr_integrated_config['ospfd'] .= " auto-cost reference-bandwidth {$frr_ospfd_conf['referencebandwidth']}\n";
 		}
-		if ($ospfd_conf['max_metric_administrative']) {
+		if ($frr_ospfd_conf['max_metric_administrative']) {
 			$frr_integrated_config['ospfd'] .= " max-metric router-lsa administrative\n";
 		}
-		if (!empty($ospfd_conf['max_metric_startup'])) {
-			$frr_integrated_config['ospfd'] .= " max-metric router-lsa on-startup {$ospfd_conf['max_metric_startup']}\n";
+		if (!empty($frr_ospfd_conf['max_metric_startup'])) {
+			$frr_integrated_config['ospfd'] .= " max-metric router-lsa on-startup {$frr_ospfd_conf['max_metric_startup']}\n";
 		}
-		if (!empty($ospfd_conf['max_metric_shutdown'])) {
-			$frr_integrated_config['ospfd'] .= " max-metric router-lsa on-shutdown {$ospfd_conf['max_metric_shutdown']}\n";
+		if (!empty($frr_ospfd_conf['max_metric_shutdown'])) {
+			$frr_integrated_config['ospfd'] .= " max-metric router-lsa on-shutdown {$frr_ospfd_conf['max_metric_shutdown']}\n";
 		}
-		if (!empty($ospfd_conf['abrtype']) && ($ospfd_conf['abrtype'] <> 'cisco')) {
-			$frr_integrated_config['ospfd'] .= " ospf abr-type {$ospfd_conf['abrtype']}\n";
+		if (!empty($frr_ospfd_conf['abrtype']) && ($frr_ospfd_conf['abrtype'] <> 'cisco')) {
+			$frr_integrated_config['ospfd'] .= " ospf abr-type {$frr_ospfd_conf['abrtype']}\n";
 		}
 
 		if (is_array($passive_interfaces)) {

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_ospf6.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_ospf6.inc
@@ -41,7 +41,7 @@ function frr_generate_config_ospf6_areas() {
 				continue;
 			}
 			list($interface_ip, $interface_subnet, $subnet) = frr_get_interfaceinfo($conf['interface'], true);
-			$interface_area = (strlen($conf['interfacearea']) > 0) ? $conf['interfacearea'] : $ospf6d_conf['defaultarea'];
+			$interface_area = (strlen($conf['interfacearea']) > 0) ? $conf['interfacearea'] : $frr_ospf6d_conf['defaultarea'];
 			if (is_subnetv6("{$subnet}/{$interface_subnet}")) {
 				$cost = (is_numeric($conf['metric']) && ($conf['metric'] >= 0)) ? $conf['metric'] : 1;
 				$conffile .= " area {$interface_area} range {$subnet}/{$interface_subnet} cost {$cost}\n";
@@ -50,11 +50,11 @@ function frr_generate_config_ospf6_areas() {
 	}
 
 	/* Automatic Area: Default */
-	if (!isset($auto_areas[$ospf6d_conf['defaultarea']]) || !is_array($auto_areas[$ospf6d_conf['defaultarea']])) {
-		$auto_areas[$ospf6d_conf['defaultarea']] = array();
+	if (!isset($auto_areas[$frr_ospf6d_conf['defaultarea']]) || !is_array($auto_areas[$frr_ospf6d_conf['defaultarea']])) {
+		$auto_areas[$frr_ospf6d_conf['defaultarea']] = array();
 	}
-	$auto_areas[$ospf6d_conf['defaultarea']]['area'] = $ospf6d_conf['defaultarea'];
-	$auto_areas[$ospf6d_conf['defaultarea']]['type'] = $ospf6d_conf['defaultareatype'];
+	$auto_areas[$frr_ospf6d_conf['defaultarea']]['area'] = $frr_ospf6d_conf['defaultarea'];
+	$auto_areas[$frr_ospf6d_conf['defaultarea']]['type'] = $frr_ospf6d_conf['defaultareatype'];
 
 	/* Copy automatic areas over only if they do not have custom settings */
 	foreach ($auto_areas as $aa) {
@@ -194,7 +194,7 @@ function frr_generate_config_ospf6_interfaces() {
 			}
 
 			/* Add area/instance mapping to main OSPFv3 configuration area */
-			$interface_area = (strlen($conf['interfacearea']) > 0) ? $conf['interfacearea'] : $ospf6d_conf['defaultarea'];
+			$interface_area = (strlen($conf['interfacearea']) > 0) ? $conf['interfacearea'] : $frr_ospf6d_conf['defaultarea'];
 			$frr_integrated_config["ospf6d"] .= " interface {$realif} area {$interface_area}\n";
 		}
 	}
@@ -208,11 +208,12 @@ function frr_generate_config_ospf6() {
 		$frr_conf = &$config['installedpackages']['frr']['config'][0];
 	} else {
 		/* If FRR is not configured, stop. */
+		frr_package_log("FRR OSPF6d: No FRR global config data found.");
 		return null;
 	}
 	/* Populate FRR OSPF6 Settings */
 	if (is_array($config['installedpackages']['frrospf6d']['config'])) {
-		$ospf6d_conf = &$config['installedpackages']['frrospf6d']['config'][0];
+		$frr_ospf6d_conf = &$config['installedpackages']['frrospf6d']['config'][0];
 	}
 
 	if (isset($config['installedpackages']['frrglobalraw']['config'][0]['ospf6d']) &&
@@ -221,24 +222,30 @@ function frr_generate_config_ospf6() {
 		$frr_integrated_config['ospf6d'] = str_replace("\r", "", base64_decode($config['installedpackages']['frrglobalraw']['config'][0]['ospf6d']));
 	} else {
 		/* If there is no raw configuration and no GUI configuration, stop. */
-		if (empty($ospf6d_conf)) {
-			log_error("FRR OSPF6d: No config data found.");
+		if (empty($frr_ospf6d_conf)) {
+			frr_package_log("FRR OSPF6d: No config data found.");
 			return;
-		} elseif (empty($frr_conf['enable']) || empty($ospf6d_conf['enable'])) {
-			/* FRR is disabled or OSPF6 is not enabled. */
+		} elseif (empty($frr_ospf6d_conf['enable'])) {
+			/* OSPF6 daemon is not enabled. */
+			frr_package_log("FRR OSPF6d: OSPF6 disabled.");
+			return;
+		} elseif (empty($frr_conf['enable'])) {
+			/* FRR is disabled or BFD Daemon is not enabled. */
+			frr_package_log("FRR OSPF6d: FRR master disabled.");
 			return;
 		}
+
 		$frr_integrated_config['ospf6d'] = "";
 
 		$redist = "";
 		$noredist = "";
 		/* Add entries for manually-defined networks */
-		if (is_array($ospf6d_conf['row'])) {
-			foreach ($ospf6d_conf['row'] as $redistr) {
+		if (is_array($frr_ospf6d_conf['row'])) {
+			foreach ($frr_ospf6d_conf['row'] as $redistr) {
 				if (empty($redistr['routevalue'])) {
 					continue;
 				}
-				$area = ($redistr['routearea'] == "") ? $ospf6d_conf['defaultarea'] : $redistr['routearea'];
+				$area = ($redistr['routearea'] == "") ? $frr_ospf6d_conf['defaultarea'] : $redistr['routearea'];
 				$cost = (is_numeric($redistr['routearea']) && ($redistr['routearea'] >= 0)) ? $redistr['routearea']: 1;
 				// Disable for now. Not yet supported in FRR.
 				$redist .= " area {$area} range {$redistr['routevalue']} cost {$cost}\n";
@@ -248,14 +255,14 @@ function frr_generate_config_ospf6() {
 		$frr_integrated_config['ospf6d'] .= "router ospf6\n";
 		/* If the router ID is defined, use that, otherwise try to use
 		 * the global router ID, if one is set. */
-		if (is_ipaddrv4($ospf6d_conf['routerid'])) {
-			$frr_integrated_config['ospf6d'] .= " ospf6 router-id {$ospf6d_conf['routerid']}\n";
+		if (is_ipaddrv4($frr_ospf6d_conf['routerid'])) {
+			$frr_integrated_config['ospf6d'] .= " ospf6 router-id {$frr_ospf6d_conf['routerid']}\n";
 		} elseif (is_ipaddrv4($frr_conf['routerid'])) {
 			$frr_integrated_config['ospf6d'] .= " ospf6 router-id {$frr_conf['routerid']}\n";
 		}
 
-		$stub_start = " area {$ospf6d_conf['defaultarea']} ";
-		switch($ospf6d_conf['updatefib']) {
+		$stub_start = " area {$frr_ospf6d_conf['defaultarea']} ";
+		switch($frr_ospf6d_conf['updatefib']) {
 			case "on":
 			case "stub":
 				$stub_start .= "stub";
@@ -272,40 +279,40 @@ function frr_generate_config_ospf6() {
 		if (!empty($stub_start)) {
 			$frr_integrated_config['ospf6d'] .= "{$stub_start}\n";
 		}
-		if ($frr_conf['logging'] && $ospf6d_conf['adjacencylog']) {
+		if ($frr_conf['logging'] && $frr_ospf6d_conf['adjacencylog']) {
 			$frr_integrated_config['ospf6d'] .= " log-adjacency-changes detail\n";
 		}
 
 		/* Route Redistribution */
-		$frr_integrated_config['ospf6d'] .= frr_generate_config_ospf_redistribute($ospf6d_conf, 'redistributeconnectedsubnets', 'connected');
-		$frr_integrated_config['ospf6d'] .= frr_generate_config_ospf_redistribute($ospf6d_conf, 'redistributekernel', 'kernel');
-		$frr_integrated_config['ospf6d'] .= frr_generate_config_ospf_redistribute($ospf6d_conf, 'redistributebgp', 'bgp');
-		$frr_integrated_config['ospf6d'] .= frr_generate_config_ospf_redistribute($ospf6d_conf, 'redistributestatic', 'static');
+		$frr_integrated_config['ospf6d'] .= frr_generate_config_ospf_redistribute($frr_ospf6d_conf, 'redistributeconnectedsubnets', 'connected');
+		$frr_integrated_config['ospf6d'] .= frr_generate_config_ospf_redistribute($frr_ospf6d_conf, 'redistributekernel', 'kernel');
+		$frr_integrated_config['ospf6d'] .= frr_generate_config_ospf_redistribute($frr_ospf6d_conf, 'redistributebgp', 'bgp');
+		$frr_integrated_config['ospf6d'] .= frr_generate_config_ospf_redistribute($frr_ospf6d_conf, 'redistributestatic', 'static');
 
-		if ($ospf6d_conf['spfholdtime'] || $ospf6d_conf['spfdelay']) {
-			$spf_minhold = ($ospf6d_conf['spfholdtime']) ? $ospf6d_conf['spfholdtime'] : 1000;
+		if ($frr_ospf6d_conf['spfholdtime'] || $frr_ospf6d_conf['spfdelay']) {
+			$spf_minhold = ($frr_ospf6d_conf['spfholdtime']) ? $frr_ospf6d_conf['spfholdtime'] : 1000;
 			$spf_maxhold = $spf_minhold * 10;
-			$spf_delay = ($ospf6d_conf['spfdelay']) ? $ospf6d_conf['spfdelay'] : 200;
+			$spf_delay = ($frr_ospf6d_conf['spfdelay']) ? $frr_ospf6d_conf['spfdelay'] : 200;
 			$frr_integrated_config['ospf6d'] .= " timers throttle spf {$spf_delay} {$spf_minhold} {$spf_maxhold}\n";
 		}
 
-		if (!empty($ospf6d_conf['referencebandwidth'])) {
-			$frr_integrated_config['ospf6d'] .= " auto-cost reference-bandwidth {$ospf6d_conf['referencebandwidth']}\n";
+		if (!empty($frr_ospf6d_conf['referencebandwidth'])) {
+			$frr_integrated_config['ospf6d'] .= " auto-cost reference-bandwidth {$frr_ospf6d_conf['referencebandwidth']}\n";
 		}
 
-		if (!empty($ospf6d_conf['distance'])) {
-			$frr_integrated_config['ospf6d'] .= " distance {$ospf6d_conf['distance']}\n";
+		if (!empty($frr_ospf6d_conf['distance'])) {
+			$frr_integrated_config['ospf6d'] .= " distance {$frr_ospf6d_conf['distance']}\n";
 		}
 
 		$odist = "";
-		if (!empty($ospf6d_conf['distance_external'])) {
-			$odist .= " external {$ospf6d_conf['distance']}";
+		if (!empty($frr_ospf6d_conf['distance_external'])) {
+			$odist .= " external {$frr_ospf6d_conf['distance']}";
 		}
-		if (!empty($ospf6d_conf['distance_interarea'])) {
-			$odist .= " inter-area {$ospf6d_conf['distance_interarea']}";
+		if (!empty($frr_ospf6d_conf['distance_interarea'])) {
+			$odist .= " inter-area {$frr_ospf6d_conf['distance_interarea']}";
 		}
-		if (!empty($ospf6d_conf['distance_intraarea'])) {
-			$odist .= " intra-area {$ospf6d_conf['distance_intraarea']}";
+		if (!empty($frr_ospf6d_conf['distance_intraarea'])) {
+			$odist .= " intra-area {$frr_ospf6d_conf['distance_intraarea']}";
 		}
 
 		if (!empty($odist)) {
@@ -317,23 +324,23 @@ function frr_generate_config_ospf6() {
 		}
 
 		/* exportlist */
-		if (!empty($ospf6d_conf['exportlist']) && ($ospf6d_conf['exportlist'] != "none")) {
-			$frr_integrated_config['ospf6d'] .= " area {$ospf6d_conf['defaultarea']} export-list {$ospf6d_conf['exportlist']}\n";
+		if (!empty($frr_ospf6d_conf['exportlist']) && ($frr_ospf6d_conf['exportlist'] != "none")) {
+			$frr_integrated_config['ospf6d'] .= " area {$frr_ospf6d_conf['defaultarea']} export-list {$frr_ospf6d_conf['exportlist']}\n";
 		}
 
 		/* importlist */
-		if (!empty($ospf6d_conf['importlist']) && ($ospf6d_conf['importlist'] != "none")) {
-			$frr_integrated_config['ospf6d'] .= " area {$ospf6d_conf['defaultarea']} import-list {$ospf6d_conf['importlist']}\n";
+		if (!empty($frr_ospf6d_conf['importlist']) && ($frr_ospf6d_conf['importlist'] != "none")) {
+			$frr_integrated_config['ospf6d'] .= " area {$frr_ospf6d_conf['defaultarea']} import-list {$frr_ospf6d_conf['importlist']}\n";
 		}
 
 		/* filterlist_out */
-		if (!empty($ospf6d_conf['filterlist_out']) && ($ospf6d_conf['filterlist_out'] != "none")) {
-			$frr_integrated_config['ospf6d'] .= " area {$ospf6d_conf['defaultarea']} filter-list prefix {$ospf6d_conf['filterlist_out']} out\n";
+		if (!empty($frr_ospf6d_conf['filterlist_out']) && ($frr_ospf6d_conf['filterlist_out'] != "none")) {
+			$frr_integrated_config['ospf6d'] .= " area {$frr_ospf6d_conf['defaultarea']} filter-list prefix {$frr_ospf6d_conf['filterlist_out']} out\n";
 		}
 
 		/* filterlist_in */
-		if (!empty($ospf6d_conf['filterlist_in']) && ($ospf6d_conf['filterlist_in'] != "none")) {
-			$frr_integrated_config['ospf6d'] .= " area {$ospf6d_conf['defaultarea']} filter-list prefix {$ospf6d_conf['filterlist_in']} in\n";
+		if (!empty($frr_ospf6d_conf['filterlist_in']) && ($frr_ospf6d_conf['filterlist_in'] != "none")) {
+			$frr_integrated_config['ospf6d'] .= " area {$frr_ospf6d_conf['defaultarea']} filter-list prefix {$frr_ospf6d_conf['filterlist_in']} in\n";
 		}
 
 		/* Area Settings */

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_ospf6.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_ospf6.inc
@@ -22,7 +22,7 @@
 require_once("frr/inc/frr_ospf.inc");
 
 function frr_generate_config_ospf6_areas() {
-	global $config, $frr_config_base, $frr_auto_config_warning;
+	global $config, $frr_auto_config_warning;
 
 	/* Populate FRR OSPF6 Settings */
 	if (is_array($config['installedpackages']['frrospf6d']['config'])) {
@@ -201,7 +201,7 @@ function frr_generate_config_ospf6_interfaces() {
 }
 
 function frr_generate_config_ospf6() {
-	global $config, $frr_config_base, $frr_integrated_config;
+	global $config, $frr_integrated_config;
 
 	/* Populate FRR Global Settings */
 	if (is_array($config['installedpackages']['frr']['config'])) {
@@ -347,6 +347,7 @@ function frr_generate_config_ospf6() {
 		$frr_integrated_config['ospf6d'] .= frr_generate_config_ospf6_areas();
 
 		/* Interface Settings */
+		/* Interface settings do not return a string as they are an accumulation of all protocols */
 		frr_generate_config_ospf6_interfaces();
 	}
 }

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_ospf6.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_ospf6.inc
@@ -23,8 +23,10 @@ require_once("frr/inc/frr_ospf.inc");
 
 function frr_generate_config_ospf6_areas() {
 	global $config, $frr_config_base, $frr_auto_config_warning;
+
+	/* Populate FRR OSPF6 Settings */
 	if (is_array($config['installedpackages']['frrospf6d']['config'])) {
-		$ospf6d_conf = &$config['installedpackages']['frrospf6d']['config'][0];
+		$frr_ospf6d_conf = &$config['installedpackages']['frrospf6d']['config'][0];
 	}
 
 	$defined_areas = array();
@@ -136,9 +138,12 @@ function frr_generate_config_ospf6_areas() {
 
 function frr_generate_config_ospf6_interfaces() {
 	global $config, $frr_integrated_config;
+
+	/* Populate FRR OSPF6 Settings */
 	if (is_array($config['installedpackages']['frrospf6d']['config'])) {
-		$ospf6d_conf = &$config['installedpackages']['frrospf6d']['config'][0];
+		$frr_ospf6d_conf = &$config['installedpackages']['frrospf6d']['config'][0];
 	}
+
 	$router_interface_areas = "";
 
 	/* Setup interface entries to define network types, costs, etc. */

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_validation.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_validation.inc
@@ -191,9 +191,6 @@ function frr_global_acls_validate_input() {
 			}
 		}
 		if (preg_match("/^source(\d+)$/", $key, $matches)) {
-			log_error(print_r($key, true));
-			log_error(print_r($_POST, true));
-			log_error(print_r("sourceany{$matches[1]}", true));
 			if (!is_subnet($_POST["source{$matches[1]}"]) && (($_POST["source{$matches[1]}"] != 'any') && !($_POST["sourceany{$matches[1]}"]))) {
 				$input_errors[] = "Source in row {$matches[1]} must be a subnet.";
 			}

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_validation.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_validation.inc
@@ -656,7 +656,7 @@ function frr_bfd_peer_validate_input() {
 			$input_errors[] = "Detect multiplier must be a number.";
 		}
 		/*detect-multiplier (2-255)*/
-		frr_validate_intrange_input("Detect multiplier", $_POST['receiveinterval'], 2, 255);
+		frr_validate_intrange_input("Detect multiplier", $_POST['detectmultiplier'], 2, 255);
 	}
 
 	if (!empty($_POST['receiveinterval'])) {
@@ -681,5 +681,57 @@ function frr_bfd_peer_validate_input() {
 		}
 		/*echo-interval (10-60000)*/
 		frr_validate_intrange_input("Echo interval", $_POST['echointerval'], 10, 60000);
+	}
+
+	if (!empty($_POST['minimumttl'])) {
+		if (!is_numeric($_POST['minimumttl'])) {
+			$input_errors[] = "Minimum TTL must be a number.";
+		}
+		/*minimum-ttl (1-254)*/
+		frr_validate_intrange_input("Minimum TTL", $_POST['minimumttl'], 1, 254);
+	}
+}
+
+function frr_bfd_profile_validate_input() {
+	global $config, $input_errors;
+
+	if (!empty($_POST['detectmultiplier'])) {
+		if (!is_numeric($_POST['detectmultiplier'])) {
+			$input_errors[] = "Detect multiplier must be a number.";
+		}
+		/*detect-multiplier (2-255)*/
+		frr_validate_intrange_input("Detect multiplier", $_POST['detectmultiplier'], 2, 255);
+	}
+
+	if (!empty($_POST['receiveinterval'])) {
+		if (!is_numeric($_POST['receiveinterval'])) {
+			$input_errors[] = "Receive interval must be a number.";
+		}
+		/*receive-interval (10-60000)*/
+		frr_validate_intrange_input("Receive interval", $_POST['receiveinterval'], 10, 60000);
+	}
+
+	if (!empty($_POST['transmitinterval'])) {
+		if (!is_numeric($_POST['transmitinterval'])) {
+			$input_errors[] = "Transmit interval must be a number.";
+		}
+		/*transmit-interval (10-60000)*/
+		frr_validate_intrange_input("Transmit interval", $_POST['transmitinterval'], 10, 60000);
+	}
+
+	if (!empty($_POST['echointerval'])) {
+		if (!is_numeric($_POST['echointerval'])) {
+			$input_errors[] = "Echo interval must be a number.";
+		}
+		/*echo-interval (10-60000)*/
+		frr_validate_intrange_input("Echo interval", $_POST['echointerval'], 10, 60000);
+	}
+
+	if (!empty($_POST['minimumttl'])) {
+		if (!is_numeric($_POST['minimumttl'])) {
+			$input_errors[] = "Minimum TTL must be a number.";
+		}
+		/*minimum-ttl (1-254)*/
+		frr_validate_intrange_input("Minimum TTL", $_POST['minimumttl'], 1, 254);
 	}
 }

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_validation.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_validation.inc
@@ -536,9 +536,9 @@ function frr_ospf6_validate_input() {
 			$input_errors[] = "Default Area must be a valid IP address or integer number.";
 		}
 	} else {
-		if (is_array($config['installedpackages']['frrospfd6interfaces'])) {
+		if (is_array($config['installedpackages']['frrospf6dinterfaces'])) {
 			$interfaces_no_area = array();
-			foreach ($config['installedpackages']['frrospfd6interfaces']['config'] as $interface) {
+			foreach ($config['installedpackages']['frrospf6dinterfaces']['config'] as $interface) {
 				if (strlen($interface['interfacearea']) == 0) { $interfaces_no_area[] = $interface['interface']; }
 			}
 			if (!empty($interfaces_no_area)) {

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_validation.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_validation.inc
@@ -149,6 +149,75 @@ function frr_sort_rows_by_seq() {
 function frr_global_acls_validate_input() {
 	global $config, $input_errors, $pkg;
 	frr_sort_rows_by_seq();
+
+	if (empty($_POST['name'])) {
+		$input_errors[] = "A name is required.";
+	}
+
+	switch ($_POST['type']) {
+		case "standard":
+			if (!is_numeric($_POST['name']) || !(frr_validate_intrange($_POST['name'], 1, 99) || frr_validate_intrange($_POST['name'], 1300, 1999))) {
+				$input_errors[] = "Standard type ACLs must have a numeric name in the range 1-99 or 1300-1999.";
+			}
+			if ($_POST["iptype"] != 'IPv4') {
+				$input_errors[] = "Standard type ACLs are only supported for IPv4.";
+			}
+			break;
+		case "extended":
+			if (!is_numeric($_POST['name']) || !(frr_validate_intrange($_POST['name'], 100, 199) || frr_validate_intrange($_POST['name'], 2000, 2699))) {
+				$input_errors[] = "Extended type ACLs must have a numeric name in the range 100-199 or 2000-2699.";
+			}
+			if ($_POST["iptype"] != 'IPv4') {
+				$input_errors[] = "Extended type ACLs are only supported for IPv4.";
+			}
+			break;
+		case "zebra":
+			if (is_numeric($_POST['name'])) {
+				$input_errors[] = "Zebra type ACLs must have a text name.";
+			}
+			break;
+	}
+
+	foreach ($_POST as $key => $value) {
+		$matches = array();
+		if (preg_match("/^seq(\d+)$/", $key, $matches)) {
+			if (!is_numeric($_POST["seq{$matches[1]}"])) {
+				$input_errors[] = "Sequence in row {$matches[1]} must be a number.";
+			}
+		}
+		if (preg_match("/^action(\d+)$/", $key, $matches)) {
+			if (!in_array($_POST["action{$matches[1]}"], array('deny', 'permit'))) {
+				$input_errors[] = "Action in row {$matches[1]} must be Deny or Permit.";
+			}
+		}
+		if (preg_match("/^source(\d+)$/", $key, $matches)) {
+			log_error(print_r($key, true));
+			log_error(print_r($_POST, true));
+			log_error(print_r("sourceany{$matches[1]}", true));
+			if (!is_subnet($_POST["source{$matches[1]}"]) && (($_POST["source{$matches[1]}"] != 'any') && !($_POST["sourceany{$matches[1]}"]))) {
+				$input_errors[] = "Source in row {$matches[1]} must be a subnet.";
+			}
+			if ((is_subnetv4($_POST["source{$matches[1]}"]) && ($_POST["iptype"] != 'IPv4')) ||
+				(is_subnetv6($_POST["source{$matches[1]}"]) && ($_POST["iptype"] != 'IPv6'))) {
+				$input_errors[] = "Source in row {$matches[1]} IP Type mismatch.";
+			}
+		}
+		if (preg_match("/^destination(\d+)$/", $key, $matches)) {
+			if ($_POST['type'] == 'extended') {
+				if (!is_subnet($_POST["destination{$matches[1]}"]) && (($_POST["destination{$matches[1]}"] != 'any')  && !($_POST["destinationany{$matches[1]}"])))  {
+					$input_errors[] = "Destination in row {$matches[1]} must be a subnet.";
+				}
+				if ((is_subnetv4($_POST["destination{$matches[1]}"]) && ($_POST["iptype"] != 'IPv4')) ||
+					(is_subnetv6($_POST["destination{$matches[1]}"]) && ($_POST["iptype"] != 'IPv6'))) {
+					$input_errors[] = "Destination in row {$matches[1]} IP Type mismatch.";
+				}
+			} else {
+				if (!empty($_POST["destination{$matches[1]}"]) || !empty($_POST["destinationany{$matches[1]}"])) {
+					$input_errors[] = "Destinations are only supported with Extended type ACLs.";
+				}
+			}
+		}
+	}
 }
 
 function frr_global_prefixes_validate_input() {
@@ -172,8 +241,12 @@ function frr_global_prefixes_validate_input() {
 			}
 		}
 		if (preg_match("/^source(\d+)$/", $key, $matches)) {
-			if (!is_subnet($_POST["source{$matches[1]}"]) && ($_POST["source{$matches[1]}"] != 'any')) {
+			if (!is_subnet($_POST["source{$matches[1]}"]) && (($_POST["source{$matches[1]}"] != 'any') && !($_POST["any{$matches[1]}"]))) {
 				$input_errors[] = "Network in row {$matches[1]} must be a subnet.";
+			}
+			if ((is_subnetv4($_POST["source{$matches[1]}"]) && ($_POST["iptype"] != 'IPv4')) ||
+				(is_subnetv6($_POST["source{$matches[1]}"]) && ($_POST["iptype"] != 'IPv6'))) {
+				$input_errors[] = "Network in row {$matches[1]} IP Type mismatch.";
 			}
 		}
 		if (preg_match("/^ge(\d+)$/", $key, $matches)) {
@@ -191,7 +264,6 @@ function frr_global_prefixes_validate_input() {
 			}
 		}
 	}
-
 }
 
 function frr_global_routemaps_validate_input() {

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_zebra.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_zebra.inc
@@ -19,34 +19,43 @@
  * limitations under the License.
  */
 
-/* Fetch the list of access lists for use in selection lists */
-function frr_get_accesslist_list() {
-	global $config;
+/* Fetch a list of lists for use in selection lists */
+function frr_get_lists_list(&$listconfig, $ipv4 = true, $ipv6 = true) {
 	$list = array();
-	$list[] = array("name" => "None", "value" => "none");
-	if (is_array($config['installedpackages']['frrglobalacls']['config'])) {
-		foreach ($config['installedpackages']['frrglobalacls']['config'] as $acl) {
-			$name = empty($acl['descr']) ? $acl['name'] : "{$acl['name']} - {$acl['descr']}";
-			$list[] = array("name" => $name, "value" => $acl['name']);
+	$list[] = PKG_FRR_LIST_NONE_VALUE;
+
+	if (is_array($listconfig)) {
+		foreach ($listconfig as $lst) {
+			$name = empty($lst['descr']) ? "{$lst['iptype']}: {$lst['name']}" : "{$lst['iptype']}: {$lst['name']} - {$lst['descr']}";
+			if (($ipv4 && (strtolower($lst['iptype']) == 'ipv4')) || ($ipv6 && (strtolower($lst['iptype']) == 'ipv6'))) {
+				$list[] = array("name" => $name, "value" => $lst['name']);
+			}
 			unset($name);
 		}
 	}
 	return ($list);
 }
 
-/* Fetch the list of prefix lists for use in selection lists */
-function frr_get_prefixlist_list() {
+/* Fetch the list of access lists for use in selection lists */
+function frr_get_accesslist_list($ipv4 = true, $ipv6 = true) {
 	global $config;
-	$list = array();
-	$list[] = array("name" => "None", "value" => "none");
-	if (is_array($config['installedpackages']['frrglobalprefixes']['config'])) {
-		foreach ($config['installedpackages']['frrglobalprefixes']['config'] as $pl) {
-			$name = empty($pl['descr']) ? $pl['name'] : "{$pl['name']} - {$pl['descr']}";
-			$list[] = array("name" => $name, "value" => $pl['name']);
-			unset($name);
-		}
+
+	if (is_array($config['installedpackages']['frrglobalacls']['config'])) {
+		return (frr_get_lists_list($config['installedpackages']['frrglobalacls']['config'], $ipv4, $ipv6));
+	} else {
+		return array(PKG_FRR_LIST_NONE_VALUE);
 	}
-	return ($list);
+}
+
+/* Fetch the list of prefix lists for use in selection lists */
+function frr_get_prefixlist_list($ipv4 = true, $ipv6 = true) {
+	global $config;
+
+	if (is_array($config['installedpackages']['frrglobalprefixes']['config'])) {
+		return (frr_get_lists_list($config['installedpackages']['frrglobalprefixes']['config'], $ipv4, $ipv6));
+	} else {
+		return array(PKG_FRR_LIST_NONE_VALUE);
+	}
 }
 
 /* Fetch the list of route maps for use in selection lists */
@@ -62,7 +71,7 @@ function frr_get_routemap_list($exitaction = false, $yesno = false) {
 		$list[] = array("name" => "IPv6", "value" => "ipv6");
 		$list[] = array("name" => "IPv4+IPv6", "value" => "yes");
 	} else {
-		$list[] = array("name" => "None", "value" => "none");
+		$list[] = PKG_FRR_LIST_NONE_VALUE;
 	}
 
 	/* If this is an exit action, return 'next' as a possible choice. */
@@ -98,7 +107,7 @@ function frr_get_routemap_list($exitaction = false, $yesno = false) {
 function frr_get_routemap_nexthop_list() {
 	global $config;
 	$list = array();
-	$list[] = array("name" => "None", "value" => "none");
+	$list[] = PKG_FRR_LIST_NONE_VALUE;
 	$list[] = array("name" => "Local (match only)", "value" => "local");
 	$list[] = array("name" => "Unchanged (set only)", "value" => "unchanged");
 	$list[] = array("name" => "Peer Address (set only)", "value" => "peer-address");
@@ -106,67 +115,45 @@ function frr_get_routemap_nexthop_list() {
 	return $list;
 }
 
-/* Determine the ACL type based on the given name */
-function frr_get_acl_type($aclname) {
-	/* 0-99, 1300-1999: Standard
-	 * 100-199, 2000-2699: Extended
-	 * WORD: Zebra
-	 */
-	$acl_type = "";
-	if (is_numeric($aclname)) {
-		if ((($aclname > 0) && ($aclname < 100)) ||
-			(($aclname > 1299) && ($aclname < 2000))) {
-			$acl_type = "standard";
-		} elseif ((($aclname > 99) && ($aclname < 200)) ||
-			(($aclname > 1999) && ($aclname < 2700))) {
-			$acl_type = "extended";
-		}
-	} elseif (frr_validate_word($aclname)) {
-		$acl_type = "zebra";
-	}
-	return $acl_type;
-}
-
-function frr_generate_acl_hostspec($address, $acl_type) {
+function frr_generate_acl_hostspec($address, $any, $acl_type) {
 	$hostspec = "";
-	switch($acl_type) {
-		case "standard":
-		case "extended":
-			if (is_subnet($address)) {
-				/* Networks are:
-				 * "x.x.x.x y.y.y.y"
-				 * 'subnet id'<space>'wildcard bits'
-				 */
-				list($ip, $bits) = explode('/', $address);
-				$hostspec = gen_subnet($ip, $bits);
-				$hostspec .= " ";
-				$hostspec .= frr_cidr_to_wildcard_bits($bits);
-			} elseif (is_ipaddr($address)) {
-				/* Hosts are "host x.x.x.x" */
-				$hostspec = "host {$address}";
-			} elseif (($address == "any") ||
-				(empty($address) &&
-				($acl_type == "extended"))) {
-				/* "any" */
-				$hostspec = "any";
-			}
-			break;
-		case "zebra":
-			/* Networks are "x.x.x.x/YY" (CIDR) */
-			if (is_subnet($address) || ($address == "any")) {
-				$hostspec = $address;
-			} if ($address == "any6") {
-				$hostspec = "any";
-			}
-			break;
-		default:
-			$hostspec = "";
+
+	if ($any) {
+		$hostspec = "any";
+	} else {
+		switch($acl_type) {
+			case "standard":
+			case "extended":
+				if (is_subnet($address)) {
+					/* Networks are:
+					 * "x.x.x.x y.y.y.y"
+					 * 'subnet id'<space>'wildcard bits'
+					 */
+					list($ip, $bits) = explode('/', $address);
+					$hostspec = gen_subnet($ip, $bits);
+					$hostspec .= " ";
+					$hostspec .= frr_cidr_to_wildcard_bits($bits);
+				} elseif (is_ipaddr($address)) {
+					/* Hosts are "host x.x.x.x" */
+					$hostspec = "host {$address}";
+				}
+				break;
+			case "zebra":
+				/* Networks are "x.x.x.x/YY" (CIDR) */
+				if (is_subnet($address)) {
+					$hostspec = $address;
+				}
+				break;
+			default:
+				$hostspec = "";
+		}
 	}
+
 	return $hostspec;
 }
 
 /* Access lists for the zebra configuration based on GUI config */
-function frr_zebra_generate_accesslists() {
+function frr_zebra_generate_accesslists($ipv4 = true, $ipv6 = true) {
 	global $config, $frr_config_base;
 	/* Populate FRR Global Settings */
 	if (is_array($config['installedpackages']['frrglobalacls']['config'])) {
@@ -178,9 +165,12 @@ function frr_zebra_generate_accesslists() {
 	/* Section header */
 	$aclconf = "";
 	/* Loop through ACLs and process */
+	frr_array_name_seq_sort($frr_acls_conf);
 	foreach ($frr_acls_conf as $acl) {
-		/* Determine ACL type */
-		$acl_type = frr_get_acl_type($acl['name']);
+		/* Skip if IP version is disabled */
+		if ((!$ipv4 && (strtolower($acl['iptype']) == 'ipv4')) || (!$ipv6 && (strtolower($acl['iptype']) == 'ipv6'))) {
+			continue;
+		}
 		/* Once an ACL is marked IPv6, all of its directives must be IPv6. */
 		$ipv6 = "";
 
@@ -195,22 +185,22 @@ function frr_zebra_generate_accesslists() {
 				continue;
 			}
 			/* The ACL Type determines how the line is formed, what is valid, etc. */
-			switch($acl_type) {
+			switch($acl['type']) {
 				case "standard":
 					/* Source address only */
-					$hostspec = frr_generate_acl_hostspec($line['source'], $acl_type);
+					$hostspec = frr_generate_acl_hostspec($line['source'], $line['sourceany'], $acl['type']);
 					break;
 				case "extended":
 					/* Source and Destination addresses */
-					$hostspec = frr_generate_acl_hostspec($line['source'], $acl_type);
+					$hostspec = frr_generate_acl_hostspec($line['source'], $line['sourceany'], $acl['type']);
 					$hostspec .= " ";
-					$hostspec .= frr_generate_acl_hostspec($line['destination'], $acl_type);
+					$hostspec .= frr_generate_acl_hostspec($line['destination'], $line['destinationany'], $acl['type']);
 					break;
 				case "zebra":
 					/* Source address only */
-					$hostspec = frr_generate_acl_hostspec($line['source'], $acl_type);
+					$hostspec = frr_generate_acl_hostspec($line['source'], $line['sourceany'], $acl['type']);
 					/* If the source is IPv6, mark this ACL as being IPv6 */
-					if (is_subnetv6($line['source']) || ($line['source'] == "any6")) {
+					if (strtolower($acl['iptype']) == 'ipv6') {
 						$ipv6 = "ipv6 ";
 					}
 					break;
@@ -228,13 +218,13 @@ function frr_zebra_generate_accesslists() {
 			}
 			$aclconf .=  " {$line['action']} ";
 			/* Extended ACLs need "ip" before the src/dst specs */
-			if ($acl_type == "extended") {
+			if ($acl['type'] == "extended") {
 				$aclconf .= "ip ";
 			}
 			/* Add on the source/destination */
 			$aclconf .= $hostspec;
 			/* Add exact-match only for Zebra ACLs */
-			if (($acl_type == "zebra") && isset($line['exactmatch'])) {
+			if (($acl['type'] == "zebra") && isset($line['exactmatch'])) {
 				$aclconf .= " exact-match";
 			}
 			$aclconf .= "\n";
@@ -255,7 +245,7 @@ function frr_zebra_generate_accesslists() {
 }
 
 /* Prefix Lists for the zebra configuration based on GUI config */
-function frr_zebra_generate_prefixlists() {
+function frr_zebra_generate_prefixlists($ipv4 = true, $ipv6 = true) {
 	global $config, $frr_config_base;
 	/* Populate FRR Global Settings */
 	if (is_array($config['installedpackages']['frrglobalprefixes']['config'])) {
@@ -267,7 +257,13 @@ function frr_zebra_generate_prefixlists() {
 	$plconf = "";
 
 	/* Loop through Prefix Lists and process */
+	frr_array_name_seq_sort($frr_prefixlists_conf);
 	foreach ($frr_prefixlists_conf as $pl) {
+		/* Skip if IP version is disabled */
+		if ((!$ipv4 && (strtolower($pl['iptype']) == 'ipv4')) || (!$ipv6 && (strtolower($pl['iptype']) == 'ipv6'))) {
+			continue;
+		}
+
 		/* Once a Prefix List is marked IPv6, all of its directives must be IPv6. */
 		$iptype = "";
 
@@ -281,16 +277,18 @@ function frr_zebra_generate_prefixlists() {
 				continue;
 			}
 			/* If the source is IPv6, mark this ACL as being IPv6 */
-			if (is_subnetv6($line['source']) || ($line['source'] == "any6")) {
+			if (strtolower($pl['iptype']) == 'ipv6') {
 				$iptype = "ipv6";
-				if ($line['source'] == "any6") {
-					$line['source'] = "any";
-				}
-			} elseif (is_subnetv4($line['source']) || ($line['source'] == "any")) {
+			} elseif ((strtolower($pl['iptype']) == 'ipv4') || ($line['source'] == "any")) {
 				$iptype = "ip";
 			} else {
 				/* If the source is empty or not a subnet, the line is invalid so skip it. */
 				continue;
+			}
+
+			/* Override the source if the any checkbox is selected */
+			if ($line['any']) {
+				$line['source'] = "any";
 			}
 
 			$plconf .= "{$iptype} prefix-list {$pl['name']} ";
@@ -299,11 +297,11 @@ function frr_zebra_generate_prefixlists() {
 			}
 			$plconf .= "{$line['action']} {$line['source']} ";
 			/* Minimum Prefix (greater than or equal to) */
-			if ($line['ge']) {
+			if ($line['ge'] && !$line['any']) {
 				$plconf .= "ge {$line['ge']} ";
 			}
 			/* Maximum Prefix (less than or equal to) */
-			if ($line['le']) {
+			if ($line['le'] && !$line['any']) {
 				$plconf .= "le {$line['le']} ";
 			}
 			$plconf .= "\n";
@@ -368,15 +366,21 @@ function frr_zebra_generate_routemaps() {
 		}
 
 		/* Access List */
-		if (in_array($rm['acl_match'], frr_get_list_values(frr_get_accesslist_list())) &&
-			($rm['acl_match'] != "none")) {
-			$rmconf .= " match ip address {$rm['acl_match']}\n";
+		if (($rm['acl_match'] != "none")) {
+			if (in_array($rm['prefix_match'], frr_get_list_values(frr_get_prefixlist_list(true, false)))) {
+				$rmconf .= " match ip address {$rm['acl_match']}\n";
+			} elseif (in_array($rm['prefix_match'], frr_get_list_values(frr_get_prefixlist_list(false, true)))) {
+				$rmconf .= " match ipv6 address {$rm['acl_match']}\n";
+			}
 		}
 
 		/* Prefix List */
-		if (in_array($rm['prefix_match'], frr_get_list_values(frr_get_prefixlist_list())) &&
-			($rm['prefix_match'] != "none")) {
-			$rmconf .= " match ip address prefix-list {$rm['prefix_match']}\n";
+		if (($rm['prefix_match'] != "none")) {
+			if (in_array($rm['prefix_match'], frr_get_list_values(frr_get_prefixlist_list(true, false)))) {
+				$rmconf .= " match ip address prefix-list {$rm['prefix_match']}\n";
+			} elseif (in_array($rm['prefix_match'], frr_get_list_values(frr_get_prefixlist_list(false, true)))) {
+				$rmconf .= " match ipv6 address prefix-list {$rm['prefix_match']}\n";
+			}
 		}
 
 		/* Next Hop */
@@ -695,10 +699,14 @@ function frr_generate_config_zebra() {
 		}
 
 		$frr_integrated_config['zebra'] = "";
-		/* Access Lists */
-		$frr_integrated_config['zebra'] .= frr_zebra_generate_accesslists();
-		/* Prefix Lists */
-		$frr_integrated_config['zebra'] .= frr_zebra_generate_prefixlists();
+		/* Access Lists IPv4*/
+		$frr_integrated_config['zebra'] .= frr_zebra_generate_accesslists(true, false);
+		/* Prefix Lists IPv4 */
+		$frr_integrated_config['zebra'] .= frr_zebra_generate_prefixlists(true, false);
+		/* Access Lists IPv6*/
+		$frr_integrated_config['zebra'] .= frr_zebra_generate_accesslists(false, true);
+		/* Prefix Lists IPv6 */
+		$frr_integrated_config['zebra'] .= frr_zebra_generate_prefixlists(false, true);
 		/* Route Maps */
 		$frr_integrated_config['zebra'] .= frr_zebra_generate_routemaps();
 		/* Default Accept Filters */

--- a/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_zebra.inc
+++ b/net/pfSense-pkg-frr/files/usr/local/pkg/frr/inc/frr_zebra.inc
@@ -690,7 +690,7 @@ function frr_generate_config_zebra() {
 	} else {
 		/* If there is no raw configuration and no GUI configuration, stop. */
 		if (empty($frr_conf)) {
-			log_error("FRR Zebra: No config data found.");
+			frr_package_log("FRR Zebra: No config data found.");
 			return;
 		}
 		if (empty($frr_conf['enable'])) {
@@ -725,7 +725,7 @@ function frr_generate_config_zebra() {
 	} else {
 		/* If there is no raw configuration and no GUI configuration, stop. */
 		if (empty($frr_conf)) {
-			log_error("FRR staticd: No config data found.");
+			frr_package_log("FRR staticd: No config data found.");
 			return;
 		}
 		if (empty($frr_conf['enable'])) {
@@ -745,7 +745,6 @@ function read_frr_running_config() {
 	global $config, $frr_config_base;
 
 	$frrRunningFile = "{$frr_config_base}/frr.conf";
-	log_error($frrRunningFile);
 	if (file_exists($frrRunningFile) && (filesize($frrRunningFile) > 0)) {
 		$moduleRunning = fopen("$frrRunningFile", "r");
 		$config['installedpackages']['frrglobalraw']['config'][0]["frrrunning"] = base64_encode(fread($moduleRunning, filesize($frrRunningFile)));

--- a/net/pfSense-pkg-frr/pkg-plist
+++ b/net/pfSense-pkg-frr/pkg-plist
@@ -25,6 +25,7 @@ pkg/frr/frr_global_prefixes.xml
 pkg/frr/frr_bgp.xml
 pkg/frr/frr_bfd.xml
 pkg/frr/frr_bfd_peers.xml
+pkg/frr/frr_bfd_profiles.xml
 pkg/frr/frr_bgp_rpki_cache_servers.xml
 bin/frrctl
 %%DATADIR%%/info.xml


### PR DESCRIPTION
- FRR reload configuration when removing a list item
- Add IP type to FRR access and prefix lists    
    - When used in a route-map the type needs to be known to select the correct `match` statement to use
    - Enhance validation so the correct address types can only be present
    - Add migrations
    - Add checkbox for `any` matches to unify behaviour between IPv4 and IPv6
- Add force service restart button to FRR main page
- FRR Improve logging
- Sort route-maps on save
- Add maxsockbuf tunable during install
- Add FRR 7.5 new features: 
    - BGP
      - Add force option to `maximum-prefix`
      - Add `maximum-prefix-out` option
      - Add neighbor shutdown message
      - Add neighbor automatic shutdown
      - Add global neighbor shutdown
  - BFD
    - Add profile support

Redmine: https://redmine.pfsense.org/issues/11206