### PR TITLE
Allow to use HAProxy "Use Client-IP" option with Captive Portal. Fixes #11937

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -2165,18 +2165,26 @@ function haproxy_is_running() {
 function haproxy_load_modules() {
 	// On FreeBSD 8 ipfw is needed to allow 'transparent' proxying (getting reply's to a non-local ip to pass back to the client-socket).
 	// On FreeBSD 9 and 10 it should have been possible to do the same with the pf(4) option "divert-reply" however that is not implemented.
-	// FreeBSD 10 patch proposal: http://lists.freebsd.org/pipermail/freebsd-bugs/2014-April/055823.html
+	// FreeBSD 10 patch proposal: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=188511
 
 	mute_kernel_msgs();
 	if (!is_module_loaded("ipfw.ko")) {
 		mwexec("/sbin/kldload ipfw");
 		/* make sure ipfw is not on pfil hooks */
-		mwexec("/sbin/sysctl net.inet.ip.pfil.inbound=\"pf\" net.inet6.ip6.pfil.inbound=\"pf\"" .
-				" net.inet.ip.pfil.outbound=\"pf\" net.inet6.ip6.pfil.outbound=\"pf\"");
+		set_sysctl(array(
+		    "net.inet.ip.pfil.inbound" => "pf",
+		    "net.inet6.ip6.pfil.inbound" => "pf",
+		    "net.inet.ip.pfil.outbound" => "pf",
+		    "net.inet6.ip6.pfil.outbound" => "pf"
+		));
 	}
 
 	/* Activate layer2 filtering */
-	mwexec("/sbin/sysctl net.link.ether.ipfw=1 net.inet.ip.fw.one_pass=1");
+	set_sysctl(array(
+	    "net.link.ether.ipfw" => "1",
+	    "net.inet.ip.fw.one_pass" => "1",
+	    "net.inet.ip.fw.tables_max" => "65534"
+	));
 
 	unmute_kernel_msgs();
 }
@@ -2266,6 +2274,7 @@ function load_ipfw_rules() {
 	$ipfw_zone_haproxy = "4000"; // seems that 4000 is a safe zone number to avoid conflicts with captive portal.. and 4095 is the max?
 
 	haproxy_load_modules();
+	delete_ipfw_rules();
 
 	$transparent_backends = haproxy_get_transparent_backends();
 
@@ -2287,7 +2296,6 @@ function load_ipfw_rules() {
 		$rulenum = 10;
 	}
 
-	$rules = "flush\n";
 	foreach($transparent_backends as $transparent_be) {
 		if (is_ipaddrv4($transparent_be["address"])) {
 			$rules .= "add $rulenum fwd 127.0.0.1 tcp from {$transparent_be["address"]} {$transparent_be["port"]} to any in recv {$transparent_be["interface"]}\n";
@@ -2307,6 +2315,20 @@ function load_ipfw_rules() {
 		mwexec("/sbin/ipfw -q {$g['tmp_path']}/ipfw_{$ipfw_zone_haproxy}.haproxy.rules", true);
 	}
 }
+
+function delete_ipfw_rules() {
+	global $g;
+
+	$rules = glob("{$g['tmp_path']}/ipfw_*.haproxy.rules");
+
+	if (is_array($rules) && !empty($rules)) {
+		foreach ($rules as $rule) {
+			mwexec("/usr/bin/sed -i '' 's/add/delete/g' {$rule} && /sbin/ipfw -q {$rule}", true);
+			unlink_if_exists($rule);
+		}
+	}
+}
+
 
 function haproxy_plugin_carp($pluginparams) {
 	// called by pfSense when a CARP interface changes its state (called multiple times when multiple interfaces change state)
@@ -2442,6 +2464,7 @@ function haproxy_check_run($reload) {
 		} else {
 			$ipfw_zone_haproxy = 4000;
 			mwexec("/sbin/ipfw zone $ipfw_zone_haproxy destroy", true);
+			delete_ipfw_rules();
 		}
 
 		if (file_exists('/var/run/haproxy.pid')){
@@ -2488,6 +2511,7 @@ function haproxy_check_run($reload) {
 			//exec("/bin/pkill -F /var/run/haproxy.pid haproxy");//doesnt work for multiple pid's in a pidfile
 			haproxy_kill();
 		}
+		delete_ipfw_rules();
 		$errcode = 0;
 	}
 	unlock($haproxylock);


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/11937
- [X] Ready for review

Do not flush all ipfw rules after enabling the "Use Client-IP to connect to backend servers." and remove associated rules if option or HAProxy  is disabled

can be merged with https://github.com/pfsense/FreeBSD-ports/pull/1059