### PR TITLE
Add WireGuard networks to Snort VPN pass list. Implements #11386

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.1.3
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -4352,6 +4352,12 @@ function snort_get_vpns_list() {
 			$vpns_arr[] = $l2tp_net;
 		}
 	}
+	/* WireGuard */
+	if (function_exists('wg_get_tunnel_networks')) {
+		foreach (wg_get_tunnel_networks() as $wgn) {
+			$vpns_arr[] = $wgn;
+		}
+	}
 
 	if (!empty($vpns_arr)) {
 		$vpns = implode(" ", array_diff($vpns_arr, array("0.0.0.0/0", "::/0")));


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/11386
- [X] Ready for review
