### PR TITLE
daq-2.2.2_3 - Backport NS_MOREFRAG bug fix from netmap upstream demo app code.

### DIFF
--- a/net/daq/Makefile
+++ b/net/daq/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=	daq
 PORTVERSION=	2.2.2
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	net
 MASTER_SITES=	https://snort.org/downloads/snortplus/ \
 		ZI

--- a/net/daq/files/patch-daq22-netmap.diff
+++ b/net/daq/files/patch-daq22-netmap.diff
@@ -4,7 +4,7 @@ diff -ruN ./daq-2.2.2.orig/os-daq-modules/daq_netmap.c ./daq-2.2.2/os-daq-module
 @@ -1,6 +1,7 @@
  /*
 -** Copyright (C) 2014 Cisco and/or its affiliates. All rights reserved.
-+** Copyright (C) 2020 Cisco and/or its affiliates. All rights reserved.
++** Copyright (C) 2021 Cisco and/or its affiliates. All rights reserved.
  ** Author: Michael R. Altizer <mialtize@cisco.com>
 +** Author: Bill Meeks <billmeeks8@gmail.com>
  **
@@ -442,7 +442,7 @@ diff -ruN ./daq-2.2.2.orig/os-daq-modules/daq_netmap.c ./daq-2.2.2/os-daq-module
                          rx_slot->flags |= NS_BUF_CHANGED;
  
 +                        /* copy the NS_MOREFRAG */
-+                        rx_slot->flags = (rx_slot->flags & ~NS_MOREFRAG) | (tx_slot->flags & NS_MOREFRAG);
++                        tx_slot->flags = (tx_slot->flags & ~NS_MOREFRAG) | (rx_slot->flags & NS_MOREFRAG);
 +
                          tx_ring->cur = nm_ring_next(tx_ring, tx_cur);
 -#if NETMAP_API >= 10


### PR DESCRIPTION
### daq-2.2.2_3
This update backports a bug fix for the NS_MOREFRAG flag from the upstream netmap code for the _bridge_ example app. The new netmap implementation in DAQ mimics code from the _bridge_ example app from the netmap base, and that code had an error where the Receive Slot NS_MOREFRAG flag was being set instead of the Transmit Slot NS_MOREFRAG flag.

The netmap implementation in this version of DAQ is used by Snort on pfSense.