### PR TITLE
pfBlockerNG-devel v3.0.0_11

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -384,8 +384,11 @@ function pfb_filter_service() {
 		exit
 	fi
 
-	# Ensure all processes are stopped
-	rc_stop
+	# clog is not required for pfSense 2.5 and above
+	filter_type='tail_pfb'
+	if [ -e "/usr/local/sbin/clog_pfb" ]; then
+		filter_type='clog_pfb'
+	fi
 
 	# Compare php/php_pfb versions
 	php_path='/usr/local/bin'
@@ -409,8 +412,9 @@ function pfb_filter_service() {
 
 	# Start pfBlockerNG Firewall filter Daemon
 	if [ -e '/var/log/filter.log' ]; then
-		# clog is not required for pfSense 2.5 and above
-		if [ -e "/usr/local/sbin/clog_pfb" ]; then
+		/usr/bin/logger -p daemon.info -t "\${filter_type}" "[pfBlockerNG] Firewall Filter Service started"
+
+		if [ "\${filter_type}" == 'clog_pfb' ]; then
 			/usr/local/sbin/clog_pfb -f /var/log/filter.log | /usr/local/bin/php_pfb -f /usr/local/pkg/pfblockerng/pfblockerng.inc filterlog &
 		else
 			/usr/bin/tail_pfb -n0 -F /var/log/filter.log | /usr/local/bin/php_pfb -f /usr/local/pkg/pfblockerng/pfblockerng.inc filterlog &
@@ -420,8 +424,16 @@ function pfb_filter_service() {
 EOF;
 	$rc['stop']	= <<<EOF
 
+	# clog is not required for pfSense 2.5 and above
+	filter_type='tail_pfb'
+	if [ -e "/usr/local/sbin/clog_pfb" ]; then
+		filter_type='clog_pfb'
+	fi
+
 	# Terminate pfBlockerNG Firewall filter Daemon (clog) and filter Daemon, if found
-	pidnum="\$(/bin/ps -wax | /usr/bin/grep '[c]log_pfb -f /var/log/filter.log\|[t]ail_pfb -F /var/log/filter.log\|[p]fblockerng.inc filterlog' | /usr/bin/awk '{print \$1}')"
+	/usr/bin/logger -p daemon.info -t "\${filter_type}" "[pfBlockerNG] Firewall Filter Service stopped"
+	/usr/bin/logger -p daemon.info -t php_pfb "[pfBlockerNG] filterlog daemon stopped"
+	pidnum="\$(/bin/ps -wax | /usr/bin/grep '[c]log_pfb -f /var/log/filter.log\|[t]ail_pfb -n0 /var/log/filter.log\|[p]fblockerng.inc filterlog' | /usr/bin/awk '{print \$1}')"
 	if [ ! -z "\${pidnum}" ]; then
 		for i in \${pidnum}; do
 			/bin/kill -9 "\${i}"
@@ -446,9 +458,6 @@ function pfb_dnsbl_service() {
 		exit
 	fi
 
-	# Ensure all processes are stopped
-	rc_stop
-
 	# Start DNSBL Lighttpd webserver (Unbound/Python mode) and DNSBL HTTPS Daemon (Unbound mode only)
 	if [ -e '/var/unbound/pfb_dnsbl_lighty.conf' ]; then
 		/usr/bin/logger -p daemon.info -t lighttpd_pfb "[pfBlockerNG] DNSBL Webserver started"
@@ -467,6 +476,7 @@ EOF;
 	$rc['stop']	= <<<EOF
 
 	# Terminate DNSBL Lighttpd webserver, if found
+	/usr/bin/logger -p daemon.info -t lighttpd_pfb "[pfBlockerNG] DNSBL Webserver stopped"
 	pidnum="\$(/bin/pgrep lighttpd_pfb)"
 	if [ ! -z "\${pidnum}" ]; then
 		/usr/bin/killall lighttpd_pfb
@@ -1167,11 +1177,12 @@ EOF;
 }
 	// Lighttpd v1.4.58+ conditional error log with 'ssl.verifyclient.activate' to collect the domain name
 	$lighty_ver = exec('/usr/local/sbin/lighttpd -v 2>&1');
-	if (strpos($lighty_ver, 'lighttpd/1.4.58') !== FALSE ||
+	if ((!$pfb['dnsbl_py_blacklist'] || $pfb['dnsbl_py_nolog'] == 'on') &&
+  	    (strpos($lighty_ver, 'lighttpd/1.4.58') !== FALSE ||
 	    strpos($lighty_ver, 'lighttpd/1.4.59') !== FALSE ||
 	    strpos($lighty_ver, 'lighttpd/1.4.60') !== FALSE ||
 	    strpos($lighty_ver, 'lighttpd/1.4.61') !== FALSE ||
-	    strpos($lighty_ver, 'lighttpd/1.5') !== FALSE) {
+	    strpos($lighty_ver, 'lighttpd/1.5') !== FALSE)) {
 
 		$pfb_conf .= <<<EOF
 ssl.verifyclient.activate	= "enable"
@@ -1931,11 +1942,6 @@ function pfb_unbound_python($mode) {
 			$python_idn = 'on';
 		}
 
-		$python_tld = 'off';
-		if ($pfb['dnsbl_pytld'] == 'on' && !empty($pfb['dnsblconfig']['pfb_pytlds_gtld'])) {
-			$python_tld = 'on';
-		}
-
 		$python_cname = 'off';
 		if ($pfb['dnsbl_cname'] == 'on') {
 			$python_cname = 'on';
@@ -1951,20 +1957,28 @@ function pfb_unbound_python($mode) {
 			$python_noaaaa = 'on';
 		}
 
-		$python_tlds = '';
-		if (!empty($pfb['dnsblconfig']['pfb_pytlds_gtld'])) {
-			$python_tlds = $pfb['dnsblconfig']['pfb_pytlds_gtld'];
+		$python_tld = 'off';
+		if ($pfb['dnsbl_pytld'] == 'on') {
+
+			$python_tlds = '';
+			if (!empty($pfb['dnsblconfig']['pfb_pytlds_gtld'])) {
+				$python_tld = 'on';
+				$python_tlds = $pfb['dnsblconfig']['pfb_pytlds_gtld'];
+			}
+			if (!empty($pfb['dnsblconfig']['pfb_pytlds_cctld'])) {
+				$python_tld = 'on';
+				$python_tlds .= ',' . $pfb['dnsblconfig']['pfb_pytlds_cctld'];
+			}
+			if (!empty($pfb['dnsblconfig']['pfb_pytlds_itld'])) {
+				$python_tld = 'on';
+				$python_tlds .= ',' . $pfb['dnsblconfig']['pfb_pytlds_itld'];
+			}
+			if (!empty($pfb['dnsblconfig']['pfb_pytlds_bgtld'])) {
+				$python_tld = 'on';
+				$python_tlds .= ',' . $pfb['dnsblconfig']['pfb_pytlds_bgtld'];
+			}
+			$python_tlds = ltrim($python_tlds, ',');
 		}
-		if (!empty($pfb['dnsblconfig']['pfb_pytlds_cctld'])) {
-			$python_tlds .= ',' . $pfb['dnsblconfig']['pfb_pytlds_cctld'];
-		}
-		if (!empty($pfb['dnsblconfig']['pfb_pytlds_itld'])) {
-			$python_tlds .= ',' . $pfb['dnsblconfig']['pfb_pytlds_itld'];
-		}
-		if (!empty($pfb['dnsblconfig']['pfb_pytlds_bgtld'])) {
-			$python_tlds .= ',' . $pfb['dnsblconfig']['pfb_pytlds_bgtld'];
-		}
-		$python_tlds = ltrim($python_tlds, ',');
 
 		$python_nolog = 'off';
 		if ($pfb['dnsbl_py_nolog'] == 'on') {
@@ -2464,11 +2478,11 @@ function tld_analysis() {
 				$s_info = trim($eparts[2]);
 
 				if ($pfb['dnsbl_v6'] == 'on') {
-					// Determine if DNSBL Logging is disabled and switch to '::'
+					// Determine if DNSBL Logging is disabled and switch to '::/0'
 					if (strpos($s_info, ' A 0.0.0.0') !== FALSE) {
-						$s_info6 = str_replace(' A 0.0.0.0', ' AAAA ::', $s_info);
+						$s_info6 = str_replace(' A 0.0.0.0', ' AAAA ::/0', $s_info);
 					} else {
-						$s_info6 = str_replace(' A ', ' AAAA ::', $s_info);
+						$s_info6 = str_replace(' A ', ' AAAA ::/0', $s_info);
 					}
 				}
 
@@ -3913,8 +3927,12 @@ function pfb_aliastables($mode) {
 				$files_to_backup = "{$pfb['aliasdir']}/pfB_*.txt";
 			}
 
-			if ($pfb['dnsbl'] == 'on' && file_exists("{$pfb['dnsbl_file']}.conf")) {
-				$files_to_backup .= " {$pfb['dnsbl_file']}.conf";
+			if ($pfb['dnsbl'] == 'on') {
+				if (file_exists("{$pfb['dnsbl_file']}.conf")) {
+					$files_to_backup .= " {$pfb['dnsbl_file']}.conf";
+				} else {
+					$files_to_backup .= " /var/unbound/pfb_unbound* /var/unbound/pfb_py_*";
+				}
 			}
 
 			// Archive IP Aliastables/Unbound DNSBL Database as required.
@@ -4001,6 +4019,7 @@ function pfb_filterrules() {
 	$rule_list		= array();
 	$rule_list['id']	= array();
 	$rule_list['other']	= array();
+	$rule_list['int']	= array();
 
 	exec("{$pfb['pfctl']} -vvsr 2>&1", $results);
 	if (!empty($results)) {
@@ -4026,6 +4045,11 @@ function pfb_filterrules() {
 					$rule_list['id'][]	= $id;
 					$rule_list[$id]['name']	= $descr;
 					$rule_list[$id]['type'] = $type;
+
+					$int = trim(strstr(trim(strstr(trim(strstr($r[1], ' on ', FALSE)), ' ', FALSE)), ' ', TRUE));
+					if (!empty($int)) {
+						 $rule_list['int'][$int] = '';
+					}
 				}
 
 				// All other non-pfBlockerNG Tracker IDs
@@ -4092,6 +4116,14 @@ function pfb_remove_states() {
 		}
 	}
 
+	if (!empty($pfb_local)) {
+		$pfb_local = array_flip($pfb_local);
+	}
+
+	// Collect Interface list that have pfB Rules assigned
+	$data		= pfb_filterrules();
+	$pfb_int	= $data['int'] ?: array();
+
 	// Collect local IPs
 	$data = pfb_collect_localip();
 	if (!empty($data[0])) {
@@ -4151,6 +4183,12 @@ function pfb_remove_states() {
 			if (!empty($sline)) {
 
 				$detail	= array_filter(explode(' ', $sline));
+
+				// Validate states for pfB Interfaces only
+				if (!isset($pfb_int[$detail[0]])) {
+					continue;
+				}
+
 				$count	= count($detail);
 				if ($count == 6) {
 					$orig_s_ip = $detail[2];
@@ -7202,10 +7240,10 @@ function sync_package_pfblockerng($cron='') {
 								$list['logging'] = 'enabled';
 							}
 
-							// If Null Blocking mode is selected, use '0.0.0.0|::', otherwise utilize DNSBL WebServer/DNSBL VIP
+							// If Null Blocking mode is selected, use '0.0.0.0|::/0', otherwise utilize DNSBL WebServer/DNSBL VIP
 							if ($list['logging'] == 'disabled') {
 								$sinkhole_type4 = '0.0.0.0';
-								$sinkhole_type6 = '::';
+								$sinkhole_type6 = '::/0';
 								$logging_type	= '2';	// Null Blocking no logging
 							}
 							elseif ($list['logging'] == 'disabled_log') {
@@ -7819,6 +7857,15 @@ function sync_package_pfblockerng($cron='') {
 			}
 			if ($pfb['dnsbl_pytld'] == 'on') {
 				$pytld_cnt = 0;
+				foreach (array('gtld', 'cctld', 'itld', 'bgtld') as $pytld) {
+					if (isset($pfb['dnsblconfig']['pfb_pytlds_' . $pytld]) && !empty($pfb['dnsblconfig']['pfb_pytlds_' . $pytld])) {
+						$p_cnt = count(explode(',', $pfb['dnsblconfig']['pfb_pytlds_' . $pytld]));
+						if (is_numeric($p_cnt) && $p_cnt > 0) {
+							$pytld_cnt += $p_cnt;
+						}
+					}
+				}
+
 				$pfb['alias_dnsbl_all'][] = 'DNSBL_TLD_Allow';
 				dnsbl_alias_update('update', 'DNSBL_TLD_Allow', '', '', $pytld_cnt);
 			}
@@ -8130,9 +8177,15 @@ function sync_package_pfblockerng($cron='') {
 								}
 
 								if ($file_chk <= 1) {
-									@file_put_contents("{$pfbfolder}/{$cc_alias}.txt", "{$pfb['ip_ph']}\n", LOCK_EX);
+									if ($vtype == '_v6') {
+                                                                                $p_ip = "::{$pfb['ip_ph']}";
+                                                                        } else {
+                                                                                $p_ip = $pfb['ip_ph'];
+                                                                        }
+
+									@file_put_contents("{$pfbfolder}/{$cc_alias}.txt", "{$p_ip}\n", LOCK_EX);
 									@copy("{$pfbfolder}/{$cc_alias}.txt", "{$pfb['aliasdir']}/{$cc_alias}.txt");
-									$log = "[ {$cc_alias} ] Found no unique IPs, adding '{$pfb['ip_ph']}' to avoid empty file\n";
+									$log = "[ {$cc_alias} ] Found no unique IPs, adding '{$p_ip}' to avoid empty file\n";
 									pfb_logger("{$log}", 1);
 								}
 							}
@@ -8547,7 +8600,13 @@ function sync_package_pfblockerng($cron='') {
 										// Auto IPv6 parser
 										if ($pftype == 'auto') {
 											if (strpos($line, ':') !== FALSE) {
-												if (is_ipaddrv6($line) || is_subnet($line)) {
+
+												// Remove any comments
+												if (strpos($line, '#') !== FALSE) {
+													$line = str_replace('#', '', strstr($line, '#', TRUE));
+												}
+
+												if (is_ipaddrv6($line) || is_subnetv6($line)) {
 													$ip_data .= $line . "\n";
 													continue;
 												}
@@ -8559,9 +8618,14 @@ function sync_package_pfblockerng($cron='') {
 											$matches = array_unique($matches[0]);
 											foreach ($matches as $match) {
 
+												// Remove any comments
+												if (strpos($match, '#') !== FALSE) {
+													$match = str_replace('#', '', strstr($match, '#', TRUE));
+												}
+
 												// Workaround to skip cloudflare error pages
 												if (strpos($oline, 'cf-footer-item') === FALSE) {
-													if (is_ipaddrv6($match) || is_subnet($match)) {
+													if (is_ipaddrv6($match) || is_subnetv6($match)) {
 														$ip_data .= $match . "\n";
 													}
 												}
@@ -8588,8 +8652,14 @@ function sync_package_pfblockerng($cron='') {
 								}
 
 								if ($file_chk == 0) {
-									$ip_data	= "{$pfb['ip_ph']}\n";
-									$log		= "  Empty file, Adding '{$pfb['ip_ph']}' to avoid download failure.\n";
+									if ($list['vtype'] == '_v6') {
+										$p_ip = "::{$pfb['ip_ph']}";
+									} else {
+										$p_ip = $pfb['ip_ph'];
+									}
+
+									$ip_data	= "{$p_ip}\n";
+									$log		= "  Empty file, Adding '{$p_ip}' to avoid download failure.\n";
 									pfb_logger("{$log}", 1);
 								}
 							}

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng.php
@@ -30,7 +30,7 @@
 
 if ($_SERVER['REMOTE_ADDR'] == '127.0.0.1' && $_REQUEST && $_REQUEST['pfb']) {
 
-	$query = htmlspecialchars($_REQUEST['pfb']);
+	$query = htmlspecialchars(trim(strstr($_REQUEST['pfb'], ' ', TRUE)));
 	if (file_exists("/var/db/aliastables/{$query}_v4.txt")) {
 		$type = '_v4';
 	} elseif (file_exists("/var/db/aliastables/{$query}_v6.txt")) {

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -108,7 +108,6 @@ $pconfig['aliasaddr_out']	= $pfb['dconfig']['aliasaddr_out']			?: '';
 $pconfig['autoproto_out']	= $pfb['dconfig']['autoproto_out']			?: '';
 $pconfig['agateway_out']	= $pfb['dconfig']['agateway_out']			?: 'default';
 
-$pconfig['blacklist']		= base64_decode($pfb['dconfig']['blacklist'])		?: '';
 $pconfig['suppression']		= base64_decode($pfb['dconfig']['suppression'])		?: '';
 
 $pconfig['alexa_enable']	= $pfb['dconfig']['alexa_enable']			?: '';
@@ -253,12 +252,6 @@ if ($_POST) {
 		$pfb['dconfig']['autoproto_out']	= $_POST['autoproto_out']			?: '';
 		$pfb['dconfig']['agateway_out']		= $_POST['agateway_out']			?: 'default';
 
-		// Set flag to update Blacklist CustomList on next Cron|Force update|Force reload
-		if (base64_decode($pfb['dconfig']['blacklist']) != $_POST['blacklist']) {
-			touch("{$pfb['dnsdir']}/DNSBL_custom.update");
-		}
-
-		$pfb['dconfig']['blacklist']		= base64_encode($_POST['blacklist'])		?: '';
 		$pfb['dconfig']['suppression']		= base64_encode($_POST['suppression'])		?: '';
 
 		$pfb['dconfig']['alexa_enable']		= $_POST['alexa_enable']			?: '';

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -248,6 +248,7 @@ $section->addInput(new Form_Input(
 	$pconfig['ip_placeholder'],
 	[ 'placeholder' => '127.1.7.7' ]
 ))->setHelp('Enter a single IPv4 placeholder address<br />'
+	. 'For IPv6 \'::\' will be prefixed to the placeholder IP.<br />'
 	. 'This address should be in an Isolated Range that is not used in your Network.<br />'
 	. 'This IP address will be used as a placeholder IP to avoid empty Feeds/Aliases.'
 );

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/www/index.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/www/index.php
@@ -53,6 +53,14 @@ if (file_exists('/var/log/pfblockerng/dnsbl.log')) {
 			}
 			usleep(50000);
 		}
+
+		if ($i == 0) {
+			@require_once('util.inc');
+			if (is_ipaddr($ptype['HTTP_HOST'])) {
+				$ptype['type'] = "DNSBL VIP: {$ptype['HTTP_HOST']}";
+				break;
+			}
+		}
 	}
 }
 

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -264,7 +264,7 @@ function pfBlockerNG_update_table() {
 	if (isset($config['filter']['rule'])) {
 		foreach ($config['filter']['rule'] as $rule) {
 
-			if ($rule['descr'] == 'pfB_DNSBL_Ping' || $rule['descr'] == 'pfB_DNSBL_Permit') {
+			if (strpos($rule['descr'], 'pfB_DNSBL_Ping') !== FALSE || strpos($rule['descr'], 'pfB_DNSBL_Permit') !== FALSE) {
 				continue;
 			}
 

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/var/unbound/pfb_unbound.py
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/var/unbound/pfb_unbound.py
@@ -812,6 +812,10 @@ def get_details_reply(m_type, qinfo, qstate, rep, kwargs):
     else:
         return True
 
+    q_ip = get_q_ip_comm(kwargs)
+    if q_ip == 'Unknown':
+        q_ip = '127.0.0.1'
+
     o_type = get_q_type(qstate, qinfo)
     if m_type == 'cache' or o_type == 'PTR':
         q_type = o_type
@@ -830,8 +834,8 @@ def get_details_reply(m_type, qinfo, qstate, rep, kwargs):
             return True
         m_type = 'reply'
 
-    # Increment totalqueries counter
-    if pfb['sqlite3_resolver_con']:
+    # Increment totalqueries counter (Don't include the Resolver DNS requests)
+    if pfb['sqlite3_resolver_con'] and q_ip != '127.0.0.1':
         write_sqlite(1, '', True)
 
     # Do not log Replies, if disabled
@@ -956,10 +960,6 @@ def get_details_reply(m_type, qinfo, qstate, rep, kwargs):
             iso_code = 'unk'
     else:
         iso_code = 'unk'
-
-    q_ip = get_q_ip_comm(kwargs)
-    if q_ip == 'Unknown':
-        q_ip = '127.0.0.1'
 
     ttl = get_rep_ttl(rep)
     # Cached TTLs are in unix timestamp (time remaining)
@@ -1418,7 +1418,7 @@ def operate(id, event, qstate, qdata):
                     if not isFound:
 
                         # Allow only approved TLDs
-                        if pfb['python_tld'] and tld != '' and tld not in pfb['python_tlds']:
+                        if pfb['python_tld'] and tld != '' and q_name not in (pfb['dnsbl_ipv4'], '::' + pfb['dnsbl_ipv4']) and tld not in pfb['python_tlds']:
                             isFound = True
                             feed = 'TLD_Allow'
                             group = 'DNSBL_TLD_Allow'

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/var/unbound/pfb_unbound_include.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/var/unbound/pfb_unbound_include.inc
@@ -77,7 +77,25 @@ function pfb_python_mount($python_mode, $verbose, $type_mount, $type_umount, $ty
 	// Force Resolver path
 	$unbound_chroot_path = '/var/unbound';
 
-	$validate = exec("/sbin/mount | /usr/bin/grep '{$grep_string}' 2>&1");
+	exec("/sbin/mount | /usr/bin/grep '{$grep_string}' 2>&1", $validate, $retval);
+
+	// Temporary workaround for Redmine: https://redmine.pfsense.org/issues/11456
+	if ($type_umount == 'devfs' && is_array($validate) && count($validate) > 1) {
+		if ($verbose) {
+			pfb_logger("\n   Removing duplicate mounts (" . count($validate) . "): /{$folder}", 1);
+		}
+
+		foreach ($validate as $v) {
+			if (!empty($v)) {
+				exec("/sbin/umount -t {$type_umount} '{$unbound_chroot_path}/{$folder}' 2>&1", $output, $retval);
+				if ($retval != 0) {
+					break;
+				}
+			}
+		}
+		$validate = '';
+	}
+
 	if ($python_mode) {
 		// Add DNS Resolver python integration
 		if (empty($validate)) {


### PR DESCRIPTION
**CHANGELOG:**

* Improve logging of Services pfb_filter and pfb_dnsbl to show stop/start events in the pfSense system.log
* Fix issue with pfb_filter service not terminating tail_pfb pids correctly (pfSense 2.5+ / pfSense Plus)
* Improve IP Kill States for selected Interfaces in the IP Tab only.
* Improve IP Placeholder settings for empty IP Alias conditions. Default for IPv4: 127.1.7.7, for IPv6 default to ::127.1.7.7
* Improve ipv6 Feed Parsing to remove comment lines after the IPv6 entry
* Fix calls from rc.update_urltables script
* Fix issue with DNSBL Block page when browsing to the DNSBL VIP Address
* Fix issue with Dashboard widget incorretly showing "pfB_DNSBL_VIPs/pfB_DNSBL_Ping/pfB_DNSBL_Permit"
* Add WireGuard interface option to IP Interface settings Redmine: https://redmine.pfsense.org/issues/11459

**Alerts Tab**:
* Remove unused code
* Fix issue with IPv6 Whitelist -> Permit Alias not working
* Fix issue with DNSBL Whitelist events not showing the Trashcan icon in Reports tabs
* Increase Max events to display from 1000 -> 5000 (Alert Settings)

**Unbound Mode Changes**:

* DNSBL IPv6 - Null blocking use ::/0 instead of ::

**Unbound Python Mode Changes**:

* Fix issue with TLD_Allow not showing the number of TLD Allows enabled in dashboard widget
* Fix issue for RAMdisk compatability to backup the /var/unbound folder files and restore on reboot
* Fix issue with the DNS Resolver DNS Requests as they were being added to the Total DNS Resolver counters, and diluting the Percentage Blocked statistic.
* Fix issue for TLD_Allow reporting block events for the DNSBL VIP address
* Add temporary workaround to address duplicate mounts for /dev - Redmine: https://redmine.pfsense.org/issues/11456