### PR TITLE
pfSense-pkg-suricata-6.0.0_6 - Update to support 5.0.5 binary, bug fix and add new features

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.0
-PORTREVISION=	5
+PORTREVISION=	6
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=5.0.4:security/suricata
+RUN_DEPENDS=	suricata>=5.0.5:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2020 Bill Meeks
+ * Copyright (C) 2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1604,7 +1604,7 @@ function suricata_get_set_flowbits($rules_map) {
 	return $set_flowbits;
 }
 
-function suricata_find_flowbit_required_rules($rules, $unchecked_flowbits) {
+function suricata_find_flowbit_required_rules($rules, $active_rules, $unchecked_flowbits) {
 
 	/********************************************************/
 	/* This function finds all rules that must be enabled   */
@@ -1613,6 +1613,8 @@ function suricata_find_flowbit_required_rules($rules, $unchecked_flowbits) {
 	/* of required rules in an array.                       */
 	/*                                                      */
 	/*           $rules     = rules_map array of all rules  */
+	/*        $active_rules = rules map array of active     */
+	/*			  rules.			*/
 	/*  $unchecked_flowbits = array of flowbit strings with */
 	/*                        unmatched set/isset pairings  */
 	/*                                                      */
@@ -1648,15 +1650,31 @@ function suricata_find_flowbit_required_rules($rules, $unchecked_flowbits) {
 						if (!is_array($required_flowbits_rules[$k1][$k2])) {
 							$required_flowbits_rules[$k1][$k2] = array();
 						}
+
+						$required_flowbits_rules[$k1][$k2]['noalert'] = $rule2['noalert'];
 						if ($rule2['disabled'] == 0) {
 							// If not disabled, just return the rule text "as is"
 							$required_flowbits_rules[$k1][$k2]['rule'] = ltrim($rule2['rule']);
 							$required_flowbits_rules[$k1][$k2]['disabled'] = $rule2['disabled'];
 						} else {
-							// If rule is disabled, remove leading '#' to enable it
+							// Rule is disabled, so remove leading '#' to enable it and add "flowbits:noalert;"
+							// tag to prevent alerts from the previously disabled rule if not already present.
 							$required_flowbits_rules[$k1][$k2]['rule'] = ltrim(substr($rule2['rule'], strpos($rule2['rule'], "#") + 1));
+							if ($rule2['noalert'] == 0) {
+								$required_flowbits_rules[$k1][$k2]['rule'] = str_replace(";", "flowbits:noalert;", $required_flowbits_rules[$k1][$k2]['rule']);
+								$required_flowbits_rules[$k1][$k2]['noalert'] = 1;
+							}
 							$required_flowbits_rules[$k1][$k2]['disabled'] = 0;
 						}
+
+						// If the required rule is not already part of the enabled rules,
+						// then add "flowbits:noalert" tag if not present to prevent alert
+						// from this rule added by flowbits resolution logic.
+						if (!isset($active_rules[$k1][$k2]) && $required_flowbits_rules[$k1][$k2]['noalert'] == 0) {
+							$required_flowbits_rules[$k1][$k2]['rule'] = str_replace(";", "flowbits:noalert;", $required_flowbits_rules[$k1][$k2]['rule']);
+							$required_flowbits_rules[$k1][$k2]['noalert'] = 1;
+						}
+
 						// Copy over the remaining rule_map entries for this rule
 						$required_flowbits_rules[$k1][$k2]['category'] = $rule2['category'];
 						$required_flowbits_rules[$k1][$k2]['action'] = $rule2['action'];
@@ -1717,7 +1735,7 @@ function suricata_resolve_flowbits($rules, $active_rules) {
 
 	// Now find all the needed "set flowbit" rules from
 	// the master list of all rules.
-	$required_rules = suricata_find_flowbit_required_rules($rules, $delta_flowbits);
+	$required_rules = suricata_find_flowbit_required_rules($rules, $active_rules, $delta_flowbits);
 
 	// Cleanup and release memory we no longer need.
 	unset($delta_flowbits);
@@ -3319,6 +3337,7 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 						$enabled_rules[$k1][$k2]['disabled'] = $v['disabled'];
 						$enabled_rules[$k1][$k2]['action'] = $v['action'];
 						$enabled_rules[$k1][$k2]['flowbits'] = $v['flowbits'];
+						$enabled_rules[$k1][$k2]['noalert'] = $v['noalert'];
 					}
 				}
 			}
@@ -3351,6 +3370,7 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 					$enabled_rules[$k1][$k2]['rule'] = $p['rule'];
 					$enabled_rules[$k1][$k2]['action'] = $p['action'];
 					$enabled_rules[$k1][$k2]['modified'] = $p['modified'];
+					$enabled_rules[$k1][$k2]['noalert'] = $p['noalert'];
 				}
 			}
 			unset($policy_rules, $policy, $p);

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2020 Bill Meeks
+ * Copyright (C) 2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -445,7 +445,7 @@ if ($snortdownload == 'on') {
 
 /*  Check for and download any new Snort GPLv2 Community Rules sigs */
 if ($snortcommunityrules == 'on') {
-	if (suricata_check_rule_md5("{$snort_community_rules_url}{$snort_community_rules_filename}/md5", "{$tmpfname}/{$snort_community_rules_filename_md5}", "Snort GPLv2 Community Rules")) {
+	if (suricata_check_rule_md5("{$snort_community_rules_url}{$snort_community_rules_filename_md5}", "{$tmpfname}/{$snort_community_rules_filename_md5}", "Snort GPLv2 Community Rules")) {
 		/* download Snort GPLv2 Community Rules file */
 		$file_md5 = trim(file_get_contents("{$tmpfname}/{$snort_community_rules_filename_md5}"));
 		if (!suricata_fetch_new_rules("{$snort_community_rules_url}{$snort_community_rules_filename}", "{$tmpfname}/{$snort_community_rules_filename}", $file_md5, "Snort GPLv2 Community Rules"))

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -255,7 +255,12 @@ if ($_POST['filterlogentries_submit']) {
 	$filterfieldsarray = array();
 	$filterfieldsarray['time'] = $_POST['filterlogentries_time'] ? $_POST['filterlogentries_time'] : null;
 	if ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline') {
-		$filterfieldsarray['action'] = $_POST['filterlogentries_action'] ? $_POST['filterlogentries_action'] : null;
+		if ($_POST['filterlogentries_action_drop']) {
+			$filterfieldsarray['action'] = $_POST['filterlogentries_action_drop'] ? $_POST['filterlogentries_action_drop'] : null;
+		}
+		elseif ($_POST['filterlogentries_action_ndrop']) {
+			$filterfieldsarray['action'] = $_POST['filterlogentries_action_ndrop'] ? $_POST['filterlogentries_action_ndrop'] : null;
+		}
 	}
 	else {
 		$filterfieldsarray['action'] = null;
@@ -810,12 +815,20 @@ $group->add(new Form_Input(
 
 if ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline') {
 	$group->add(new Form_Checkbox(
-		'filterlogentries_action',
+		'filterlogentries_action_drop',
 		'Dropped',
 		null,
 		$filterfieldsarray['action'] == "Drop" ? true:false,
 		'Drop'
 	))->setHelp('Dropped');
+
+	$group->add(new Form_Checkbox(
+		'filterlogentries_action_ndrop',
+		'Not Dropped',
+		null,
+		$filterfieldsarray['action'] == "!Drop" ? true:false,
+		'!Drop'
+	))->setHelp('Not Dropped');
 }
 
 $group->add(new Form_Checkbox(
@@ -826,23 +839,24 @@ $group->add(new Form_Checkbox(
 	'on'
 ))->setHelp('Exact Match');
 
+$section->add($group);
+
+$group = new Form_Group('');
 $group->add(new Form_Button(
 	'filterlogentries_submit',
-	'Filter',
+	'Apply Filter',
 	null,
 	'fa-filter'
-))->setHelp("Apply filter")
-  ->removeClass("btn-primary")
-  ->addClass("btn-success");
+))->removeClass("btn-primary btn-default")
+  ->addClass("btn-success btn-sm");
 
 $group->add(new Form_Button(
 	'filterlogentries_clear',
-	'Clear',
+	'Clear Filter',
 	null,
 	'fa-trash-o'
-))->setHelp("Remove all filters")
-  ->removeclass("btn-primary")
-  ->addClass("btn-danger no-confirm");
+))->removeclass("btn-primary btn-default")
+  ->addClass("btn-danger no-confirm btn-sm");
 
 $section->add($group);
 
@@ -1358,6 +1372,16 @@ events.push(function() {
 	//-- Click handlers ------------------------------------------------------
 	$('#instance').on('change', function() {
 		$('#formalert').submit();
+	});
+
+	// When 'filterlogentries_action_drop' is clicked, uncheck 'filterlogentries_action_ndrop' control
+	$('#filterlogentries_action_drop').click(function() {
+		$('#filterlogentries_action_ndrop').prop('checked', false);
+	});
+
+	// When 'filterlogentries_action_ndrop' is clicked, uncheck 'filterlogentries_action_drop' control
+	$('#filterlogentries_action_ndrop').click(function() {
+		$('#filterlogentries_action_drop').prop('checked', false);
 	});
 
 });

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2020 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -157,10 +157,10 @@ $section->addInput(new Form_Input(
 ))->setHelp('You may enter a description here for your reference.');
 $form->add($section);
 
-$content_help = gettext('Valid keywords are \'suppress\', \'event_filter\' and \'rate_filter\'.') . '<br />';
+$content_help = gettext('Valid keywords are \'suppress\', \'event_filter\' and \'threshold\'.') . '<br />';
 $content_help .= gettext('Example 1: suppress gen_id 1, sig_id 1852, track by_src, ip 10.1.1.54') . '<br />';
 $content_help .= gettext('Example 2: event_filter gen_id 1, sig_id 1851, type limit, track by_src, count 1, seconds 60') . '<br />';
-$content_help .= gettext('Example 3: rate_filter gen_id 135, sig_id 1, track by_src, count 100, seconds 1, new_action log, timeout 10');
+$content_help .= gettext('Example 3: threshold gen_id 135, sig_id 1, type threshold, track by_src, count 100, seconds 1');
 
 $section = new Form_Section('Suppression List Content');
 $section->addInput(new Form_Textarea (


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.0_6
This update to the GUI package provides support for the latest 5.0.5 binary from upstream. One bug fix and three new features are included.

**New Features:**
1. When enabling required Flowbits rules, add the _flowbits:noalert_ tag to rules that were not enabled initially. This will allow flowbits logic to function by pulling in required but disabled rules, but will suppress alerts for those rules not specifically enabled by the user.
2. Add a checkbox selection for "Not Dropped" in the filtering section on the ALERTS tab. Of interest only when the engine mode is "INLINE IPS".
3. Add a checkbox selections for "Drop" and "Reject" in the filtering section on the RULES tab when BLOCK_OFFENDERS is enabled. The "Reject" checkbox is only available when INLINE_IPS mode is also enabled.

**Bug Fixes:**
1. Fix typo in Snort GPLv2 Community Rules MD5 file path on line 448 of suricata_check_for_rule_updates.php. See Forum post here: Fix typo in Snort GPLv2 Community Rules MD5 file path on line 448 of suricata_check_for_rule_updates.php. See Forum post here: [https://forum.netgate.com/topic/159168/problems-downloading-custom-rules-in-suricata/4](https://forum.netgate.com/topic/159168/problems-downloading-custom-rules-in-suricata/4).