### PR TITLE
pfSense-pkg-snort-4.1.4 -- Support new 2.9.18 binary, add FEODO Tracker rules, and bug fixes

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -1,8 +1,8 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-snort
-PORTVERSION=	4.1.3
-PORTREVISION=	5
+PORTVERSION=	4.1.4
+PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package snort
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	snort>=2.9.17.1:security/snort
+RUN_DEPENDS=	snort>=2.9.18:security/snort
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -104,5 +104,9 @@ if (!defined("ET_PRO_FILE_PREFIX"))
 	define("ET_PRO_FILE_PREFIX", "etpro-");
 if (!defined("OPENAPPID_FILE_PREFIX"))
 	define("OPENAPPID_FILE_PREFIX", "openappid-");
+if (!defined("FEODO_TRACKER_DNLD_FILENAME"))
+	define("FEODO_TRACKER_DNLD_FILENAME", "feodotracker.tar.gz");
+if (!defined("FEODO_TRACKER_DNLD_URL"))
+	define("FEODO_TRACKER_DNLD_URL", "https://feodotracker.abuse.ch/downloads/");
 
 ?>

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -47,7 +47,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 		define("SNORT_BIN_VERSION", $matches[0]);
 	}
 	else {
-		define("SNORT_BIN_VERSION", "2.9.17.1");
+		define("SNORT_BIN_VERSION", "2.9.18");
 	}
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
@@ -45,6 +45,7 @@ $etpro = $config['installedpackages']['snortglobal']['emergingthreats_pro'];
 $snortcommunityrules = $config['installedpackages']['snortglobal']['snortcommunityrules'];
 $openappid_detectors = $config['installedpackages']['snortglobal']['openappid_detectors'];
 $openappid_rules_detectors = $config['installedpackages']['snortglobal']['openappid_rules_detectors'];
+$feodotracker_rules = $config['installedpackages']['snortglobal']['enable_feodo_botnet_c2_rules'];
 
 /* Get last update information if available */
 if (file_exists(SNORTDIR . "/rulesupd_status")) {
@@ -65,6 +66,8 @@ else {
 	$emergingthreats_filename = SNORT_ET_DNLD_FILENAME;
 	$et_name = gettext("Emerging Threats Open Rules");
 }
+
+$feodotracker_rules_filename = FEODO_TRACKER_DNLD_FILENAME;
 
 /* quick md5 chk of downloaded rules */
 if ($snortdownload == 'on') {
@@ -132,6 +135,20 @@ if (file_exists("{$snortdir}/{$snort_openappid_rules_filename}.md5") && $openapp
         $openappid_detectors_rules_sig_chk_local = file_get_contents("{$snortdir}/{$snort_openappid_rules_filename}.md5");
         $openappid_detectors_rules_sig_date = date(DATE_RFC850, filemtime("{$snortdir}/{$snort_openappid_rules_filename}.md5"));
 }
+
+if ($feodotracker_rules == 'on') {
+	$feodotracker_sig_chk_local = 'Not Downloaded';
+	$feodotracker_sig_sig_date = 'Not Downloaded';
+}
+else {
+	$feodotracker_sig_chk_local = 'Not Enabled';
+	$feodotracker_sig_sig_date = 'Not Enabled';
+}
+if ($feodotracker_rules == 'on' && file_exists("{$snortdir}/{$feodotracker_rules_filename}.md5")) {
+	$feodotracker_sig_chk_local = file_get_contents("{$snortdir}/{$feodotracker_rules_filename}.md5");
+	$feodotracker_sig_sig_date = date(DATE_RFC850, filemtime("{$snortdir}/{$feodotracker_rules_filename}.md5"));
+}
+
 // Check status of the background rules update process (when launched)
 if ($_REQUEST['ajax'] == 'status') {
 	if (is_numeric($_REQUEST['pid'])) {
@@ -249,6 +266,11 @@ display_top_tabs($tab_array, true);
                                         <td><?=trim($openappid_detectors_rules_sig_chk_local);?></td>
                                         <td><?=gettext($openappid_detectors_rules_sig_date);?></td>
                                 </tr>
+				<tr>
+					<td><?=gettext("Feodo Tracker Botnet C2 IP Rules");?></td>
+					<td><?=trim($feodotracker_sig_chk_local);?></td>
+					<td><?=gettext($feodotracker_sig_sig_date);?></td>
+				</tr>
 				</tbody>
 			</table>
 		</div>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
@@ -190,6 +190,7 @@ if (isset($_POST['mode'])) {
 		unlink_if_exists("{$snortdir}/{$snort_community_rules_filename}.md5");
 		unlink_if_exists("{$snortdir}/{$snort_rules_file}.md5");
 		unlink_if_exists("{$snortdir}/{$snort_openappid_filename}.md5");
+		unlink_if_exists("{$snortdir}/{$feodotracker_rules_filename}.md5");
 	}
 	
 	// Launch a background process to download the updates

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_httpinspect_engine.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_httpinspect_engine.php
@@ -140,9 +140,15 @@ if ($_POST['cancel']) {
 // Check for returned "selected alias" if action is import
 if ($_GET['act'] == "import") {
 	session_start();
+
+	// Initialize our SESSION array if necessary
+	if (!isset($_SESSION['http_inspect_import'])) {
+		$_SESSION['http_inspect_import'] = array();
+	}
+
+	// Grab the passed alias values and store them
 	if (($_GET['varname'] == "bind_to" || $_GET['varname'] == "ports") && !empty($_GET['varvalue'])) {
 		$pconfig[$_GET['varname']] = htmlspecialchars($_GET['varvalue']);
-		$_SESSION['http_inspect_import'] = array();
 		$_SESSION['http_inspect_import'][$_GET['varname']] = $_GET['varvalue'];
 		if (isset($_SESSION['http_inspect_import']['bind_to']))
 			$pconfig['bind_to'] = $_SESSION['http_inspect_import']['bind_to'];

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_global.php
@@ -50,6 +50,7 @@ else {
 	$pconfig['openappid_rules_detectors'] = $config['installedpackages']['snortglobal']['openappid_rules_detectors'] == "on" ? 'on' : 'off';
 	$pconfig['hide_deprecated_rules'] = $config['installedpackages']['snortglobal']['hide_deprecated_rules'] == "on" ? 'on' : 'off';
 	$pconfig['curl_no_verify_ssl_peer'] = $config['installedpackages']['snortglobal']['curl_no_verify_ssl_peer'] == "on" ? 'on' : 'off';
+	$pconfig['enable_feodo_botnet_c2_rules'] = $config['installedpackages']['snortglobal']['enable_feodo_botnet_c2_rules'] == "on" ? 'on' : 'off';
 }
 
 /* Set sensible values for any empty default params */
@@ -91,6 +92,7 @@ if (!$input_errors) {
 		$config['installedpackages']['snortglobal']['snortcommunityrules'] = $_POST['snortcommunityrules'] ? 'on' : 'off';
 		$config['installedpackages']['snortglobal']['emergingthreats'] = $_POST['emergingthreats'] ? 'on' : 'off';
 		$config['installedpackages']['snortglobal']['emergingthreats_pro'] = $_POST['emergingthreats_pro'] ? 'on' : 'off';
+		$config['installedpackages']['snortglobal']['enable_feodo_botnet_c2_rules'] = $_POST['enable_feodo_botnet_c2_rules'] ? 'on' : 'off';
 		$config['installedpackages']['snortglobal']['clearblocks'] = $_POST['clearblocks'] ? 'on' : 'off';
 		$config['installedpackages']['snortglobal']['verbose_logging'] = $_POST['verbose_logging'] ? 'on' : 'off';
 		$config['installedpackages']['snortglobal']['openappid_detectors'] = $_POST['openappid_detectors'] ? 'on' : 'off';
@@ -115,6 +117,8 @@ if (!$input_errors) {
 			$disabled_rules[] = ET_PRO_FILE_PREFIX;
 		if ($config['installedpackages']['snortglobal']['openappid_rules_detectors'] == 'off')
 			$disabled_rules[] = OPENAPPID_FILE_PREFIX;
+		if ($config['installedpackages']['snortglobal']['enable_feodo_botnet_c2_rules'] == 'off')
+			$disabled_rules[] = "feodotracker";
 
 		// Now walk all the configured interface rulesets and remove
 		// any matching the disabled ruleset prefixes.
@@ -291,6 +295,21 @@ $group->setHelp('Note - the AppID Open Text Rules file is maintained by a volunt
 'The URL for the file ' . 'is <a href="' . SNORT_OPENAPPID_RULES_URL . SNORT_OPENAPPID_RULES_FILENAME . '" target="_blank">' . 
 SNORT_OPENAPPID_RULES_URL . SNORT_OPENAPPID_RULES_FILENAME . '</a>.');
 $section->add($group);
+$form->add($section);
+
+$section = new Form_Section('FEODO Tracker Botnet C2 IP Rules');
+$section->addInput(new Form_Checkbox(
+	'enable_feodo_botnet_c2_rules',
+	'Enable FEODO Tracker Botnet C2 IP Rules',
+	'Click to enable download of FEODO Tracker Botnet C2 IP rules',
+	$pconfig['enable_feodo_botnet_c2_rules'] == 'on' ? true:false,
+	'on'
+));
+$section->addInput(new Form_StaticText(
+	null,
+	'Feodo Tracker tracks certain families that are related to, or that evolved from, Feodo. Originally, Feodo was an ebanking Trojan used by cybercriminals to commit ebanking fraud. Since 2010, various malware families evolved from Feodo, such as Cridex, Dridex, Geodo, Heodo and Emotet.'
+));
+
 $form->add($section);
 
 $section = new Form_Section('Rules Update Settings');

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
@@ -66,6 +66,7 @@ $emergingdownload = $config['installedpackages']['snortglobal']['emergingthreats
 $etpro = $config['installedpackages']['snortglobal']['emergingthreats_pro'] == 'on' ? 'on' : 'off';
 $snortcommunitydownload = $config['installedpackages']['snortglobal']['snortcommunityrules'] == 'on' ? 'on' : 'off';
 $openappid_rulesdownload = $config['installedpackages']['snortglobal']['openappid_rules_detectors'] == 'on' ? 'on' : 'off';
+$feodotrackerdownload = $config['installedpackages']['snortglobal']['enable_feodo_botnet_c2_rules'] == 'on' ? 'on' : 'off';
 
 $no_emerging_files = false;
 $no_snort_files = false;
@@ -91,6 +92,8 @@ if (empty($test))
 	$no_openappid_files = true;
 if (!file_exists("{$snortdir}/rules/" . GPL_FILE_PREFIX . "community.rules"))
 	$no_community_files = true;
+if (!file_exists("{$snortdir}/rules/feodotracker.rules"))
+	$no_feodotracker_files = true;
 
 $inline_ips_mode = $a_nat[$id]['ips_mode'] == 'ips_mode_inline' ? true:false;
 
@@ -228,6 +231,11 @@ if (isset($_POST['selectall'])) {
 		foreach ($files as $file)
 			$enabled_rulesets_array[] = basename($file);
 	}
+
+	if ($feodotrackerdownload == 'on') {
+		$enabled_rulesets_array[] = "feodotracker.rules";
+	}
+
 	if ($openappid_rulesdownload == 'on') {
 		$files = glob("{$snortdir}/rules/" . OPENAPPID_FILE_PREFIX . "*.rules");
 		foreach ($files as $file)
@@ -504,6 +512,88 @@ if ($snortdownload == "on") {
 		</div>
 	<?php endif; ?>
 <!-- End of GPLv2 Community rules -->
+
+<!-- Process Feodo Tracker Rules if enabled -->
+	<?php if ($no_feodotracker_files)
+			$msg_feodotracker = gettext("NOTE: Feodo Tracker Botnet C2 IP Rules have not been downloaded.  Perform a Rules Update to enable them.");
+	      else
+			$msg_feodotracker = gettext("Feodo Tracker Botnet C2 IP Rules");
+		  $feodotracker_rules_file = gettext("feodotracker.rules");
+	?>
+	<?php if ($feodotrackerdownload == 'on'): ?>
+		<div class="table-responsive col-sm-12">
+			<table class="table table-striped table-hover table-condensed">
+				<thead>
+					<tr>
+						<th><?=gettext("Enable"); ?></th>
+						<th><?=gettext('Ruleset: FEODO Tracker Botnet C2 IP Rules'); ?></th>
+						<th></th>
+						<th></th>
+						<th></th>
+						<th></th>
+					</tr>
+				</thead>
+				<tbody>
+			<?php if (isset($cat_mods[$feodotracker_rules_file])): ?>
+				<?php if ($cat_mods[$feodotracker_rules_file] == 'enabled') : ?>
+					<tr>
+						<td>
+							<i class="fa fa-adn text-success" title="<?=gettext('Auto-enabled by settings on SID Mgmt tab'); ?>"></i>
+						</td>
+						<td colspan="5">
+							<?php if ($no_feodotracker_files): ?>
+								<?php echo gettext("{$msg_feodotracker}"); ?>
+							<?php else: ?>
+								<a href='snort_rules.php?id=<?=$id;?>&openruleset=<?=$feodotracker_rules_file;?>'><?=gettext('{$msg_feodotracker}');?></a>
+							<?php endif; ?>
+						</td>
+					</tr>
+				<?php else: ?>
+					<tr>
+						<td>
+							<i class="fa fa-adn text-danger" title="<?=gettext("Auto-disabled by settings on SID Mgmt tab");?>"><i>
+						</td>
+						<td colspan="5">
+							<?php if ($no_feodotracker_files): ?>
+								<?php echo gettext("{$msg_feodotracker}"); ?>
+							<?php else: ?>
+								<a href='snort_rules_edit.php?id=<?=$id;?>&openruleset=<?=$feodotracker_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext("{$msg_feodotracker}"); ?></a>
+							<?php endif; ?>
+						</td>
+					</tr>
+				<?php endif; ?>
+			<?php elseif (in_array($feodotracker_rules_file, $enabled_rulesets_array)): ?>
+				<tr>
+					<td>
+						<input type="checkbox" name="toenable[]" value="<?=$feodotracker_rules_file;?>" checked="checked"/>
+					</td>
+					<td colspan="5">
+						<?php if ($no_feodotracker_files): ?>
+							<?php echo gettext("{$msg_feodotracker}"); ?>
+						<?php else: ?>
+							<a href='snort_rules.php?id=<?=$id;?>&openruleset=<?=$feodotracker_rules_file;?>'><?php echo gettext("{$msg_feodotracker}"); ?></a>
+						<?php endif; ?>
+					</td>
+				</tr>
+			<?php else: ?>
+				<tr>
+					<td>
+						<input type="checkbox" name="toenable[]" value="<?=$feodotracker_rules_file; ?>" />
+					</td>
+					<td colspan="5">
+						<?php if ($no_feodotracker_files): ?>
+							<?php echo gettext("{$msg_feodotracker}"); ?>
+						<?php else: ?>
+							<a href='snort_rules_edit.php?id=<?=$id;?>&openruleset=<?=$feodotracker_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=gettext("{$msg_feodotracker}"); ?></a>
+						<?php endif; ?>
+					</td>
+				</tr>
+			<?php endif; ?>
+				</tbody>
+			</table>
+		</div>
+	<?php endif; ?>
+<!-- End of Feodo Tracker rules -->
 
 <!-- Set strings for rules file state of "not enabled" or "not downloaded" -->
 			<?php if ($no_emerging_files && ($emergingdownload == 'on' || $etpro == 'on'))


### PR DESCRIPTION
### pfSense-pkg-Snort v4.1.4
This update to the Snort GUI package provides support for the latest 2.9.18 binary from upstream, adds a new FEODO Tracker Botnet C2 IP rules package option, and fixes two Redmine-reported bugs.

**New Features:**
1. Add support for the FEODO Tracker Botnet C2 IP Rules package.

**Bug Fixes:**
1. Fix issue with losing previously entered alias values when adding a new HTTP_INSPECT server engine on the PREPROCESSORS tab. [Redmine Issue #11637](https://redmine.pfsense.org/issues/11637).
2. Make rules update process smarter about restarting running Snort interfaces at the end of the update cycle. See [Redmine Issue #6235](https://redmine.pfsense.org/issues/6235).