### PR TITLE
HAProxy httpchk method fix. Issue #11491

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -922,6 +922,17 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 		if ($check_type == "Agent") {
 			$checkport = " port " . $pool['monitor_agentport'];
 		}
+		if (($check_type == "HTTP") && (haproxy_version() >= '2.2')) {
+			$httpchecksend = "\thttp-check\t\tsend meth {$pool['httpcheck_method']}";
+			if (!empty($pool['monitor_uri'])) {
+				$httpchecksend .= " uri {$pool['monitor_uri']}";
+			}
+			if (!empty($pool['monitor_httpversion'])) {
+				$httpchecksend .= " ver {$pool['monitor_httpversion']}";
+			}
+			fwrite ($fd, $httpchecksend . "\n");
+			$optioncheck = "httpchk";
+		}
 	}
 
 	if ($pool['balance']) {


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/11491
- [X] Ready for review

https://cbonte.github.io/haproxy-dconv/2.2/configuration.html#option%20httpchk:
> Note : For a while, there was no way to add headers or body in the request
       used for HTTP health checks. So a workaround was to hide it at the end
       of the version string with a "\r\n" after the version. It is now
       deprecated. The directive "http-check send" must be used instead.

can be merged with https://github.com/pfsense/FreeBSD-ports/pull/1059