### PR TITLE
add syslog support for DNSBL and GeoIP alerts. implements #12097

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -255,6 +255,9 @@ function pfb_global() {
 	$pfb['min']		= $pfb['config']['pfb_min']		?: '0';	// User defined CRON start minute
 	$pfb['hour']		= $pfb['config']['pfb_hour']		?: '0';	// Start hour of the scheduler
 	$pfb['24hour']		= $pfb['config']['pfb_dailystart']	?: '0';	// Start hour of the 'Once a day' schedule
+	$pfb['syslog']		= $pfb['config']['enable_syslog']	?: '';	// Enable/Disable of logging to system log
+	$pfb['syslog_facility']	= $pfb['config']['syslog_facility']	?: LOG_AUTH;  // System log facility
+	$pfb['syslog_priority']	= $pfb['config']['syslog_priority']	?: LOG_ALERT; // System log priority
 
 	$pfb['supp']		= $pfb['ipconfig']['suppression'];		// Enable Suppression
 	$pfb['cc']		= $pfb['ipconfig']['database_cc'];		// Disable Country database CRON updates
@@ -5011,10 +5014,17 @@ function pfb_daemon_filterlog() {
 					}
 				}
 				@file_put_contents("{$iplog}", "{$log},{$details},{$dup_entry}\n", FILE_APPEND | LOCK_EX);
-
+				
 				// Write to Unified Log
 				if ($dup_entry == '+') {
 					@file_put_contents("{$pfb['unilog']}", "{$l_type},{$log},{$details},{$dup_entry}\n", FILE_APPEND | LOCK_EX);
+				}
+				
+				// Write to syslog
+				if($pfb['syslog'] == 'on'){
+					openlog("pfblockerng", 0, $pfb['syslog_facility']);
+					syslog($pfb['syslog_priority'], "${l_type},${details},${dup_entry}");
+					closelog();
 				}
 			}
 		}
@@ -5532,6 +5542,13 @@ function pfb_log_event($type, $domain, $src_ip, $req_agent) {
 	
 	// Write to Unified Log
 	@file_put_contents($pfb['unilog'], "{$log}", FILE_APPEND | LOCK_EX);
+
+	// Write to syslog
+	if($pfb['syslog'] == 'on'){
+		openlog("pfblockerng", 0, $pfb['syslog_facility']);
+		syslog($pfb['syslog_priority'], "${type},${details},${dup_entry}");
+		closelog();
+	}
 
 	// Increment DNSBL Widget counter
 	if (!empty($pfb_group)) {

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -110,7 +110,7 @@ if ($_POST) {
 			if($syslog_changed){
 				syslog(LOG_NOTICE, '[pfBlockerNG] sytem logging settings changed, restarting services.');
 				restart_service('pfb_filter');
-				restart_service('dnsbl');
+				restart_service('pfb_dnsbl');
 			}
 			
 			header('Location: /pfblockerng/pfblockerng_general.php');


### PR DESCRIPTION
[https://redmine.pfsense.org/issues/12097](https://redmine.pfsense.org/issues/12097)

Adds possibility to log DSNBL and GeoIP alerts to syslog (and thus remote).
By default it is disabled.

Syslog facility and priority can be set (default to LOG_AUTH and LOG_ALERT respectively).