### PR TITLE
pfSense-pkg-snort-4.1.3_2 - add support for multiple custom IP and alias Pass List entries, and misc bug fixes

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.1.3
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package snort
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	snort>=2.9.17:security/snort
+RUN_DEPENDS=	snort>=2.9.17_1:security/snort
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -268,7 +268,12 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
 
 	/***********************************************************/
 	/* The default is to build a HOME_NET variable unless      */
-	/* '$whitelist' is set to 'true' when calling.             */
+	/* '$whitelist' or '$externallist is set to TRUE when      */
+	/* calling.                                                */
+	/*                                                         */
+	/* When '$whitelist' is TRUE, a Pass List is built.        */
+	/* When '$externalist' is TRUE, the EXTERNAL_NET variable  */
+	/* is built.                                               */
 	/***********************************************************/
 
 	global $config, $g, $aliastable, $filterdns;
@@ -282,14 +287,39 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
                 if (empty($list))
                         return $list;
 		$localnet = $list['localnets'];
-//		$wanip = $list['wanips'];
 		$wanip = 'yes';
 		$wangw = $list['wangateips'];
 		$wandns = $list['wandnsips'];
 		$vips = $list['vips'];
 		$vpns = $list['vpnips'];
-		if (!empty($list['address']) && is_alias($list['address']))
-			$home_net = explode(" ", trim(filter_expand_alias($list['address'])));
+
+		// Process any custom IPs or aliases defined for the list.
+		// We allow dynamically updated aliases only for a Pass
+		// List. So for Pass Lists, we test for null strings from
+		// filter_expand_alias() and assume the passed alias is a
+		// FQDN or other dynamically updated alias.
+		if (is_array($list['address']['item']) && count($list['address']['item']) > 0) {
+			foreach ($list['address']['item'] as $addr) {
+				if (!$whitelist) {
+					if (is_alias($addr)) {
+						$home_net = array_merge($home_net, explode(" ", trim(filter_expand_alias($addr))));
+					} elseif (is_ipaddr($addr) || is_subnet($addr)) {
+						$home_net[] = $addr;
+					}
+				} elseif ($whitelist) {
+					if (is_alias($addr)) {
+						$tmp = trim(filter_expand_alias($addr));
+						if ($tmp <> "") {
+							$home_net = array_merge($home_net, explode(" ", $tmp));
+						} else {
+							$home_net[] = $addr;
+						}
+					} elseif (is_ipaddr($addr) || is_subnet($addr)) {
+						$home_net[] = $addr;
+					}
+				}
+			}
+		}
 	}
 
 	/* Always add loopback addresses to HOME_NET and whitelist */

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
@@ -227,6 +227,27 @@ if (empty($config['installedpackages']['snortglobal']['rule_update_starttime']) 
 }
 
 /**********************************************************/
+/* Add new multiple alias & custom IP assignment feature  */
+/* for Pass Lists by converting existing <address>        */
+/* element for existing entries into an array. Migrate    */
+/* any existing <address> to the new array structure.     */
+/**********************************************************/
+if (is_array($config['installedpackages']['snortglobal']['whitelist']['item'])) {
+	foreach ($config['installedpackages']['snortglobal']['whitelist']['item'] as &$wlisti) {
+		if (!is_array($wlisti['address']) && !is_array($wlisti['address']['item']) && !empty($wlisti['address'])) {
+			$tmp = $wlisti['address'];
+			$wlisti['address'] = array();
+			$wlisti['address']['item'] = array();
+			$wlisti['address']['item'][] = $tmp;
+			$updated_cfg = true;
+		}
+	}
+
+	// Release reference to whitelist array
+	unset($wlisti);
+}
+
+/**********************************************************/
 /* Migrate per interface settings if required.            */
 /**********************************************************/
 foreach ($config['installedpackages']['snortglobal']['rule'] as &$rule) {

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_migrate_config.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2019-2021 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2013-2020 Bill Meeks
+ * Copyright (c) 2013-2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -687,34 +687,34 @@ foreach ($config['installedpackages']['snortglobal']['rule'] as &$rule) {
 	/* Migrate any enabled Unified logging from Barnyard2 to  */
 	/* the new snort_xxxx.u2 log interface logging.           */
 	/**********************************************************/
-	if (!isset($pconfig['unified2_logging_enable'])) {
+	if (!isset($rule['unified2_logging_enable'])) {
 		// Continue U2 logging if Barnyard2 was enabled
-		if (isset($pconfig['barnyard_enable']) && $pconfig['barnyard_enable'] == 'on') {
-			$pconfig['unified2_logging_enable'] = 'on';
+		if (isset($rule['barnyard_enable']) && $rule['barnyard_enable'] == 'on') {
+			$rule['unified2_logging_enable'] = 'on';
 		}
 		else {
-			$pconfig['unified2_logging_enable'] = 'off';
+			$rule['unified2_logging_enable'] = 'off';
 		}
 
 		// Check if VLAN or MPLS events logging is enabled
-		if (isset($pconfig['barnyard_log_vlan_events']) && $pconfig['barnyard_log_vlan_events'] == 'on') {
-			$pconfig['unified2_log_vlan_events'] = 'on';
+		if (isset($rule['barnyard_log_vlan_events']) && $rule['barnyard_log_vlan_events'] == 'on') {
+			$rule['unified2_log_vlan_events'] = 'on';
 		}
 		else {
-			$pconfig['unified2_log_vlan_events'] = 'off';
+			$rule['unified2_log_vlan_events'] = 'off';
 		}
-		if (isset($pconfig['barnyard_log_mpls_events']) && $pconfig['barnyard_log_mpls_events'] == 'on') {
-			$pconfig['unified2_log_mpls_events'] = 'on';
+		if (isset($rule['barnyard_log_mpls_events']) && $rule['barnyard_log_mpls_events'] == 'on') {
+			$rule['unified2_log_mpls_events'] = 'on';
 		}
 		else {
-			$pconfig['unified2_log_mpls_events'] = 'off';
+			$rule['unified2_log_mpls_events'] = 'off';
 		}
 
-		if (!isset($pconfig['unified2_log_limit'])) {
-			$pconfig['unified2_log_limit'] = '500';
+		if (!isset($rule['unified2_log_limit'])) {
+			$rule['unified2_log_limit'] = '500';
 		}
-		if (!isset($pconfig['u2_archived_log_retention'])) {
-			$pconfig['u2_archived_log_retention'] = '336';
+		if (!isset($rule['u2_archived_log_retention'])) {
+			$rule['u2_archived_log_retention'] = '336';
 		}
 		$updated_cfg = true;
 	}
@@ -723,116 +723,116 @@ foreach ($config['installedpackages']['snortglobal']['rule'] as &$rule) {
 	/* Remove deprecated Barnyard2 configuration parameters   */
 	/* from this interface if any are present.                */
 	/**********************************************************/
-	if (isset($pconfig['barnyard_enable'])) {
-		unset($pconfig['barnyard_enable']);
+	if (isset($rule['barnyard_enable'])) {
+		unset($rule['barnyard_enable']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_show_year'])) {
-		unset($pconfig['barnyard_show_year']);
+	if (isset($rule['barnyard_show_year'])) {
+		unset($rule['barnyard_show_year']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_archive_enable'])) {
-		unset($pconfig['barnyard_archive_enable']);
+	if (isset($rule['barnyard_archive_enable'])) {
+		unset($rule['barnyard_archive_enable']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_dump_payload'])) {
-		unset($pconfig['barnyard_dump_payload']);
+	if (isset($rule['barnyard_dump_payload'])) {
+		unset($rule['barnyard_dump_payload']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_obfuscate_ip'])) {
-		unset($pconfig['barnyard_obfuscate_ip']);
+	if (isset($rule['barnyard_obfuscate_ip'])) {
+		unset($rule['barnyard_obfuscate_ip']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_log_vlan_events'])) {
-		unset($pconfig['barnyard_log_vlan_events']);
+	if (isset($rule['barnyard_log_vlan_events'])) {
+		unset($rule['barnyard_log_vlan_events']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_log_mpls_events'])) {
-		unset($pconfig['barnyard_log_mpls_events']);
+	if (isset($rule['barnyard_log_mpls_events'])) {
+		unset($rule['barnyard_log_mpls_events']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_mysql_enable'])) {
-		unset($pconfig['barnyard_mysql_enable']);
+	if (isset($rule['barnyard_mysql_enable'])) {
+		unset($rule['barnyard_mysql_enable']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_syslog_enable'])) {
-		unset($pconfig['barnyard_syslog_enable']);
+	if (isset($rule['barnyard_syslog_enable'])) {
+		unset($rule['barnyard_syslog_enable']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_syslog_local'])) {
-		unset($pconfig['']);
+	if (isset($rule['barnyard_syslog_local'])) {
+		unset($rule['']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_syslog_local'])) {
-		unset($pconfig['']);
+	if (isset($rule['barnyard_syslog_local'])) {
+		unset($rule['']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_bro_ids_enable'])) {
-		unset($pconfig['barnyard_bro_ids_enable']);
+	if (isset($rule['barnyard_bro_ids_enable'])) {
+		unset($rule['barnyard_bro_ids_enable']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_disable_sig_ref_tbl'])) {
-		unset($pconfig['barnyard_disable_sig_ref_tbl']);
+	if (isset($rule['barnyard_disable_sig_ref_tbl'])) {
+		unset($rule['barnyard_disable_sig_ref_tbl']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_syslog_opmode'])) {
-		unset($pconfig['barnyard_syslog_opmode']);
+	if (isset($rule['barnyard_syslog_opmode'])) {
+		unset($rule['barnyard_syslog_opmode']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_syslog_payload_encoding'])) {
-		unset($pconfig['barnyard_syslog_payload_encoding']);
+	if (isset($rule['barnyard_syslog_payload_encoding'])) {
+		unset($rule['barnyard_syslog_payload_encoding']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_syslog_proto'])) {
-		unset($pconfig['barnyard_syslog_proto']);
+	if (isset($rule['barnyard_syslog_proto'])) {
+		unset($rule['barnyard_syslog_proto']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_sensor_name'])) {
-		unset($pconfig['barnyard_sensor_name']);
+	if (isset($rule['barnyard_sensor_name'])) {
+		unset($rule['barnyard_sensor_name']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_dbhost'])) {
-		unset($pconfig['barnyard_dbhost']);
+	if (isset($rule['barnyard_dbhost'])) {
+		unset($rule['barnyard_dbhost']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_dbname'])) {
-		unset($pconfig['barnyard_dbname']);
+	if (isset($rule['barnyard_dbname'])) {
+		unset($rule['barnyard_dbname']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_dbuser'])) {
-		unset($pconfig['barnyard_dbuser']);
+	if (isset($rule['barnyard_dbuser'])) {
+		unset($rule['barnyard_dbuser']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_dbpwd'])) {
-		unset($pconfig['barnyard_dbpwd']);
+	if (isset($rule['barnyard_dbpwd'])) {
+		unset($rule['barnyard_dbpwd']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_syslog_rhost'])) {
-		unset($pconfig['barnyard_syslog_rhost']);
+	if (isset($rule['barnyard_syslog_rhost'])) {
+		unset($rule['barnyard_syslog_rhost']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_syslog_dport'])) {
-		unset($pconfig['barnyard_syslog_dport']);
+	if (isset($rule['barnyard_syslog_dport'])) {
+		unset($rule['barnyard_syslog_dport']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_syslog_facility'])) {
-		unset($pconfig['barnyard_syslog_facility']);
+	if (isset($rule['barnyard_syslog_facility'])) {
+		unset($rule['barnyard_syslog_facility']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_syslog_priority'])) {
-		unset($pconfig['barnyard_syslog_priority']);
+	if (isset($rule['barnyard_syslog_priority'])) {
+		unset($rule['barnyard_syslog_priority']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_bro_ids_rhost'])) {
-		unset($pconfig['barnyard_bro_ids_rhost']);
+	if (isset($rule['barnyard_bro_ids_rhost'])) {
+		unset($rule['barnyard_bro_ids_rhost']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnyard_bro_ids_dport'])) {
-		unset($pconfig['barnyard_bro_ids_dport']);
+	if (isset($rule['barnyard_bro_ids_dport'])) {
+		unset($rule['barnyard_bro_ids_dport']);
 		$updated_cfg = true;
 	}
-	if (isset($pconfig['barnconfigpassthru'])) {
-		unset($pconfig['barnconfigpassthru']);
+	if (isset($rule['barnconfigpassthru'])) {
+		unset($rule['barnconfigpassthru']);
 		$updated_cfg = true;
 	}
 	/**********************************************************/

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -6,7 +6,7 @@
  * Copyright (c) 2006-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
- * Copyright (c) 2020 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
  * All rights reserved.
  *
@@ -593,7 +593,8 @@ foreach ($a_instance as $id => $instance) {
 	$interfaces[$id] = convert_friendly_interface_to_friendly_descr($instance['interface']) . " (" . get_real_interface($instance['interface']) . ")";
 }
 
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Alerts"));
+$pglinks = array("", "/snort/snort_interfaces.php", "@self");
+$pgtitle = array("Services", "Snort", "Alerts");
 include("head.inc");
 
 /* refresh every 60 secs */

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_blocked.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_blocked.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2014-2018 Bill Meeks
+ * Copyright (c) 2014-2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -120,8 +120,6 @@ if ($_POST['download'])
 			unlink_if_exists("{$g['tmp_path']}/{$file_name}");
 			rmdir_recursive("{$g['tmp_path']}/snort_blocked");
 
-//			header("Location: /snort/snort_blocked.php");
-//			exit;
 		} else
 			$savemsg = gettext("An error occurred while creating archive");
 	} else
@@ -143,7 +141,8 @@ if ($_POST['save'])
 
 }
 
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Blocked Hosts"));
+$pglinks = array("", "/snort/snort_interfaces.php", "@self");
+$pgtitle = array("Services", "Snort", "Blocked Hosts");
 include("head.inc");
 
 /* refresh every 60 secs */

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_define_servers.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_define_servers.php
@@ -6,7 +6,7 @@
  * Copyright (c) 2019-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2008-2009 Robert Zelaya.
- * Copyright (c) 2014-2020 Bill Meeks
+ * Copyright (c) 2014-2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -158,7 +158,9 @@ if ($_POST['save']) {
 $if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']);
 if (empty($if_friendly)) {
 	$if_friendly = "None";
-}$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Interface Servers and Ports Variables - {$if_friendly}"));
+}
+$pglinks = array("", "/snort/snort_interfaces.php", "/snort/snort_interfaces_edit.php?id={$id}", "@self");
+$pgtitle = array("Services", "Snort", "Interface Settings", "{$if_friendly} - Server and Port Variables");
 include("head.inc");
 
 /* Display Alert message */

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2004-2021 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2019 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -188,7 +188,8 @@ if (isset($_POST['mode'])) {
 	}
 }
 
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Update Rules"));
+$pglinks = array("", "/snort/snort_interfaces.php", "@self");
+$pgtitle = array("Services", "Snort", "Updates");
 include("head.inc");
 
 if ($savemsg) {

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_frag3_engine.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_frag3_engine.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2018-2021 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2013-2018 Bill Meeks
+ * Copyright (c) 2013-2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -195,7 +195,8 @@ if ($_POST['save']) {
 }
 
 $if_friendly = convert_friendly_interface_to_friendly_descr($config['installedpackages']['snortglobal']['rule'][$id]['interface']);
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Frag3 Preprocessor Engine"), gettext("{$if_friendly}"));
+$pglinks = array("", "/snort/snort_interfaces.php", "/snort/snort_interfaces_edit.php?id={$id}", "@self");
+$pgtitle = array("Services", "Snort", "Interface Settings", "{$if_friendly} - Frag3 Preprocessor Engine");
 include("head.inc");
 
 if ($input_errors) print_input_errors($input_errors);

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ftp_client_engine.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ftp_client_engine.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2018-2021 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2013-2018 Bill Meeks
+ * Copyright (c) 2013-2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -226,7 +226,8 @@ if ($_POST['save']) {
 }
 
 $if_friendly = convert_friendly_interface_to_friendly_descr($config['installedpackages']['snortglobal']['rule'][$id]['interface']);
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("FTP Preprocessor Client Engine"), gettext("{$if_friendly}"));
+$pglinks = array("", "/snort/snort_interfaces.php", "/snort/snort_interfaces_edit.php?id={$id}", "@self");
+$pgtitle = array("Services", "Snort", "Interface Settings", "{$if_friendly} - FTP Preprocessor Client Engine");
 include("head.inc");
 
 if ($input_errors) print_input_errors($input_errors);

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ftp_server_engine.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ftp_server_engine.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2018-2021 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2013-2018 Bill Meeks
+ * Copyright (c) 2013-2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -197,7 +197,8 @@ if ($_POST['save']) {
 }
 
 $if_friendly = convert_friendly_interface_to_friendly_descr($config['installedpackages']['snortglobal']['rule'][$id]['interface']);
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("FTP Preprocessor Server Engine"), gettext("{$if_friendly}"));
+$pglinks = array("", "/snort/snort_interfaces.php", "/snort/snort_interfaces_edit.php?id={$id}", "@self");
+$pgtitle = array("Services", "Snort", "Interface Settings", "{$if_friendly} - FTP Preprocessor Server Engine");
 include("head.inc");
 
 if ($input_errors) print_input_errors($input_errors);

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_httpinspect_engine.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_httpinspect_engine.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2018-2021 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2013-2018 Bill Meeks
+ * Copyright (c) 2013-2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -306,7 +306,8 @@ if ($_POST['save']) {
 }
 
 $if_friendly = convert_friendly_interface_to_friendly_descr($config['installedpackages']['snortglobal']['rule'][$id]['interface']);
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("HTTP_Inspect Preprocessor Engine"), gettext("{$if_friendly}"));
+$pglinks = array("", "/snort/snort_interfaces.php", "/snort/snort_interfaces_edit.php?id={$id}", "@self");
+$pgtitle = array("Services", "Snort", "Interface Settings", "{$if_friendly} - HTTP_Inspect Preprocessor Engine");
 include("head.inc");
 
 if ($input_errors) print_input_errors($input_errors);

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_import_aliases.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_import_aliases.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2018-2021 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2013-2018 Bill Meeks
+ * Copyright (c) 2013-2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -302,7 +302,7 @@ include("head.inc");
 	<?php
 	print_info_box('<strong>' . gettext('Note:') . '<br></strong>' . gettext('Fully-Qualified Domain Name (FQDN) host Aliases cannot be used as Snort configuration parameters. ' .
 		' Aliases resolving to a single FQDN value are disabled in the list above. ' .
-		'In the case of nested Aliases where one or more of the nested values is a FQDN host, the FQDN host will not be included in ' . $title . ' configuration.'), info, false);
+		'In the case of nested Aliases where one or more of the nested values is a FQDN host, the FQDN host will not be included in ' . $title . ' configuration.'), "info", false);
 	?>
 <?php endif; ?>
 </div>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interface_logs.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interface_logs.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2014-2020 Bill Meeks
+ * Copyright (c) 2014-2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -79,7 +79,9 @@ if ($_POST['action'] == 'load') {
 $if_friendly = convert_friendly_interface_to_friendly_descr($a_instance[$id]['interface']);
 if (empty($if_friendly)) {
 	$if_friendly = "None";
-}$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Interface Logs"), gettext("{$if_friendly}"));
+}
+$pglinks = array("", "/snort/snort_interfaces.php", "/snort/snort_interfaces_edit.php?id={$id}", "@self");
+$pgtitle = array("Services", "Snort", "Interface Settings", "{$if_friendly} - Logs");
 include("head.inc");
 
 if ($input_errors) {

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2011-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (C) 2008-2009 Robert Zelaya
- * Copyright (c) 2020 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -584,7 +584,8 @@ if (empty($if_friendly)) {
 // Finished with config array reference, so release it
 unset($a_rule);
 
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Edit Interface"), gettext("{$if_friendly}"));
+$pglinks = array("", "/snort/snort_interfaces.php", "@self");
+$pgtitle = array("Services", "Snort", "{$if_friendly} - Interface Settings");
 include("head.inc");
 
 if ($input_errors) {

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
@@ -6,7 +6,7 @@
  * Copyright (c) 2011-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2006 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2008-2009 Robert Zelaya
- * Copyright (c) 2020 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -177,7 +177,8 @@ if (!$input_errors) {
 	}
 }
 
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Global Settings"));
+$pglinks = array("", "/snort/snort_interfaces.php", "@self");
+$pgtitle = array("Services", "Snort", "Global Settings");
 include("head.inc");
 
 if ($input_errors)

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2004-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya.
- * Copyright (c) 2019 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * originially part of m0n0wall (http://m0n0.ch/wall)
@@ -107,7 +107,8 @@ else {
 	}
 }
 
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Suppression Lists"));
+$pglinks = array("", "/snort/snort_interfaces.php", "@self");
+$pgtitle = array("Services", "Snort", "Suppression Lists");
 include_once("head.inc");
 if ($input_errors) {
 	print_input_errors($input_errors);

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress_edit.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2004-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya.
- * Copyright (c) 2019 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * originially part of m0n0wall (http://m0n0.ch/wall)
@@ -135,7 +135,8 @@ if ($_POST['save']) {
 // Finished with config array reference, so release it
 unset($a_suppress);
 
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Suppression List Edit"));
+$pglinks = array("", "/snort/snort_interfaces.php", "/snort/snort_interfaces_suppress.php", "@self");
+$pgtitle = array("Services", "Snort", "Suppression List", "Edit");
 include_once("head.inc");
 
 if ($input_errors)

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ip_list_mgmt.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ip_list_mgmt.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2004-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya.
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * originially part of m0n0wall (http://m0n0.ch/wall)
@@ -127,7 +127,8 @@ if (isset($_POST['save']) && isset($_POST['iplist_data'])) {
 // so we can pick up any changes made to files in code above.
 $ipfiles = return_dir_as_array($iprep_path);
 
-$pgtitle = array(gettext('Services'), gettext('Snort'), gettext('IP Reputation Lists'));
+$pglinks = array("", "/snort/snort_interfaces.php", "@self");
+$pgtitle = array('Services', 'Snort', 'IP Reputation Lists');
 include_once("head.inc");
 
 if ($input_errors) {

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ip_reputation.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ip_reputation.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2019-2021 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2020 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -209,7 +209,9 @@ if ($_POST['save']) {
 $if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']);
 if (empty($if_friendly)) {
 	$if_friendly = "None";
-}$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("IP Reputation Preprocessor"), gettext("{$if_friendly}"));
+}
+$pglinks = array("", "/snort/snort_interfaces.php", "/snort/snort_interfaces_edit.php?id={$id}", "@self");
+$pgtitle = array("Services", "Snort", "Interface Settings", "{$if_friendly} - IP Reputation");
 include("head.inc");
 
 /* Display Alert message */

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_log_mgmt.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_log_mgmt.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2020 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -182,7 +182,8 @@ if (isset($_POST['save']) || isset($_POST['apply'])) {
 	}
 }
 
-$pgtitle = array(gettext('Services'), gettext('Snort'), gettext('Log Management'));
+$pglinks = array("", "/snort/snort_interfaces.php", "@self");
+$pgtitle = array('Services', 'Snort', 'Log Management');
 include_once("head.inc");
 
 /* Display Alert message, under form tag or no refresh */

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2004-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2019 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * originially part of m0n0wall (http://m0n0.ch/wall)
@@ -112,7 +112,8 @@ else {
 	}
 }
 
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Pass Lists"));
+$pglinks = array("", "/snort/snort_interfaces.php", "@self");
+$pgtitle = array("Services", "Snort", "Pass Lists");
 include_once("head.inc");
 
 /* Display Alert message */
@@ -150,7 +151,6 @@ display_top_tabs($tab_array, true);
 			<tr>
 				<th>&nbsp;</th>
 				<th>List Name</th>
-				<th>Assigned Alias</th>
 				<th>Description</th>
 				<th>Actions</th>
 			</tr>
@@ -160,13 +160,6 @@ display_top_tabs($tab_array, true);
 			<tr>
 				<td><input type="checkbox" id="frc<?=$i?>" name="del[]" value="<?=$i?>" onclick="fr_bgcolor('<?=$i?>')" /></td>
 				<td ondblclick="document.location='snort_passlist_edit.php?id=<?=$i;?>';"><?=htmlspecialchars($list['name']);?></td>
-		<?php if (strlen($list['address']) > 0) : ?>
-				<td ondblclick="document.location='snort_passlist_edit.php?id=<?=$i;?>';" title="<?=filter_expand_alias($list['address']);?>">
-					<?=gettext($list['address']);?></td>
-		<?php else : ?>
-				<td ondblclick="document.location='snort_passlist_edit.php?id=<?=$i;?>';">
-				</td>
-		<?php endif; ?>
 				<td ondblclick="document.location='snort_passlist_edit.php?id=<?=$i;?>';"><?=htmlspecialchars($list['descr']);?>&nbsp;</td>
 				<td style="cursor: pointer;"><a href="snort_passlist_edit.php?id=<?=$i;?>" class="fa fa-pencil" title="<?=gettext('Edit Pass List');?>"></a>
 				<a class="fa fa-trash no-confirm" id="Xcdel_<?=$i?>" title="<?=gettext('Delete Pass List'); ?>"></a>
@@ -178,12 +171,12 @@ display_top_tabs($tab_array, true);
 	</div>
 
 	<nav class="action-buttons">
-		<a href="snort_passlist_edit.php?id=<?php echo $id_gen;?>" role="button" class="btn btn-sm btn-success" title="<?=gettext('add a new pass list');?>">
+		<a href="snort_passlist_edit.php?id=<?php echo $id_gen;?>" role="button" class="btn btn-sm btn-success" title="<?=gettext('Add a new pass list');?>">
 			<i class="fa fa-plus icon-embed-btn"></i>
 			<?=gettext("Add");?>
 		</a>
 		<?php if (count($a_passlist) > 0): ?>
-			<button type="submit" name="del_btn" id="del_btn" class="btn btn-danger btn-sm" title="<?=gettext('Delete Selected Items');?>">
+			<button type="submit" name="del_btn" id="del_btn" class="btn btn-danger btn-sm" title="<?=gettext('Delete selected items');?>">
 				<i class="fa fa-trash icon-embed-btn"></i>
 				<?=gettext('Delete');?>
 			</button>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist.php
@@ -151,6 +151,7 @@ display_top_tabs($tab_array, true);
 			<tr>
 				<th>&nbsp;</th>
 				<th>List Name</th>
+				<th>Assigned</th>
 				<th>Description</th>
 				<th>Actions</th>
 			</tr>
@@ -160,10 +161,11 @@ display_top_tabs($tab_array, true);
 			<tr>
 				<td><input type="checkbox" id="frc<?=$i?>" name="del[]" value="<?=$i?>" onclick="fr_bgcolor('<?=$i?>')" /></td>
 				<td ondblclick="document.location='snort_passlist_edit.php?id=<?=$i;?>';"><?=htmlspecialchars($list['name']);?></td>
+				<td ondblclick="document.location='snort_passlist_edit.php?id=<?=$i;?>';"><?=snort_is_passlist_used($list['name']) ? gettext("Yes"):gettext("No");?></td>
 				<td ondblclick="document.location='snort_passlist_edit.php?id=<?=$i;?>';"><?=htmlspecialchars($list['descr']);?>&nbsp;</td>
-				<td style="cursor: pointer;"><a href="snort_passlist_edit.php?id=<?=$i;?>" class="fa fa-pencil" title="<?=gettext('Edit Pass List');?>"></a>
-				<a class="fa fa-trash no-confirm" id="Xcdel_<?=$i?>" title="<?=gettext('Delete Pass List'); ?>"></a>
-				<button style="display: none;" class="btn btn-xs btn-warning" type="submit" id="cdel_<?=$i?>" name="cdel_<?=$i?>" value="cdel_<?=$i?>" title="<?=gettext('Delete Pass List'); ?>">Delete Pass List</button></td>
+				<td style="cursor: pointer;"><a href="snort_passlist_edit.php?id=<?=$i;?>" class="fa fa-pencil" title="<?=gettext('Edit this Pass List');?>"></a>
+				<a class="fa fa-trash no-confirm" id="Xcdel_<?=$i?>" title="<?=gettext('Delete this Pass List'); ?>"></a>
+				<button style="display: none;" class="btn btn-xs btn-warning" type="submit" id="cdel_<?=$i?>" name="cdel_<?=$i?>" value="cdel_<?=$i?>" title="<?=gettext('Delete this Pass List'); ?>">Delete Pass List</button></td>
 			</tr>
 		<?php endforeach; ?>
 			</tbody>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist_edit.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2004-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2019 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * originially part of m0n0wall (http://m0n0.ch/wall)
@@ -30,15 +30,14 @@ require_once("/usr/local/pkg/snort/snort.inc");
 
 $pconfig = array();
 
-if ($_POST['cancel']) {
-	header("Location: /snort/snort_passlist.php");
-	exit;
-}
+// Arbitrary limit for IP or Alias entries per Pass List.
+$max_addresses = 1000;
 
 if (!is_array($config['installedpackages']['snortglobal']['whitelist']))
 	$config['installedpackages']['snortglobal']['whitelist'] = array();
 if (!is_array($config['installedpackages']['snortglobal']['whitelist']['item']))
 	$config['installedpackages']['snortglobal']['whitelist']['item'] = array();
+
 $a_passlist = &$config['installedpackages']['snortglobal']['whitelist']['item'];
 
 if (isset($_POST['id']) && is_numericint($_POST['id']))
@@ -49,41 +48,34 @@ elseif (isset($_GET['id']) && is_numericint($_GET['id'])) {
 
 /* Should never be called without identifying list index, so bail */
 if (is_null($id)) {
-	unset($a_passlist);
 	header("Location: /snort/snort_passlist.php");
 	exit;
 }
 
 if (isset($id) && isset($a_passlist[$id])) {
 	/* Retrieve saved settings */
-	$pconfig['name'] = $a_passlist[$id]['name'];
-	$pconfig['uuid'] = $a_passlist[$id]['uuid'];
-	$pconfig['address'] = $a_passlist[$id]['address'];
-	$pconfig['descr'] = html_entity_decode($a_passlist[$id]['descr']);
-	$pconfig['localnets'] = $a_passlist[$id]['localnets'];
-	$pconfig['wangateips'] = $a_passlist[$id]['wangateips'];
-	$pconfig['wandnsips'] = $a_passlist[$id]['wandnsips'];
-	$pconfig['vips'] = $a_passlist[$id]['vips'];
-	$pconfig['vpnips'] = $a_passlist[$id]['vpnips'];
+	$pconfig = $a_passlist[$id];
 }
 
-// Check for returned "selected alias" if action is import
-if ($_GET['act'] == "import") {
-
-	// Retrieve previously typed values we passed to SELECT ALIAS page
-	$pconfig['name'] = htmlspecialchars($_GET['name']);
-	$pconfig['uuid'] = htmlspecialchars($_GET['uuid']);
-	$pconfig['address'] = htmlspecialchars($_GET['address']);
-	$pconfig['descr'] = htmlspecialchars($_GET['descr']);
-	$pconfig['localnets'] = htmlspecialchars($_GET['localnets'])? 'yes' : 'no';
-	$pconfig['wangateips'] = htmlspecialchars($_GET['wangateips'])? 'yes' : 'no';
-	$pconfig['wandnsips'] = htmlspecialchars($_GET['wandnsips'])? 'yes' : 'no';
-	$pconfig['vips'] = htmlspecialchars($_GET['vips'])? 'yes' : 'no';
-	$pconfig['vpnips'] = htmlspecialchars($_GET['vpnips'])? 'yes' : 'no';
-
-	// Now retrieve the "selected alias" returned from SELECT ALIAS page
-	if ($_GET['varname'] == "address" && isset($_GET['varvalue']))
-		$pconfig[$_GET['varname']] = htmlspecialchars($_GET['varvalue']);
+// Set defaults for any non-initialized values
+if (!isset($pconfig['localnets'])) {
+	$pconfig['localnets'] = "yes";
+}
+if (!isset($pconfig['wangateips'])) {
+	$pconfig['wangateips'] = "yes";
+}
+if (!isset($pconfig['wandnsips'])) {
+	$pconfig['wandnsips'] = "yes";
+}
+if (!isset($pconfig['vips'])) {
+	$pconfig['vips'] = "yes";
+}
+if (!isset($pconfig['vpnips'])) {
+	$pconfig['vpnips'] = "yes";
+}
+if (!is_array($pconfig['address'])) {
+	$pconfig['address'] = array();
+	$pconfig['address']['item'] = array();
 }
 
 /* If no entry for this passlist, then create a UUID and treat it like a new list */
@@ -101,20 +93,10 @@ elseif (!empty($pconfig['uuid'])) {
 else
 	$passlist_uuid = $a_passlist[$id]['uuid'];
 
-/* returns true if $name is a valid name for a pass list file name or ip */
-function is_validpasslistname($name) {
-	if (!is_string($name))
-		return false;
-
-	if (!preg_match("/[^a-zA-Z0-9\_\.\/]/", $name))
-		return true;
-
-	return false;
-}
-
-if ($_POST['save']) {
+if ($_POST['save'] == "Save") {
 	unset($input_errors);
-	$pconfig = $_POST;
+	$pconfig = array();
+	$p_list = array();
 
 	/* input validation */
 	$reqdfields = explode(" ", "name");
@@ -123,31 +105,36 @@ if ($_POST['save']) {
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if(strtolower($_POST['name']) == "defaultpasslist")
-		$input_errors[] = gettext("Pass List file names may not be named defaultpasslist.");
-
-	if (is_validpasslistname($_POST['name']) == false)
-		$input_errors[] = gettext("Pass List file name may only consist of the characters \"a-z, A-Z, 0-9 and _\". Note: No Spaces or dashes. Press Cancel to reset.");
+		$input_errors[] = gettext("Pass List file names may not be named 'defaultpasslist' as that is a reserved name.");
 
 	/* check for name conflicts */
-	foreach ($a_passlist as $p_list) {
-		if (isset($id) && ($a_passlist[$id]) && ($a_passlist[$id] === $p_list))
+	foreach ($a_passlist as $k) {
+		if (isset($id) && isset($a_passlist[$id]) && ($a_passlist[$id] === $k))
 			continue;
 
-		if ($p_list['name'] == $_POST['name']) {
-			$input_errors[] = gettext("A Pass List file name with this name already exists.");
+		if ($k['name'] == $_POST['name']) {
+			$input_errors[] = gettext("A Pass List with this name already exists.");
 			break;
 		}
 	}
 
-	if ($_POST['address']) {
-		if (!is_alias($_POST['address']))
-			$input_errors[] = gettext("A valid alias must be provided.");
-		if (is_alias($_POST['address']) && trim(filter_expand_alias($_POST['address'])) == "")
-			$input_errors[] = gettext("FQDN aliases are not supported in Snort.");
+	// Iterate and validate the returned $_POST['address'] values (these will be "addressX" where "X" is a number from 0 - 999).
+	$addrs = array();
+	for ($x = 0; $x < ($max_addresses - 1); $x++) {
+		if ($_POST["address{$x}"] <> "") {
+
+			// Verify the entry is a valid IP address, subnet or alias name
+			if (is_ipaddroralias($_POST["address{$x}"]) || is_subnet($_POST["address{$x}"])) {
+				$addrs[] = $_POST["address{$x}"];
+			} else {
+				$input_errors[] = gettext("Custom Address entry '" . $_POST["address{$x}"] . "' is not a valid IP address, IP subnet or Alias name!");
+				$addrs[] = $_POST["address{$x}"];
+			}
+		}
 	}
 
 	if (!$input_errors) {
-		$p_list = array();
+
 		/* post user input */
 		$p_list['name'] = $_POST['name'];
 		$p_list['uuid'] = $passlist_uuid;
@@ -156,25 +143,36 @@ if ($_POST['save']) {
 		$p_list['wandnsips'] = $_POST['wandnsips']? 'yes' : 'no';
 		$p_list['vips'] = $_POST['vips']? 'yes' : 'no';
 		$p_list['vpnips'] = $_POST['vpnips']? 'yes' : 'no';
-		$p_list['address'] = $_POST['address'];
+		$p_list['address']['item'] = $addrs;
 		$p_list['descr']  =  mb_convert_encoding($_POST['descr'],"HTML-ENTITIES","auto");
 
-		if (isset($id) && $a_passlist[$id])
+		if (isset($id) && isset($a_passlist[$id])) {
 			$a_passlist[$id] = $p_list;
-		else
+		} else {
 			$a_passlist[] = $p_list;
+		}
+
+		$pconfig = $p_list;
 
 		write_config("Snort pkg: modified PASS LIST {$p_list['name']}.");
 
-		/* create pass list and homenet file, then sync files */
+		/* create pass list file, then sync file with configured partners */
 		sync_snort_package_config();
-		unset($a_passlist);
-		header("Location: /snort/snort_passlist.php");
-		exit;
+	} else {
+		$pconfig['name'] = $_POST['name'];
+		$pconfig['uuid'] = $passlist_uuid;
+		$pconfig['localnets'] = $_POST['localnets']? 'yes' : 'no';
+		$pconfig['wangateips'] = $_POST['wangateips']? 'yes' : 'no';
+		$pconfig['wandnsips'] = $_POST['wandnsips']? 'yes' : 'no';
+		$pconfig['vips'] = $_POST['vips']? 'yes' : 'no';
+		$pconfig['vpnips'] = $_POST['vpnips']? 'yes' : 'no';
+		$pconfig['descr']  =  mb_convert_encoding($_POST['descr'],"HTML-ENTITIES","auto");
+		$pconfig['address']['item'] = $addrs;
 	}
 }
 
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Pass List Edit"));
+$pglinks = array("", "/snort/snort_interfaces.php", "/snort/snort_passlist.php", "@self");
+$pgtitle = array("Services", "Snort", "Pass List", "Pass List Edit");
 include_once("head.inc");
 
 if ($input_errors)
@@ -196,7 +194,25 @@ $tab_array[] = array(gettext("Log Mgmt"), false, "/snort/snort_log_mgmt.php");
 $tab_array[] = array(gettext("Sync"), false, "/pkg_edit.php?xml=snort/snort_sync.xml");
 display_top_tabs($tab_array,true);
 
-$form = new Form(FALSE);
+$pattern_str = array(	'network' => '[a-zA-Z0-9_:.-]+(/[0-9]+)?( [a-zA-Z0-9_:.-]+(/[0-9]+)?)*',	// Alias Name, Host Name, IP Address, FQDN, Network or IP Address Range
+			'host'	  => '[\pL0-9_:.-]+(/[0-9]+)?( [a-zA-Z0-9_:.-]+(/[0-9]+)?)*'		// Alias Name, Host Name, IP Address, FQDN
+);
+$help = gettext("Enter as many IP addresses or alias names as desired. Enter ONLY an IP address, IP subnet or alias name! Do NOT enter a FQDN (fully qualified domain name) directly! " . 
+		"To use a FQDN, first create the necessary firewall alias, and then provide the alias name here. FQDN aliases are periodically re-resolved and updated by the firewall. " . 
+		"You can also provide an IP subnet with a proper netmask of the form network/mask such as 1.2.3.0/24.");
+
+$form = new Form();
+
+// Include the Pass List ID in a hidden form field with any $_POST
+if (isset($id)) {
+	$form->addGlobal(new Form_Input(
+		'id',
+		'id',
+		'hidden',
+		$id
+	));
+}
+
 $section = new Form_Section('General Information');
 $section->addInput(new Form_Input(
 	'name',
@@ -216,93 +232,146 @@ $section = new Form_Section('Auto-Generated IP Addresses');
 $section->addInput(new Form_Checkbox(
 	'localnets',
 	'Local Networks',
-	'Add firewall Locally-Attached Networks to the list (excluding WAN).',
+	'Add firewall Locally-Attached Networks to the list (excluding WAN). Default is Checked.',
 	$pconfig['localnets'] == 'yes' ? true:false,
 	'yes'
 ));
 $section->addInput(new Form_Checkbox(
 	'wangateips',
 	'WAN Gateways',
-	'Add WAN Gateways to the list.',
+	'Add WAN Gateways to the list. Default is Checked.',
 	$pconfig['wangateips'] == 'yes' ? true:false,
 	'yes'
 ));
 $section->addInput(new Form_Checkbox(
 	'wandnsips',
 	'WAN DNS Servers',
-	'Add WAN DNS servers to the list.',
+	'Add WAN DNS servers to the list. Default is Checked.',
 	$pconfig['wandnsips'] == 'yes' ? true:false,
 	'yes'
 ));
 $section->addInput(new Form_Checkbox(
 	'vips',
 	'Virtual IP Addresses',
-	'Add Virtual IP Addresses to the list.',
+	'Add Virtual IP Addresses to the list. Default is Checked.',
 	$pconfig['vips'] == 'yes' ? true:false,
 	'yes'
 ));
 $section->addInput(new Form_Checkbox(
 	'vpnips',
 	'VPN Addresses',
-	'Add VPN Addresses to the list.',
+	'Add VPN Addresses to the list. Default is Checked.',
 	$pconfig['vpnips'] == 'yes' ? true:false,
 	'yes'
 ));
 $form->add($section);
 
-$section = new Form_Section('Custom IP Address from Configured Alias');
-$section->addInput(new Form_Input(
-	'address',
-	'Assigned Alias',
-	'text',
-	$pconfig['address']
-))->setHelp('Enter the name of an existing Alias.')->setAttribute('title', trim(filter_expand_alias($pconfig['address'])));
-$form->add($section);
+$section = new Form_Section('Custom IP Addresses and Configured Firewall Aliases');
 
-$section = new Form_Section('');
-$btnsave = new Form_Button(
-	'save',
-	'Save',
-	null,
-	'fa-save'
-);
-$btncancel = new Form_Button(
-	'cancel',
-	'Cancel'
-);
-$btnsave->addClass('btn-primary')->addClass('btn-default');
-$btncancel->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-warning');
-
+// Make somewhere to park the help text, and give it a class so we can update it later if desired
 $section->addInput(new Form_StaticText(
-	null,
-	$btnsave . $btncancel
+	'Hint',
+	'<span class="helptext">' . $help . '</span>'
 ));
+
+// Iterate any defined IPs or Aliases defined for this list, otherwise
+// create a single empty initial empty row.
+if (count($pconfig['address']['item']) > 0) {
+	$counter = 0;
+	while ($counter < count($pconfig['address']['item'])) {
+		$group = new Form_Group('IP or Alias');
+		$group->addClass('repeatable');
+
+		$group->add(new Form_IpAddress(
+			'address' . $counter,
+			'Address',
+			$pconfig['address']['item'][$counter],
+			'ALIASV4V6'
+		));
+
+		$group->add(new Form_Button(
+			'deleterow' . $counter,
+			'Delete',
+			null,
+			'fa-trash'
+		))->addClass('btn-warning btn-sm nowarn')->setAttribute('title', "Delete this entry from list");
+
+		$section->add($group);
+		$counter++;
+	}
+} else {
+	$group = new Form_Group('IP or Alias');
+	$group->addClass('repeatable');
+
+	$group->add(new Form_IpAddress(
+		'address0',
+		'Address',
+		'',
+		'ALIASV4V6'
+	));
+
+	$group->add(new Form_Button(
+		'deleterow0',
+		'Delete',
+		null,
+		'fa-trash'
+	))->addClass('btn-warning btn-sm nowarn')->setAttribute('title', "Delete this entry from list");
+
+	$section->add($group);
+}
 $form->add($section);
 
-// Include the Pass List ID in a hidden form field with any $_POST
-if (isset($id)) {
-	$form->addGlobal(new Form_Input(
-		'id',
-		'id',
-		'hidden',
-		$id
-	));
-}
+$form->addGlobal(new Form_Button(
+	'addrow',
+	'Add IP',
+	null,
+	'fa-plus'
+))->addClass('btn-success addbtn')->setAttribute('title', "Add new IP address, subnet or alias name row");
 
 print($form);
-unset($a_passlist);
 ?>
 
 <script type="text/javascript">
 //<![CDATA[
+// ---------- Autocomplete --------------------------------------------------------------------
+var addressarray = <?= json_encode(get_alias_list(array("host", "network"))) ?>;
+
 events.push(function() {
 
-	// ---------- Autocomplete --------------------------------------------------------------------
+	// Hide and disable all rows >= that specified
+	function hideRowsAfter(row, hide) {
+		var idx = 0;
 
-	var addressarray = <?= json_encode(get_alias_list(array("host", "network", "openvpn"))) ?>;
+		$('.repeatable').each(function(el) {
+			if (idx >= row) {
+				hideRow(idx, hide);
+			}
 
-	$('#address').autocomplete({
-		source: addressarray
+			idx++;
+		});
+	}
+
+	function hideRow(row, hide) {
+		if (hide) {
+			$('#deleterow' + row).parent('div').parent().addClass('hidden');
+		} else {
+			$('#deleterow' + row).parent('div').parent().removeClass('hidden');
+		}
+
+		// We need to disable the elements so they are not submitted in the POST
+		$('#address' + row).prop("disabled", hide);
+		$('#deleterow' + row).prop("disabled", hide);
+	}
+
+	checkLastRow();
+
+	// Autocomplete
+	$('[id^=address]').each(function() {
+		if (this.id.substring(0, 8) != "address_") {
+			$(this).autocomplete({
+				source: addressarray
+			});
+		}
 	});
 });
 //]]>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist_edit.php
@@ -172,7 +172,7 @@ if ($_POST['save'] == "Save") {
 }
 
 $pglinks = array("", "/snort/snort_interfaces.php", "/snort/snort_passlist.php", "@self");
-$pgtitle = array("Services", "Snort", "Pass List", "Pass List Edit");
+$pgtitle = array("Services", "Snort", "Pass List", "Edit");
 include_once("head.inc");
 
 if ($input_errors)

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_preprocessors.php
@@ -6,7 +6,7 @@
  * Copyright (c) 2011-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2008-2009 Robert Zelaya
- * Copyright (c) 2013-2020 Bill Meeks
+ * Copyright (c) 2013-2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -811,7 +811,8 @@ if ($pconfig['host_attribute_table'] == 'on' && empty($pconfig['host_attribute_d
 if (empty($if_friendly)) {
 	$if_friendly = "None";
 }
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Preprocessors and Flow"), gettext("{$if_friendly}"));
+$pglinks = array("", "/snort/snort_interfaces.php", "/snort/snort_interfaces_edit.php?id={$id}", "@self");
+$pgtitle = array("Services", "Snort", "Interface Settings", "{$if_friendly} - Preprocessors and Flow");
 include("head.inc");
 
 /* Display Alert message */

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
@@ -938,7 +938,9 @@ elseif ($_POST['apply']) {
 $if_friendly = convert_friendly_interface_to_friendly_descr($a_rule[$id]['interface']);
 if (empty($if_friendly)) {
 	$if_friendly = "None";
-}$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Rules"), gettext("{$if_friendly}"));
+}
+$pglinks = array("", "/snort/snort_interfaces.php", "/snort/snort_interfaces_edit.php?id={$id}", "@self");
+$pgtitle = array("Services", "Snort", "Interface Settings", "{$if_friendly} - Rules");
 include("head.inc");
 
 // Display error messages if we have any

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009 Robert Zelaya
- * Copyright (c) 2020 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -261,7 +261,8 @@ $if_friendly = convert_friendly_interface_to_friendly_descr($a_nat[$id]['interfa
 if (empty($if_friendly)) {
 	$if_friendly = "None";
 }
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Categories"), gettext("{$if_friendly}"));
+$pglinks = array("", "/snort/snort_interfaces.php", "/snort/snort_interfaces_edit.php?id={$id}", "@self");
+$pgtitle = array("Services", "Snort", "Interface Settings", "{$if_friendly} - Categories");
 include_once("head.inc");
 
 /* Display message */

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_select_alias.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_select_alias.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -219,7 +219,7 @@ if (!in_array($alias['type'], $a_types))
 
 	print_info_box('<strong>' . gettext('Note:') . '<br></strong>' . gettext('Fully-Qualified Domain Name (FQDN) host Aliases cannot be used as Snort configuration parameters. ' .
 		' Aliases resolving to a single FQDN value are disabled in the list above. ' .
-		'In the case of nested Aliases where one or more of the nested values is a FQDN host, the FQDN host will not be included in ' . $title . ' configuration.'), info, false);
+		'In the case of nested Aliases where one or more of the nested values is a FQDN host, the FQDN host will not be included in ' . $title . ' configuration.'), "info", false);
 } ?>
 </div>
 </form>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2019 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -360,7 +360,8 @@ foreach ($sidmodlists as $list) {
 	$sidmodselections[] = $list['name'];
 }
 
-$pgtitle = array(gettext('Services'), gettext('Snort'), gettext('SID Management'));
+$pglinks = array("", "/snort/snort_interfaces.php", "@self");
+$pgtitle = array('Services', 'Snort', 'SID Management');
 include_once("head.inc");
 
 /* Display Alert message, under form tag or no refresh */

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_stream5_engine.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_stream5_engine.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2018-2021 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2013-2018 Bill Meeks
+ * Copyright (c) 2013-2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -338,7 +338,8 @@ if ($_POST['save']) {
 }
 
 $if_friendly = convert_friendly_interface_to_friendly_descr($config['installedpackages']['snortglobal']['rule'][$id]['interface']);
-$pgtitle = array(gettext("Services"), gettext("Snort"), gettext("Stream5 Preprocessor TCP Engine"), gettext("{$if_friendly}"));
+$pglinks = array("", "/snort/snort_interfaces.php", "/snort/snort_interfaces_edit.php?id={$id}", "@self");
+$pgtitle = array("Services", "Snort", "Interface Settings", "{$if_friendly} - Stream5 Preprocessor TCP Engine");
 include("head.inc");
 
 if ($input_errors) print_input_errors($input_errors);


### PR DESCRIPTION
### pfSense-pkg-snort-4.1.3_2
This update to the Snort GUI package provides support for the assignment of multiple custom IP addresses, IP subnets and/or alias names to a Pass List. This includes aliases with content that is dynamically updated by the _filterdns_ daemon. Two new features and three bug fixes are included.

**New Features:**
1. Support for multiple custom IP address, IP subnet and/or alias names in a Pass List.
2. On the PASS LISTS tab, a new column indicates if a Pass List is currently assigned to an active interface.

**Bug Fixes:**
1. Undefined constant warning from PHP due to missing quotes in Select Alias and Import Alias dialogs when the help info block is opened.
2. Incorrect variable name in config migration script resulting in config migration repeating and attempting to remove deprecated Barnyard2 settings with each upgrade.
3. Add proper breadcrumbs links to page headers in the GUI.