### PR TITLE
ACME: Support specifying non-default port for nsupdate DNS validation method

### DIFF
--- a/security/pfSense-pkg-acme/Makefile
+++ b/security/pfSense-pkg-acme/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-acme
-PORTVERSION=	0.6.9
-PORTREVISION=	3
+PORTVERSION=	0.6.10
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_sh.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_sh.inc
@@ -254,8 +254,7 @@ EOF;
 				$envvariables['NSUPDATE_SERVER'] = $nsupdatefileprefix;
 				$envvariables['NSUPDATE_KEY'] = $nsupdatefileprefix;
 				$envvariables['NSUPDATE_ZONE'] = $domain->NSUPDATE_ZONE;
-				if (strpos($domain->NSUPDATE_SERVER, ":") !== false)
-				{
+				if (strpos($domain->NSUPDATE_SERVER, ":") !== false) {
 					$parts = explode(":" ,$domain->NSUPDATE_SERVER);
 					$domain->NSUPDATE_SERVER = $parts[0];
 					$envvariables['NSUPDATE_SERVER_PORT'] = $parts[1];

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_sh.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_sh.inc
@@ -254,6 +254,12 @@ EOF;
 				$envvariables['NSUPDATE_SERVER'] = $nsupdatefileprefix;
 				$envvariables['NSUPDATE_KEY'] = $nsupdatefileprefix;
 				$envvariables['NSUPDATE_ZONE'] = $domain->NSUPDATE_ZONE;
+				if (strpos($domain->NSUPDATE_SERVER, ":") !== false)
+				{
+					$parts = explode(":" ,$domain->NSUPDATE_SERVER);
+					$domain->NSUPDATE_SERVER = $parts[0];
+					$envvariables['NSUPDATE_SERVER_PORT'] = $parts[1];
+				}
 				$nsupdatedomain = $domain->domainname;
 				if (!empty($domain->challengealias)) {
 					$nsupdatedomain = $domain->challengealias;


### PR DESCRIPTION
This PR allows requesting ACME certificates using nsupdate validation method, with non-standard (53) ports, by allowing host:port syntax on NSUPDATE_SERVER field.