### PR TITLE
Bug #12114: Fix generated configuration to make syslog-ng bind on all specified interfaces

### DIFF
--- a/sysutils/pfSense-pkg-syslog-ng/Makefile
+++ b/sysutils/pfSense-pkg-syslog-ng/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-syslog-ng
 PORTVERSION=	1.15
-PORTREVISION=	7
+PORTREVISION=	8
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
@@ -129,7 +129,7 @@ function syslogng_build_default_objects($settings) {
 	$default_logdir = $settings['default_logdir'];
 	$default_logfile = $settings['default_logfile'];
 
-	$default_objects[0] = array("objecttype"=>"source", "objectname"=>"_DEFAULT", "objectparameters"=>"{ internal(); syslog(transport($default_protocol) port($default_port)");
+	$default_objects[0] = array("objecttype"=>"source", "objectname"=>"_DEFAULT", "objectparameters"=>"{ internal();");
 
 	if ($settings['default_protocol'] == 'tls') {
 		safe_mkdir(SYSLOGNG_DIR);
@@ -146,10 +146,10 @@ function syslogng_build_default_objects($settings) {
 	foreach (explode(",", $interfaces) as $interface) {
 		$interface_address = syslogng_get_real_interface_address($interface);
 		if ($interface_address[0]) {
-			$default_objects[0]['objectparameters'] .= " ip({$interface_address[0]})";
+			$default_objects[0]['objectparameters'] .= " syslog(transport($default_protocol) port($default_port) ip({$interface_address[0]}));";
 		}
 	}
-	$default_objects[0]['objectparameters'] .= "); };";
+	$default_objects[0]['objectparameters'] .= " };";
 	$default_objects[0]['objectparameters'] = base64_encode($default_objects[0]['objectparameters']);
 	$default_objects[1] = array("objecttype"=>"destination", "objectname"=>"_DEFAULT", "objectparameters"=>"{ file(\"$default_logdir/$default_logfile\"); };");
 	$default_objects[1]['objectparameters'] = base64_encode($default_objects[1]['objectparameters']);


### PR DESCRIPTION
A separate driver for each interface will now be configured.

The corresponding bug can be found [here](https://redmine.pfsense.org/issues/12114).