### PR TITLE
pfSense-pkg-suricata-6.0.0_7 - Bug fixes for auto-flowbits logic, IPS Policy Mode and RULES tab filtering.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.0
-PORTREVISION=	6
+PORTREVISION=	7
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -1661,7 +1661,7 @@ function suricata_find_flowbit_required_rules($rules, $active_rules, $unchecked_
 							// tag to prevent alerts from the previously disabled rule if not already present.
 							$required_flowbits_rules[$k1][$k2]['rule'] = ltrim(substr($rule2['rule'], strpos($rule2['rule'], "#") + 1));
 							if ($rule2['noalert'] == 0) {
-								$required_flowbits_rules[$k1][$k2]['rule'] = str_replace(";", "flowbits:noalert;", $required_flowbits_rules[$k1][$k2]['rule']);
+								$required_flowbits_rules[$k1][$k2]['rule'] = substr($required_flowbits_rules[$k1][$k2]['rule'], 0, strrpos($required_flowbits_rules[$k1][$k2]['rule'], ")")) . " flowbits:noalert;)";
 								$required_flowbits_rules[$k1][$k2]['noalert'] = 1;
 							}
 							$required_flowbits_rules[$k1][$k2]['disabled'] = 0;
@@ -1671,7 +1671,7 @@ function suricata_find_flowbit_required_rules($rules, $active_rules, $unchecked_
 						// then add "flowbits:noalert" tag if not present to prevent alert
 						// from this rule added by flowbits resolution logic.
 						if (!isset($active_rules[$k1][$k2]) && $required_flowbits_rules[$k1][$k2]['noalert'] == 0) {
-							$required_flowbits_rules[$k1][$k2]['rule'] = str_replace(";", "flowbits:noalert;", $required_flowbits_rules[$k1][$k2]['rule']);
+								$required_flowbits_rules[$k1][$k2]['rule'] = substr($required_flowbits_rules[$k1][$k2]['rule'], 0, strrpos($required_flowbits_rules[$k1][$k2]['rule'], ")")) . " flowbits:noalert;)";
 							$required_flowbits_rules[$k1][$k2]['noalert'] = 1;
 						}
 
@@ -3228,6 +3228,7 @@ function suricata_get_filtered_rules($rules, $filter) {
 				$filtered_map[$k1][$k2]['state_toggled'] = $tmp_map[$k1][$k2]['state_toggled'];
 				$filtered_map[$k1][$k2]['default_state'] = $tmp_map[$k1][$k2]['default_state'];
 				$filtered_map[$k1][$k2]['default_action'] = $tmp_map[$k1][$k2]['default_action'];
+				$filtered_map[$k1][$k2]['noalert'] = $tmp_map[$k1][$k2]['noalert'];
 			}
 		}
 	}
@@ -3273,12 +3274,12 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 	// if auto-SID Mgmt is enabled and conf files exist for the interface.
 	$cat_mods = suricata_sid_mgmt_auto_categories($suricatacfg, TRUE);
 
+	// Load up all the rules into a Rules Map array.
+	$all_rules = suricata_load_rules_map(SURICATA_RULES_DIR);
+
 	// Only rebuild rules if some are selected or an IPS Policy is enabled
 	if (!empty($suricatacfg['rulesets']) || $suricatacfg['ips_policy_enable'] == 'on' || !empty($cat_mods)) {
 		$no_rules_defined = false;
-
-		// Load up all the rules into a Rules Map array.
-		$all_rules = suricata_load_rules_map(SURICATA_RULES_DIR);
 
 		// Create an array with the filenames of the enabled
 		// rule category files if we have any.
@@ -3337,7 +3338,12 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 						$enabled_rules[$k1][$k2]['disabled'] = $v['disabled'];
 						$enabled_rules[$k1][$k2]['action'] = $v['action'];
 						$enabled_rules[$k1][$k2]['flowbits'] = $v['flowbits'];
+						$enabled_rules[$k1][$k2]['managed'] = $v['managed'];
+						$enabled_rules[$k1][$k2]['default_state'] = $v['default_state'];
+						$enabled_rules[$k1][$k2]['default_action'] = $v['default_action'];
+						$enabled_rules[$k1][$k2]['state_toggled'] = $v['state_toggled'];
 						$enabled_rules[$k1][$k2]['noalert'] = $v['noalert'];
+						$enabled_rules[$k1][$k2]['modified'] = $v['modified'];
 					}
 				}
 			}
@@ -3364,13 +3370,17 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 					if (!is_array($enabled_rules[$k1][$k2])) {
 						$enabled_rules[$k1][$k2] = array();
 					}
+					$enabled_rules[$k1][$k2]['rule'] = $p['rule'];
 					$enabled_rules[$k1][$k2]['category'] = $p['category'];
 					$enabled_rules[$k1][$k2]['disabled'] = $p['disabled'];
-					$enabled_rules[$k1][$k2]['flowbits'] = $p['flowbits'];
-					$enabled_rules[$k1][$k2]['rule'] = $p['rule'];
 					$enabled_rules[$k1][$k2]['action'] = $p['action'];
-					$enabled_rules[$k1][$k2]['modified'] = $p['modified'];
+					$enabled_rules[$k1][$k2]['flowbits'] = $p['flowbits'];
+					$enabled_rules[$k1][$k2]['managed'] = $p['managed'];
+					$enabled_rules[$k1][$k2]['default_state'] = $p['default_state'];
+					$enabled_rules[$k1][$k2]['default_action'] = $p['default_action'];
+					$enabled_rules[$k1][$k2]['state_toggled'] = $p['state_toggled'];
 					$enabled_rules[$k1][$k2]['noalert'] = $p['noalert'];
+					$enabled_rules[$k1][$k2]['modified'] = $p['modified'];
 				}
 			}
 			unset($policy_rules, $policy, $p);
@@ -3399,7 +3409,6 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 			// Just put an empty file to always have the file present
 			suricata_write_flowbit_rules_file(array(), "{$suricatacfgdir}/rules/{$flowbit_rules_file}");
 		}
-		unset($all_rules);
 	}
 	// If no rule categories were enabled, then use auto-SID management if enabled, since it may enable some rules
 	elseif ($config['installedpackages']['suricata']['config'][0]['auto_manage_sids'] == 'on' &&
@@ -3422,14 +3431,13 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 				syslog(LOG_NOTICE, '[Suricata] Enabling any flowbit-required rules for: ' . convert_friendly_interface_to_friendly_descr($suricatacfg['interface']) . '...');
 
 				// Load up all rules into a Rules Map array for flowbits assessment
-				$all_rules = suricata_load_rules_map(SURICATA_RULES_DIR);
 				$fbits = suricata_resolve_flowbits($all_rules, $enabled_rules);
 
 				// Check for and disable any flowbit-required rules the
 				// user has manually forced to a disabled state.
 				suricata_modify_sids($fbits, $suricatacfg);
 				suricata_write_flowbit_rules_file($fbits, "{$suricatacfgdir}/rules/{$flowbit_rules_file}");
-				unset($all_rules, $fbits);
+				unset($fbits);
 			} else {
 				// Just put an empty file to always have the file present
 				suricata_write_flowbit_rules_file(array(), "{$suricatacfgdir}/rules/{$flowbit_rules_file}");
@@ -3444,6 +3452,8 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 		suricata_write_enforcing_rules_file(array(), "{$suricatacfgdir}/rules/{$suricata_enforcing_rules_file}");
 		suricata_write_flowbit_rules_file(array(), "{$suricatacfgdir}/rules/{$flowbit_rules_file}");
 	}
+
+	unset($all_rules);
 
 	if (!empty($suricatacfg['customrules'])) {
 		@file_put_contents("{$suricatacfgdir}/rules/custom.rules", base64_decode($suricatacfg['customrules']));

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -1212,11 +1212,15 @@ print($section);
 
 								// Apply rule state and action filters if filtering is enabled
 								if ($filterrules) {
-									if (isset($filterfieldsarray['show_disabled']) && $v['disabled'] == 0) {
-										continue;
+									if (isset($filterfieldsarray['show_disabled'])) {
+										if (($v['disabled'] == 0 || isset($enablesid[$gid][$sid])) && !isset($disablesid[$gid][$sid])) {
+											continue;
+										}
 									}
-									elseif (isset($filterfieldsarray['show_enabled']) && $v['disabled'] == 1) {
-										continue;
+									if (isset($filterfieldsarray['show_enabled'])) {
+										if ($v['disabled'] == 1 || isset($disablesid[$gid][$sid])) {
+											continue;
+										}
 									}
 									if (isset($filterfieldsarray['show_drop']) && $v['action'] != "drop") {
 										continue;

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2020 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -65,6 +65,7 @@ $snortcommunitydownload = $config['installedpackages']['suricata']['config'][0][
 
 $no_emerging_files = false;
 $no_snort_files = false;
+$inline_ips_mode = $a_nat[$id]['ips_mode'] == 'ips_mode_inline' ? true:false;
 
 $enabled_rulesets_array = explode("||", $a_nat[$id]['rulesets']);
 
@@ -661,7 +662,11 @@ events.push(function() {
 		var endis = !($('#ips_policy_enable').prop('checked'));
 
 		hideInput('ips_policy', endis);
-		hideInput('ips_policy_mode', endis);
+	<?php if ($inline_ips_mode): ?>
+			hideInput('ips_policy_mode', endis);
+	<?php else: ?>
+			hideInput('ips_policy_mode', true);
+	<?php endif;?>
 
 		$('input[type="checkbox"]').each(function() {
 			var str = $(this).val();


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.0_7
This update for the Suricata GUI package corrects a bug introduced in version 6.0.0_6 with the auto-flowbits resolution logic. It also corrects a cosmetic issue with the IPS Policy Mode selector on the CATEGORIES tab and beefs up the logic to ensure user-forced-disabled rules are properly filtered on the RULES tab.

**New Features:**
None

**Bug Fixes:**
1. Correct bug introduced in the auto-flowbits resolution logic that rendered rules added by the flowbits resolution logic corrupted and unreadable.
2. The IPS Policy Mode drop-down selector should be hidden when the IPS Mode is not IPS MODE INLINE.
3. Logic in the filter panel on the RULES tab may not correctly filter user-forced-disabled rules.