### PR TITLE
HAProxy SSL/TLS Compatibility Mode improvement. Feature #10779

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -1528,8 +1528,8 @@ function haproxy_writeconf($configpath) {
 				fwrite ($fd, "\tssl-default-bind-ciphersuites\tTLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256\n");
 				fwrite ($fd, "\tssl-default-server-ciphersuites\tTLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256\n");
 			}
-			fwrite ($fd, "\tssl-default-bind-options\tno-sslv3 no-tlsv10 no-tlsv11 no-tlsv12 no-tls-tickets\n");
-			fwrite ($fd, "\tssl-default-server-options\tno-sslv3 no-tlsv10 no-tlsv11 no-tlsv12 no-tls-tickets\n");
+			fwrite ($fd, "\tssl-default-bind-options\tssl-min-ver TLSv1.3 no-tls-tickets\n");
+			fwrite ($fd, "\tssl-default-server-options\tssl-min-ver TLSv1.3 no-tls-tickets\n");
 
 		} elseif ($a_global['sslcompatibilitymode'] == 'intermediate') {
 			/* https://ssl-config.mozilla.org/#server=haproxy&version=2.1&config=intermediate&openssl=1.1.1d&guideline=5.4 */
@@ -1538,9 +1538,9 @@ function haproxy_writeconf($configpath) {
 				fwrite ($fd, "\tssl-default-server-ciphersuites\tTLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256\n");
 			}
 			fwrite ($fd, "\tssl-default-bind-ciphers\tECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384\n");
-			fwrite ($fd, "\tssl-default-bind-options\tno-sslv3 no-tlsv10 no-tlsv11 no-tls-tickets\n");
+			fwrite ($fd, "\tssl-default-bind-options\tssl-min-ver TLSv1.2 no-tls-tickets\n");
 			fwrite ($fd, "\tssl-default-server-ciphers\tECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384\n");
-			fwrite ($fd, "\tssl-default-server-options\tno-sslv3 no-tlsv10 no-tlsv11 no-tls-tickets\n");
+			fwrite ($fd, "\tssl-default-server-options\tssl-min-ver TLSv1.2 no-tls-tickets\n");
 		} elseif ($a_global['sslcompatibilitymode'] == 'old') {
 			/* https://ssl-config.mozilla.org/#server=haproxy&version=2.1&config=old&openssl=1.1.1d&guideline=5.4 */
 			if ($openssl111) {
@@ -1548,9 +1548,9 @@ function haproxy_writeconf($configpath) {
 				fwrite ($fd, "\tssl-default-server-ciphersuites\tTLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256\n");
 			}
 			fwrite ($fd, "\tssl-default-bind-ciphers\tECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA\n");
-			fwrite ($fd, "\tssl-default-bind-options\tno-sslv3 no-tls-tickets\n");
+			fwrite ($fd, "\tssl-default-bind-options\tssl-min-ver TLSv1.0 no-tls-tickets\n");
 			fwrite ($fd, "\tssl-default-server-ciphers\tECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA\n");
-			fwrite ($fd, "\tssl-default-server-options\tno-sslv3 no-tls-tickets\n");
+			fwrite ($fd, "\tssl-default-server-options\tssl-min-ver TLSv1.0 no-tls-tickets\n");
 
 		}
 		if ($a_global['ssldefaultdhparam']) {


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10779
- [X] Ready for review

`no-sslv3/no-tlsv1x` are deprecated, use `ssl-min-ver` instead

can be merged with https://github.com/pfsense/FreeBSD-ports/pull/1059