### PR TITLE
pfSense-pkg-snort-4.1.3 5 - Fix issue #11637, part of issue #11466, and add support for 2.9.17.1 binary.

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.1.3
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package snort
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	snort>=2.9.17_1:security/snort
+RUN_DEPENDS=	snort>=2.9.17.1:security/snort
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2020 Bill Meeks
+ * Copyright (c) 2013-2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,7 +47,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 		define("SNORT_BIN_VERSION", $matches[0]);
 	}
 	else {
-		define("SNORT_BIN_VERSION", "2.9.17");
+		define("SNORT_BIN_VERSION", "2.9.17.1");
 	}
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_frag3_engine.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_frag3_engine.php
@@ -232,7 +232,7 @@ if ($pconfig['name'] <> "default") {
 	$btnaliases = new Form_Button(
 		'btnSelectAlias',
 		' ' . 'Aliases',
-		'snort_select_alias.php?id=' . $id . '&eng_id=<?=' . $eng_id . '&type=host|network&varname=bind_to&act=import&multi_ip=yes&returl=' . urlencode($_SERVER['PHP_SELF']),
+		'snort_select_alias.php?id=' . $id . '&eng_id=' . $eng_id . '&type=host|network&varname=bind_to&act=import&multi_ip=yes&returl=' . urlencode($_SERVER['PHP_SELF']),
 		'fa-search-plus'
 	);
 	$btnaliases->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-success')->addClass('btn-sm');

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ftp_client_engine.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ftp_client_engine.php
@@ -263,7 +263,7 @@ if ($pconfig['name'] <> "default") {
 	$btnaliases = new Form_Button(
 		'btnSuppressList',
 		' ' . 'Aliases',
-		'snort_select_alias.php?id=' . $id . '&eng_id=<?=' . $eng_id . '&type=host|network&varname=bind_to&act=import&multi_ip=yes&returl=' . urlencode($_SERVER['PHP_SELF']),
+		'snort_select_alias.php?id=' . $id . '&eng_id=' . $eng_id . '&type=host|network&varname=bind_to&act=import&multi_ip=yes&returl=' . urlencode($_SERVER['PHP_SELF']),
 		'fa-search-plus'
 	);
 	$btnaliases->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-success')->addClass('btn-sm');
@@ -328,7 +328,7 @@ $bind_to->setHelp('Default is blank.  Supplied value must be a pre-configured IP
 $btnaliases = new Form_Button(
 	'btnSelectAlias',
 	' ' . 'Aliases',
-	'snort_select_alias.php?id=' . $id . '&eng_id=<?=' . $eng_id . '&type=host|network&varname=bounce_to_net&act=import&returl=' . urlencode($_SERVER['PHP_SELF']),
+	'snort_select_alias.php?id=' . $id . '&eng_id=' . $eng_id . '&type=host|network&varname=bounce_to_net&act=import&returl=' . urlencode($_SERVER['PHP_SELF']),
 	'fa-search-plus'
 );
 $btnaliases->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-success')->addClass('btn-sm');
@@ -349,7 +349,7 @@ $bind_to->setHelp('Default is blank.  Supplied value must be a pre-configured Po
 $btnaliases = new Form_Button(
 	'btnSelectAlias',
 	' ' . 'Aliases',
-	'snort_select_alias.php?id=' . $id . '&eng_id=<?=' . $eng_id . '&type=port&varname=bounce_to_port&act=import&returl=' . urlencode($_SERVER['PHP_SELF']),
+	'snort_select_alias.php?id=' . $id . '&eng_id=' . $eng_id . '&type=port&varname=bounce_to_port&act=import&returl=' . urlencode($_SERVER['PHP_SELF']),
 	'fa-search-plus'
 );
 $btnaliases->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-success')->addClass('btn-sm');

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ftp_server_engine.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_ftp_server_engine.php
@@ -234,7 +234,7 @@ if ($pconfig['name'] <> "default") {
 	$btnaliases = new Form_Button(
 		'btnSuppressList',
 		' ' . 'Aliases',
-		'snort_select_alias.php?id=' . $id . '&eng_id=<?=' . $eng_id . '&type=host|network&varname=bind_to&act=import&multi_ip=yes&returl=' . urlencode($_SERVER['PHP_SELF']),
+		'snort_select_alias.php?id=' . $id . '&eng_id=' . $eng_id . '&type=host|network&varname=bind_to&act=import&multi_ip=yes&returl=' . urlencode($_SERVER['PHP_SELF']),
 		'fa-search-plus'
 	);
 	$btnaliases->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-success')->addClass('btn-sm');
@@ -265,7 +265,7 @@ $bind_to->setHelp('Specify which ports to check for FTP data.  Default value is 
 $btnaliases = new Form_Button(
 	'btnSelectAlias',
 	' ' . 'Aliases',
-	'snort_select_alias.php?id=' . $id . '&eng_id=<?=' . $eng_id . '&type=port&varname=ports&act=import&returl=' . urlencode($_SERVER['PHP_SELF']),
+	'snort_select_alias.php?id=' . $id . '&eng_id=' . $eng_id . '&type=port&varname=ports&act=import&returl=' . urlencode($_SERVER['PHP_SELF']),
 	'fa-search-plus'
 );
 $btnaliases->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-success')->addClass('btn-sm');

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_httpinspect_engine.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_httpinspect_engine.php
@@ -140,11 +140,9 @@ if ($_POST['cancel']) {
 // Check for returned "selected alias" if action is import
 if ($_GET['act'] == "import") {
 	session_start();
-	if (($_GET['varname'] == "bind_to" || $_GET['varname'] == "ports") 
-	     && !empty($_GET['varvalue'])) {
+	if (($_GET['varname'] == "bind_to" || $_GET['varname'] == "ports") && !empty($_GET['varvalue'])) {
 		$pconfig[$_GET['varname']] = htmlspecialchars($_GET['varvalue']);
-			$_SESSION['http_inspect_import'] = array();
-
+		$_SESSION['http_inspect_import'] = array();
 		$_SESSION['http_inspect_import'][$_GET['varname']] = $_GET['varvalue'];
 		if (isset($_SESSION['http_inspect_import']['bind_to']))
 			$pconfig['bind_to'] = $_SESSION['http_inspect_import']['bind_to'];
@@ -343,7 +341,7 @@ if ($pconfig['name'] <> "default") {
 	$btnaliases = new Form_Button(
 		'btnSuppressList',
 		' ' . 'Aliases',
-		'snort_select_alias.php?id=' . $id . '&eng_id=<?=' . $eng_id . '&type=host|network&varname=bind_to&act=import&multi_ip=yes&returl=' . urlencode($_SERVER['PHP_SELF']),
+		'snort_select_alias.php?id=' . $id . '&eng_id=' . $eng_id . '&type=host|network&varname=bind_to&act=import&multi_ip=yes&returl=' . urlencode($_SERVER['PHP_SELF']),
 		'fa-search-plus'
 	);
 	$btnaliases->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-success')->addClass('btn-sm');
@@ -374,7 +372,7 @@ $bind_to->setHelp('Specify which ports to check for HTTP data.  Default value is
 $btnaliases = new Form_Button(
 	'btnSelectAlias',
 	' ' . 'Aliases',
-	'snort_select_alias.php?id=' . $id . '&eng_id=<?=' . $eng_id . '&type=port&varname=ports&act=import&returl=' . urlencode($_SERVER['PHP_SELF']),
+	'snort_select_alias.php?id=' . $id . '&eng_id=' . $eng_id . '&type=port&varname=ports&act=import&returl=' . urlencode($_SERVER['PHP_SELF']),
 	'fa-search-plus'
 );
 $btnaliases->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-success')->addClass('btn-sm');

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_stream5_engine.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_stream5_engine.php
@@ -375,7 +375,7 @@ if ($pconfig['name'] <> "default") {
 	$btnaliases = new Form_Button(
 		'btnSuppressList',
 		' ' . 'Aliases',
-		'snort_select_alias.php?id=' . $id . '&eng_id=<?=' . $eng_id . '&type=host|network&varname=bind_to&act=import&multi_ip=yes&returl=' . urlencode($_SERVER['PHP_SELF']),
+		'snort_select_alias.php?id=' . $id . '&eng_id=' . $eng_id . '&type=host|network&varname=bind_to&act=import&multi_ip=yes&returl=' . urlencode($_SERVER['PHP_SELF']),
 		'fa-search-plus'
 	);
 	$btnaliases->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-success')->addClass('btn-sm');
@@ -416,7 +416,7 @@ $bind_to->setHelp('Specify which ports to check for data.  Default value is <em>
 $btnaliases = new Form_Button(
 	'btnSelectAlias',
 	' ' . 'Aliases',
-	'snort_select_alias.php?id=' . $id . '&eng_id=<?=' . $eng_id . '&type=port&varname=ports_client&act=import&returl=' . urlencode($_SERVER['PHP_SELF']),
+	'snort_select_alias.php?id=' . $id . '&eng_id=' . $eng_id . '&type=port&varname=ports_client&act=import&returl=' . urlencode($_SERVER['PHP_SELF']),
 	'fa-search-plus'
 );
 $btnaliases->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-success')->addClass('btn-sm');
@@ -441,7 +441,7 @@ $bind_to->setHelp('Specify which ports to check for data.  Default value is <em>
 $btnaliases = new Form_Button(
 	'btnSelectAlias',
 	' ' . 'Aliases',
-	'snort_select_alias.php?id=' . $id . '&eng_id=<?=' . $eng_id . '&type=port&varname=ports_server&act=import&returl=' . urlencode($_SERVER['PHP_SELF']),
+	'snort_select_alias.php?id=' . $id . '&eng_id=' . $eng_id . '&type=port&varname=ports_server&act=import&returl=' . urlencode($_SERVER['PHP_SELF']),
 	'fa-search-plus'
 );
 $btnaliases->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-success')->addClass('btn-sm');
@@ -469,7 +469,7 @@ $bind_to->setHelp('Specify which ports to check for data.  Default value is <em>
 $btnaliases = new Form_Button(
 	'btnSelectAlias',
 	' ' . 'Aliases',
-	'snort_select_alias.php?id=' . $id . '&eng_id=<?=' . $eng_id . '&type=port&varname=ports_both&act=import&returl=' . urlencode($_SERVER['PHP_SELF']),
+	'snort_select_alias.php?id=' . $id . '&eng_id=' . $eng_id . '&type=port&varname=ports_both&act=import&returl=' . urlencode($_SERVER['PHP_SELF']),
 	'fa-search-plus'
 );
 $btnaliases->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-success')->addClass('btn-sm');


### PR DESCRIPTION
### pfSense-pkg-snort-4.1.3_5
This update for the Snort GUI package provides support for the 2.9.17.1 Snort binary version and includes a fix for Redmine Issue #11637, and a fix for one of the two issues identified in Redmine Issue #11466. There are no new added features in this release.

**New Features:**
None

**Bug Fixes:**
1. Correct problem resulting in a duplicate "default" read-only engine name created when adding a new engine to the _HTTP_Inspect_, _Stream5_, _Frag3_, _FTP Server_ or _FTP Client_ preprocessor engines list and clicking the **Select Alias** button to add an existing alias as the "Bind-To" or "Ports" target. See [Redmine Issue #11637](https://redmine.pfsense.org/issues/11637).
2. Correct the issue with "Unknown" or blank being shown for the interface name on other tabs when adding a new interface (or cloning an existing one). The GUI now hides certain tabs when creating a new interface before saving it. This is one of two issues identified in [Redmine #11466](https://redmine.pfsense.org/issues/11466). The other issue in that ticket, the PHP crash on 32-bit ARM hardware, is not addressed in this release.