### PR TITLE
Fix net-snmp netsnmptrapd.conf generation.

### DIFF
--- a/net-mgmt/pfSense-pkg-net-snmp/files/usr/local/pkg/net-snmp.inc
+++ b/net-mgmt/pfSense-pkg-net-snmp/files/usr/local/pkg/net-snmp.inc
@@ -710,7 +710,7 @@ function netsnmp_resync_snmptrapd() {
 
 	/* Agent address list is comma-separated, no spaces: a:b:c,d:e:f,g:h:i */
 	if (!empty($agentaddresses)) {
-		$snmptrapd_config .= "agentaddress " . implode(',', $agentaddresses) . "\n";
+		$snmptrapd_config .= "snmpTrapdAddr " . implode(',', $agentaddresses) . "\n";
 	}
 
 	if (!empty($nsettings['donotretainnotificationlogs'])) {


### PR DESCRIPTION
The snmptrapd configuration uses the keyword "snmpTrapdAddr" instead of
"agentaddress". This is probably a copy-paste bug.

Without this change, the "interface binding" option in the snmptrapd configuration page is ineffective:

    > head -n 1 /var/etc/netsnmptrapd.conf
    agentaddress udp:127.0.0.1:162
    > netstat -lanf inet | fgrep .162
    udp4       0      0 *.162                  *.*

, whereas:

    > head -n 1 /var/etc/netsnmptrapd.conf
    snmpTrapdAddr udp:127.0.0.1:162
    > netstat -lanf inet | fgrep .162
    udp4       0      0 127.0.0.1.162          *.*
