### PR TITLE
snort-2.9.18 -- Update Snort binary to latest 2.9.18 version from upstream.

### DIFF
--- a/security/snort/Makefile
+++ b/security/snort/Makefile
@@ -1,7 +1,7 @@
 # Created by: Dirk Froemberg <dirk@FreeBSD.org>
 
 PORTNAME=	snort
-PORTVERSION=	2.9.17.1
+PORTVERSION=	2.9.18
 PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	https://snort.org/downloads/snort/

--- a/security/snort/distinfo
+++ b/security/snort/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1617369739
-SHA256 (snort-2.9.17.1.tar.gz) = 303d3d5dc5affecfeaad3a331d3163f901d48d960fdd6598cb55c6d1591eed82
-SIZE (snort-2.9.17.1.tar.gz) = 6980147
+TIMESTAMP = 1624033263
+SHA256 (snort-2.9.18.tar.gz) = d0308642f69e0d36f70db9703e5766afce2f44ff05b7d2c9cc8e3ac8323b2c77
+SIZE (snort-2.9.18.tar.gz) = 6909928


### PR DESCRIPTION
### Snort 2.9.18
This updates the Snort binary to the latest 2.9.18 version from upstream. Release Notes can be found here:  [https://blog.snort.org/2021/06/snort-29180-released.html](https://blog.snort.org/2021/06/snort-29180-released.html).