### PR TITLE
pfBlockerNG-devel v3.0.0_10

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG-devel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-pfBlockerNG-devel
 PORTVERSION=	3.0.0
-PORTREVISION=	9
+PORTREVISION=	10
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfb_dnsbl.doh.conf
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfb_dnsbl.doh.conf
@@ -3,6 +3,7 @@ local-zone: "cloudflare-dns.com" always_nxdomain
 local-zone: "security.cloudflare-dns.com" always_nxdomain
 local-zone: "family.cloudflare-dns.com" always_nxdomain
 local-zone: "dns.google" always_nxdomain
+local-zone: "doh.dns.apple.com" always_nxdomain
 local-zone: "doh.opendns.com" always_nxdomain
 local-zone: "doh.familyshield.opendns.com" always_nxdomain
 local-zone: "dns.quad9.net" always_nxdomain

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -162,7 +162,7 @@ foreach (array('existing', 'actual') as $pftype) {
 }
 
 // Default cURL options
-$pfb['curl_defaults'] = array(  CURLOPT_USERAGENT	=> 'pfSense/pfBlockerNG cURL download agent',
+$pfb['curl_defaults'] = array(  CURLOPT_USERAGENT	=> 'pfSense/pfBlockerNG cURL download agent-' . system_get_uniqueid(),
 				CURLOPT_SSL_CIPHER_LIST	=> 'TLSv1.3, TLSv1.2',
 				CURLOPT_FOLLOWLOCATION	=> true,
 				CURLOPT_SSL_VERIFYPEER	=> true,
@@ -1165,6 +1165,20 @@ accesslog.filename		= "|/usr/local/bin/php -f /usr/local/pkg/pfblockerng/pfblock
 
 EOF;
 }
+	// Lighttpd v1.4.58+ conditional error log with 'ssl.verifyclient.activate' to collect the domain name
+	$lighty_ver = exec('/usr/local/sbin/lighttpd -v 2>&1');
+	if (strpos($lighty_ver, 'lighttpd/1.4.58') !== FALSE ||
+	    strpos($lighty_ver, 'lighttpd/1.4.59') !== FALSE ||
+	    strpos($lighty_ver, 'lighttpd/1.4.60') !== FALSE ||
+	    strpos($lighty_ver, 'lighttpd/1.4.61') !== FALSE ||
+	    strpos($lighty_ver, 'lighttpd/1.5') !== FALSE) {
+
+		$pfb_conf .= <<<EOF
+ssl.verifyclient.activate	= "enable"
+
+EOF;
+	}
+
 	$pfb_conf .= <<<EOF
 
 \$HTTP["scheme"] == "http" {
@@ -5162,53 +5176,100 @@ function pfb_daemon_dnsbl() {
 		syslog(LOG_NOTICE, '[pfBlockerNG] DNSBL parser daemon started');
 
 		$lighty_47	= FALSE;
-		$checkpos	= 3;
+		$lighty_58	= FALSE;
+		$checkpos	= 3; 	// Pre Lighttpd v1.4.47
+
 		while (!feof($h_handle)) {
 			$pfb_buffer = @fgets($h_handle);
 
-			// Lighttpd v1.4.47 uses mod_openssl with a different conditional log formatting
-			if (strpos($pfb_buffer, 'global/HTTPscheme') !== FALSE) {
-				$lighty_47	= TRUE;
-				$checkpos	= 1;
-				continue;
-			}
+			if (!$lighty_58) {
 
-			// Parse only HTTP["xxx"] log lines
-			if (strpos($pfb_buffer, 'HTTP[') === FALSE) {
-				continue;
-			}
-
-			// Verify only HTTPS lines
-			if (strpos($pfb_buffer, '( https') !== FALSE) {
-				if ($lighty_47) {
+				// Lighttpd v1.4.58+ conditional error log with 'ssl.verifyclient.activate' to collect the domain name
+				if (!$lighty_47 &&
+				    (strpos($pfb_buffer, 'lighttpd/1.4.58') !== FALSE ||
+				    strpos($pfb_buffer, 'lighttpd/1.4.59') !== FALSE ||
+				    strpos($pfb_buffer, 'lighttpd/1.4.60') !== FALSE ||
+				    strpos($pfb_buffer, 'lighttpd/1.4.61') !== FALSE ||
+				    strpos($pfb_buffer, 'lighttpd/1.5') !== FALSE)) {
+					$lighty_58	= TRUE;
 					continue;
 				}
-				$checkpos = 0;
+
+				// Lighttpd v1.4.47 uses mod_openssl with a different conditional log formatting
+				elseif (strpos($pfb_buffer, 'global/HTTPscheme') !== FALSE) {
+					$lighty_47	= TRUE;
+					$checkpos	= 1;
+					continue;
+				}
+
 			}
 
-			// Verify HTTP["remoteip"]
-			if ($checkpos == 1 && strpos($pfb_buffer, '["re') !== FALSE) {
-				$src_ip = strstr($pfb_buffer, ' ) compare', TRUE);
-				$src_ip = ltrim(strstr($src_ip, '] ( ', FALSE), '] ( ');
-				$src_ip = (filter_var($src_ip, FILTER_VALIDATE_IP) !== FALSE) ? $src_ip : '';
-			}
+			if ($lighty_58) {
 
-			// Verify HTTP["host"]
-			elseif ($checkpos == 2 && strpos($pfb_buffer, '["ho') !== FALSE) {
-				$lighty_47	= FALSE;
-				$domain		= strstr($pfb_buffer, ' ) compare', TRUE);
-				$domain		= ltrim(strstr($domain, '] ( ', FALSE), '] ( ');
+				// Verify HTTP["remoteip"]
+				if (empty($src_ip)) {
+					if (strpos($pfb_buffer, '["re') !== FALSE) {
+						$src_ip = strstr($pfb_buffer, ') compare', TRUE);
+						$src_ip = ltrim(strstr($src_ip, '] (', FALSE), '] (');
+						$src_ip = (filter_var($src_ip, FILTER_VALIDATE_IP) !== FALSE) ? $src_ip : '';
+					}
+					continue;
+				}
 
-				// URL/Referer/URI/Agent String not available for HTTPS events
-				$req_agent	= 'Unknown';
-				$type		= 'DNSBL-HTTPS';
-
-				// Log event and Increment SQLite DNSBL Group counter
+				if (!empty($src_ip) && strpos($pfb_buffer, "SSL: ") === FALSE) {
+					continue;
+				}
+				if (empty($domain) && strpos($pfb_buffer, "SSL: can't verify client without ssl.ca-file") !== FALSE) {
+					$domain = str_replace(' server name ', '', strstr(trim($pfb_buffer), ' server name ', FALSE));
+				}
 				if (!empty($domain) && !empty($src_ip)) {
-				 	pfb_log_event($type, $domain, $src_ip, $req_agent);
+
+					// URL/Referer/URI/Agent String not available for HTTPS events
+					$req_agent	= 'Unknown';
+					$type		= 'DNSBL-HTTPS';
+
+					pfb_log_event($type, $domain, $src_ip, $req_agent);
+					$domain = $src_ip = '';
 				}
 			}
-			$checkpos++;
+			else {
+				// Parse only HTTP["xxx"] log lines
+				if (strpos($pfb_buffer, 'HTTP[') === FALSE) {
+					continue;
+				}
+
+				// Verify only HTTPS lines
+				if (strpos($pfb_buffer, '( https') !== FALSE) {
+					if ($lighty_47) {
+						continue;
+					}
+					$checkpos = 0;
+				}
+
+				// Verify HTTP["remoteip"]
+				if ($checkpos == 1 && strpos($pfb_buffer, '["re') !== FALSE) {
+					$src_ip = strstr($pfb_buffer, ' ) compare', TRUE);
+					$src_ip = ltrim(strstr($src_ip, '] ( ', FALSE), '] ( ');
+					$src_ip = (filter_var($src_ip, FILTER_VALIDATE_IP) !== FALSE) ? $src_ip : '';
+				}
+
+				// Verify HTTP["host"]
+				elseif ($checkpos == 2 && strpos($pfb_buffer, '["ho') !== FALSE) {
+					$lighty_47	= FALSE;
+					$domain		= strstr($pfb_buffer, ' ) compare', TRUE);
+					$domain		= ltrim(strstr($domain, '] ( ', FALSE), '] ( ');
+
+					// URL/Referer/URI/Agent String not available for HTTPS events
+					$req_agent	= 'Unknown';
+					$type		= 'DNSBL-HTTPS';
+
+					// Log event and Increment SQLite DNSBL Group counter
+					if (!empty($domain) && !empty($src_ip)) {
+					 	pfb_log_event($type, $domain, $src_ip, $req_agent);
+					}
+				}
+				$checkpos++;
+			}
 		}
 	}
 	else {
@@ -6697,6 +6758,13 @@ function sync_package_pfblockerng($cron='') {
 							);
 
 			$safesearch_update = $pfb_found = FALSE;
+
+			// Remove deprecated firefox conf file
+			if (file_exists("{$pfb['dnsbldir']}/pfb_dnsbl.firefoxdoh.conf")) {
+				unlink_if_exists("{$pfb['dnsbldir']}/pfb_dnsbl.firefoxdoh.conf");
+				$safesearch_update = TRUE;
+			}
+
 			foreach ($safesearch_types as $safe_type) {
 				if ($pfb[$safe_type[0]] == $safe_type[1]) {
 					$pfb_found = TRUE;
@@ -6800,7 +6868,8 @@ function sync_package_pfblockerng($cron='') {
 					if (isset($data['nxdomain'])) {
 						$line = "{$host},nxdomain,nxdomain\n";
 					} else {
-						$line = "{$host}," . ($data['A'] ?: '') . ',' . ($data['AAAA'] ?: '') . "\n";
+						$line = "{$host}," . ($data['A'] ?: '') . ',' . ($data['AAAA'] ?: '') . "\n"
+							. "www.{$host}," . ($data['A'] ?: '') . ',' . ($data['AAAA'] ?: '') . "\n";
 					}
 					@file_put_contents('/var/unbound/pfb_py_ss.raw', $line, FILE_APPEND);
 				}
@@ -9509,7 +9578,6 @@ function pfblockerng_php_pre_deinstall_command() {
 	unlink_if_exists("{$pfb['dnsbl_resolver']}");
 	unlink_if_exists("{$pfb['dnsbl_cache']}");
 	unlink_if_exists("/var/tmp/unbound_cache");
-	unlink_if_exists("{$pfb['asn_cache']}");
 	unlink_if_exists("{$pfb['ip_cache']}");
 
 	// Remove incorrect xml setting

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4495,19 +4495,22 @@ function pfb_daemon_filterlog() {
 	if ($pfb['asn_reporting'] != 'disabled') {
 		switch ($pfb['asn_reporting']) {
 			case '1hour':
-				$asn_cache = '1 hours';
+				$asn_cache = '-1 hour';
 				break;
 			case '4hour':
-				$asn_cache = '4 hours';
+				$asn_cache = '-4 hours';
 				break;
 			case '12hour':
-				$asn_cache = '12 hours';
+				$asn_cache = '-12 hours';
 				break;
 			case '24hour':
-				$asn_cache = '24 hours';
+				$asn_cache = '-24 hours';
+				break;
+			case 'week':
+				$asn_cache = '-1 week';
 				break;
 			default:
-				$asn_cache = '24 hours';
+				$asn_cache = '-24 hours';
 		}
 	}
 
@@ -4835,7 +4838,7 @@ function pfb_daemon_filterlog() {
 					$asn = 'null';
 					if ($pfb['asn_reporting'] != 'disabled') {
 
-						$asn_cache = FALSE;
+						$is_asn_cache = FALSE;
 						$db_handle = pfb_open_sqlite(5, 'Query ASN cache');
 						if ($db_handle) {
 
@@ -4854,14 +4857,14 @@ function pfb_daemon_filterlog() {
 								$stmt->bindValue(':host', $ip, SQLITE3_TEXT);
 								$result = $stmt->execute();
 								if ($result) {
-									$asn_cache = $result->fetchArray(SQLITE3_ASSOC);
+									$is_asn_cache = $result->fetchArray(SQLITE3_ASSOC);
 								}
 							}
 						}
 						pfb_close_sqlite($db_handle);
 
 						// If Host IP is not in ASN cache, collect ASN from BGPview API
-						if (!$asn_cache) {
+						if (!$is_asn_cache) {
 
 							$asn		= '';
 							$bgp_url	= "https://api.bgpview.io/ip/{$ip}";
@@ -4918,7 +4921,7 @@ function pfb_daemon_filterlog() {
 
 						// Use cached ASN Entry
 						else {
-							$asn = "{$asn_cache['asn']}"	?: 'Unknown';
+							$asn = "{$is_asn_cache['asn']}"	?: 'Unknown';
 						}
 					}
 

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -4917,7 +4917,7 @@ function select_whitelist(mode, permit_list) {
 									$('#dnsbl_customlist').val(val);
 								}
 								$(this).dialog('close');
-								add_description('dns_reply');
+								add_description(mode);
 							};
 	});
 	buttons['Cancel'] = function() { $(this).dialog('close'); };

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.json
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.json
@@ -155,6 +155,7 @@
 			"cron":		"01hour",
 			"feeds": [
 				{
+					"status":	"discontinued",
 					"feed":		"Autoshun",
 					"website":	"https://www.autoshun.org",
 					"contact":	"https://www.autoshun.org/contact/",

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -256,8 +256,12 @@ $section->addInput(new Form_Select(
 	'asn_reporting',
 	'ASN Reporting',
 	$pconfig['asn_reporting'],
-	[	'disabled' => 'Disabled', '24hour' => 'Enabled - ASN entries cached for 24 hours', '12hour' => 'Enabled - ASN entries cached for 12 hours',
-		'4hour' => 'Enabled - ASN entries cached for 4 hours', '1hour' => 'Enabled - ASN entries cached for 1 hour' ]
+	[	'disabled'	=> 'Disabled',
+		'week'		=> 'Enabled - ASN entries cached for 1 week',
+		'24hour'	=> 'Enabled - ASN entries cached for 24 hours',
+		'12hour'	=> 'Enabled - ASN entries cached for 12 hours',
+		'4hour'		=> 'Enabled - ASN entries cached for 4 hours',
+		'1hour'		=> 'Enabled - ASN entries cached for 1 hour' ]
 ))->setHelp('Query for the ASN (BGPview.io API) for each block/reject/permit/match IP entry. ASN values are cached as per the defined selection.')
   ->setAttribute('style', 'width: auto');
 

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_safesearch.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_safesearch.php
@@ -134,6 +134,7 @@ $section->addInput(new Form_Select(
 	'security.cloudflare-dns.com' => 'CloudFlare Security',
 	'family.cloudflare-dns.com' => 'CloudFlare Family',
 	'dns.google' => 'Google',
+	'doh.dns.apple.com' => 'Apple',
 	'doh.opendns.com' => 'OpenDNS',
 	'doh.familyshield.opendns.com' => 'OpenDNS Family',
 	'dns.quad9.net' => 'Quad9',

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -236,8 +236,10 @@ function pfBlockerNG_update_table() {
 				}
 				$pfb_table[$pfb_alias] = array('count' => $match[1], 'img' => $pfb['down']);
 				exec("{$pfb['ls']} -l -D'%b %d %T' {$pfb['aliasdir']}/{$pfb_alias}.txt | {$pfb['awk']} '{ print $6,$7,$8 }'", $update);
-				$pfb_table[$pfb_alias]['update'] = $update[0];
-				$pfb_table[$pfb_alias]['rule'] = 0;
+
+				$pfb_table[$pfb_alias]['update']	= $update[0];
+				$pfb_table[$pfb_alias]['rule']		= 0;
+				$pfb_table[$pfb_alias]['packets']	= 0;
 				unset($match, $update);
 				continue;
 			}
@@ -269,7 +271,12 @@ function pfBlockerNG_update_table() {
 			if (isset($rule['source']['address']) && stripos($rule['source']['address'], 'pfb_') !== FALSE) {
 				foreach ($pfb_packets as $pkey => $prule) {
 					if ($rule['tracker'] == $prule['tracker']) {
-						$pfb_table[$rule['source']['address']]['packets'] += $prule['packets'];
+						if (!isset($pfb_table[$rule['source']['address']]['packets'])) {
+							$pfb_table[$rule['source']['address']]['packets'] = 0;
+						}
+						if (isset($prule['packets']) && $prule['packets'] > 0) {
+							$pfb_table[$rule['source']['address']]['packets'] += $prule['packets'];
+						}
 						unset($pfb_packets[$pkey]);
 						break;
 					}
@@ -284,7 +291,12 @@ function pfBlockerNG_update_table() {
 			if (isset($rule['destination']['address']) && stripos($rule['destination']['address'], 'pfb_') !== FALSE) {
 				foreach ($pfb_packets as $pkey => $prule) {
 					if ($rule['tracker'] == $prule['tracker']) {
-						$pfb_table[$rule['destination']['address']]['packets'] += $prule['packets'];
+						if (!isset($pfb_table[$rule['destination']['address']]['packets'])) {
+							$pfb_table[$rule['destination']['address']]['packets'] = 0;
+						}
+						if (isset($prule['packets']) && $prule['packets'] > 0) {
+							$pfb_table[$rule['destination']['address']]['packets'] += $prule['packets'];
+						}
 						unset($pfb_packets[$pkey]);
 						break;
 					}
@@ -456,28 +468,55 @@ function pfBlockerNG_get_header($mode='') {
 	$pfb_table = pfBlockerNG_update_table();
 
 	$pfb_table['stats'] = $pfb_table['counts'] = array();
-	$types = array_flip(array('Deny', 'Pass', 'Match'));
+	$pfb_ip_types = array_flip(array('Deny', 'Pass', 'Match'));
 
 	if (!empty($pfb_table)) {
 		foreach ($pfb_table as $pfb_alias => $values) {
 
+			if (empty($values)) {
+				continue;
+			}
+
 			// TODO: Split Deny evaluations into Block and Reject
-			if ($values['type'] == 'Block' || $values['type'] == 'Reject') {
+			if (isset($values['type']) && ($values['type'] == 'Block' || $values['type'] == 'Reject')) {
 				$values['type'] = 'Deny';
 			}
 
 			if (!isset($values['id'])) {
-				$pfb_table['stats']['DNSBL']		+= $values['packets'];
-				$pfb_table['counts']['DNSBL']		+= $values['count'];
+				if (!isset($pfb_table['stats']['DNSBL'])) {
+					$pfb_table['stats']['DNSBL'] = 0;
+				}
+				if (!isset($pfb_table['counts']['DNSBL'])) {
+					$pfb_table['counts']['DNSBL'] = 0;
+				}
+
+				if (is_numeric($values['packets'])) {
+					$pfb_table['stats']['DNSBL']		+= $values['packets'];
+				}
+				if (is_numeric($values['count'])) {
+					$pfb_table['counts']['DNSBL']		+= $values['count'];
+				}
 			}
-			elseif (isset($values['id']) && isset($types[$values['type']])) {
-				$pfb_table['stats'][$values['type']]	+= $values['packets'];
-				$pfb_table['counts'][$values['type']]	+= $values['count'];
+			elseif (isset($values['id']) && isset($values['type']) && isset($pfb_ip_types[$values['type']])) {
+				if (!isset($pfb_table['stats'][$values['type']])) {
+					$pfb_table['stats'][$values['type']] = 0;
+				}
+
+				if (!isset($pfb_table['counts'][$values['type']])) {
+					$pfb_table['counts'][$values['type']] = 0;
+				}
+
+				if (is_numeric($values['packets'])) {
+					$pfb_table['stats'][$values['type']]	+= $values['packets'];
+				}
+				if (is_numeric($values['count'])) {
+					$pfb_table['counts'][$values['type']]	+= $values['count'];
+				}
 			}
 		}
 	}
 
-	foreach ($types as $key => $type) {
+	foreach ($pfb_ip_types as $key => $itype) {
 		if (!isset($pfb_table['stats'][$key])) {
 			$pfb_table['stats'][$key] = 0;
 		}
@@ -492,7 +531,7 @@ function pfBlockerNG_get_header($mode='') {
 		$pfb_msg	= 'pfBlockerNG is Active.';
 
 		// Check Masterfile Database Sanity
-		if ($pfb['config']['enable_dup'] == 'on') {
+		if (isset($pfb['config']['enable_dup']) && $pfb['config']['enable_dup'] == 'on') {
 			$db_sanity = exec("{$pfb['grep']} 'Sanity check' {$pfb['logdir']}/pfblockerng.log | tail -1 | {$pfb['grep']} -o 'PASSED'");
 			if ($db_sanity != 'PASSED') {
 				$pfb_status	= 'fa fa-exclamation-circle text-warning';
@@ -563,7 +602,7 @@ function pfBlockerNG_get_header($mode='') {
 
 			$stats[$key][$type] = 0;
 			if ($type == 'DNSBL') {
-				if ($pfb['dnsbl_missing']) {
+				if (isset($pfb['dnsbl_missing'])) {
 					$stats[$key][$type] = "<span title='*** SQLite database missing, Force Reload DNSBL to recover! ***'>Unknown</span>";
 				} else {
 					$stats[$key][$type] = $pfb_table['stats']['DNSBL'];


### PR DESCRIPTION
* Add doh.dns.apple.com to DoH Block list (SafeSearch page)
* Add RR_TYPE_SIG, RR_TYPE64, RR_TYPE65 to Unbound Python mode DNSBL validation.
* Remove deprecated SafeSearch pfb_dnsbl.firefoxdoh.conf file
* Fix regression with "+" icon Add IP to Whitelist Alias (Reports Tab)
* Add pfSense Uniq_id string to the Curl User Agent String (Should improve BGPView issues for IP Blocked events ASN Reporting.)
* Under the hood improvements to the Widget
* Upgrade DNSBL Unbound mode parser for Lighttpd changes (pfSense 2.5 only)
* Remove AutoShun Feed
* Unbound Python mode improve Log events for potential file permission errors.
* Fix ASN Cache clearing of old ASN Entries, add a "1 Week" ASN Cache option