### PR TITLE
pfSense-pkg-snort-4.1.3 -- Support latest 2.9.17 binary and add bug fixes and new features

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-snort
-PORTVERSION=	4.1.2
-PORTREVISION=	5
+PORTVERSION=	4.1.3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +12,7 @@ COMMENT=	pfSense package snort
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	snort>=2.9.16.1:security/snort
+RUN_DEPENDS=	snort>=2.9.17:security/snort
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2020 Bill Meeks
+ * Copyright (c) 2013-2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1564,13 +1564,24 @@ function snort_get_set_flowbits($rules_map) {
 	return $set_flowbits;
 }
 
-function snort_find_flowbit_required_rules($rules, $unchecked_flowbits) {
+function snort_find_flowbit_required_rules($rules, $active_rules, $unchecked_flowbits) {
 
 	/********************************************************/
 	/* This function finds all rules that must be enabled   */
 	/* in order to satisfy the "checked flowbits" used by   */
 	/* the currently enabled rules.  It returns the list    */
 	/* of required rules in an array.                       */
+	/*                                                      */
+	/*           $rules     = rules_map array of all rules  */
+	/*        $active_rules = rules map array of active     */
+	/*			  rules.			*/
+	/*  $unchecked_flowbits = array of flowbit strings with */
+	/*                        unmatched set/isset pairings  */
+	/*                                                      */
+	/*              Returns = rules_map array consisting    */
+	/*                        of additional rules needed    */
+	/*                        to satisfy all set/isset      */
+	/*                        flowbit pairings              */
 	/********************************************************/
 
 	$required_flowbits_rules = array();
@@ -1593,15 +1604,39 @@ function snort_find_flowbit_required_rules($rules, $unchecked_flowbits) {
 							$required_flowbits_rules[$k1] = array();
 						if (!is_array($required_flowbits_rules[$k1][$k2]))
 							$required_flowbits_rules[$k1][$k2] = array();
-						$required_flowbits_rules[$k1][$k2]['category'] = $rule2['category'];
-						if ($rule2['disabled'] == 0)
-							/* If not disabled, just return the rule text "as is"   */
+						$required_flowbits_rules[$k1][$k2]['noalert'] = $rule2['noalert'];
+						if ($rule2['disabled'] == 0) {
+							// If not disabled, just return the rule text "as is"
 							$required_flowbits_rules[$k1][$k2]['rule'] = ltrim($rule2['rule']);
-						else {
-							/* If rule is disabled, remove leading '#' to enable it */
+							$required_flowbits_rules[$k1][$k2]['disabled'] = $rule2['disabled'];
+						} else {
+							// Rule is disabled, so remove leading '#' to enable it and add "flowbits:noalert;"
+							// tag to prevent alerts from the previously disabled rule if not already present.
 							$required_flowbits_rules[$k1][$k2]['rule'] = ltrim(substr($rule2['rule'], strpos($rule2['rule'], "#") + 1));
+							if ($rule2['noalert'] == 0) {
+								$required_flowbits_rules[$k1][$k2]['rule'] = substr($required_flowbits_rules[$k1][$k2]['rule'], 0, strrpos($required_flowbits_rules[$k1][$k2]['rule'], ")")) . " flowbits:noalert;)";
+								$required_flowbits_rules[$k1][$k2]['noalert'] = 1;
+							}
 							$required_flowbits_rules[$k1][$k2]['disabled'] = 0;
 						}
+
+						// If the required rule is not already part of the enabled rules,
+						// then add "flowbits:noalert" tag if not present to prevent alert
+						// from this rule added by flowbits resolution logic.
+						if (!isset($active_rules[$k1][$k2]) && $required_flowbits_rules[$k1][$k2]['noalert'] == 0) {
+							$required_flowbits_rules[$k1][$k2]['rule'] = substr($required_flowbits_rules[$k1][$k2]['rule'], 0, strrpos($required_flowbits_rules[$k1][$k2]['rule'], ")")) . " flowbits:noalert;)";
+							$required_flowbits_rules[$k1][$k2]['noalert'] = 1;
+						}
+
+						// Copy over the remaining rule_map entries for this rule
+						$required_flowbits_rules[$k1][$k2]['category'] = $rule2['category'];
+						$required_flowbits_rules[$k1][$k2]['action'] = $rule2['action'];
+						$required_flowbits_rules[$k1][$k2]['managed'] = $rule2['managed'];
+						$required_flowbits_rules[$k1][$k2]['modified'] = $rule2['modified'];
+						$required_flowbits_rules[$k1][$k2]['default_state'] = $rule2['default_state'];
+						$required_flowbits_rules[$k1][$k2]['default_action'] = $rule2['default_action'];
+						$required_flowbits_rules[$k1][$k2]['state_toggled'] = $rule2['state_toggled'];
+						$required_flowbits_rules[$k1][$k2]['flowbits'] = $rule2['flowbits'];
 					}
 				}
 			}
@@ -1653,7 +1688,7 @@ function snort_resolve_flowbits($rules, $active_rules) {
 
 	/* Now find all the needed "set flowbit" rules from   */
 	/* the master list of all rules.                      */
-	$required_rules = snort_find_flowbit_required_rules($rules, $delta_flowbits);
+	$required_rules = snort_find_flowbit_required_rules($rules, $active_rules, $delta_flowbits);
 
 	/* Cleanup and release memory we no longer need.      */
 	unset($delta_flowbits);
@@ -3141,6 +3176,7 @@ function snort_get_filtered_rules($rules, $filter) {
 				$filtered_map[$k1][$k2]['state_toggled'] = $tmp_map[$k1][$k2]['state_toggled'];
 				$filtered_map[$k1][$k2]['default_state'] = $tmp_map[$k1][$k2]['default_state'];
 				$filtered_map[$k1][$k2]['default_action'] = $tmp_map[$k1][$k2]['default_action'];
+				$filtered_map[$k1][$k2]['noalert'] = $tmp_map[$k1][$k2]['noalert'];
 			}
 		}
 	}
@@ -3379,11 +3415,12 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 	/* into the $enabled_rules array.                     */
 	$enabled_rules = snort_load_rules_map("{$snortcfgdir}/preproc_rules/");
 
+	/* Load up all the available text rules into a Rules */
+	/* Map array.                                        */
+	$all_rules = snort_load_rules_map("{$snortdir}/rules/");
+
 	/* Process CATEGORIES rules if some are selected or an IPS Policy is enabled  */
 	if (!empty($snortcfg['rulesets']) || $snortcfg['ips_policy_enable'] == 'on') {
-
-		/* Load up all the text rules into a Rules Map array. */
-		$all_rules = snort_load_rules_map("{$snortdir}/rules/");
 
 		/* Create an array with the filenames of the enabled  */
 		/* rule category files if we have any.                */
@@ -3434,6 +3471,12 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 						$enabled_rules[$k1][$k2]['disabled'] = $v['disabled'];
 						$enabled_rules[$k1][$k2]['action'] = $v['action'];
 						$enabled_rules[$k1][$k2]['flowbits'] = $v['flowbits'];
+						$enabled_rules[$k1][$k2]['managed'] = $v['managed'];
+						$enabled_rules[$k1][$k2]['default_state'] = $v['default_state'];
+						$enabled_rules[$k1][$k2]['default_action'] = $v['default_action'];
+						$enabled_rules[$k1][$k2]['state_toggled'] = $v['state_toggled'];
+						$enabled_rules[$k1][$k2]['noalert'] = $v['noalert'];
+						$enabled_rules[$k1][$k2]['modified'] = $v['modified'];
 					}
 				}
 			}
@@ -3463,6 +3506,12 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 					$enabled_rules[$k1][$k2]['disabled'] = $p['disabled'];
 					$enabled_rules[$k1][$k2]['action'] = $p['action'];
 					$enabled_rules[$k1][$k2]['flowbits'] = $p['flowbits'];
+					$enabled_rules[$k1][$k2]['managed'] = $p['managed'];
+					$enabled_rules[$k1][$k2]['default_state'] = $p['default_state'];
+					$enabled_rules[$k1][$k2]['default_action'] = $p['default_action'];
+					$enabled_rules[$k1][$k2]['state_toggled'] = $p['state_toggled'];
+					$enabled_rules[$k1][$k2]['noalert'] = $p['noalert'];
+					$enabled_rules[$k1][$k2]['modified'] = $p['modified'];
 				}
 			}
 			unset($policy_rules, $policy, $p);
@@ -3504,7 +3553,6 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 		} else
 			/* Just put an empty file to always have the file present */
 			snort_write_flowbit_rules_file(array(), "{$snortcfgdir}/rules/{$flowbit_rules_file}");
-		unset($all_rules);
 	}
 
 	// Process SID Management directives if enabled
@@ -3522,14 +3570,13 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 			syslog(LOG_NOTICE, '[Snort] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . '...');
 
 			// Load up all rules into a Rules Map array for flowbits assessment
-			$all_rules = snort_load_rules_map("{$snortdir}/rules/");
 			$fbits = snort_resolve_flowbits($all_rules, $enabled_rules);
 
 			// Check for and disable any flowbit-required rules the
 			// user has manually forced to a disabled state.
 			snort_modify_sids($fbits, $snortcfg);
 			snort_write_flowbit_rules_file($fbits, "{$snortcfgdir}/rules/{$flowbit_rules_file}");
-			unset($all_rules, $fbits);
+			unset($fbits);
 		} else
 			// Just put an empty file to always have the file present
 		snort_write_flowbit_rules_file(array(), "{$snortcfgdir}/rules/{$flowbit_rules_file}");
@@ -3538,6 +3585,8 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 		snort_write_enforcing_rules_file(array(), "{$snortcfgdir}/rules/{$snort_enforcing_rules_file}");
 		snort_write_flowbit_rules_file(array(), "{$snortcfgdir}/rules/{$flowbit_rules_file}");
 	}
+
+	unset($all_rules);
 
 	if (!empty($snortcfg['customrules'])) {
 		@file_put_contents("{$snortcfgdir}/rules/custom.rules", base64_decode($snortcfg['customrules']));

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009 Robert Zelaya
- * Copyright (c) 2013-2020 Bill Meeks
+ * Copyright (c) 2013-2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -281,8 +281,8 @@ function snort_check_rule_md5($file_url, $file_dst, $desc = "") {
 
 		// check md5 hash in new file against current file to see if new download is posted
 		if (file_exists("{$snortdir}/{$filename_md5}")) {
-			$md5_check_new = file_get_contents($file_dst);
-			$md5_check_old = file_get_contents("{$snortdir}/{$filename_md5}");
+			$md5_check_new = trim(file_get_contents($file_dst));
+			$md5_check_old = trim(file_get_contents("{$snortdir}/{$filename_md5}"));
 			snort_update_status(gettext(" done.") . "\n");
 			if ($md5_check_new == $md5_check_old) {
 				snort_update_status(gettext("{$desc} are current. No update required.") . "\n");
@@ -448,7 +448,7 @@ if ($snortdownload == 'on') {
 
 /*  Check for and download any new Snort OpenAppID detectors */
 if ($openappid_detectors == 'on') {
-	if (snort_check_rule_md5("{$snort_openappid_url}{$snort_openappid_filename}/md5", "{$tmpfname}/{$snort_openappid_filename_md5}","Snort OpenAppID detectors")) {
+	if (snort_check_rule_md5("{$snort_openappid_url}{$snort_openappid_filename_md5}", "{$tmpfname}/{$snort_openappid_filename_md5}","Snort OpenAppID detectors")) {
 		$file_md5 = trim(file_get_contents("{$tmpfname}/{$snort_openappid_filename_md5}"));
 		file_put_contents("{$tmpfname}/{$snort_openappid_filename_md5}", $file_md5);
 		/* download snort-openappid file */
@@ -460,7 +460,7 @@ if ($openappid_detectors == 'on') {
 }
 /*  Check for and download any new Snort AppID Open Text Rules */
 if ($openappid_rules_detectors == 'on') {
-        if (snort_check_rule_md5("{$snort_openappid_rules_url}{$snort_openappid_rules_filename}.md5", "{$tmpfname}/{$snort_openappid_rules_filename_md5}", "Snort AppID Open Text Rules")) {
+        if (snort_check_rule_md5("{$snort_openappid_rules_url}{$snort_openappid_rules_filename_md5}", "{$tmpfname}/{$snort_openappid_rules_filename_md5}", "Snort AppID Open Text Rules")) {
                 $file_md5 = trim(file_get_contents("{$tmpfname}/{$snort_openappid_rules_filename_md5}"));
                 file_put_contents("{$tmpfname}/{$snort_openappid_rules_filename_md5}", $file_md5);
                 /* download snort-openappid file rules */
@@ -473,7 +473,7 @@ if ($openappid_rules_detectors == 'on') {
 
 /*  Check for and download any new Snort GPLv2 Community Rules sigs */
 if ($snortcommunityrules == 'on') {
-	if (snort_check_rule_md5("{$snort_community_rules_url}{$snort_community_rules_filename}/md5", "{$tmpfname}/{$snort_community_rules_filename_md5}", "Snort GPLv2 Community Rules")) {
+	if (snort_check_rule_md5("{$snort_community_rules_url}{$snort_community_rules_filename_md5}", "{$tmpfname}/{$snort_community_rules_filename_md5}", "Snort GPLv2 Community Rules")) {
 		/* download Snort GPLv2 Community Rules file */
 		$file_md5 = trim(file_get_contents("{$tmpfname}/{$snort_community_rules_filename_md5}"));
 		if (!snort_fetch_new_rules("{$snort_community_rules_url}{$snort_community_rules_filename}", "{$tmpfname}/{$snort_community_rules_filename}", $file_md5, "Snort GPLv2 Community Rules"))

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -47,7 +47,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 		define("SNORT_BIN_VERSION", $matches[0]);
 	}
 	else {
-		define("SNORT_BIN_VERSION", "2.9.16.1");
+		define("SNORT_BIN_VERSION", "2.9.17");
 	}
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress_edit.php
@@ -173,10 +173,11 @@ $section->addInput(new Form_Input(
 ))->setHelp('You may enter a description here for your reference.');
 $form->add($section);
 
-$content_help = 'Valid keywords are \'suppress\', \'event_filter\' and \'rate_filter\'.' . '<br />';
+$content_help = 'Valid keywords are \'suppress\' and \'event_filter\'.' . '<br />';
+$content_help .= 'There are three types of event filters: (1) limit; (2) threshold; and (3) both.' . '<br />';
 $content_help .= 'Example 1: suppress gen_id 1, sig_id 1852, track by_src, ip 10.1.1.54' . '<br />';
 $content_help .= 'Example 2: event_filter gen_id 1, sig_id 1851, type limit, track by_src, count 1, seconds 60' . '<br />';
-$content_help .= 'Example 3: rate_filter gen_id 135, sig_id 1, track by_src, count 100, seconds 1, new_action log, timeout 10';
+$content_help .= 'Example 3: event_filter gen_id 135, sig_id 1, type threshold track by_src, count 100, seconds 1';
 $section = new Form_Section('Suppression List Content');
 $section->addInput(new Form_Textarea (
 	'suppresspassthru',

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2004-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2008-2009 Robert Zelaya
- * Copyright (c) 2020 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1214,11 +1214,15 @@ print($section);
 
 								// Apply rule state filters if filtering is enabled
 								if ($filterrules) {
-									if (isset($filterfieldsarray['show_disabled']) && $v['disabled'] == 0) {
-										continue;
-									}
-									elseif (isset($filterfieldsarray['show_enabled']) && $v['disabled'] == 1) {
-										continue;
+									if (isset($filterfieldsarray['show_disabled'])) {
+										if (($v['disabled'] == 0 || isset($enablesid[$gid][$sid])) && !isset($disablesid[$gid][$sid])) {
+											continue;
+										}
+										if (isset($filterfieldsarray['show_enabled'])) {
+											if ($v['disabled'] == 1 || isset($disablesid[$gid][$sid])) {
+												continue;
+											}
+										}
 									}
 								}
 
@@ -1406,17 +1410,21 @@ print($section);
 								foreach ($rules_map as $k1 => $rulem) {
 									foreach ($rulem as $k2 => $v) {
 										$ruleset = $currentruleset;
-										$sid = snort_get_sid($v['rule']);
-										$gid = snort_get_gid($v['rule']);
+										$sid = $k2;
+										$gid = $k1;
 										$style = "";
 
 										// Apply rule state filters if filtering is enabled
 										if ($filterrules) {
-											if (isset($filterfieldsarray['show_disabled']) && $v['disabled'] == 0) {
-												continue;
+											if (isset($filterfieldsarray['show_disabled'])) {
+												if (($v['disabled'] == 0 || isset($enablesid[$gid][$sid])) && !isset($disablesid[$gid][$sid])) {
+													continue;
+												}
 											}
-											elseif (isset($filterfieldsarray['show_enabled']) && $v['disabled'] == 1) {
-												continue;
+											if (isset($filterfieldsarray['show_enabled'])) {
+												if ($v['disabled'] == 1 || isset($disablesid[$gid][$sid])) {
+													continue;
+												}
 											}
 										}
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
@@ -1218,10 +1218,10 @@ print($section);
 										if (($v['disabled'] == 0 || isset($enablesid[$gid][$sid])) && !isset($disablesid[$gid][$sid])) {
 											continue;
 										}
-										if (isset($filterfieldsarray['show_enabled'])) {
-											if ($v['disabled'] == 1 || isset($disablesid[$gid][$sid])) {
-												continue;
-											}
+									}
+									if (isset($filterfieldsarray['show_enabled'])) {
+										if ($v['disabled'] == 1 || isset($disablesid[$gid][$sid])) {
+											continue;
 										}
 									}
 								}

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
@@ -92,8 +92,7 @@ if (empty($test))
 if (!file_exists("{$snortdir}/rules/" . GPL_FILE_PREFIX . "community.rules"))
 	$no_community_files = true;
 
-if (($snortdownload == 'off') || ($a_nat[$id]['ips_policy_enable'] != 'on'))
-	$policy_select_disable = "disabled";
+$inline_ips_mode = $a_nat[$id]['ips_mode'] == 'ips_mode_inline' ? true:false;
 
 // If a Snort Subscriber Rules policy is enabled and selected, remove all Snort
 // Subscriber rules from the configured rule sets to allow automatic selection.
@@ -362,35 +361,33 @@ print($section);
 
 if ($snortdownload == "on") {
 	$section = new Form_Section('Snort Subscriber IPS Policy Selection');
-	$section->addInput(new Form_Checkbox(
+	$group = new Form_Group('Use IPS Policy');
+	$group->add(new Form_Checkbox(
 		'ips_policy_enable',
 		'Use IPS Policy',
 		'If checked, Snort will use rules from one of three pre-defined IPS policies in the Snort Subscriber rules. Default is Not Checked.',
 		$pconfig['ips_policy_enable'] == 'on' ? true:false,
 		'on'
-	));
-	$section->addInput(new Form_StaticText(
-	null,
-	'<span class="help-block">Selecting this option disables manual selection of Snort Subscriber categories in the list below, ' . 
+	))->setHelp('Selecting this option disables manual selection of Snort Subscriber categories in the list below, ' . 
 		'although Emerging Threats categories may still be selected if enabled on the Global Settings tab.  These ' . 
-		'will be added to the pre-defined Snort IPS policy rules from the Snort VRT.</span>'
-	));
-	$section->addInput(new Form_Select(
+		'will be added to the pre-defined Snort IPS policy rules from the Snort VRT.');
+	$section->add($group);
+
+	$group = new Form_Group('IPS Policy Selection');
+	$group->add(new Form_Select(
 		'ips_policy',
 		'IPS Policy Selection',
 		$pconfig['ips_policy'],
 		array('connectivity' => 'Connectivity', 'balanced' => 'Balanced', 'security' => 'Security', 'max-detect' => 'Max-Detect')
-	))->setHelp('Snort IPS policies are:  Connectivity, Balanced, Security or Max-Detect.');
-
-	$section->addInput(new Form_StaticText(
-		'',
-		'<span class="help-block">Connectivity blocks most major threats with few or no false positives. ' . 
+	))->setHelp('Snort IPS policies are:  Connectivity, Balanced, Security or Max-Detect.' . '</br>' . 
+		'Connectivity blocks most major threats with few or no false positives. ' . 
 		'Balanced is a good starter policy. It is speedy, has good base coverage level, and covers ' . 
 		'most threats of the day.  It includes all rules in Connectivity. Security is a stringent ' . 
 		'policy.  It contains everything in the first two plus policy-type rules such as a Flash object ' . 
 		'in an Excel file.  Max-Detect is a policy created for testing network traffic through your ' . 
-		'device.  This policy should be used with caution on production systems!</span>'
-	));
+		'device.  This policy should be used with caution on production systems!');
+	$section->add($group);
+
 	$section->addInput(new Form_Select(
 		'ips_policy_mode',
 		'IPS Policy Mode',
@@ -769,24 +766,28 @@ if ($snortdownload == "on") {
 
 		function enable_change()
 		{
-		var endis = !($('#ips_policy_enable').prop('checked'));
+			var endis = !($('#ips_policy_enable').prop('checked'));
 
-		hideInput('ips_policy', endis);
-		hideInput('ips_policy_mode', endis);
+			hideInput('ips_policy', endis);
+	<?php if ($inline_ips_mode): ?>
+			hideInput('ips_policy_mode', endis);
+	<?php else: ?>
+			hideInput('ips_policy_mode', true);
+	<?php endif;?>
 
-		$('input[type="checkbox"]').each(function() {
-			var str = $(this).val();
+			$('input[type="checkbox"]').each(function() {
+				var str = $(this).val();
 
-			if (str.substr(0,6) == "snort_") {
-				$(this).attr('disabled', !endis);
-				if (!endis) {
-					$(this).prop('title', 'Disabled because an IPS Policy is selected');
+				if (str.substr(0,6) == "snort_") {
+					$(this).attr('disabled', !endis);
+					if (!endis) {
+						$(this).prop('title', 'Disabled because an IPS Policy is selected');
+					}
+					else {
+						$(this).prop('title', '');
+					}
 				}
-				else {
-					$(this).prop('title', '');
-				}
-			}
-		});
+			});
 		}
 
 	events.push(function(){


### PR DESCRIPTION
### pfSense-pkg-snort-4.1.3
This update to the GUI package provides support for the latest Snort 2.9.17 binary. Four bug fixes and one new feature is included in the update.

**New Features:**
1. When enabling required Flowbits rules using the automatic flowbits resolution logic, add the _flowbits:noalert_ tag to rules that were not enabled initially by the user but needed to be enabled to satisfy checked flowbits.

**Bug Fixes:**
1. On the CATEGORIES tab, the IPS Policy Mode control should be hidden unless Inline IPS Mode is selected.
2. On the RULES tab, make sure User-Disabled rules are included when filtering for Disabled Rules.
3. Update the help text on the SUPPRESS LIST EDIT tab.
4. Fix typo in Snort GPLv2 Community Rules MD5 file path. See Forum post here: [https://forum.netgate.com/topic/159168/problems-downloading-custom-rules-in-suricata/4](https://forum.netgate.com/topic/159168/problems-downloading-custom-rules-in-suricata/4).