### PR TITLE
WireGuard Package v0.1.5

### DIFF
--- a/net/pfSense-pkg-WireGuard/Makefile
+++ b/net/pfSense-pkg-WireGuard/Makefile
@@ -1,12 +1,11 @@
 PORTNAME=	pfSense-pkg-WireGuard
-DISTVERSION=	0.1.3
-PORTREVISION=	1
+PORTVERSION=	0.1.5
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty
 EXTRACT_ONLY=	# empty
 
-MAINTAINER=	rcmcdonald91@gmail.com
+MAINTAINER=	coreteam@pfsense.org
 COMMENT=	pfSense package WireGuard (EXPERIMENTAL)
 
 LICENSE=	APACHE20
@@ -26,24 +25,36 @@ do-extract:
 do-install:
 	${MKDIR} ${STAGEDIR}/etc/inc/priv
 
-	${MKDIR} ${STAGEDIR}${PREFIX}/pkg/wireguard
+	${MKDIR} ${STAGEDIR}${PREFIX}/pkg/wireguard/classes
+	${MKDIR} ${STAGEDIR}${PREFIX}/pkg/wireguard/includes
 
 	${MKDIR} ${STAGEDIR}${PREFIX}/www/shortcuts
+	${MKDIR} ${STAGEDIR}${PREFIX}/www/widgets/include
+	${MKDIR} ${STAGEDIR}${PREFIX}/www/widgets/widgets
 	${MKDIR} ${STAGEDIR}${PREFIX}/www/wg/js
 
 	${MKDIR} ${STAGEDIR}${DATADIR}
 
-	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/wireguard.priv.inc \
+	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/*.priv.inc \
 		${STAGEDIR}/etc/inc/priv
 
-	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/wireguard.xml \
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/*.xml \
 		${STAGEDIR}${PREFIX}/pkg
 
-	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/wireguard/*.inc \
-		${STAGEDIR}${PREFIX}/pkg/wireguard
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/wireguard/classes/*.class.php \
+		${STAGEDIR}${PREFIX}/pkg/wireguard/classes
 
-	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/shortcuts/pkg_wireguard.inc \
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/wireguard/includes/*.inc \
+		${STAGEDIR}${PREFIX}/pkg/wireguard/includes
+
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/shortcuts/*.inc \
 		${STAGEDIR}${PREFIX}/www/shortcuts
+
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/widgets/include/*.inc \
+		${STAGEDIR}${PREFIX}/www/widgets/include
+
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/widgets/widgets/*.widget.php \
+		${STAGEDIR}${PREFIX}/www/widgets/widgets
 
 	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/wg/*.php \
 		${STAGEDIR}${PREFIX}/www/wg

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard.xml
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard.xml
@@ -30,7 +30,7 @@
 	<name>wireguard</name>
 	<version>%%PKGVERSION%%</version>
 	<title>VPN/WireGuard</title>
-	<include_file>/usr/local/pkg/wireguard/wg.inc</include_file>
+	<include_file>/usr/local/pkg/wireguard/includes/wg.inc</include_file>
 	<menu>
 		<name>WireGuard</name>
 		<section>VPN</section>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/classes/wgconfig.class.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/classes/wgconfig.class.php
@@ -1,0 +1,567 @@
+<?php
+/*
+ * wgconfig.class.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2021 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2021 R. Christian McDonald (https://github.com/theonemcdonald)
+ * Copyright (c) 2020 Dirk Henrici (https://github.com/towalink)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class wgconfig {
+
+	private const SECTION_FIRSTLINE		= '_index_firstline';
+	private const SECTION_LASTLINE		= '_index_lastline';
+	private const SECTION_RAW		= '_rawdata';
+
+	private const LINE_ATTR			= '_attr';
+	private const LINE_VALUE		= '_value';
+	private const LINE_COMMENT		= '_comment';
+
+	private const KEY_ATTR			= 'PublicKey';
+
+	private const INTERFACE_ATTR		= 'Interface';
+	private const PEER_ATTR			= 'Peer';
+
+	private const VALID_SECTIONS		= array(
+							'interface' => self::INTERFACE_ATTR,
+							'peer' => self::PEER_ATTR);
+	protected $tunnel_path;
+
+	protected $lines			= array();
+	protected $comment_lines		= array();
+
+	protected $interface			= array();
+	protected $peers			= array();
+
+	function __construct($tunnel_path = null, $default_local = true) {
+
+		$this->tunnel_path = self::tunnel_absolute_path($tunnel_path, $default_local);
+
+		$this->initialize_file();
+
+	}
+
+	function initialize_file($leading_comment = null) {
+
+		$this->lines = array();
+
+		$this->_add_leading_comment($leading_comment);
+
+		$this->lines[] = sprintf('[%s]', self::INTERFACE_ATTR);
+
+	}
+
+	function read_file() {
+
+		// Flush lines cache before reading the file
+		unset($this->lines);
+
+		if (file_exists($this->tunnel_path)) {
+
+			$this->lines = explode(PHP_EOL, file_get_contents($this->tunnel_path));
+
+		}
+
+	}
+
+	function write_file() {
+
+		if (!empty($this->lines)) {
+
+			$old_mask = umask(077);
+
+			file_put_contents($this->tunnel_path, implode(PHP_EOL, $this->lines), LOCK_EX);
+
+			umask($old_mask);
+
+		}
+
+	}
+
+	function get_conf_string() {
+
+		if (!empty($this->lines)) {
+
+			return implode(PHP_EOL, $this->lines);
+
+		}
+
+	}
+
+	function set_conf_string($conf_string) {
+
+		unset($this->lines);
+
+		$this->lines = explode(PHP_EOL, $conf_string);
+
+	}
+
+	function get_path() {
+
+		return $this->tunnel_path;
+
+	}
+
+	function set_path($tunnel_path = null, $default_local = true) {
+
+		$this->tunnel_path = self::tunnel_absolute_path($tunnel_path, $default_local);
+
+	}
+
+	function get_peers() {
+
+		$this->_parse_lines();
+
+		return $this->peers;
+
+	}
+
+	function get_interface() {
+
+		$this->_parse_lines();
+
+		return $this->interface;
+
+	}
+
+	function get_peer($key) {
+
+		$peers = $this->get_peers();
+
+		return $peers[$key];
+
+	}
+
+	function add_peer($key, $leading_comment = null) {
+
+		// Ensure each peer has a unique public key
+		if (!array_key_exists($key, $this->get_peers())) {
+
+			// Seperate each peer with a blank line
+			$this->lines[] 	= null;
+
+			$this->_add_leading_comment($leading_comment);
+
+			$this->lines[] 	= sprintf('[%s]', self::PEER_ATTR);
+
+			$this->lines[]	= sprintf('%s = %s', self::KEY_ATTR, $key);
+
+		}
+
+	}
+
+	function get_interface_attr($attr, $as_line = false) {
+
+		$interface = $this->get_interface();
+
+		$value = $interface[$attr][self::LINE_VALUE];
+
+		return $as_line ? implode(',', (array) $value) : $value;
+
+	}
+
+	function get_peer_attr($key, $attr, $as_line = false) {
+
+		$peers = $this->get_peers();
+
+		$value = $peers[$key][$attr][self::LINE_VALUE];
+
+		return $as_line ? implode(',', (array) $value) : $value;
+
+	}
+
+	function set_interface_attr($attr, $value, $leading_comment = null) {
+
+		$this->_set_attr(null, $attr, $value, $leading_comment);
+
+	}
+
+	function set_peer_attr($key, $attr, $value, $leading_comment = null) {
+
+		$this->_set_attr($key, $attr, $value, $leading_comment);
+
+	}
+
+	function del_interface_attr($attr, $value = null, $remove_leading_comments = true) {
+
+		$this->_del_attr(null, $attr, $value, $remove_leading_comments);
+
+	}
+
+	function del_peer_attr($key, $attr, $value = null, $remove_leading_comments = true) {
+
+		$this->_del_attr($key, $attr, $value, $remove_leading_comments);
+
+	}
+
+	function add_interface_attr($attr, $value, $leading_comment = null, $append_as_line = false) {
+
+		$this->_add_attr(null, $attr, $value, $leading_comment, $append_as_line);
+
+	}
+
+	function add_peer_attr($key, $attr, $value, $leading_comment = null, $append_as_line = false) {
+
+		$this->_add_attr($key, $attr, $value, $leading_comment, $append_as_line);
+
+	}
+
+	/*
+	 * Below are the private functions
+	*/
+
+	private function _parse_line($line) {
+
+		[$attr, $value] = explode('=', $line, 2);
+
+		$attr = trim($attr);
+
+		$parts = explode('#', $value, 2);
+
+		$value = explode(',', trim($parts[0]));
+
+		$comment = trim($parts[1]);
+
+		array_walk($value, function(&$x) {
+
+			$x = trim($x);
+
+		});
+
+		return array(self::LINE_ATTR => $attr, self::LINE_VALUE => $value, self::LINE_COMMENT => $comment);
+
+	}
+
+	private function _parse_lines() {
+		
+		$section = null;
+
+		$section_data = array();
+
+		$last_empty_line_in_section = -1;
+
+		foreach ((array) $this->lines as $i => $line) {
+
+			$line = trim($line);
+
+			if (strlen($line) == 0) {
+
+				$last_empty_line_in_section = $i;
+
+				continue;
+
+			}
+
+			if (self::str_starts_with($line, '[')) {
+
+				if (!is_null($last_empty_line_in_section)) {
+
+					$section_data[self::SECTION_LASTLINE] = $last_empty_line_in_section - 1;
+
+				}
+
+				$this->_close_section($section, $section_data);
+
+				$section_data = array();
+
+				$section = strtolower(explode(']', substr($line, 1))[0]);
+
+				if (is_null($last_empty_line_in_section)) {
+
+					$section_data[self::SECTION_FIRSTLINE] = $i;
+
+				} else {
+
+					$section_data[self::SECTION_FIRSTLINE] = $last_empty_line_in_section + 1;
+
+					$last_empty_line_in_section = null;
+
+				}
+
+				$section_data[self::SECTION_LASTLINE] = $i;
+				
+				if (!in_array($section, array_keys(self::VALID_SECTIONS))) {
+
+					continue;
+
+				}
+
+			} elseif (self::str_starts_with($line, '#')) {
+
+				$this->comment_lines[] = $line;
+
+				$section_data[self::SECTION_LASTLINE] = $i;
+
+			} else {
+
+				[self::LINE_ATTR => $attr, self::LINE_VALUE => $value, self::LINE_COMMENT => $comment] = $this->_parse_line($line);
+
+				$section_data[$attr] = array(self::LINE_ATTR => $attr, self::LINE_VALUE => $value, self::LINE_COMMENT => $comment);
+
+				$section_data[self::SECTION_LASTLINE] = $i;
+
+			}
+
+		}
+
+		$this->_close_section($section, $section_data);
+
+	}
+
+	private function _set_attr($key, $attr, $value, $leading_comment = null) {
+
+		$this->_del_attr($key, $attr, null, true);
+
+		$this->_add_attr($key, $attr, $value, $leading_comment, false);
+
+	}
+
+	private function _del_attr($key, $attr, $value = null, $remove_leading_comments = true) {
+
+		$lines_found = array();
+
+		if ([self::SECTION_FIRSTLINE => $section_firstline, self::SECTION_LASTLINE => $section_lastline] = $this->_get_section_range($key)) {
+
+			foreach (range($section_firstline + 1, $section_lastline + 1) as $i) {
+
+				[self::LINE_ATTR => $line_attr, self::LINE_VALUE => $line_value, self::LINE_COMMENT => $line_comment] = $this->_parse_line($this->lines[$i]);
+
+				if ($attr == $line_attr) {
+
+					if (is_null($value) || in_array($value, $line_value)) {
+
+						$lines_found[] = $i;
+
+					} 
+
+				}
+
+			}
+
+			foreach (array_reverse($lines_found) as $i) {
+
+				if (is_null($value)) {
+
+					array_splice($this->lines, $i, 1);
+
+				} else {
+
+					[self::LINE_ATTR => $line_attr, self::LINE_VALUE => $line_value, self::LINE_COMMENT => $line_comment] = $this->_parse_line($this->lines[$i]);
+
+					array_splice($this->lines, array_search($value, $line_value), 1);
+
+					if (count($line_value) > 0) {
+
+						$line_values = implode(', ', $line_value);
+
+						$line_comment = (strlen($line_comment) > 0) ? " # {$line_comment}" : null;
+		
+						$this->lines[$i] = "{$line_attr} = {$line_values}{$line_comment}";
+
+					} else {
+
+						array_splice($this->lines, $i, 1);
+
+					}
+
+				}
+
+			}
+
+		}
+
+	}
+
+	private function _add_attr($key, $attr, $value, $leading_comment = null, $append_as_line = false) {
+
+		$line_found = false;
+
+		// Check if the section is valid and if the desired attribute value is valid...
+		if (([self::SECTION_FIRSTLINE => $section_firstline, self::SECTION_LASTLINE => $section_lastline] = $this->_get_section_range($key))
+		    && (!empty($value))) {
+
+			foreach (range($section_firstline + 1, $section_lastline + 1) as $i) {
+
+				[self::LINE_ATTR => $line_attr, self::LINE_VALUE => $line_value, self::LINE_COMMENT => $line_comment] = $this->_parse_line($this->lines[$i]);
+
+				if ($attr == $line_attr) {
+
+					$line_found = $i;
+
+				}
+
+			}
+
+			if (($line_found == false) || $append_as_line) {
+
+				$line_found = ($line_found === false) ? $section_lastline : $line_found;
+				
+				$line_found++;
+
+				$attr_value = sprintf('%s = %s', $attr, $value);
+
+				array_splice($this->lines, $line_found, 0, $attr_value);
+
+				$this->_add_leading_comment($leading_comment, $line_found);
+
+			} else {
+
+				[self::LINE_ATTR => $line_attr, self::LINE_VALUE => $line_value, self::LINE_COMMENT => $line_comment] = $this->_parse_line($this->lines[$line_found]);
+
+				$line_value[] = $value;
+
+				$line_values = implode(',', $line_value);
+
+				$line_comment = (strlen($line_comment) > 0) ? " # {$line_comment}" : null;
+
+				$this->lines[$line_found] = "{$line_attr} = {$line_values}{$line_comment}";
+
+			}
+
+		}
+
+	}
+
+	private function _add_leading_comment($leading_comment = null, $position = null) {
+
+		if (!is_null($leading_comment)) {
+
+			$leading_comment = trim($leading_comment);
+
+			array_splice($this->lines, (is_null($position) ? count($this->lines) : $position), 0, "# {$leading_comment}");
+
+		}
+
+	}
+
+	private function _close_section($section, $section_data) {
+
+		if (!is_null($section)) {
+
+			$section_data[self::SECTION_RAW] = array_slice($this->lines, $section_data[self::SECTION_FIRSTLINE], ($section_data[self::SECTION_LASTLINE] - $section_data[self::SECTION_FIRSTLINE] + 1));
+
+			switch (strtolower($section)) {
+
+				// Interface Section
+				case (strtolower(self::INTERFACE_ATTR)):
+
+					$this->interface = $section_data;
+
+					break;
+
+				// Peer Section
+				case (strtolower(self::PEER_ATTR)):
+
+					[self::LINE_VALUE => $value, self::LINE_COMMENT => $comment] = $section_data[self::KEY_ATTR];
+
+					$this->peers[$value[0]] = $section_data;
+
+					break;
+
+			}
+
+		}
+
+	}
+
+	private function _get_interface_section_range() {
+
+		return $this->_get_section_range(null);
+
+	}
+
+	private function _get_peer_section_range($key) {
+
+		return $this->_get_section_range($key);
+
+	}
+
+	private function _get_section_range($key = null) {
+
+		// Assume it is not...
+		$is_range_valid = false;
+
+		if (is_null($key)) {
+
+			$interface = $this->get_interface();
+
+			$section_firstline = $interface[self::SECTION_FIRSTLINE];
+
+			$section_lastline = $interface[self::SECTION_LASTLINE];
+
+			$is_range_valid = true;
+
+		} else {
+
+			$peers = $this->get_peers();
+
+			if (array_key_exists($key, $peers)) {
+
+				$section_firstline = $peers[$key][self::SECTION_FIRSTLINE];
+	
+				$section_lastline = $peers[$key][self::SECTION_LASTLINE];
+
+				$is_range_valid = true;
+	
+			}
+
+		}
+
+		return $is_range_valid ? array(self::SECTION_FIRSTLINE => $section_firstline, self::SECTION_LASTLINE => $section_lastline) : $is_range_valid;
+
+	}
+
+	/*
+	 * Below are static helper functions
+	*/
+
+	static function tunnel_absolute_path($tunnel_path = null, $default_local = true) {
+
+		if (!is_null($tunnel_path)) {
+
+			$path = pathinfo($tunnel_path);
+
+			if ($path['basename'] == $tunnel_path) {
+
+				if (empty($path['extension'])) {
+
+					$tunnel_path .= '.conf';
+
+				}
+
+				$root = $default_local ? '/usr/local' : null;
+
+				$tunnel_path = "{$root}/etc/wireguard/{$tunnel_path}";
+
+			}
+
+		}
+
+		return $tunnel_path;
+
+	}
+
+	static function str_starts_with($haystack, $needle) {
+
+		return (((string) $needle !== '') && (strncmp($haystack, $needle, strlen($needle)) === 0));
+
+	}
+
+}
+
+
+?>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg.inc
@@ -1,0 +1,1140 @@
+<?php
+/*
+ * wg.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2021 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2021 R. Christian McDonald (https://github.com/theonemcdonald)
+ * Copyright (c) 2020 Ascrod
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// pfSense includes
+require_once('config.inc');
+require_once('gwlb.inc');
+require_once('util.inc');
+
+// WireGuard includes
+require_once('wireguard/includes/wg_api.inc');
+require_once('wireguard/includes/wg_install.inc');
+require_once('wireguard/includes/wg_service.inc');
+require_once('wireguard/includes/wg_validate.inc');
+
+global $wgg;
+
+/*
+ * This toggles a given tunnel based on index
+ */
+function wg_toggle_tunnel($tunnel_name) {
+	global $wgg;
+
+	// Make sure we have the latest info
+	wg_globals();
+
+	// Assume no changes will be made...
+	$changes = false;
+
+	$input_errors = array();
+
+	if ([$tun_idx, $tunnel, $is_new] = wg_tunnel_get_config_by_name($tunnel_name)) {
+
+		$is_enabled = (isset($tunnel['enabled']) && ($tunnel['enabled']) == 'yes');
+
+		// Toggle the tunnel state
+		$tunnel['enabled']	= $is_enabled ? 'no' : 'yes';
+
+		$input_errors		= wg_validate_tunnel_toggle($tunnel);
+
+		if (empty($input_errors)) {
+
+			$wgg['tunnels'][$tun_idx] = $tunnel;
+
+			$action_txt = $is_enabled ? 'Disabled' : 'Enabled';
+			
+			// Sync with configuration backend
+			wg_write_config("{$action_text} tunnel {$tunnel['name']}.", true);
+
+			// Resync the package
+			wg_resync();
+
+			// We've got meaningful changes...
+			$changes = true;
+
+			// What tunnel would we need to sync to apply these changes?
+			$tuns_to_sync[] = $tunnel['name'];
+
+		}
+
+	}
+
+	return array('input_errors' => $input_errors, 'changes' => $changes, 'tuns_to_sync' => $tuns_to_sync);
+
+}
+
+/*
+ * This toggles a given peer based on config array index
+ */
+function wg_toggle_peer($peer_idx) {
+	global $wgg;
+
+	// Make sure we have the latest info
+	wg_globals();
+
+	// Assume no changes will be made...
+	$changes = false;
+
+	$input_errors = array();
+
+	if ([$peer_idx, $peer, $is_new] = wg_peer_get_config($peer_idx)) {
+
+		$is_enabled = (isset($peer['enabled']) && ($peer['enabled']) == 'yes');
+
+		// Toggle the peer state
+		$peer['enabled']	= $is_enabled ? 'no' : 'yes';
+
+		$input_errors		= wg_validate_peer_toggle($peer);
+
+		// Boilerplate...
+		if (empty($input_errors)) {
+
+			$wgg['peers'][$peer_idx] = $peer;
+
+			$action_text = $is_enabled ? 'Disabled' : 'Enabled';
+
+			// Sync with configuration backend
+			wg_write_config("{$action_text} peer {$peer['publickey']} on {$peer['tun']}.", true);
+
+			// Resync the package
+			wg_resync();
+
+			// This checks if the peer tunnel is a valid tunnel
+			if (wg_is_valid_tunnel($peer['tun'])) {
+
+				// We've got meaningful changes...
+				$changes = true;
+
+				// What tunnel would we need to sync to apply these changes?
+				$tuns_to_sync[] = $peer['tun'];
+
+			}
+
+		}
+
+	}
+
+	return array('input_errors' => $input_errors, 'changes' => $changes, 'tuns_to_sync' => $tuns_to_sync);
+
+}
+
+/*
+ * This deletes a given peer based on config array index
+ */
+function wg_delete_peer($peer_idx) {
+	global $wgg;
+
+	// Make sure we have the latest info
+	wg_globals();
+
+	$changes = false;
+
+	$input_errors = array();
+
+	if ([$peer_idx, $peer, $is_new] = wg_peer_get_config($peer_idx)) {
+
+		$input_errors		= wg_validate_peer_delete($peer);
+
+		// Boilerplate...
+		if (empty($input_errors)) {
+
+			// Delete the peer
+			unset($wgg['peers'][$peer_idx]);
+
+			// Sync with configuration backend
+			wg_write_config("Deleted peer {$peer_idx} ({$peer['publickey']}).", true);
+
+			// Resync the package
+			wg_resync();
+
+			// This checks if the peer's tunnel was a valid tunnel
+			if (wg_is_valid_tunnel($peer['tun'])) {
+
+				// We've got meaningful changes...
+				$changes = true;
+
+				// What tunnel would we need to sync to apply these changes?
+				$tuns_to_sync[] = $peer['tun'];
+
+			}
+
+		}
+		
+	}
+
+	return array('input_errors' => $input_errors, 'changes' => $changes, 'tuns_to_sync' => $tuns_to_sync);
+
+}
+
+/*
+ * This deletes a given tunnel based on name
+ */
+function wg_delete_tunnel($tunnel_name) {
+	global $wgg;
+
+	// Make sure we have the latest info
+	wg_globals();
+
+	$changes = false;
+
+	$input_errors = array();
+
+	if ([$tun_idx, $tunnel, $is_new] = wg_tunnel_get_config_by_name($tunnel_name)) {
+
+		$input_errors		= wg_validate_tunnel_delete($tunnel);
+
+		if (empty($input_errors)) {
+
+			// Delete the tunnel
+			unset($wgg['tunnels'][$tun_idx]);
+
+			// Sync with configuration backend
+			wg_write_config("Deleted tunnel {$tunnel['name']}.", true);
+			
+			// Mark any peers as unassigned
+			wg_tunnel_unassign_peers($tunnel['name']);
+
+			// Resync the package
+			wg_resync();
+
+			// We've got meaningful changes...
+			$changes = true;
+
+			// What tunnel would we need to sync to apply these changes?
+			$tuns_to_sync[] = $tunnel['name'];
+
+		}
+
+	}
+
+	return array('input_errors' => $input_errors, 'changes' => $changes, 'tuns_to_sync' => $tuns_to_sync);
+
+}
+
+function wg_toggle_wireguard() {
+	global $wgg;
+
+	if (wg_is_service_enabled() && !wg_is_service_running()) {
+
+		return wg_service_fpm_start();
+
+	} elseif (!wg_is_service_enabled() && wg_is_service_running()) {
+
+		return wg_service_fpm_stop();
+
+	} else {
+
+		return false;
+
+	}
+
+}
+
+function wg_tunnel_unassign_peers($tunnel_name) {
+	global $wgg;
+
+	wg_globals();
+
+	// Assume there is no peers to unassign...
+	$changes = false;
+	
+	foreach (wg_tunnel_get_peers_config($tunnel_name) as [$peer_idx, $peer, $is_new]) {
+
+		$wgg['peers'][$peer_idx]['tun'] = 'unassigned';
+
+		// We've got at least one, so we need to resync with the backend...
+		$changes = true;
+
+	}
+
+	if ($changes) {
+
+		// Sync with configuration backend
+		wg_write_config("Unassigned tunnel {$tunnel_name} peers.", true);
+
+	}
+
+}
+
+/*
+ * This transforms a raw peer post consisting of repeatables 
+ */
+function wg_peer_allowedips($post) {
+
+	// Convert the post into proper arrays
+	$allowedips = wg_parse_post_repeatables($post, array('address', 'address_subnet', 'address_descr'));
+
+	$ret_array = array();
+
+	// Loop through each address entry
+	foreach ($allowedips as $row) {
+
+		// Remove any accidental whitespace
+		$row['address'] = trim($row['address']);
+
+		if (!empty($row['address'])) {
+
+			$ret_array[] 	= array(
+						'address'	=> $row['address'], 
+						'mask'		=> $row['address_subnet'], 
+						'descr'		=> $row['address_descr']);
+
+		}
+
+	}
+
+	// Consumers expect an array
+	return $ret_array;
+
+}
+
+/*
+ * This transforms a raw tunnel post consisting of repeatables 
+ */
+function wg_tunnel_addresses($post) {
+
+	// Convert the post into proper arrays
+	$addresses = wg_parse_post_repeatables($post, array('address', 'address_subnet', 'address_descr'));
+
+	$ret_array = array();
+
+	// Loop through each address entry
+	foreach ($addresses as $row) {
+
+		// Remove any accidental whitespace
+		$row['address'] = trim($row['address']);
+
+		if (!empty($row['address'])) {
+
+			$ret_array[] 	= array(
+						'address' 	=> $row['address'], 
+						'mask' 		=> $row['address_subnet'], 
+						'descr' 	=> $row['address_descr']);
+
+		}
+
+	}
+
+	// Consumers expect an array
+	return $ret_array;
+
+}
+
+/*
+ * This converts a raw form post containing any repeatables like addresses, subnets, and descriptions and returns an actual array
+ */
+function wg_parse_post_repeatables($post, $fields = null) {
+
+	$ret_array = array();
+
+	if (is_array($fields)) {
+
+		foreach ($fields as $field) {
+
+			$x = 0;
+
+			while (!is_null($post["{$field}{$x}"])) {
+
+				$ret_array[$x][$field] = $post["{$field}{$x}"];
+
+				$x++;
+
+			}
+
+		}
+
+	}
+
+	return $ret_array;
+
+}
+
+function wg_destroy_rogue_peers($tunnel_name, &$cmds = null) {
+	global $wgg;
+
+	// Assume this will be successful...
+	$res = true;
+
+	$running_peers = wg_tunnel_get_peers_running_keys($tunnel_name);
+
+	foreach ((array) $running_peers as $key) {
+
+		// This will return false for both invalid and disabled peers...
+		if (!wg_peer_is_enabled($tunnel_name, $key)) {
+
+			$res &= wg_peer_set_remove($tunnel_name, $key, $cmds);
+
+		}
+
+	}
+
+	return $res;
+
+}
+
+/*
+ * This resolves peer endpoint hostnames per tunnel and updates the kernel accordingly
+ * This returns a DateTime object corresponding to the last update time
+ */
+function wg_resolve_endpoints() {
+	global $wgg;
+
+	// Get the latest info
+	wg_globals();
+
+	// Do we have any peers?
+	if (isset($wgg['peers']) && is_array($wgg['peers'])) {
+
+		foreach ((array) $wgg['peers'] as $peer) {
+
+			// Strip port if empty
+			$peer['port'] = !empty($peer['port']) ? ":{$peer['port']}" : null;
+
+			$endpoint = "{$peer['endpoint']}{$peer['port']}";
+
+			wg_peer_set_endpoint($peer['tun'], $peer['publickey'], $endpoint);
+
+		}
+
+	}
+
+	$last_update_time = new DateTime();
+
+	return $last_update_time;
+
+}
+
+/*
+ * Determines if endpoint hostnames should be re-resolved
+ * based on the last time the hostnames were re-resolved
+ * 
+ * An interval of 0 will effectively disable re-resolving
+ */
+function wg_should_reresolve_endpoints($last_update_time) {
+	global $wgg;
+
+	try {
+
+		// Get the current timestamp
+		$current_time = (new DateTimeImmutable)->getTimestamp();
+
+		// Calculate the time for the next update event
+		$time_to_update = $last_update_time->getTimestamp() + wg_get_endpoint_resolve_interval();
+
+		// Should we update? A 0 TTL means disabled.
+		return ((wg_get_endpoint_resolve_interval() > 0) && ($time_to_update <= $current_time));
+
+	} catch (Exception $e) {
+
+		// Something probably went wrong with DateTime, just bail out...
+		return false;
+
+	}
+
+}
+
+/*
+ * Gets the hostname resolve interval (in seconds)
+ * Returns package default if something is wrong with the configuration
+ */
+function wg_get_endpoint_resolve_interval() {
+	global $config, $wgg;
+
+	// Are we tracking the system value?
+	if (isset($wgg['config']['resolve_interval_track']) 
+	    && ($wgg['config']['resolve_interval_track'] == 'yes')) {
+
+		if (isset($config['system']['aliasesresolveinterval']) 
+		    && is_numeric($config['system']['aliasesresolveinterval'])) {
+
+			return $config['system']['aliasesresolveinterval'];
+
+		}
+			
+		// Package default is the same as pfSense default (300 seconds)
+		return $wgg['default_resolve_interval'];
+
+	} elseif (isset($wgg['config']['resolve_interval'])
+	          && is_numericint($wgg['config']['resolve_interval'])) {
+
+		return $wgg['config']['resolve_interval'];
+
+	} else {
+
+		// Something is wrong, so just return the package default...
+		return $wgg['default_resolve_interval'];
+
+	}
+
+	// Should never be here...
+	return 0;
+
+}
+
+function wg_do_settings_post($post) {
+	global $wgg;
+
+	wg_globals();
+
+	$pconfig = $input_errors = array();
+
+	// Assume no changes will be made...
+	$changes = false;
+
+	// We need to save the "old config" to compare against later...
+	$pconfig = $old_config = $wgg['config'];
+
+	$pconfig['enable']			= (!empty($post['enable']) && $post['enable'] == 'yes') ? 'on' : 'off';
+
+	$pconfig['keep_conf'] 			= empty($post['keep_conf']) ? 'no' : $post['keep_conf'];
+
+	$pconfig['resolve_interval']		= empty($post['resolve_interval']) && ($post['resolve_interval'] !== '0') ? $wgg['default_resolve_interval'] : $post['resolve_interval'];
+
+	$pconfig['resolve_interval_track']	= empty($post['resolve_interval_track']) ? 'no' : $post['resolve_interval_track'];
+
+	$pconfig['interface_group']		= empty($post['interface_group']) ? 'all' : $post['interface_group'];
+	
+	$pconfig['hide_secrets']		= empty($post['hide_secrets']) ? 'no' : $post['hide_secrets'];
+
+	$input_errors = wg_validate_settings_post($pconfig);
+
+	if (empty($input_errors)) {
+
+		$wgg['config'] = $pconfig;
+
+		// Sync with configuration backend
+		wg_write_config('Saved package settings.', true);
+
+		// Resync the package
+		wg_resync();
+
+		// Do we have meaningful changes?
+		$changes = ($pconfig != $old_config);
+
+	}
+
+	return array('input_errors' => $input_errors, 'changes' => $changes, 'pconfig' => $pconfig);
+
+}
+
+/*
+ * Takes a raw post for a peer, validates it, and saves it to the configuration system
+ */
+function wg_do_peer_post($post) {
+	global $wgg;
+
+	wg_globals();
+
+	$pconfig = $input_errors = array();
+
+	// Assume no changes will be made...
+	$changes = false;
+
+	[$peer_idx, $pconfig, $is_new] = wg_peer_get_config($post['index'], true);
+
+	// We need to save the "old config" to compare against later...
+	$old_pconfig = $pconfig;
+
+	$pconfig['enabled'] 		= empty($post['enabled']) ? 'no' : $post['enabled'];
+
+	$pconfig['tun'] 		= $post['tun'];
+
+	$pconfig['descr'] 		= $post['descr'];
+
+	$pconfig['endpoint'] 		= $post['endpoint'];
+
+	$pconfig['port'] 		= empty($post['port']) ? $wgg['default_port'] : $post['port'];
+
+	$pconfig['persistentkeepalive']	= $post['persistentkeepalive'];
+
+	$pconfig['publickey'] 		= $post['publickey'];
+	
+	$pconfig['presharedkey']	= $post['presharedkey'];
+
+	$pconfig['allowedips']['row'] 	= wg_peer_allowedips($post);
+
+	// Looks like we have a dynamic endpoint, so clear endpoint or port variables before saving
+	if (isset($post['dynamic']) && $post['dynamic'] == 'yes') {
+
+		unset($pconfig['endpoint'], $pconfig['port']);
+
+	}
+
+	$input_errors = wg_validate_peer_post($pconfig, $peer_idx);
+
+	if (empty($input_errors)) {
+
+		$wgg['peers'][$peer_idx] = $pconfig;
+
+		// Sync with configuration backend
+		wg_write_config("Updated peer {$peer_idx} ({$peer['publickey']}).", true);
+
+		// Resync the package
+		wg_resync();
+
+		/*
+		 * Figure out what tunnel to sync to make these changes (if any).
+		 * 
+		 * If the peer is re-unassigned, then $old_pconfig['tun'] needs to be resynced.
+		 */
+		foreach (array($pconfig['tun'], $old_pconfig['tun']) as $tun) {
+
+			if (wg_is_valid_tunnel($tun)) {
+
+				$changes = ($pconfig != $old_pconfig) || $is_new;
+
+				$tuns_to_sync[] = $tun;
+
+			}
+
+		}
+
+	}
+
+	return array('input_errors' => $input_errors, 'changes' => $changes, 'tuns_to_sync' => $tuns_to_sync, 'pconfig' => $pconfig);
+
+}
+
+/*
+ * Takes a raw post for a tunnel, validates it, and saves it to the configuration system
+ */
+function wg_do_tunnel_post($post) {
+	global $wgg;
+
+	wg_globals();
+
+	$pconfig = $input_errors = array();
+
+	// Assume no changes will be made...
+	$changes = false;
+
+	[$tun_idx, $pconfig, $is_new] = wg_tunnel_get_config($post['index'], true);
+
+	// We need to save the "old config" to compare against later...
+	$old_pconfig = $pconfig;
+
+	$key = wg_gen_publickey($post['privatekey']);
+
+	$pconfig['name']		= empty($pconfig['name']) ? next_wg_if() : $pconfig['name'];
+
+	$pconfig['enabled']		= empty($post['enabled']) ? 'no' : $post['enabled'];
+
+	$pconfig['descr']		= $post['descr'];
+
+	$pconfig['listenport']		= empty($post['listenport']) ? next_wg_port() : $post['listenport'];
+
+	$pconfig['privatekey']		= $key['privkey'];
+
+	$pconfig['publickey']		= $key['pubkey'];
+
+	$pconfig['mtu']			= empty($post['mtu']) ? $wgg['default_mtu'] : $post['mtu'];
+
+	$pconfig['addresses']['row'] 	= wg_tunnel_addresses($post);
+
+	$input_errors			= wg_validate_tunnel_post($pconfig, $tun_idx);
+
+	if (empty($input_errors)) {
+
+		$wgg['tunnels'][$tun_idx] = $pconfig;
+
+		// Sync with configuration backend
+		wg_write_config("Updated tunnel {$pconfig['name']}.", true);
+
+		// Resync the package
+		wg_resync();
+
+		// Do we have meaningful changes?
+		$changes = ($pconfig != $old_pconfig);
+
+		// What tunnel would we need to sync to apply these changes?
+		$tuns_to_sync[] = $pconfig['name'];
+
+	}
+
+	return array('input_errors' => $input_errors, 'changes' => $changes, 'tuns_to_sync' => $tuns_to_sync, 'pconfig' => $pconfig);
+
+}
+
+function wg_apply_list_get($list, $delete_after_get = true) {
+	global $wgg;
+
+	$toapplylist = array();
+
+	if (isset($wgg['applylist'][$list])) {
+
+		$listpath = $wgg['applylist'][$list];
+
+		if (file_exists($listpath)) {
+
+			$toapplylist = (array) unserialize(file_get_contents($listpath));
+
+		}
+
+		// Usually just want to delete the apply list after we read it...
+		if ($delete_after_get) {
+
+			unlink_if_exists($listpath);
+
+		}
+
+	}
+
+	return $toapplylist;
+
+}
+
+function wg_apply_list_add($list, $entries) {
+	global $wgg;
+
+	$toapplylist = array();
+
+	if (isset($wgg['applylist'][$list])) {
+
+		$listpath = $wgg['applylist'][$list];
+
+		// Get the current list without deleting it...
+		$toapplylist = wg_apply_list_get($list, false);
+
+		// Need to type cast $entires to array and remove duplicates
+		$toapplylist = array_unique(array_merge($toapplylist, (array) $entries));
+
+		file_put_contents($listpath, serialize($toapplylist));
+
+		$toapplylist = unserialize(file_get_contents($listpath));
+
+	}
+
+	return $toapplylist;
+
+}
+
+/*
+ * This compares the running vs configured tunnels and destroys any rogues
+ */
+function wg_destroy_rogue_tunnels(&$cmds = null) {
+	global $wgg;
+
+	// Assume this will be successful
+	$res = true;
+
+	$running_ifs = wg_get_running_ifs();
+
+	$config_ifs = wg_get_configured_ifs();
+
+	$rogue_tunnels = array_diff($running_ifs, $config_ifs);
+
+	foreach ($rogue_tunnels as $tunnel) {
+
+		$res &= wg_ifconfig_if_destroy($tunnel, $cmds);
+
+	}
+
+	return $res;
+
+}
+
+/*
+ * This builds, rebuilds, or destroys tunnel interfaces
+ * If $tunnel_names is null, this will apply to all configured tunnel interfaces
+ */
+function wg_tunnel_sync($tunnel_names, $restart_services = false, $resolve_endpoints = true, $json = false) {
+	global $wgg;
+
+	// Fetch and build the latest info
+	wg_resync();
+
+	// Let's assume everything will be fine
+	$ret_code = 0;
+
+	$tunnels = array();
+
+	// We need to destroy any rogue tunnels not created by pfSense
+	wg_destroy_rogue_tunnels();
+
+	// This is only necessary if the sevice is running
+	if (wg_is_service_running()) {
+
+		// Sync each tunnel
+		foreach ((array) $tunnel_names as $tunnel_name) {
+
+			// Attempt to sync the tunnel
+			$tun_sync_status = wg_tunnel_sync_by_name($tunnel_name, false);
+
+			// Build an aggregated return code
+			$ret_code |= $tun_sync_status['ret_code'];
+
+			// Collect the return from each individual tunnel
+			$tunnels[] = array(
+					'name' 		=> $tun_sync_status['config']['name'],
+					'ret_code' 	=> $tun_sync_status['ret_code'], 
+					'errors' 	=> $tun_sync_status['errors'],
+					'config' 	=> $tun_sync_status['config']);
+
+			// We need to destroy any rogue peers too...
+			wg_destroy_rogue_peers($tunnel_name);
+
+		}
+		
+		// Reconfigure system routing
+		system_routing_configure();
+		
+		// Reconfigure pf packet filter
+		filter_configure();
+
+		// Handle any extra services that need restarting
+		if ($restart_services) {
+
+			wg_restart_extra_services();
+
+		}
+
+		// Handle resolving endpoints
+		if ($resolve_endpoints) {
+
+			wg_resolve_endpoints();
+			
+		}
+
+	}
+
+	$res = array('ret_code' => $ret_code, 'tunnels' => $tunnels);
+
+	return $json ? json_encode($res) : $res;
+
+}
+
+/*
+ * This builds or rebuilds a specific tunnel interface by name
+ */
+function wg_tunnel_sync_by_name($tunnel_name, $json = false) {
+	global $wgg;
+
+	// Get the latest info
+	wg_globals();
+
+	$cmds = $errors = $tunnel = array();
+
+	// We've got a tunnel that we need to build...
+	if ([$tun_idx, $tunnel, $is_new] = wg_tunnel_get_config_by_name($tunnel_name)) {
+
+		// Determine desired state of the tunnel
+		$state = (isset($tunnel['enabled']) && $tunnel['enabled'] == 'yes');
+
+		// Create the tunnel interface if it does not yet exist
+		if (wg_ifconfig_if_create($tunnel['name'], $cmds)) {
+
+			// Add the tunnel interface to the WireGuard interface group
+			wg_interface_update_groups($tunnel['name'], $cmds);
+
+			// Update the addresses on the tunnel interface
+			wg_interface_update_addresses($tunnel['name'], $cmds);
+
+			// Toggle the interface accordingly instead of tearing it down completely
+			wg_ifconfig_if_updown($tunnel['name'], $state, $cmds);
+
+			// Sync interface with WireGuard wg(8)
+			wg_wg_if_sync($tunnel['name'], $cmds);
+
+		}
+
+	}
+
+	$parsed_cmds = wg_parse_cmds_array($cmds);
+
+	// Build the return array
+	$res = array(
+		'ret_code'	=> $parsed_cmds['ret_code'], 
+		'errors'	=> $parsed_cmds['errors'], 
+		'cmds'		=> $parsed_cmds['cmds'],
+		'config'	=> $tunnel);
+
+	return $json ? json_encode($res) : $res;
+
+}
+
+/*
+ * Parses an array of $cmds
+ */
+function wg_parse_cmds_array($cmds) {
+
+	$ret_code = 0;
+	
+	$errors = array();
+
+	if (isset($cmds) && is_array($cmds)) {
+
+		foreach($cmds as $cmd) {
+
+			$ret_code |= $cmd['ret_code'];
+
+			// Unwrap and collect any errors
+			array_push($errors, ...$cmd['errors']);
+
+		}
+
+	}
+
+	return array('ret_code' => $ret_code, 'errors' => $errors, 'cmds' => $cmds);
+
+}
+
+/*
+ * This performs some routine checks just to make sure everything is still in order
+ */
+function wg_resync() {
+	global $g, $wgg;
+
+	// Update globals
+	wg_globals();
+
+	// Create WireGuard configuration files
+	wg_create_config_files();
+
+	// Not really important if we are installing...
+	if (!$g['wireguard_installing']) {
+
+		// Reinstall earlyshellcmd in case it was accidently deleted
+		wg_earlyshellcmd_install();
+
+		// Recreate interface group in case it was accidently deleted
+		wg_ifgroup_install();
+
+		// Update Unbound ACL by recreating it
+		wg_unbound_acl_install();
+
+		// Update ListenPort Alias by recreating it
+		wg_listenport_alias_install();
+
+		// Just as a clarity check...
+		wg_defaults_install();
+
+	}
+
+	if (wg_is_service_running()) {
+
+		// Go ahead and resolve DNS when we call package resync
+		wg_resolve_endpoints();
+
+	} elseif (is_module_loaded($wgg['kmod'])) {
+
+		// We don't want active tunnels when the service isn't running
+		wg_destroy_tunnels();
+
+	}
+
+	// We definitely aren't installing at this point...
+	unset($g['wireguard_installing']);
+
+}
+
+/*
+ * Returns an array of enabled tunnels
+ */
+function wg_get_enabled_tunnels() {
+	global $wgg;
+
+	wg_globals();
+
+	$ret_tunnels = array();
+
+	foreach ($wgg['tunnels'] as $tunnel) {
+
+		if (isset($tunnel['enabled']) && $tunnel['enabled'] == 'yes') {
+
+			$ret_tunnels[] = $tunnel;
+
+		}
+
+	}
+
+	return $ret_tunnels;
+
+}
+
+/*
+ * Creates (or recreates) all WireGuard .conf files based on the current XML configuration
+ */
+function wg_create_config_files($clean = true) {
+	global $wgg;
+
+	wg_globals();
+
+	// Create configuration path if it is missing
+	if (!file_exists($wgg['conf_path'])) {
+
+		mkdir($wgg['conf_path'], 0700, true);
+
+	} else {
+
+		chmod($wgg['conf_path'], 0700);
+
+	}
+
+	// We almost always want to just overwrite the old configurations
+	if ($clean) {
+
+		wg_delete_config_files();
+
+	}
+
+	// Check if there are any configurations to write to disk
+	if (isset($wgg['tunnels']) && is_array($wgg['tunnels'])) {
+
+		foreach ($wgg['tunnels'] as $tunnel) {
+
+			wg_make_tunnel_conf_file($tunnel, false);
+
+		}
+
+	}
+
+}
+
+/* 
+ * Remove all wg .conf files from any potential configuration directory
+ */
+function wg_delete_config_files() {
+	global $wgg;
+
+	// Loop through each potential conf path and delete all .conf files
+	foreach ($wgg['conf_paths_to_clean'] as $path) {
+
+		unlink_if_exists("{$path}/*.conf");
+
+	}
+
+}
+
+/* 
+ * Removes any configuration xml paths as defined by $wgg['xml_conf_tags']
+ */
+function wg_remove_config_settings() {
+	global $config, $wgg;
+
+	// Loop through each potential conf path and unset it
+	foreach ($wgg['xml_paths_to_clean'] as $path) {
+
+		array_unset_value($config, $path);
+
+	}
+
+	// Now write out the new config to disk
+	wg_write_config('Removed package configuration and settings.', false);
+
+}
+
+/*
+ * Writes a WireGuard configuration file for a given tunnel to the configuration path
+ */
+function wg_make_tunnel_conf_file($tunnel, $include_endpoint = false) {
+	global $wgg;
+
+	// Init a new wgconfig object
+	$wc = new wgconfig($tunnel['name'], true);
+
+	$wc->set_path("{$wgg['conf_path']}/{$tunnel['name']}.conf");
+
+	$wc->initialize_file("Description: {$tunnel['descr']}");
+
+	// Process interface PrivateKey
+	$key = wg_gen_publickey($tunnel['privatekey']);
+
+	$wc->set_interface_attr('PrivateKey', $key['privkey_clamped']);
+
+	// Process interface ListenPort
+	$wc->set_interface_attr('ListenPort', $tunnel['listenport']);
+
+	// Process peer sections
+	foreach (wg_tunnel_get_peers_config($tunnel['name']) as [$peer_idx, $peer, $is_new]) {
+
+		if (isset($peer['enabled']) && $peer['enabled'] == 'yes') {
+
+			// Process peer entry and PublicKey
+			$wc->add_peer($peer['publickey'], "Peer: {$peer['descr']}");
+
+			// Process PresharedKey
+			$wc->set_peer_attr($peer['publickey'], 'PresharedKey', $peer['presharedkey']);
+
+			// Process AllowedIPs
+			foreach ((array) $peer['allowedips']['row'] as $ip) {
+
+				$wc->add_peer_attr($peer['publickey'], 'AllowedIPs', "{$ip['address']}/{$ip['mask']}");
+
+			}
+
+			// Process PersistentKeepalive
+			$keepalive = $peer['persistentkeepalive'];
+
+			$keepalive = (!empty($keepalive) && is_numericint($keepalive)) ? $keepalive : '0';
+
+			$wc->set_peer_attr($peer['publickey'], 'PersistentKeepalive', $keepalive);
+
+		}
+
+	}
+
+	$wc->write_file();
+
+}
+
+function wg_download_tunnel($tunnel_name, $failure_redirect) {
+	global $wgg;
+
+	// Fetch and build the latest info
+	wg_resync();
+
+	$now = new DateTimeImmutable();
+
+	$stamp = $now->format('YmdHis');
+
+	$conf_path = "{$wgg['conf_path']}/{$tunnel_name}.conf";
+
+	$name = "tunnel-{$tunnel_name}-{$stamp}.conf";
+
+	if (file_exists($conf_path)) {
+
+		send_user_download('file', $conf_path, $name);
+
+	}
+
+	// If something goes wrong, bail out to the failure redirect location
+	header("Location: {$failure_redirect}");
+
+}
+
+function wg_autoloader($classname) {
+	global $wgg;
+
+	$path = "{$wgg['wg_classes']}/{$classname}.class.php";
+
+	if (file_exists($path)){
+
+		require_once($path);
+
+	}
+
+}
+
+spl_autoload_register('wg_autoloader');
+
+?>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_api.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_api.inc
@@ -1,0 +1,1161 @@
+<?php
+/*
+ * wg_api.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2021 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2021 R. Christian McDonald (https://github.com/theonemcdonald)
+ * Copyright (c) 2021 Vajonam
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// pfSense includes
+require_once('config.inc');
+require_once('interfaces.inc');
+require_once('util.inc');
+require_once('services.inc');
+require_once('service-utils.inc');
+
+// WireGuard includes
+require_once('wireguard/includes/wg_globals.inc');
+require_once('wireguard/includes/wg_install.inc');
+
+/*
+ * A wrapper for wg_get_running_config to export everything plus extras for the status page
+ */
+function wg_get_status($json = false) {
+
+	return wg_get_running_config(true, $json);
+
+}
+
+/*
+ * Returns a massive associative array of current wg status
+ * 
+ * $extras returns additional info not provided by `wg show all dump`
+ */
+function wg_get_running_config($extras = false, $json = false) {
+	global $wgg;
+
+	$tunnel_output_keys = array('private_key', 'public_key', 'listen_port', 'fwmark');
+
+	$peer_output_keys = array('public_key', 'preshared_key', 'endpoint', 'allowed_ips', 'latest_handshake', 'transfer_rx', 'transfer_tx', 'persistent_keepalive');
+
+	$ret_config = $cmd_output_rows = array();
+
+	exec("{$wgg['wg']} show all dump", $cmd_output_rows, $ret_code);
+
+	if ($ret_code == 0) {
+
+		foreach ($cmd_output_rows as $row) {
+
+			$tmp_tunnel = $tmp_peer = array();
+
+			$a_device = explode("\t", $row);
+
+			$current_device = $a_device[0];
+
+			if (strcmp($current_device, $last_device)) {
+
+				foreach ($tunnel_output_keys as $key_index => $key) {
+
+					$tmp_tunnel[$key] = $a_device[$key_index + 1];
+
+				}
+
+				if ($extras) {
+
+					// Gets some extra information about tunnels not returned by `wg show all dump`
+					$tunnel_if_stats		= pfSense_get_interface_stats($current_device);
+
+					$tmp_tunnel['status']		= wg_interface_status($current_device) ? 'up' : 'down';
+
+					$tmp_tunnel['transfer_rx']	= $tunnel_if_stats['inbytes'];
+
+					$tmp_tunnel['transfer_tx']	= $tunnel_if_stats['outbytes'];
+
+					$tmp_tunnel['inpkts']		= $tunnel_if_stats['inpkts'];
+
+					$tmp_tunnel['outpkts']		= $tunnel_if_stats['outpkts'];
+
+					$tmp_tunnel['mtu']		= $tunnel_if_stats['mtu'];
+
+					[$tun_idx, $tmp_tunnel['config'], $is_new] = wg_tunnel_get_config_by_name($current_device);
+
+				}
+
+				// Add the tunnel to the array
+				$ret_config[$current_device] = $tmp_tunnel;
+
+				// Now provision an empty peer array
+				$ret_config[$current_device]['peers'] = array();
+
+				$last_device = $a_device[0];
+
+			} else {
+
+				foreach ($peer_output_keys as $key_index => $key) {
+
+					$tmp_peer[$key] = $a_device[$key_index + 1];
+
+				}
+
+				if ($extras) {
+
+					[$peer_idx, $tmp_peer['config'], $is_new] = wg_peer_get_config_by_name($last_device, $tmp_peer['public_key']);
+			
+				}
+
+				// Add the peer to the array
+				$ret_config[$last_device]['peers'][$a_device[1]] = $tmp_peer;
+
+			}
+
+		}
+
+	}
+
+	return ($json ? json_encode($ret_config) : $ret_config);
+
+}
+
+/*
+ * Returns a peer's config array index by public key and tunnel name
+ */
+function wg_peer_get_array_idx($public_key, $tunnel_name) {
+	global $wgg;
+
+	foreach ((array) $wgg['peers'] as $peer_idx => $peer){
+
+		if ($public_key == $peer['publickey'] && $tunnel_name == $peer['tun']) {
+
+			return $peer_idx;
+
+		}
+
+	}
+
+	return -1;
+
+}
+
+function wg_get_address_family($address) {
+
+	if (is_v4($address)) {
+
+		return 'inet';
+
+	} elseif (is_v6($address)) {
+
+		return 'inet6';
+
+	} else {
+
+		return false;
+
+	}
+
+}
+
+function wg_ifconfig_if_address_adddel($if_name, $masked_address, $add = true, &$cmds = null) {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	$ret_code = 0;
+
+	$action = $add ? 'add' : 'delete';
+
+	$error = $add ? WG_ERROR_IF_SETADDR : WG_ERROR_IF_DELADDR;
+
+	if (wg_is_valid_tunnel($if_name, true)
+	    && ($family = wg_get_address_family($masked_address))) {
+
+		$cmd = "{$wgg['ifconfig']} {$s(escapeshellarg($if_name))} {$s(escapeshellarg($family))} {$s(escapeshellarg($masked_address))} {$s(escapeshellarg($action))} 2>&1";
+
+		$cmds[] = $res = wg_exec($cmd, 'interface', $error);
+
+		$ret_code = $res['ret_code'];
+
+	}
+
+	return ($ret_code == 0);
+
+}
+
+function wg_interface_in_group($if_name, $group = null) {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	$ifs = array();
+
+	// Assume this will fail...
+	$res = false;
+
+	// Default to the package-installed interface group...
+	$group = (is_null($group)) ? $wgg['ifgroupentry']['ifname'] : $group;
+
+	if (wg_is_valid_tunnel($if_name, true)) {
+
+		$cmd = "{$wgg['ifconfig']} -g {$s(escapeshellarg($group))} 2>&1";
+
+		exec($cmd, $ifs, $ret_code);
+
+		$res = ($ret_code <> 0) ? $res : in_array($if_name, $ifs);
+
+	}
+
+	return $res;
+
+}
+
+function wg_kld_loadunload($load = true, &$cmds = null) {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	$ret_code = 0;
+
+	$kmod = $wgg['kmod'];
+
+	// Determine which binary to use
+	$kldbin = $load ? $wgg['kldload'] : $wgg['kldunload'];
+
+	$error = $load ? WG_ERROR_KLD_LOAD : WG_ERROR_KLD_UNLOAD;
+
+	if (($load && !is_module_loaded($kmod))
+	    || (!$load && is_module_loaded($kmod))) {
+
+		$cmd = "{$kldbin} {$s(escapeshellarg($kmod))} 2>&1";
+
+		$cmds[] = $res = wg_exec($cmd, 'kld', $error);
+
+		$ret_code = $res['ret_code'];
+
+	}
+
+	return ($ret_code == 0);
+
+}
+
+function wg_ifconfig_if_updown($if_name, $up = true, &$cmds = null) {
+	global $wgg;
+
+	$s = fn($x) => $x;
+	
+	$state = fn($up) => $up ? 'up' : 'down';
+
+	$ret_code = 0;
+
+	// Is this even a real interface?
+	if (wg_is_valid_tunnel($if_name, true)) { 
+
+		// Are we trying to down-an-up or up-a-down? Anything else is wrong in this context...
+		if ((!wg_interface_status($if_name) && $up) || (wg_interface_status($if_name) && !$up)) {
+
+			$cmd = "{$wgg['ifconfig']} {$s(escapeshellarg($if_name))} {$s(escapeshellarg($state($up)))} 2>&1";
+
+			$error = $up ? WG_ERROR_IF_UP : WG_ERROR_IF_DOWN;
+
+			$cmds[] = $res = wg_exec($cmd, 'interface', $error);
+
+			$ret_code = $res['ret_code'];
+
+		}
+
+	}
+
+	return ($ret_code == 0);
+
+}
+
+/*
+ * This updates the addresses of the specified interface without tearing it down
+ */
+function wg_interface_update_addresses($if_name, &$cmds = null) {
+	global $wgg;
+
+	// Assume this will be successful...
+	$res = true;
+
+	if (wg_is_valid_tunnel($if_name, true)
+	    && ([$tun_idx, $tunnel, $is_new] = wg_tunnel_get_config_by_name($if_name))) {
+
+		// Assigned tunnel interfaces are handled by pfSense and should be ignored here
+		if (!is_wg_tunnel_assigned($tunnel['name'])) {
+
+			// Get an array of the current addresses assigned to the tunnel interface
+			$current = pfSense_getall_interface_addresses($tunnel['name']);
+
+			// Get an array of the addresses to be assigned to the interface
+			$desired = array_map(function($x) {
+
+				return "{$x['address']}/{$x['mask']}"; 
+
+			}, $tunnel['addresses']['row']);
+
+			// Determine the addresses to remove
+			$addresses_to_remove = array_diff($current, array_intersect($current, $desired));
+
+			// Now remove them
+			foreach ($addresses_to_remove as $address) {
+
+				$res &= wg_ifconfig_if_address_adddel($tunnel['name'], $address, false, $cmds);
+
+			}
+
+			// Determine the addresses to add
+			$addresses_to_add = array_diff($desired, array_intersect($current, $desired));
+
+			// Now add them
+			foreach ($addresses_to_add as $address) {
+
+				$res &= wg_ifconfig_if_address_adddel($tunnel['name'], $address, true, $cmds);
+
+			}
+
+		// Need to let pfSense handle the assigned interfaces
+		} elseif (is_wg_tunnel_assigned($tunnel['name'])) {
+
+			if ($pfsense_if_name = wg_get_pfsense_interface_info($tunnel['name'])) {
+
+				// This doesn't return anything useful...
+				interface_reconfigure($pfsense_if_name['name']);
+
+			}
+
+		}
+
+	}
+
+	// This will return false if anything went wrong...
+	return $res;
+
+}
+
+/* 
+ * Translates WireGuard interface names to pfSense interface names and descriptions
+ */
+function wg_get_pfsense_interface_info($tunnel_name) {
+
+	$ret_array = array();
+
+	$iflist = get_configured_interface_list_by_realif(true);
+
+	$ifdescr = get_configured_interface_with_descr(true);
+
+	if (isset($iflist[$tunnel_name])) {
+
+		$tmp_name = $iflist[$tunnel_name];
+
+		$ret_array['name'] 	= $tmp_name;
+
+		$ret_array['descr']	= $ifdescr[$tmp_name];
+
+		return $ret_array;
+
+	}
+
+	// Consumers of this function always expect an array type
+	return $ret_array;
+
+}
+
+/*
+ * A wrapper for just setting peer endpoints
+ */
+function wg_peer_set_endpoint($tunnel_name, $public_key, $endpoint, &$cmds = null) {
+
+	// We only want to run this in running peers...
+	if (in_array($public_key, wg_tunnel_get_peers_running_keys($tunnel_name))) {
+
+		return wg_peer_set_config($tunnel_name, $public_key, 'endpoint', $endpoint, WG_ERROR_PEER_ENDPOINT, $cmds);
+
+	}
+
+}
+
+/*
+ * A wrapper for just removing peers
+ */
+function wg_peer_set_remove($tunnel_name, $public_key, &$cmds = null) {
+
+	// We only want to run this in running peers...
+	if (in_array($public_key, wg_tunnel_get_peers_running_keys($tunnel_name))) {
+
+		return wg_peer_set_config($tunnel_name, $public_key, 'remove', null, WG_ERROR_PEER_REMOVE, $cmds);
+
+	}
+
+}
+
+/*
+ * A wrapper for `wg set <wg_ifname> peer <public_key> <key> <value>`
+ * 
+ * If $key and $value are null, this will just create a peer entry
+ */
+function wg_peer_set_config($tunnel_name, $public_key, $key = null, $value = null, $error_flag = 0, &$cmds = null) {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	$key = (!is_null($key)) ? " {$s(escapeshellarg($key))}" : null;
+
+	$value = (!is_null($value)) ? " {$s(escapeshellarg($value))}" : null;
+
+	if (wg_is_valid_tunnel($tunnel_name, true)) {
+
+		$cmd = "{$wgg['wg']} set {$s(escapeshellarg($tunnel_name))} peer {$s(escapeshellarg($public_key))}{$key}{$value} 2>&1";
+
+		$cmds[] = $res = wg_exec($cmd, 'peer', $error_flag);
+
+		$ret_code = $res['ret_code'];
+
+	}
+
+	return ($ret_code == 0);
+
+}
+
+function wg_wg_if_sync($if_name, &$cmds = null) {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	$ret_code = 0;
+
+	// We need to make sure latest conf files are on disk
+	wg_resync();
+
+	$conf_path = "{$wgg['conf_path']}/{$if_name}.conf";
+
+	if (file_exists($conf_path)
+	    && wg_is_valid_tunnel($if_name, true)) {
+
+		$cmd = "{$wgg['wg']} syncconf {$s(escapeshellarg($if_name))} {$s(escapeshellarg($conf_path))}";
+
+		$cmds[] = $res = wg_exec($cmd, 'interface', WG_ERROR_IF_SYNC);
+
+		$ret_code = $res['ret_code'];
+
+	}
+
+	return ($ret_code == 0);
+
+}
+
+/*
+ * This creates a WireGuard interface of a specified name
+ */
+function wg_ifconfig_if_create($if_name, &$cmds = null) {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	$ret_code = 0;
+
+	if (!wg_is_valid_tunnel($if_name, true)) {
+
+		$cmd = "{$wgg['ifconfig']} wg create name {$s(escapeshellarg($if_name))} 2>&1";
+
+		$cmds[] = $res = wg_exec($cmd, 'interface', WG_ERROR_IF_CREATE);
+
+		$ret_code = $res['ret_code'];
+
+	}
+
+	return ($ret_code == 0);
+
+}
+
+function wg_exec($cmd, $error_type = null, $error_flag = 1) {
+
+	$ret_code = 0;
+
+	$output = $errors = array();
+	
+	exec($cmd, $output, $ret_code);
+
+	$ret_code = ($ret_code <> 0) ? $error_flag : $ret_code;
+
+	$errors = wg_get_errors($error_type, $ret_code);
+	
+	return array('cmd' => $cmd, 'output' => $output, 'ret_code' => $ret_code, 'errors' => $errors);
+
+}
+
+function wg_get_errors($type, $ret_code) {
+	global $wgg;
+
+	$errors = array();
+
+	foreach ((array) $wgg['error_flags'][$type] as $error_mask => $error_text) {
+
+		if (($ret_code & $error_mask) > 0) {
+
+			$errors[$error_mask] = $error_text;
+
+		}
+
+	}
+
+	return $errors;
+
+}
+
+/*
+ * This destroys a WireGuard interface of a specified name
+ */
+function wg_ifconfig_if_destroy($if_name, &$cmds = null) {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	$ret_code = 0;
+
+	if (wg_is_valid_tunnel($if_name, true)) {
+
+		$cmd = "{$wgg['ifconfig']} {$s(escapeshellarg($if_name))} destroy 2>&1";
+
+		$cmds[] = $res = wg_exec($cmd, 'interface', WG_ERROR_IF_DESTROY);
+
+		$ret_code = $res['ret_code'];
+
+	}
+
+	return ($ret_code == 0);
+
+}
+
+/*
+ * Returns an array of running WireGuard tunnel interfaces per wg(8)
+ */
+function wg_get_running_ifs() {
+
+	return array_keys(wg_get_running_config());
+
+}
+
+/*
+ * Returns an array of configured WireGuard tunnel interfaces
+ */
+function wg_get_configured_ifs() {
+	global $wgg;
+
+	return array_map(fn($x) => $x['name'], (array) $wgg['tunnels']);
+
+}
+
+function wg_ifconfig_if_group_addremove($if_name, $group, $remove = false, &$cmds = null) {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	$ret_code = 0;
+
+	$action = $remove ? '-group' : 'group';
+
+	// Is this a real interface and not already in the group?
+	if (in_array($if_name, pfSense_interface_listget())
+	    && ((!wg_interface_in_group($if_name, $group) && !$remove) || (wg_interface_in_group($if_name, $group) && $remove))) {
+
+		$cmd = "{$wgg['ifconfig']} {$s(escapeshellarg($if_name))} {$s(escapeshellarg($action))} {$s(escapeshellarg($group))} 2>&1";
+
+		$cmds[] = $res = wg_exec($cmd, 'interface', WG_ERROR_IF_GROUP);
+
+		$ret_code = ($res['ret_code']);
+			
+	}
+
+	return ($ret_code == 0);
+
+}
+
+/*
+ * This adds a WireGuard interface to the WireGuard interface groups
+ */
+function wg_interface_update_groups($if_name, &$cmds = null) {
+	global $wgg;
+
+	// Assume this will be successful...
+	$res = true;
+
+	// Is this a real interface?
+	if (in_array($if_name, pfSense_interface_listget())) {
+
+		$res &= wg_ifconfig_if_group_addremove($if_name, $wgg['ifgroupentry']['ifname'], true, $cmds);
+
+		$res &= wg_ifconfig_if_group_addremove($if_name, 'wg', false, $cmds);
+
+		if (isset($wgg['config']['interface_group'])
+		    && (($wgg['config']['interface_group'] == 'none') || (($wgg['config']['interface_group'] == 'unassigned') && is_wg_tunnel_assigned($if_name)))) {
+
+			// We don't want to add the tunnel to the WireGuard group...
+			return $res;
+
+		}
+
+		// Default behavior is to just add everything...
+		$res &= wg_ifconfig_if_group_addremove($if_name, $wgg['ifgroupentry']['ifname'], false, $cmds);
+
+	}
+
+	return $res;
+
+}
+
+function wg_interface_status($if_name) {
+
+	$if_flags = wg_ifconfig_get_flags($if_name);
+
+	return in_array('UP', $if_flags);
+
+}
+
+function wg_ifconfig_get_flags($if_name) {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	$flags = $output = array();
+
+	if (wg_is_valid_tunnel($if_name, true)) {
+
+		exec("{$wgg['ifconfig']} {$s(escapeshellarg($if_name))}", $output, $ret_code);
+
+		if (($ret_code == 0) && preg_match("/flags=.*<(?P<flags>.*)>/", $output[0], $matches)) {
+
+			$flags = explode(',', $matches['flags']);
+
+		}
+
+	}
+
+	// Consumers of this function always expect an array type
+	return $flags;
+
+}
+
+// Get various package infos and return an associative array
+function wg_pkg_info() {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	$ret_array = array();
+
+	$fields = array('name'=> '%n', 'version' => '%v', 'comment' => '%c');
+
+	$return_keys = array_values(array_flip($fields));
+
+	$field_string = implode("\t", $fields);
+
+	// Each package needs to be escaped individually before imploding
+	$packages = array_map(fn($x) => escapeshellarg($x), $wgg['depends_names']);
+
+	$packages_string = implode(' ', $packages);
+
+	exec("{$wgg['pkg']} query {$s(escapeshellarg($field_string))} {$packages_string}", $output, $ret_code);
+
+	if ($ret_code == 0) {
+
+		foreach ($output as $pkg_index => $package) {
+
+			$fields = explode("\t", $package);
+
+			foreach ($fields as $field_index => $field) {
+
+				$ret_array[$pkg_index][$return_keys[$field_index]] = $field;
+
+			}
+
+		}
+
+	}
+
+	// Consumers of this function always expect an array type
+	return $ret_array;
+
+}
+
+// Generate private key
+function wg_gen_keypair($json = false) {
+	global $wgg;
+
+	$privkey = exec("{$wgg['wg']} genkey");
+
+	return wg_gen_publickey($privkey, $json);
+
+}
+
+// Compose the public key from a provided private key
+function wg_gen_publickey($privkey, $json = false) {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	$was_clamped = wg_is_key_clamped($privkey);
+
+	$privkey_clamped = wg_clamp_key($privkey);
+
+	$pubkey = exec("echo {$s(escapeshellarg($privkey))} | {$wgg['wg']} pubkey");
+
+	$res = array('privkey' => $privkey, 'privkey_clamped' => $privkey_clamped, 'pubkey' => $pubkey, 'was_clamped' => $was_clamped);
+
+	return $json ? json_encode($res) : $res;
+
+}
+
+/*
+ * Reference0: https://lists.zx2c4.com/pipermail/wireguard/2021-June/006787.html
+ * Reference1: https://git.zx2c4.com/wireguard-freebsd/tree/src/crypto.h#n100
+ * 
+ * Even though any 256-bit bitstring generated from a csprng is a fine private key,
+ * the kernel clamps private keys according to the transformation implemented here.
+ * Some WireGuard key generators aren't properly pre-clamping generated keys and this
+ * can cause confusion for some users who might stumble across local .conf files 
+ * and wg(8) output and see 'different' private keys, even though these keys result in
+ * the same public key.
+ * 
+ * The way WireGuard is implemented, you can technically have two valid private keys,
+ * one that is pre-clamped and one that is not, that can both result in the same public key.
+ * 
+ * These routines detect if the key is clamped or not, so we can at least include a note
+ * in the .conf file so users who stumble onto them during troubleshooting won't freak out.
+ * 
+ * These routines might also become useful in the future for logging facilities.
+ * 
+ * Private keys and pre-shared Keys must undergo this transformaton.
+ * 
+ */
+function wg_clamp_key($key) {
+
+	if (wg_is_valid_key($key)) {
+
+		$decoded_key = base64_decode($key);
+
+		$key_bytes = array_slice(unpack("C*", "\0{$decoded_key}"), 1);
+
+		$key_bytes[0] &= 248;
+
+		$key_bytes[31] = ($key_bytes[31] & 127) | 64;
+
+		$decoded_clamped_key = pack("C*", ...$key_bytes);
+
+		return base64_encode($decoded_clamped_key);
+
+	}
+
+	return null;
+
+}
+
+/*
+ * Checks if a given $key is clamped
+ */
+function wg_is_key_clamped($key) {
+
+	if (wg_is_valid_key($key)) {
+
+		return ($key == wg_clamp_key($key));
+
+	}
+
+	return true;
+
+}
+
+/*
+ * Reference0: https://lists.zx2c4.com/pipermail/wireguard/2020-December/006222.html
+ * 
+ * Checks if a given private, public, or pre-shared key is valid
+ */
+function wg_is_valid_key($key) {
+
+	return preg_match('/^[A-Za-z0-9+\/]{42}[A|E|I|M|Q|U|Y|c|g|k|o|s|w|4|8|0]=$/', $key);
+
+}
+
+/*
+ * Generate a pre-shared key
+ */
+function wg_gen_psk() {
+	global $wgg;
+
+	$psk = exec("{$wgg['wg']} genpsk");
+
+	return $psk;
+	
+}
+
+/*
+ * Return the next available WireGuard port
+ */
+function next_wg_port() {
+	global $wgg;
+
+	wg_globals();
+
+	for ($idx = $wgg['default_port']; $idx < $wgg['max_port']; $idx++) {
+
+		// Check to see if the port is already in use
+		$found = false;
+
+		foreach ((array) $wgg['tunnels'] as $tunnel) {
+
+			if ($tunnel['listenport'] == $idx) {
+
+				$found = true;
+
+				break;
+
+			}
+
+		}
+
+		// If not, it can be used
+		if (!$found) {
+
+			return $idx;
+
+		}
+
+	}
+
+	// We've run out of ports
+	return false;
+
+}
+
+// Wrapper to return just the xml array index
+function wg_tunnel_get_array_idx($tunnel_name) {
+	global $wgg;
+
+	foreach ((array) $wgg['tunnels'] as $tun_idx => $tunnel) {
+
+		if ($tunnel['name'] == $tunnel_name) {
+
+			return $tun_idx;
+
+		}
+
+	}
+
+	return -1;
+
+}
+
+// Return the next available WireGuard interface
+function next_wg_if() {
+	global $wgg;
+
+	wg_globals();
+
+	for ($ifnum = 0; $ifnum < $wgg['max_tunnels']; $ifnum++) {
+
+		$want_if = "{$wgg['if_prefix']}{$ifnum}";
+
+		if (!in_array($want_if, wg_get_configured_ifs())) {
+
+			return $want_if;
+
+		}
+
+	}
+
+	// We've run out of tuns
+	return false;
+
+}
+
+// Check if wg tunnel is assigned to an interface
+function is_wg_tunnel_assigned($tunnel_name, $disabled = true) {
+
+	$if_list = get_configured_interface_list_by_realif($disabled);
+
+	return array_key_exists($tunnel_name, $if_list);
+
+}
+
+/*
+ * Checks if a peer is enabled
+ */
+function wg_peer_is_enabled($tunnel, $public_key) {
+
+	if ([$peer_idx, $peer, $is_new] = wg_peer_get_config_by_name($tunnel, $public_key)) {
+
+		return (isset($peer['enabled']) && ($peer['enabled'] == 'yes'));
+
+	}
+
+	return false;
+
+}
+
+/*
+ * Check if a given WireGuard peer is valid
+ */
+function wg_peer_is_valid($tunnel_name, $public_key, $running_state = false) {
+	global $wgg;
+
+	return in_array($public_key, ($running_state ? wg_tunnel_get_peers_running_keys($tunnel_name) : wg_tunnel_get_peers_config_keys($tunnel_name)));
+
+}
+
+
+/*
+ * Check if a given WireGuard tunnel is valid
+ */
+function wg_is_valid_tunnel($tunnel_name, $running_state = false) {
+	global $wgg;
+
+	return in_array($tunnel_name, ($running_state ? wg_get_running_ifs() : wg_get_configured_ifs()));
+
+}
+
+// Checks if the service is or should be enabled
+function wg_is_service_enabled() {
+	global $wgg;
+
+	$enable = $wgg['config']['enable'];
+
+	$is_enabled = (isset($enable) && (($enable === 'on') || $enable === 'yes'));
+
+	$should_be_enabled = wg_is_wg_assigned();
+
+	return ($is_enabled || $should_be_enabled);
+
+}
+
+// Check if at least one tunnel is enabled
+function is_wg_enabled() {
+	global $wgg;
+
+	wg_globals();
+
+	foreach ((array) $wgg['tunnels'] as ['enabled' => $enabled]) {
+
+		if (isset($enabled) && $enabled == 'yes') {
+
+			// We found one, no need to keep checking
+			return true;
+
+		}
+
+	}
+
+	return false;
+	
+}
+
+/*
+ * Check if at least one tunnel is assigned to a pfSense interface
+ */
+function wg_is_wg_assigned($disabled = true) {
+	global $wgg;
+
+	foreach ((array) $wgg['tunnels'] as ['name' => $name]) {
+
+		if (is_wg_tunnel_assigned($name, $disabled)) {
+
+			// We found one, no need to keep checking
+			return true;
+
+		}
+
+	}
+
+	return false;
+
+}
+
+function wg_peer_get_config_by_name($tunnel_name, $public_key) {
+	global $wgg;
+
+	$peer_idx = wg_peer_get_array_idx($public_key, $tunnel_name);
+
+	return wg_peer_get_config($peer_idx, false);
+
+}
+
+function wg_tunnel_get_config_by_name($tunnel_name) {
+	global $wgg;
+
+	$tun_idx = wg_tunnel_get_array_idx($tunnel_name);
+
+	return wg_tunnel_get_config($tun_idx, false);
+
+}
+
+function wg_tunnel_get_config($tun_idx, $return_empty = false) {
+	global $wgg;
+
+	wg_globals();
+
+	$tunnel = array();
+
+	$valid = (isset($wgg['tunnels'][$tun_idx]) && is_array($wgg['tunnels'][$tun_idx]));
+
+	$is_new = !$valid;
+
+	$tun_idx = !$valid ? count($wgg['tunnels']) : $tun_idx;
+
+	$tunnel = $wgg['tunnels'][$tun_idx];
+
+	wg_init_config_arr($tunnel, array('addresses', 'row'));
+
+	return ($valid || $return_empty) ? array($tun_idx, $tunnel, $is_new) : false;
+
+}
+
+function wg_peer_get_config($peer_idx, $return_empty = false) {
+	global $wgg;
+
+	wg_globals();
+
+	$peer = array();
+
+	$valid = (isset($wgg['peers'][$peer_idx]) && is_array($wgg['peers'][$peer_idx]));
+
+	$is_new = !$valid;
+
+	$peer_idx = !$valid ? count($wgg['peers']) + 1 : $peer_idx;
+
+	$peer = $wgg['peers'][$peer_idx];
+
+	wg_init_config_arr($peer, array('allowedips', 'row'));
+
+	return ($valid || $return_empty) ? array($peer_idx, $peer, $is_new) : false;
+
+}
+
+/*
+ * This returns an array of peer configs for a given tunnel
+ */
+function wg_tunnel_get_peers_config($tunnel_name) {
+	global $wgg;
+
+	wg_globals();
+
+	$ret_peers = array();
+
+	// Look through array of peers for matching tunnel name
+	foreach ((array) $wgg['peers'] as $peer_idx => $peer) {
+
+		if ($peer['tun'] == $tunnel_name) {
+
+			$ret_peers[] = wg_peer_get_config($peer_idx, false);
+
+		}
+
+	}
+
+	// Return the list of filtered peers
+	return $ret_peers;
+
+}
+
+/*
+ * This returns an array of peer keys for a given tunnel
+ * 
+ * These are actually *running* and bound to a tunnel
+ */
+function wg_tunnel_get_peers_running_keys($tunnel_name) {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	$output = $res = array();
+
+	$cmd = "{$wgg['wg']} show {$s(escapeshellarg($tunnel_name))} peers 2>&1";
+
+	exec($cmd, $output, $ret_code);
+
+	$res = ($ret_code <> 0) ? $res : $output;
+
+	return $res;
+
+}
+
+/*
+ * This returns an array of peer keys for a given tunnel
+ * 
+ * These are actually *configured* and bound to a tunnel
+ */
+function wg_tunnel_get_peers_config_keys($tunnel_name) {
+
+	// Pull out the public keys
+	$keys = array_map(function($s) { 
+		
+		[$peer_idx, $peer, $is_new] = $s;
+
+		return $peer['publickey'];
+		
+	}, wg_tunnel_get_peers_config($tunnel_name));
+
+	return $keys;
+
+}
+
+/* 
+ * Return WireGuard tunnel networks for a given address family
+ */
+function wg_get_tunnel_networks($family = 'both') {
+	global $wgg;
+
+	$wg_tunnel_networks = array();
+
+	// Bail out early if WireGuard is not enabled...
+	if (!is_wg_enabled()) {
+
+		return $wg_tunnel_networks;
+
+	}
+
+	foreach ((array) $wgg['tunnels'] as $tunnel) {
+
+		foreach ((array) $tunnel['addresses']['row'] as $address) {
+
+			$masked_address = "{$address['address']}/{$address['mask']}";
+
+			if ((is_ipaddrv6($masked_address) && ($family == 'ipv4')) 
+			    || (is_ipaddrv4($masked_address) && ($family == 'ipv6'))) {
+
+				continue;
+
+			}
+
+			if (is_subnet($masked_address)) {
+
+				$network = gen_subnet($address['address'], $address['mask']);
+
+				$wg_tunnel_networks[] 	= array(
+								'network' => $network, 
+								'mask' => $address['mask'],
+								'tun' => $tunnel['name'],
+								'descr' => $tunnel['descr']);
+
+			}
+
+		}
+
+	}
+
+	return $wg_tunnel_networks;
+
+}
+
+?>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_foot.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_foot.inc
@@ -1,11 +1,9 @@
 <?php
 /*
- * pkg_wireguard.inc
+ * wg_foot.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2021 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2021 R. Christian McDonald
- * Copyright (c) 2020 Ascrod
+ * Copyright (c) 2021 R. Christian McDonald (https://github.com/theonemcdonald)
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,12 +18,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-global $shortcuts;
-
-$shortcuts['wireguard'] = array();
-$shortcuts['wireguard']['main'] = '/wg/vpn_wg_settings.php';
-$shortcuts['wireguard']['status'] = '/wg/status_wireguard.php';
-$shortcuts['wireguard']['service'] = 'wireguard';
-
 ?>
+
+<script src="/wg/js/WireGuardHelpers.js?v=<?=filemtime('/usr/local/www/wg/js/WireGuardHelpers.js')?>"></script>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_globals.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_globals.inc
@@ -1,0 +1,280 @@
+<?php
+/*
+ * wg_globals.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2021 R. Christian McDonald (https://github.com/theonemcdonald)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Global defines
+
+// pfSense includes
+require_once('config.inc');
+require_once('globals.inc');
+
+global $g, $wgg;
+
+define('WG_ERROR_IF_NAME',		1);
+define('WG_ERROR_IF_CREATE',		2);
+define('WG_ERROR_IF_GROUP',		4);
+define('WG_ERROR_IF_SETADDR',		8);
+define('WG_ERROR_IF_DELADDR',		16);
+define('WG_ERROR_IF_UP',		32);
+define('WG_ERROR_IF_DOWN',		64);
+define('WG_ERROR_IF_SYNC',		128);
+define('WG_ERROR_IF_DESTROY',		256);
+
+define('WG_ERROR_KLD_LOAD',		1);
+define('WG_ERROR_KLD_UNLOAD',		2);
+
+define('WG_ERROR_PEER_SET',		1);
+define('WG_ERROR_PEER_ENDPOINT',	2);
+define('WG_ERROR_PEER_REMOVE',		4);
+
+define('WG_ERROR_SVC_DISABLED',		1);
+define('WG_ERROR_SVC_RUNNING',		2);
+define('WG_ERROR_SVC_START',		4);
+define('WG_ERROR_SVC_STOP',		8);
+define('WG_ERROR_SVC_CREATE',		16);
+
+$wgg = array(
+	'wg'			=> '/usr/local/bin/wg',
+	'ifconfig'		=> '/sbin/ifconfig',
+	'pkg'			=> '/usr/sbin/pkg',
+	'kldload'		=> '/sbin/kldload',
+	'kldunload'		=> '/sbin/kldunload',
+	'php'			=> '/usr/local/bin/php',
+	'php_wg'		=> '/usr/local/bin/php_wg',
+	'wg_pkg_root'		=> '/usr/local/pkg/wireguard',
+	'kmod'			=> 'if_wg.ko',
+	'subsystem_prefix'	=> 'wireguard',
+	'service_name'		=> 'wireguardd',
+	'nrb'			=> '-NoReMoTeBaCkUp',
+	'applylist'		=> array(
+					'tunnels' => "{$g['tmp_path']}/.wireguard_tunnel.apply"),
+	'pkg_name'		=> 'pfSense-pkg-WireGuard',
+	'conf_path'		=> '/usr/local/etc/wireguard',
+	'xml_path'		=> array('installedpackages', 'wireguard'),
+	'if_prefix'		=> 'tun_wg',
+	'ifgroupentry'		=> array(
+					'ifname' => 'WireGuard', 
+					'descr' => gettext('WireGuard Interface Group (DO NOT EDIT/DELETE!)'),
+					'members' => null),
+	'unboundaclentry'	=> array(
+					'aclname' => 'WireGuard',
+					'aclaction' => 'allow',
+					'description' => gettext('WireGuard Unbound ACL (DO NOT EDIT/DELETE!)')),
+	'listenportalias'	=> array(
+					'name' => 'WireGuardListenPorts',
+					'type' => 'port',
+					'descr' => gettext('WireGuard ListenPort Alias (DO NOT EDIT/DELETE!)')),
+	'handshake_thresholds' 	=> array(
+					86400 => array('class' => 'text-danger', 'title' => gettext('Greater than 1 day')),
+					300 => array('class' => 'text-warning', 'title' => gettext('Greater than 5 minutes')),
+					0 => array('class' => 'text-success', 'title' => gettext('Less than 5 minutes'))),
+	'error_flags'		=> array(
+					'interface' => array(
+						WG_ERROR_IF_NAME	=> gettext('Invalid WireGuard tunnel name'),
+						WG_ERROR_IF_CREATE	=> gettext('Unable to create WireGuard tunnel interface'),
+						WG_ERROR_IF_GROUP	=> gettext('Unable to add WireGuard tunnel interface to the WireGuard interface group'),
+						WG_ERROR_IF_SETADDR	=> gettext('Unable to set WireGuard tunnel interface address(es)'),
+						WG_ERROR_IF_DELADDR	=> gettext('Unable to delete WireGuard tunnel interface address(es)'),
+						WG_ERROR_IF_UP		=> gettext('Unable to bring up WireGuard tunnel interface'),
+						WG_ERROR_IF_DOWN	=> gettext('Unable to bring down WireGuard tunnel interface'),
+						WG_ERROR_IF_SYNC	=> gettext('Unable to sync WireGuard tunnel configuration with wg(8)'),
+						WG_ERROR_IF_DESTROY	=> gettext('Unable to destroy WireGuard tunnel interface')),
+					'kld' => array(
+						WG_ERROR_KLD_LOAD	=> gettext('Unable to load WireGuard kernel module'),
+						WG_ERROR_KLD_UNLOAD	=> gettext('Unable to unload WireGuard kernel module')),
+					'peer' => array(
+						WG_ERROR_PEER_SET	=> gettext('Unable to set peer configuration'),
+						WG_ERROR_PEER_ENDPOINT	=> gettext('Unable to resolve peer endpoint'),
+						WG_ERROR_PEER_REMOVE	=> gettext('Unable to remove peer')),
+					'service' => array(
+						WG_ERROR_SVC_DISABLED	=> gettext('WireGuard service is disabled'),
+						WG_ERROR_SVC_RUNNING	=> gettext('WireGuard service is already running'),
+						WG_ERROR_SVC_START	=> gettext('Unable to start WireGuard service'),
+						WG_ERROR_SVC_STOP	=> gettext('Unable to stop WireGuard service'),
+						WG_ERROR_SVC_CREATE	=> gettext('Unable to create WireGuard tunnel(s)'))),
+	'default_mtu'				=> 1420,
+	'default_port'				=> 51820,
+	'default_resolve_interval'		=> 300,
+	'default_widget_activity_threshold'	=> 180,
+	'default_widget_refresh_interval'	=> 1,
+	'max_port'				=> 65535,
+	'max_tunnels'				=> 32768
+);
+
+// These all depend on one more more of the above values
+
+$wgg['wg_classes']		= "{$wgg['wg_pkg_root']}/classes";
+$wgg['wg_includes']		= "{$wgg['wg_pkg_root']}/includes";
+
+$wgg['conf_paths_to_clean']	= array($wgg['conf_path'], '/etc/wireguard', '/etc/wg');
+$wgg['xml_paths_to_clean']	= array($wgg['xml_path'], array('wireguard'));
+
+$wgg['depends_names']		= array(
+					$wgg['pkg_name'],
+					'wireguard-kmod',
+					'wireguard-tools-lite');
+
+$wgg['pid_path']		= "{$g['varrun_path']}/{$wgg['service_name']}.pid";
+$wgg['subsystems']		= array(
+					'wg' => $wgg['subsystem_prefix'], 
+					'postboot' => "{$wgg['subsystem_prefix']}_postboot");
+$wgg['wg_daemon'] 		= "{$wgg['php_wg']} -f {$wgg['wg_includes']}/wg_service.inc";
+
+$wgg['shellcmdentries']		= array(
+					array(
+						'cmd' => "service {$wgg['service_name']} start",
+						'cmdtype' => 'earlyshellcmd',
+						'description' => 'WireGuard earlyshellcmd (DO NOT EDIT/DELETE!)'));
+
+function &array_get_value(array &$array, $parents) {
+
+	$ref = &$array;
+
+	foreach ((array) $parents as $parent) {
+
+		if (is_array($ref) && array_key_exists($parent, $ref)) {
+
+			$ref = &$ref[$parent];
+
+		} else {
+
+			return null;
+
+		}
+
+	}
+
+	return $ref;
+
+}
+
+function array_set_value(array &$array, $parents, $value) {
+
+	$ref = &$array;
+
+	foreach ((array) $parents as $parent) {
+
+	if (isset($ref) && !is_array($ref)) {
+
+		$ref = array();
+
+	}
+
+	$ref = &$ref[$parent];
+
+	}
+
+	$ref = $value;
+
+}
+
+function array_unset_value(&$array, $parents) {
+
+	$key = array_shift($parents);
+
+	if (empty($parents)) {
+
+		unset($array[$key]);
+
+	} else {
+
+		array_unset_value($array[$key], $parents);
+
+	}
+
+}
+
+/*
+ * This is a generalized implementation of init_config_arr
+ */
+function wg_init_config_arr(&$a_config, $keys) {
+
+	$c = &$a_config;
+
+	if (!is_array($keys)) {
+
+		return null;
+
+	}
+
+	foreach ($keys as $k) {
+
+		if (!is_array($c[$k])) {
+
+			$c[$k] = array();
+
+		}
+
+		$c = &$c[$k];
+
+	}
+	
+}
+
+/*
+ * A wrapper for write_config() with the ability to easily toggle ACB on or off
+ * 
+ * Ephemeral changes to the config should not hammer the ACB system. Only changes
+ * to <installedpackages><wireguard>...</wireguard></installedpackages> tree should
+ * invoke a ACB backup event.
+ */
+function wg_write_config($desc = 'unknown', $do_acb = false, $backup = true, $write_config_only = false) {
+	global $wgg;
+
+	$descACB = fn($desc, $do_acb) => $do_acb ? $desc : "{$desc}{$wgg['nrb']}";
+
+	$desc = "[{$wgg['pkg_name']}] {$descACB($desc, $do_acb)}";
+
+	return write_config($desc, $backup, $write_config_only);
+
+}
+
+/*
+ * This populates the $wgg with the latest information from config.xml
+ */
+function wg_globals() {
+	global $config, $wgg;
+
+	// Reload config.xml to get any recent changes
+	$config = parse_config(true);
+
+	// An array of configuration paths we need
+	$conf_paths 	= array(
+				'config' => array_merge($wgg['xml_path'], array('config', 0)),
+				'tunnels' => array_merge($wgg['xml_path'], array('tunnels', 'item')),
+				'peers' => array_merge($wgg['xml_path'], array('peers', 'item')));
+
+
+	// Need to initialize these config paths as arrays and then assign by reference to $wgg
+	foreach ($conf_paths as $key => $path) {
+
+		wg_init_config_arr($config, $path);
+
+		$wgg[$key] = &array_get_value($config, $path);
+
+	}
+
+
+}
+
+// Call this often to read the latest configuration information
+wg_globals();
+
+?>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_guiconfig.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_guiconfig.inc
@@ -1,0 +1,453 @@
+<?php
+/*
+ * wg_guiconfig.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2021 R. Christian McDonald (https://github.com/theonemcdonald)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// pfSense includes
+require_once('guiconfig.inc');
+require_once('util.inc');
+
+// WireGuard includes
+require_once('wireguard/includes/wg.inc');
+require_once('wireguard/includes/wg_globals.inc');
+
+function wg_print_service_warning($only_with_tunnels = true) {
+	global $wgg;
+
+	if (!wg_is_service_running() 
+	    && (!$only_with_tunnels || count($wgg['tunnels']) > 0)) {
+
+		print_info_box(gettext('The WireGuard service is not running.'), 'danger', null);
+	
+	}
+
+
+}
+
+function wg_print_config_apply_box() {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	if (is_subsystem_dirty($wgg['subsystems']['wg'])) {
+
+		print_apply_box("{$s(gettext('The WireGuard configuration has been changed.'))}<br />
+					{$s(gettext('The changes must be applied for them to take effect.'))}<br />
+					{$s(gettext('Notice: This action may momentarily suspend active WireGuard peer connections on any changed tunnels.'))}");
+	
+	}
+
+}
+
+// Formats peer endpoint address and port for the UI
+function wg_format_endpoint($header = true, $peer = null, $endpoint_key = 'endpoint', $port_key = 'port') {
+
+	$s = fn($x) => $x;
+
+	if ($header) {
+
+		return "{$s(gettext('Endpoint'))} : {$s(gettext('Port'))}";
+
+	}
+
+	if (!is_null($peer)) {
+
+		if (!empty($peer[$endpoint_key])) {
+
+			return "{$peer[$endpoint_key]}:{$peer[$port_key]}";
+
+		} else {
+
+			return gettext('Dynamic');
+
+		}
+
+	}
+
+}
+
+// Gets a list of available tunnels in a format suitable for input selection boxes
+function wg_get_tun_list() {
+	global $config, $wgg;
+
+	// Format tunnel description if one is configured
+	$tunDescr = fn($tunnel) => !empty($tunnel['descr']) ? " ({$tunnel['descr']})" : null;
+
+	$a_ret = array();
+
+	// Always include the unassigned option first
+	$a_ret['unassigned'] = 'Unassigned';
+
+	if (is_array($wgg['tunnels'])) {
+
+		foreach ($wgg['tunnels'] as $tunnel) {
+
+			$a_ret[$tunnel['name']] = "{$tunnel['name']}{$tunDescr($tunnel)}";	
+
+		}
+	
+	}
+
+	// Consumers of this function always expect an array type
+	return $a_ret;
+
+}
+
+// Truncates a given string if necessary and formats it to make it look good
+function wg_truncate_pretty($text, $max_length) {
+
+	$s_truncated = substr($text, 0, $max_length);
+
+	$s_pretty_dots = (strlen($text) > $max_length) ? '...' : null;
+
+	return "{$s_truncated}{$s_pretty_dots}";
+
+}
+
+function wg_interface_status_icon($status = 'up', $enabled_class = "fa fa-arrow-up text-success", $disabled_class = "fa fa-arrow-down text-danger") {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	$ret_class = ($status === 'up') ? $enabled_class : $disabled_class;
+
+	$ret_html = "<i class=\"{$s(htmlspecialchars($ret_class))}\" style=\"vertical-align: middle;\" title=\"{$s(htmlspecialchars($status))}\"></i>";
+
+	return $ret_html;
+
+}
+
+/* 
+ * Returns the appropriate icon for peer handshake status based on latest handshake time
+ * 
+ * $latest_handshake should be format compatible with DateTime
+ */
+function wg_handshake_status_icon($latest_handshake = '@0', $tunnel_status = 'up', $fa_icon = "fa-handshake") {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	try {
+
+		$end_time = new DateTimeImmutable;
+
+		$start_time = new DateTime($latest_handshake);
+
+	} catch (Exception $e) {
+
+		return null;
+
+	}
+
+	$diff_time = $end_time->diff($start_time);
+
+	$diff_time_seconds = abs($end_time->getTimestamp() - $start_time->getTimestamp());
+
+	$a_thresholds = $wgg['handshake_thresholds'];
+
+	foreach ($a_thresholds as $threshold => $value) {
+
+		if ($diff_time_seconds >= $threshold) {
+	
+			$ret_class = $value['class'];
+
+			$ret_title = $value['title'];
+
+			break;
+
+		}
+
+	}
+
+	$ret_html = "<i class=\"fa {$s(htmlspecialchars($fa_icon))} {$s(htmlspecialchars($ret_class))}\" style=\"vertical-align: middle;\" title=\"{$s(htmlspecialchars($ret_title))}\"></i>";
+
+	return $ret_html;
+
+}
+
+/* 
+ * Formats a given time difference in a human-friendly way
+ * 
+ * $start and $end should be format compatible with DateTime
+ */
+function wg_human_time_diff($start, $end = null, $num_units = 2, $from_epoch = false) {
+
+	if (is_null($end)) {
+
+		$end = new DateTime('now');
+
+	}
+
+	// If these fail for any reason, just bail out...
+	try {
+
+		if (!($start instanceof DateTime)) {
+
+			$start = new DateTime($start);
+
+		}
+
+		if (!($end instanceof DateTime)) {
+
+			$end = new DateTime($end);
+
+		}
+
+	} catch (Exception $e) {
+
+		return gettext('never');
+
+	}
+
+	$interval = $end->diff($start);
+
+	$doPlural = fn($nb, $str) => ($nb <= 1) ? $str[0] : $str[1];
+
+	$doTense = fn($interval) => ($interval->invert) ? gettext('ago') : gettext('from now');
+
+	$a_format = array();
+
+	$a_interval = get_object_vars($interval);
+
+	$tokens	= array(
+			'y' => array(gettext('year'), gettext('years')),
+			'm' => array(gettext('month'), gettext('months')),
+			'd' => array(gettext('day'), gettext('days')),
+			'h' => array(gettext('hour'), gettext('hours')),
+			'i' => array(gettext('minute'), gettext('minutes')),
+			's' => array(gettext('second'), gettext('seconds')));
+
+	foreach ($tokens as $key => $value) {
+
+		if ($a_interval[$key] != 0) {
+
+			$a_format[] = "%{$key} {$doPlural($a_interval[$key], $value)}";
+
+		}
+
+	}
+
+	if ((count($a_format) == 0) || (($start->getTimestamp() == 0) && !$from_epoch)) {
+
+		return gettext('never');
+
+	}
+
+	$s_format = implode(', ', array_slice($a_format, 0, $num_units));
+
+	return "{$interval->format($s_format)} {$doTense($interval)}";
+
+}
+
+// Returns the appropriate text input field type for secrets
+function wg_secret_input_type() {
+	global $wgg;
+
+	wg_globals();
+
+	$type = 'text';
+
+	if (isset($wgg['config']['hide_secrets'])
+	    && $wgg['config']['hide_secrets'] =='yes') {
+
+		$type = 'password';
+
+	}
+
+	return $type;
+	
+}
+
+function wg_tunnel_status_class($tunnel = null) {
+	global $wgg;
+
+	if (isset($tunnel) && is_array($tunnel)) {
+
+		if (wg_is_service_running() && ($tunnel['enabled'] == 'yes')) {
+
+			return 'enabled';
+
+		}
+
+	}
+
+	return 'disabled';
+
+}
+
+function wg_peer_status_class($peer = null) {
+	global $wgg;
+
+	if (isset($peer) && is_array($peer)) {
+
+		$tunnel_state = true;
+
+		// We want to visually disable peers if the tunnel is disabled...
+		if ([$tun_idx, $tunnel, $is_new] = wg_tunnel_get_config_by_name($peer['tun'])) {
+
+			$tunnel_state = ($tunnel['enabled'] == 'yes');
+
+		}
+
+		if (wg_is_service_running() && ($peer['enabled'] == 'yes') && $tunnel_state) {
+
+			return 'enabled';
+
+		}
+
+	}
+
+	return 'disabled';
+
+}
+
+// Generates a toggle icon link based on the status of the target
+function wg_generate_toggle_icon_link($enabled = true, $type = null, $href = '#', $post = true, $icon_enabled = 'fa-ban', $icon_disabled = 'fa-check-square-o') {
+
+	$s = fn($x) => $x;
+	
+	$icon = $enabled ? $icon_enabled : $icon_disabled;
+
+	$action = $enabled ? gettext('Disable') : gettext('Enable');
+
+	$title = "{$action} {$type}";
+
+	$usepost = $post ? ' usepost' : null;
+
+	return "<a class=\"fa {$s(htmlspecialchars($icon))}\" title=\"{$s(htmlspecialchars($title))}\" href=\"{$s(htmlspecialchars($href))}\"{$s(htmlspecialchars($usepost))}></a>";
+
+}
+
+function wg_compose_address_popover_link($addresses, $title, $href) {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	$getDescr = fn($x) => !empty($x) ? htmlspecialchars($x) : "<i>({$s(gettext('none'))})</i>";
+
+	$ret_html = null;
+
+	if (is_array($addresses) && count($addresses) > 0) {
+
+		$extras = count($addresses) - 1;
+
+		if ($extras > 0) {
+
+			$data_html = 	<<<"START"
+					<table>
+						<thead>
+							<th>{$s(gettext('Address'))}</th>
+							<th style='padding-left: 10px;'>{$s(gettext('Description'))}</th>
+						</thead>
+						<tbody>
+
+					START;
+
+			foreach ($addresses as $address) {
+
+				$address['address'] = "{$address['address']}/{$address['mask']}";
+
+				$data_html .= 	<<<"ROW"
+								<tr>
+									<td>{$s(htmlspecialchars($address['address']))}</td>
+									<td style='padding-left: 10px;'>{$getDescr($address['descr'])}</td>
+								</tr>
+
+						ROW;
+
+			}
+
+			$data_html .= 	<<<"END"
+						</tbody>
+					</table>
+					END;
+
+			$hint = "{$addresses[0]['address']}/{$addresses[0]['mask']} (+{$extras})";
+
+			$popover_params = " data-toggle=\"popover\" data-trigger=\"hover focus\" data-content=\"{$data_html}\" data-html=\"true\"";
+
+		} else {
+
+			$title = $addresses[0]['descr'];
+
+			$hint = "{$addresses[0]['address']}/{$addresses[0]['mask']}";
+
+			$popover_params = null;
+		
+		}
+
+		$ret_html = "<a href=\"{$s(htmlspecialchars($href))}\" title=\"{$s(htmlspecialchars($title))}\"{$popover_params}>{$s(htmlspecialchars($hint))}</a>";
+
+	} else {
+
+		$ret_html = "({$s(gettext('none'))})";
+
+	}
+
+	return $ret_html;
+
+}
+
+function wg_generate_tunnel_address_popover_link($tunnel_name) {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	if ([$tun_idx, $tunnel, $is_new] = wg_tunnel_get_config_by_name($tunnel_name, false)) {
+
+		if (!is_wg_tunnel_assigned($tunnel['name'])) {
+			
+			return wg_compose_address_popover_link($tunnel['addresses']['row'], gettext('Interface Addresses'), "vpn_wg_tunnels_edit.php?tun={$tunnel_name}");
+
+		} else {
+
+			$wg_pfsense_if = wg_get_pfsense_interface_info($tunnel['name']);
+
+			$ret_html = 	<<<"RET"
+					<i class="fa fa-sitemap" style="vertical-align: middle;"></i>
+					<a style="padding-left: 3px" href="../../interfaces.php?if={$s(htmlspecialchars($wg_pfsense_if['name']))}">{$s(htmlspecialchars($wg_pfsense_if['descr']))} ({$s(htmlspecialchars($wg_pfsense_if['name']))})</a>
+					
+					RET;
+
+			return $ret_html;
+
+		}
+
+	}
+
+	return null;
+
+}
+
+function wg_generate_peer_allowedips_popup_link($peer_idx) {
+	global $wgg;
+
+	$s = fn($x) => $x;
+
+	if ([$peer_idx, $peer, $is_new] = wg_peer_get_config($peer_idx, false)) {
+
+		return wg_compose_address_popover_link($peer['allowedips']['row'], gettext('Allowed IPs'), "vpn_wg_peers_edit.php?peer={$peer_idx}");
+
+	}
+
+	return null;
+
+}
+
+?>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_install.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_install.inc
@@ -1,0 +1,498 @@
+<?php
+/*
+ * wg_install.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2021 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2021 R. Christian McDonald (https://github.com/theonemcdonald)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// pfSense includes
+require_once('config.inc');
+require_once('services.inc');
+require_once('service-utils.inc');
+require_once('unbound.inc');
+require_once('util.inc');
+
+// WireGuard includes
+require_once('wireguard/includes/wg_api.inc');
+require_once('wireguard/includes/wg_globals.inc');
+require_once('wireguard/includes/wg_service.inc');
+
+/*
+ * This is the main install hook
+ */
+function wg_install() {
+	global $g;
+
+	$g['wireguard_installing'] = true;
+
+	update_status("\n  Upgrading any existing WireGuard XML configuration...");
+
+	update_status("done.\n  Installing WireGuard early shell commands...");
+
+	// Installs the WireGuard earlyshellcmds
+	wg_earlyshellcmd_install();
+
+	update_status("done.\n  Creating WireGuard interface group...");
+
+	// Create the 'WireGuard' interface group
+	wg_ifgroup_install();
+
+	update_status("done.\n  Creating WireGuard Unbound access list...");
+
+	// Create the WireGuard Unbound ACL
+	wg_unbound_acl_install();
+
+	update_status("done.\n  Installing WireGuard service...");
+
+	// Create the WireGuard service
+	wg_service_install();
+
+	update_status("done.\n  Applying WireGuard default settings as necessary...");
+
+	wg_defaults_install();
+
+	update_status("done.\n");
+
+}
+
+/*
+ * This is the main deinstall hook
+ */
+function wg_deinstall() {
+	global $config, $wgg;
+
+	wg_globals();
+
+	update_status("  Removing WireGuard early shell commands...");
+
+	// Removes the WireGuard earlyshellcmds
+	wg_earlyshellcmd_deinstall();
+
+	update_status("done.\n  Removing WireGuard interface group...");
+
+	// Removes the 'WireGuard' interface group
+	wg_ifgroup_deinstall();
+
+	update_status("done.\n  Removing WireGuard temporary files...");
+
+	// Removes WireGuard temporary files
+	wg_delete_temp_files();
+
+	// Only delete WireGuard configuration if keep_conf is explicitly 'no'
+	if (isset($wgg['config']['keep_conf']) && $wgg['config']['keep_conf'] == 'no') {
+
+		update_status("done.\n  Removing WireGuard configuration settings...");
+
+		// Removes WireGuard configuration
+		wg_remove_config_settings();
+
+	} else {
+
+		update_status("done.\n  Keeping WireGuard configuration settings...");
+
+	}
+
+	update_status("done.\n  Removing WireGuard Unbound access list...");
+
+	// Remove Unbound ACL
+	wg_unbound_acl_deinstall();
+
+	update_status("done.\n  Destroying WireGuard tunnels...");
+
+	// Teardown any WireGuard tunnel interfaces
+	wg_destroy_tunnels();
+
+	update_status("done.\n  Stopping and removing the WireGuard service...");
+
+	// Stop and remove the WireGuard service
+	wg_service_deinstall(true);
+
+	update_status("done.\n");
+
+}
+
+function wg_delete_temp_files() {
+	global $wgg;
+
+	// Removes WireGuard temporary configuration files
+	wg_delete_config_files();
+
+	// This nukes any lingering .apply files
+	foreach ($wgg['applylist'] as $path) {
+
+		unlink_if_exists($path);
+
+	}
+
+	// Package is uninstalling, so clear lingering dirty status too...
+	foreach ($wgg['subsystems'] as $subsystem) {
+
+		clear_subsystem_dirty($subsystem);
+
+	}
+
+}
+
+/*
+ * This just ensures that there are defaults in the XML.
+ * The package should function correctly without these being set at all.
+ * This is just to make sure the XML is reflecting the running behavior.
+ */
+function wg_defaults_install() {
+	global $wgg;
+
+	// Read latest settings
+	wg_globals();
+
+	$wgg['config']['enable']			= wg_is_service_enabled() ? 'on' : 'off';
+
+	$wgg['config']['keep_conf']			= isset($wgg['config']['keep_conf']) ? $wgg['config']['keep_conf'] : 'yes';
+
+	$wgg['config']['resolve_interval']		= isset($wgg['config']['resolve_interval']) ? $wgg['config']['resolve_interval'] : $wgg['default_resolve_interval'];
+	
+	$wgg['config']['resolve_interval_track']	= isset($wgg['config']['resolve_interval_track']) ? $wgg['config']['resolve_interval_track'] : 'no';
+	
+	$wgg['config']['interface_group']		= isset($wgg['config']['interface_group']) ? $wgg['config']['interface_group'] : 'all';
+	
+	$wgg['config']['hide_secrets'] 			= isset($wgg['config']['hide_secrets']) ? $wgg['config']['hide_secrets'] : 'yes';
+	
+	wg_write_config('Applied package default settings as necessary.', false);
+
+}
+
+function wg_service_rcfile() {
+	global $wgg;
+
+	$start = $stop = array();
+
+	$start[] 		= "{$wgg['wg_daemon']} start";
+
+	$stop[] 		= "{$wgg['wg_daemon']} stop";
+
+	$rcfile['file'] 	= $wgg['service_name'];
+
+	$rcfile['start'] 	= implode("\n\t", $start);
+
+	$rcfile['stop'] 	= implode("\n\t", $stop);
+
+	write_rcfile($rcfile);
+
+}
+
+function wg_service_install() {
+	global $wgg;
+
+	wg_service_rcfile();
+
+	wg_service_deinstall();
+
+	link($wgg['php'], $wgg['php_wg']);
+
+}
+
+function wg_service_deinstall($force_stop = false) {
+	global $wgg;
+	
+	if ($force_stop) {
+
+		wg_service_fpm_stop();
+
+	}
+
+	unlink_if_exists($wgg['php_wg']);
+
+}
+
+function wg_destroy_tunnels(&$cmds = null) {
+	global $wgg;
+
+	// Assume this will be successful...
+	$res = true;
+
+	// Tear down interfaces
+	foreach (wg_get_running_ifs() as $tunnel) {
+
+		$res &= wg_ifconfig_if_destroy($tunnel, $cmds);
+		
+	}
+
+	// Now attempt to unload the module if the above was successful
+	if ($res) {
+
+		$res &= wg_kld_loadunload(false, $cmds);
+
+	}
+
+	return $res;
+
+}
+
+function wg_listenport_alias_install() {
+	global $config, $wgg;
+
+	wg_globals();
+
+	// TODO ?
+
+}
+
+
+/*
+ * This function creates earlyshellcmd entries in the config
+ */
+function wg_earlyshellcmd_install() {
+	global $config, $wgg;
+
+	wg_globals();
+
+	wg_earlyshellcmd_deinstall();
+
+	init_config_arr(array('system', 'earlyshellcmd'));
+
+	init_config_arr(array('installedpackages', 'shellcmdsettings', 'config'));
+
+	$a_earlyshellcmd = &$config['system']['earlyshellcmd'];
+
+	$a_shellcmdsettings = &$config['installedpackages']['shellcmdsettings']['config'];
+
+	$shellcmd_pkg_cmds = array_map(fn($x) => $x['cmd'], $a_shellcmdsettings);
+
+	foreach ($wgg['shellcmdentries'] as $shellcmd) {
+
+		// Need to escape slashes from the path
+		$escaped_cmd = preg_quote($shellcmd['cmd'], '/');
+
+		// Install the earlyshellcmd
+		if (!preg_grep("/{$escaped_cmd}/", $a_earlyshellcmd)) {
+
+			// Put our entry at the top of the list
+			array_unshift($a_earlyshellcmd, $shellcmd['cmd']);
+
+		}
+
+		// Update the shellcmd package too
+		if (!preg_grep("/{$escaped_cmd}/", $shellcmd_pkg_cmds)) {
+
+			// Put our entry at the top of the list
+			array_unshift($a_shellcmdsettings, $shellcmd);
+
+		}
+
+	}
+
+	wg_write_config('Installed earlyshellcmd(s).', false);
+
+}
+
+/*
+ * This function removes earlyshellcmd entries in the config
+ */
+function wg_earlyshellcmd_deinstall() {
+	global $config, $wgg;
+
+	wg_globals();
+
+	init_config_arr(array('system', 'earlyshellcmd'));
+	
+	init_config_arr(array('installedpackages', 'shellcmdsettings', 'config'));
+
+	$a_earlyshellcmd = &$config['system']['earlyshellcmd'];
+
+	$a_shellcmdsettings = &$config['installedpackages']['shellcmdsettings']['config'];
+
+	$shellcmd_pkg_cmds = array_map(fn($x) => $x['cmd'], $a_shellcmdsettings);
+
+	foreach ($wgg['shellcmdentries'] as $shellcmd) {
+
+		// Need to escape slashes from the path
+		$escaped_cmd = preg_quote($shellcmd['cmd'], '/');
+
+		// Deinstall the earlyshellcmd
+		if ($cmds = preg_grep("/{$escaped_cmd}/", $a_earlyshellcmd)) {
+
+			foreach ($cmds as $cmd_idx => $cmd) {
+
+				unset($a_earlyshellcmd[$cmd_idx]);
+
+			}
+
+		}
+
+		// Update the shellcmd package too
+		if ($cmds = preg_grep("/{$escaped_cmd}/", $shellcmd_pkg_cmds)) {
+
+			foreach ($cmds as $cmd_idx => $cmd) {
+
+				unset($a_shellcmdsettings[$cmd_idx]);
+
+			}
+
+		}
+
+	}
+
+	wg_write_config('De-installed earlyshellcmd(s).', false);
+
+}
+
+/*
+ * This function creates the WireGuard interface group
+ */
+function wg_ifgroup_install() {
+	global $config, $wgg;
+
+	wg_globals();
+
+	wg_ifgroup_deinstall();
+
+	if (isset($wgg['config']['interface_group'])
+	    && ($wgg['config']['interface_group'] == 'none')) {
+
+		// No point installing the interface group...
+		return;
+
+	}
+
+	init_config_arr(array('ifgroups', 'ifgroupentry'));
+
+	$a_ifgroups = &$config['ifgroups']['ifgroupentry'];
+
+	$ifgroup_names = array_map(fn($x) => $x['ifname'], $a_ifgroups);
+
+	if (!preg_grep("/{$wgg['ifgroupentry']['ifname']}/", $ifgroup_names)) {
+
+		// Put our entry at the top of the list
+		array_unshift($a_ifgroups, $wgg['ifgroupentry']);
+
+	}
+
+	wg_write_config("Installed interface group ({$wgg['ifgroupentry']['ifname']}).", false);
+
+}
+
+/*
+ * This function removes the WireGuard interface group
+ */
+function wg_ifgroup_deinstall() {
+	global $config, $wgg;
+
+	wg_globals();
+
+	init_config_arr(array('ifgroups', 'ifgroupentry'));
+
+	$a_ifgroups = &$config['ifgroups']['ifgroupentry'];
+
+	$ifgroup_names = array_map(fn($x) => $x['ifname'], $a_ifgroups);
+
+	if ($groups = preg_grep("/{$wgg['ifgroupentry']['ifname']}/", $ifgroup_names)) {
+
+		foreach ($groups as $group_idx => $group) {
+
+			unset($a_ifgroups[$group_idx]);
+
+		}
+
+	}
+
+	wg_write_config("De-installed interface group ({$wgg['ifgroupentry']['ifname']}).", false);
+
+}
+
+/*
+ * This function removes the WireGuard Unbound access list
+ */
+function wg_unbound_acl_deinstall() {
+	global $config, $wgg;
+
+	wg_globals();
+
+	init_config_arr(array('unbound', 'acls'));
+
+	$a_unbound_acls = &$config['unbound']['acls'];
+
+	$a_unbound_acls_names = array_map(fn($x) => $x['aclname'], $a_unbound_acls);
+
+	if ($acls = preg_grep("/{$wgg['unboundaclentry']['aclname']}/", $a_unbound_acls_names)) {
+
+		foreach ($acls as $acl_idx => $acl) {
+
+			unset($a_unbound_acls[$acl_idx]);
+
+		}
+
+	}
+
+	wg_write_config("De-installed Unbound ACL group ({$wgg['unboundaclentry']['aclname']}).", false);
+
+}
+
+/*
+ * This function creates the WireGuard Unbound access list
+ */
+function wg_unbound_acl_install() {
+	global $config, $wgg;
+
+	// Format tunnel description if one is configured
+	$tunDescr = fn($tunnel) => !empty($tunnel['descr']) ? " ({$tunnel['descr']})" : null;
+
+	wg_globals();
+
+	wg_unbound_acl_deinstall();
+
+	$tun_networks = wg_get_tunnel_networks();
+
+	init_config_arr(array('unbound', 'acls'));
+
+	$a_unbound_acls = &$config['unbound']['acls'];
+
+	$a_unbound_acls_names = array_map(fn($x) => $x['aclname'], $a_unbound_acls);
+
+	// Only need to create the ACL if we actually have tunnel networks to add
+	if (!empty($tun_networks) && is_array($tun_networks)) {
+
+		if (!preg_grep("/{$wgg['unboundaclentry']['aclname']}/", $a_unbound_acls_names)) {
+
+			$wgg['unboundaclentry']['aclid'] = unbound_get_next_id();
+
+			$tmp_acls = array();
+
+			foreach ($tun_networks as $network_idx => $network) {
+
+				$tmp_acls[$network_idx]['acl_network'] 	= $network['network'];
+
+				$tmp_acls[$network_idx]['mask']		= $network['mask'];
+
+				$tmp_acls[$network_idx]['description']	= "{$network['tun']}{$tunDescr($network['descr'])}";
+
+				$wgg['unboundaclentry']['row'] = $tmp_acls;
+
+			}
+
+			// Put our entry at the top of the list
+			array_unshift($a_unbound_acls, $wgg['unboundaclentry']);
+
+		}
+
+	}
+
+	wg_write_config("Installed Unbound ACL group ({$wgg['unboundaclentry']['aclname']}).", false);
+
+}
+
+
+?>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_service.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_service.inc
@@ -1,0 +1,592 @@
+<?php
+/*
+ * wg_service.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2021 R. Christian McDonald (https://github.com/theonemcdonald)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+// pfSense includes
+require_once('config.inc');
+require_once('globals.inc');
+require_once('gwlb.inc');
+require_once('util.inc');
+require_once('services.inc');
+require_once('service-utils.inc');
+
+// WireGuard includes
+require_once('wireguard/includes/wg.inc');
+
+global $wgg;
+
+if (isset($argv[1])) {
+
+	$ret_code = 0;
+
+	ignore_user_abort(true);
+
+	set_time_limit(0);
+
+	pcntl_async_signals(true);
+
+	if (!wg_is_cli()) {
+
+		// Bail out if we aren't in the CLI...
+		die("FATAL: This script can only be started through the CLI.\n");
+
+	}
+
+	if (PHP_BINARY != $wgg['php_wg']) {
+
+		// Bail out if we aren't running under under the correct executable...
+		die("FATAL: This script can only be executed by {$wgg['php_wg']}.\n");
+
+	}
+
+	// Should we serialize the return output?
+	$serialize = (isset($argv[2]) && strtolower($argv[2]) == 'serialize');
+
+	switch (strtolower($argv[1])) {
+		
+		case 'start':
+
+			$ret_code = wg_service_cli_start($serialize);
+			
+			break;
+
+		case 'stop':
+	
+			$ret_code = wg_service_cli_stop($serialize);
+
+			break;
+
+		case 'restart':
+
+			$ret_code = wg_service_cli_restart($serialize);
+
+			break;
+
+		default:
+
+			fwrite(STDOUT, "Usage: {$wgg['wg_daemon']} {START|STOP|RESTART} [SERIALIZE]");
+
+			$ret_code = 1;
+
+			break;
+
+	}
+
+	// We are done...
+	exit($ret_code);
+
+}
+
+// This is a wrapper for safely calling from web frontend
+function wg_service_fpm_restart() {
+	global $wgg;
+
+	$exec_output = $unserialize_output = $ret_output = array();
+
+	// Invokes service restart with serialization flag so we can cleanly report back to the web frontend.
+	exec("{$wgg['wg_daemon']} restart serialize", $exec_output, $ret_code);
+
+	if ($unserialize_output = unserialize($exec_output[0])) {
+
+		if (is_array($unserialize_output)) {
+
+			$ret_output = $unserialize_output;
+
+		}
+
+	}
+
+	// Consumers expect an array...
+	return $ret_output;
+
+}
+
+function wg_service_cli_restart($serialize = true) {
+	global $wgg;
+
+	$ret_code = 0;
+
+	if (wg_is_service_running()) {
+
+		$ret_code = wg_service_cli_stop($serialize);
+
+		if ($ret_code <> 0) {
+
+			return $ret_code;
+		}
+
+	}
+
+	$ret_code = wg_service_cli_start($serialize);
+
+	return $ret_code;
+
+}
+
+// This is a wrapper for safely calling from web frontend
+function wg_service_fpm_stop() {
+	global $wgg;
+
+	$exec_output = $unserialize_output = $ret_output = array();
+
+	// Invokes service stop with serialization flag so we can cleanly report back to the web frontend.
+	exec("{$wgg['wg_daemon']} stop serialize", $exec_output, $ret_code);
+
+	if ($unserialize_output = unserialize($exec_output[0])) {
+
+		if (is_array($unserialize_output)) {
+
+			$ret_output = $unserialize_output;
+
+		}
+
+	}
+
+	// Consumers expect an array...
+	return $ret_output;
+
+}
+
+// Only for calling service stop from the CLI
+function wg_service_cli_stop($serialize = true) {
+	global $wgg;
+
+	$ret_code = 0;
+
+	if (!wg_is_cli()) {
+
+		$ret_code |= WG_ERROR_SVC_STOP;
+
+		wg_service_parse_errors($ret_code, $serialize);
+
+		// Terminate early...
+		return $ret_code;
+
+	}
+
+	// Need to wait here for just a second...
+	if (killbypid($wgg['pid_path'], 1) <> 0) {
+
+		$ret_code |= WG_ERROR_SVC_STOP;
+
+		wg_service_parse_errors($ret_code, $serialize);
+
+	}
+
+	return $ret_code;
+
+}
+
+// This is a wrapper for safely calling from the web frontend
+function wg_service_fpm_start() {
+	global $wgg;
+
+	$exec_output = $unserialize_output = $ret_output = array();
+
+	// Invokes service start with serialization flag so we can cleanly report back to the web frontend
+	exec("{$wgg['wg_daemon']} start serialize", $exec_output, $ret_code);
+
+	// Catch unserialization results before returning
+	if ($unserialize_output = unserialize($exec_output[0])) {
+
+		if (is_array($unserialize_output)) {
+
+			$ret_output = $unserialize_output;
+
+		}
+
+	}
+
+	// Consumers expect an array...
+	return $ret_output;
+
+}
+
+// Only for calling service start from the CLI
+function wg_service_cli_start($serialize = true) {
+	global $g, $wgg;
+
+	$s = fn($x) => $x;
+
+	// Set the process name
+	cli_set_process_title('WireGuard service');
+	
+	$ret_code = 0;
+
+	if (!wg_is_service_enabled()) {
+
+		$ret_code |= WG_ERROR_SVC_DISABLED;
+
+		wg_service_parse_errors($ret_code, $serialize);
+
+		return $ret_code;
+
+	}
+
+	if (wg_is_service_running()) {
+
+		$ret_code |= WG_ERROR_SVC_RUNNING;
+
+		wg_service_parse_errors($ret_code, $serialize);
+
+		return $ret_code;
+
+	}
+
+	if (!wg_is_cli()) {
+
+		$ret_code |= WG_ERROR_SVC_START;
+
+		wg_service_parse_errors($ret_code, $serialize);
+
+		return $ret_code;
+
+	}
+
+	// Register the service environment and lock early to ensure singletons
+	wg_register_service_env(false);
+
+	if (platform_booting()) {
+
+		// Output during booting must be to STDERR for some reason
+		fwrite(STDERR, gettext('Configuring WireGuard tunnels...'));
+
+		// Supresses ifconfig spew 
+		mute_kernel_msgs();
+
+	}
+
+	// Get the tunnel interfaces to build
+	$ifs_to_build = wg_get_configured_ifs();
+
+	// Now build them...
+	$sync_status = wg_tunnel_sync($ifs_to_build, false, false);
+
+	if ($sync_status['ret_code'] <> 0 ) {
+
+		$ret_code |= WG_ERROR_SVC_CREATE;
+
+	}
+
+	if (platform_booting()) {
+
+		unmute_kernel_msgs();
+
+		fwrite(STDERR, "{$s(gettext('done.'))}\n");
+
+		return $ret_code;
+
+	}
+
+	// Now, the initial fork...
+	$newpid = pcntl_fork();
+
+	if ($newpid === -1) {
+
+		$ret_code |= WG_ERROR_SVC_START;
+
+		wg_destroy_tunnels();
+
+		wg_service_parse_errors($ret_code, $serialize);
+
+		return $ret_code;
+
+	} elseif ($newpid) {
+
+		wg_service_parse_errors($ret_code, $serialize);
+
+		return $ret_code;
+
+	}
+
+	// Now become the session leader
+	if (posix_setsid() < 0) {
+
+		wg_destroy_tunnels();
+
+		return 1;
+
+	}
+
+	// The second fork...
+	$newpid = pcntl_fork();
+
+	if ($newpid === -1) {
+
+		wg_destroy_tunnels();
+
+		return 1;
+
+	} elseif ($newpid) {
+
+		// Reap the child process below...
+		pcntl_waitpid($newpid, $status);
+
+		// Boilerplate if we want to trap service ret codes and halt...
+		$ret_code = pcntl_wexitstatus($status);
+
+		if ($ret_code <> 0) {
+
+			return $ret_code;
+		}
+
+		// Move on to the actual daemon
+		wg_service_daemon();
+
+		// We shouldn't be here...
+		return 0;
+
+	} else {
+
+		// Now we restart any additional services
+		$ret_code = wg_restart_extra_services();
+
+		return $ret_code;
+
+	}
+
+	// We shouldn't be here...
+	return 1;
+
+}
+
+// This is where we restart any extra services
+function wg_restart_extra_services() {
+
+	if (!platform_booting()) {
+
+		// dpinger
+		setup_gateways_monitor();
+
+		// unbound
+		services_unbound_configure();
+
+		// TODO: This is where we will add facilities for users to pick what services to restart
+
+	}
+
+	// This is currently just a best effort attempt...
+	return 0;
+
+}
+
+// Main WireGuard service loop
+function wg_service_daemon() {
+	global $wgg;
+
+	$esa = fn($s) => escapeshellarg($s);
+
+	// Re-register the service environment
+	wg_register_service_env(true);
+
+	// Now that we are properly daemonized, register the service signal handlers
+	wg_register_daemon_sig_handler();
+
+	// Attempt to load the kmod, required to run the service without any tunnels configured
+	wg_kld_loadunload(true);
+
+	// Now we resolve endpoint hostnames here...
+	$last_update_time = wg_resolve_endpoints();
+
+	// Main WireGuard service loop
+	while (true) {
+
+		// The whole point of this daemon...
+		if (!is_module_loaded($wgg['kmod'])) {
+
+			break;
+
+		}
+		
+		// Check if we should reresolve hostnames
+		if (wg_should_reresolve_endpoints($last_update_time)) {
+
+			// Reresolve endpoint hostnames again
+			$last_update_time = wg_resolve_endpoints();
+
+		}
+
+		// Wait a bit before trying again
+		sleep(1);
+
+	}
+
+	// Execute SIGTERM handler to exit gracefully
+	wg_daemon_sig_handler(SIGTERM);
+
+}
+
+function wg_deregister_service_env() {
+	global $h_lock, $wgg;
+
+	if (!is_null($h_lock)) {
+
+		// Attempt to release exclusive lock
+		@flock($h_lock, LOCK_UN);
+
+		// Attempt to close file handler
+		@fclose($h_lock);
+
+	}
+
+	// Attempt to delete PID file
+	unlink_if_exists($wgg['pid_path']);
+
+}
+
+function wg_register_service_env($close_fdio = false) {
+	global $h_lock, $wgg;
+
+	wg_deregister_service_env();
+
+	if ($h_lock = fopen($wgg['pid_path'], 'a+')) {
+
+		flock($h_lock, LOCK_EX);
+
+		ftruncate($h_lock, 0);
+
+		fseek($h_lock, 0, 0);
+
+		fwrite($h_lock, getmypid());
+
+		fflush($h_lock);
+
+	}
+
+	if ($close_fdio) {
+
+		fclose(STDIN);
+
+		fclose(STDOUT);
+
+		fclose(STDERR);
+
+	}
+
+}
+
+function wg_register_daemon_sig_handler() {
+
+	pcntl_signal(SIGTERM, 'wg_daemon_sig_handler');
+
+}
+
+function wg_daemon_sig_handler($signo) {
+
+	switch ($signo) {
+
+		case SIGTERM:
+
+			// Teardown any tunnels and unload the module
+			wg_destroy_tunnels();
+
+			// Cleanup the service environment
+			wg_deregister_service_env();
+
+			// We are done...
+			exit(0);
+
+			break;
+
+		default:
+
+			break;
+
+	}
+
+}
+
+function wg_service_parse_errors($ret_code, $serialize_output = true, $extras = null) {
+	global $wgg;
+
+	$errors = array();
+
+	// Collect any errors
+	foreach ($wgg['error_flags']['service'] as $error_mask => $error_text) {
+
+		if (($ret_code & $error_mask) > 0) {
+
+			$errors[$error_mask] = $error_text;
+
+			if (!$serialize_output) {
+
+				// Send each error to STDERR as it is found
+				fwrite(STDERR, "{$error_text}\n");
+
+			}
+
+		}
+
+	}
+
+	if ($serialize_output) {
+
+		$res = array('ret_code' => $ret_code, 'errors' => $errors);
+
+		$res = is_array($extras) ? array_merge($res, $extras) : $res;
+
+		$res_serialized = serialize($res);
+
+		fwrite(STDOUT, "{$res_serialized}\n");
+
+	}
+
+	return;
+
+}
+
+// Check if we are in CLI or not
+function wg_is_cli() {
+
+	return (PHP_SAPI == 'cli');
+
+}
+
+// Checks if the service is running
+function wg_is_service_running() {
+	global $wgg;
+
+	if (!($h_lock = @fopen($wgg['pid_path'], 'r')) || !file_exists($wgg['pid_path'])) {
+
+		return false;
+
+	}
+
+	$not_running = flock($h_lock, LOCK_EX | LOCK_NB, $wouldblock);
+
+	if ($not_running) {
+	
+		flock($h_lock, LOCK_UN);
+
+	}
+
+	$pid = fgets($h_lock);
+	
+	fclose($h_lock);
+
+	// Another trick to test if a process is running
+	$sig_test = posix_kill($pid, 0);
+
+	return (!$not_running || $wouldblock || $sig_test);
+
+}
+
+?>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_validate.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_validate.inc
@@ -1,0 +1,281 @@
+<?php
+/*
+ * wg_validate.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2021 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2021 R. Christian McDonald (https://github.com/theonemcdonald)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// pfSense includes 
+require_once('config.inc');
+require_once('pfsense-utils.inc');
+require_once('util.inc');
+
+// WireGuard includes
+require_once('wireguard/includes/wg_api.inc');
+
+function wg_validate_peer_toggle($peer) {
+
+	$input_errors = array();
+
+	// Boilerplate...
+
+	return $input_errors;
+
+}
+
+function wg_validate_peer_delete($peer) {
+
+	$input_errors = array();
+
+	// Boilerplate...
+
+	return $input_errors;
+	
+}
+
+function wg_validate_tunnel_delete($tunnel) {
+
+	$input_errors = array();
+
+	// We can't delete assigned tunnels
+	if (is_wg_tunnel_assigned($tunnel['name'])) {
+
+		$wg_pfsense_if = wg_get_pfsense_interface_info($tunnel['name']);
+
+		$input_errors[] = "Cannot delete {$tunnel['name']} while it is assigned to {$wg_pfsense_if['descr']} ({$wg_pfsense_if['name']})";
+
+	}
+
+	return $input_errors;
+
+}
+
+function wg_validate_tunnel_toggle($tunnel) {
+
+	$input_errors = array();
+
+	$is_enabled = (isset($tunnel['enabled']) && ($tunnel['enabled']) == 'yes');
+
+	if (!$is_enabled && is_wg_tunnel_assigned($tunnel['name'])) {
+
+		$wg_pfsense_if = wg_get_pfsense_interface_info($tunnel['name']);
+
+		$input_errors[] = "Cannot disable {$tunnel['name']} while it is assigned to {$wg_pfsense_if['descr']} ({$wg_pfsense_if['name']}).";
+
+	}
+
+	// Consumers expect an array
+	return $input_errors;
+
+}
+
+/*
+ * Validate package settings
+ */
+function wg_validate_settings_post($pconfig) {
+
+	$input_errors = array();
+
+	$enable = $pconfig['enable'];
+
+	if (wg_is_wg_assigned() && (isset($enable) && (empty($enable) || ($enable == 'off')))) {
+
+		$input_errors[] = gettext('Cannot disable WireGuard when one or more tunnels is assigned to a pfSense interface.');
+	
+	}
+	
+	// Check endpoint hostname resolve interval
+	$resolve_interval = $pconfig['resolve_interval'];
+
+	if (!empty($resolve_interval) && !is_numericint($resolve_interval)) {
+
+		$input_errors[] = "Invalid endpoint hostname resolve interval ({$resolve_interval}).";
+
+	}
+
+	// Consumers expect an array
+	return $input_errors;
+
+}
+
+/*
+ * Valildate a tunnel
+ * These validation checks should be in the same order as the UI for consistency
+ */
+function wg_validate_tunnel_post($pconfig, $idx_from_post) {
+
+	$input_errors = array();
+
+	// Check enabled/disabled status
+	if (is_wg_tunnel_assigned($pconfig['name']) && (!isset($pconfig['enabled']) || ($pconfig['enabled'] != 'yes'))) {
+
+		$wg_pfsense_if = wg_get_pfsense_interface_info($pconfig['name']);
+
+		$input_errors[] = "Cannot disable {$pconfig['name']} while it is assigned to {$wg_pfsense_if['name']} ({$wg_pfsense_if['name']}).";
+
+	}
+
+	// Check listen port
+	$lport = $pconfig['listenport'];
+
+	if (!empty($lport) && (!ctype_digit($lport) || !is_port($lport))) {
+
+		$input_errors[] = "Invalid interface listen port ({$lport}).";
+
+	}
+
+	// Check keys
+	if (empty($pconfig['privatekey'])) {
+
+		$input_errors[] = gettext('A private key must be specified.');
+
+	} elseif (!wg_is_valid_key($pconfig['privatekey'])) {
+
+		$input_errors[] = gettext('The private key specified is not a valid WireGuard private key.');
+
+	}
+
+	// Assigned tunnels don't need these validation checks
+	if (!is_wg_tunnel_assigned($pconfig['name'])) {
+
+		foreach ((array) $pconfig['addresses']['row'] as $address) {
+
+			// Remove any accidental whitespace
+			$address['address'] = trim($address['address']);
+
+			$tmp_subnet = "{$address['address']}/{$address['mask']}";
+
+			if (!empty($address['address']) && !is_subnet($tmp_subnet)) {
+
+				$input_errors[] = "Address {$tmp_subnet} is not a valid CIDR address.";
+
+			}
+
+			$conflicts = where_is_ipaddr_configured($address['address'], $skip, true, true, $address['mask']);
+
+			if (!empty($conflicts)) {
+
+				foreach ($conflicts as $conflict) {
+
+					$ifname = strtoupper($conflict['if']);
+
+					$input_errors[] = "Address {$address['address']} is already configured on this firewall. [ {$ifname} ({$conflict['ip_or_subnet']}) ]";
+				
+				}
+			}
+		}
+	
+	}
+
+	// Consumers expect an array
+	return $input_errors;
+
+}
+
+/*
+ * Valildate a peer
+ * These validation checks should be in the same order as the UI for consistency
+ */
+function wg_validate_peer_post($pconfig, $posted_peer_idx) {
+
+	$input_errors = array();
+
+	// Check remote endpoint
+	$ep = trim($pconfig['endpoint']);
+
+	if (!empty($ep) && !is_hostname($ep) && !is_ipaddr($ep)) {
+
+		$input_errors[] = "Endpoint {$ep} must be a valid IPv4 or IPv6 address or hostname.";
+
+	}
+
+	// Check remote port
+	$rport = $pconfig['port'];
+
+	if (!empty($rport) && (!ctype_digit($rport) || !is_port($rport))) {
+
+		$input_errors[] = "Invalid peer remote port ({$rport}).";
+	}
+
+	// Check persistent keep alive
+	$keepalive = $pconfig['persistentkeepalive'];
+
+	if (!empty($keepalive) && !is_numericint($keepalive)) {
+
+		$input_errors[] = "Invalid keep alive interval ({$keepalive}).";
+
+	}
+
+	// Check public key
+	if (empty($pconfig['publickey'])) {
+
+		$input_errors[] = gettext('A public key must be specified.');
+
+	} elseif (!wg_is_valid_key($pconfig['publickey'])) {
+
+		$input_errors[] = "The public key ({$pconfig['publickey']}) is not a valid WireGuard public key.";
+
+	} elseif (!empty($pconfig['tun'])) {
+
+		foreach (wg_tunnel_get_peers_config($pconfig['tun']) as [$peer_idx, $peer, $is_new]) {
+
+			// We don't want duplicate public keys per tunnel, but re-saving is okay...
+			if (($peer['publickey'] == $pconfig['publickey']) && ($peer_idx != $posted_peer_idx)) {
+
+				$input_errors[] = "The public key ({$pconfig['publickey']}) is already assigned to a peer on this tunnel ({$pconfig['tun']}).";
+
+				break;
+
+			}
+
+		}
+
+	}
+
+	// Check pre-shared key
+	if (!empty($pconfig['presharedkey']) && !wg_is_valid_key($pconfig['presharedkey'])) {
+
+		$input_errors[] = "The pre-shared key ({$pconfig['presharedkey']}) is not a valid WireGuard pre-shared key.";
+
+	}
+
+	// Check allowed ips
+	if (!empty($pconfig['allowedips']['row']) && is_array($pconfig['allowedips']['row'])) {
+
+		foreach ((array) $pconfig['allowedips']['row'] as $row) {
+
+			$row['address'] = trim($row['address']);
+
+			$tmp_subnet = "{$row['address']}/{$row['mask']}";
+
+			if (!empty($row['address']) && !is_subnet($tmp_subnet)) {
+
+				$input_errors[] = "Address {$tmp_subnet} is not a valid IPv4 or IPv6 CIDR subnet address.";
+
+			}
+
+		}
+
+	}
+
+	// Consumers expect an array
+	return $input_errors;
+
+}
+
+?>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/share/pfSense-pkg-WireGuard/info.xml
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/share/pfSense-pkg-WireGuard/info.xml
@@ -14,7 +14,7 @@
 				heavy development, but already it might be regarded as the&lt;br /&gt;
 				most secure, easiest to use, and simplest VPN solution in&lt;br /&gt;
 				the industry.]]></descr>
-		<pkginfolink>https://github.com/theonemcdonald/pfSense-pkg-WireGuard</pkginfolink>
+		<pkginfolink>https://github.com/pfsense/FreeBSD-ports/commits/devel/net/pfSense-pkg-WireGuard</pkginfolink>
 		<version>%%PKGVERSION%%</version>
 		<configurationfile>wireguard.xml</configurationfile>
 	</package>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/js/WireGuardHelpers.js
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/js/WireGuardHelpers.js
@@ -3,7 +3,6 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2021 R. Christian McDonald (https://github.com/theonemcdonald)
- * Copyright (c) 2021 Vajonam (https://github.com/vajonam)
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,40 +18,12 @@
  * limitations under the License.
  */
 
-/*
- * fixed version of bump_input_id(newGroup) 
- * Ref: https://github.com/pfsense/pfsense/pull/4517
- * Ref: https://redmine.pfsense.org/issues/11880
- */
+function wgRegTrimHandler() {
 
-function bump_input_id(newGroup) {
-	$(newGroup).find('input').each(function() {
-		$(this).prop("id", bumpStringInt(this.id));
-		$(this).prop("name", bumpStringInt(this.name));
-		if (!$(this).is('[id^=delete]'))
-			$(this).val('');
+	$('body').on('change', '.trim', function () {
+
+		$(this).val($(this).val().replace(/\s/g, ''));
+
 	});
 
-	// Increment the suffix number for the deleterow button element in the new group
-	$(newGroup).find('[id^=deleterow]').each(function() {
-		$(this).prop("id", bumpStringInt(this.id));
-		$(this).prop("name", bumpStringInt(this.name));
-	});
-
-	// Do the same for selectors
-	$(newGroup).find('select').each(function() {
-		$(this).prop("id", bumpStringInt(this.id));
-		$(this).prop("name", bumpStringInt(this.name));
-		// If this selector lists mask bits, we need it to be reset to all 128 options
-		// and no items selected, so that automatic v4/v6 selection still works
-		if ($(this).is('[id^=address_subnet]')) {
-			$(this).empty();
-			for (idx=128; idx>=0; idx--) {
-				$(this).append($('<option>', {
-					value: idx,
-					text: idx
-				}));
-			}
-		}
-	});
 }

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/status_wireguard.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/status_wireguard.php
@@ -33,9 +33,8 @@ require_once('guiconfig.inc');
 require_once('util.inc');
 
 // WireGuard includes
-require_once('wireguard/wg.inc');
-require_once('wireguard/wg_guiconfig.inc');
-require_once('wireguard/wg_service.inc');
+require_once('wireguard/includes/wg.inc');
+require_once('wireguard/includes/wg_guiconfig.inc');
 
 global $wgg;
 
@@ -109,7 +108,7 @@ $a_devices = wg_get_status();
 			<thead>
 				<th><?=gettext('Tunnel')?></th>
 				<th><?=gettext('Description')?></th>
-				<th><?=gettext('# Peers')?></th>
+				<th><?=gettext('Peers')?></th>
 				<th><?=gettext('Public Key')?></th>
 				<th><?=gettext('Address / Assignment')?></th>
 				<th><?=gettext('MTU')?></th>
@@ -126,7 +125,7 @@ if (!empty($a_devices)):
 				<tr class="tunnel-entry">
 					<td>
 						<?=wg_interface_status_icon($device['status'])?>
-						<a href="vpn_wg_tunnels_edit.php?tun=<?=htmlspecialchars($device_name)?>"><?=htmlspecialchars($device_name)?>
+						<a href="vpn_wg_tunnels_edit.php?tun=<?=htmlspecialchars($device_name)?>"><?=htmlspecialchars($device_name)?></a>
 					</td>
 					<td><?=htmlspecialchars(wg_truncate_pretty($device['config']['descr'], 16))?></td>
 					<td><?=count($device['peers'])?></td>
@@ -167,7 +166,7 @@ if (!empty($a_devices)):
 										<?=htmlspecialchars(wg_truncate_pretty($peer['public_key'], 16))?>
 									</td>
 									<td><?=htmlspecialchars($peer['endpoint'])?></td>
-									<td><?=wg_generate_peer_allowedips_popup_link(wg_get_peer_idx($peer['config']['publickey'], $peer['config']['tun']))?></td>
+									<td><?=wg_generate_peer_allowedips_popup_link(wg_peer_get_array_idx($peer['config']['publickey'], $peer['config']['tun']))?></td>
 									<td><?=htmlspecialchars(format_bytes($peer['transfer_rx']))?></td>
 									<td><?=htmlspecialchars(format_bytes($peer['transfer_tx']))?></td>
 								</tr>
@@ -230,14 +229,12 @@ endif;
 			</thead>
 			<tbody>
 <?php
-			$a_packages = wg_pkg_info();
-
-			foreach ($a_packages as $package):
+			foreach (wg_pkg_info() as ['name' => $name, 'version' => $version, 'comment' => $comment]):
 ?>
     				<tr>
-					<td><?=htmlspecialchars($package['name'])?></td>
-					<td><?=htmlspecialchars($package['version'])?></td>
-					<td><?=htmlspecialchars($package['comment'])?></td>
+					<td><?=htmlspecialchars($name)?></td>
+					<td><?=htmlspecialchars($version)?></td>
+					<td><?=htmlspecialchars($comment)?></td>
 
 				</tr>
 <?php
@@ -270,11 +267,7 @@ events.push(function() {
 //]]>
 </script>
 
-<?php 
-
+<?php
+include('wireguard/includes/wg_foot.inc');
 include('foot.inc');
-
-// Must be included last
-include('wireguard/wg_foot.inc');
-
 ?>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers.php
@@ -32,8 +32,8 @@ require_once('functions.inc');
 require_once('guiconfig.inc');
 
 // WireGuard includes
-require_once('wireguard/wg.inc');
-require_once('wireguard/wg_guiconfig.inc');
+require_once('wireguard/includes/wg.inc');
+require_once('wireguard/includes/wg_guiconfig.inc');
 
 global $wgg;
 
@@ -177,7 +177,7 @@ if (is_array($wgg['peers']) && count($wgg['peers']) > 0):
 						<td><?=htmlspecialchars(wg_format_endpoint(false, $peer))?></td>
 						<td style="cursor: pointer;">
 							<a class="fa fa-pencil" title="<?=gettext('Edit Peer')?>" href="<?="vpn_wg_peers_edit.php?peer={$peer_idx}"?>"></a>
-							<?=wg_generate_toggle_icon_link($peer, 'Click to toggle enabled/disabled status', "?act=toggle&peer={$peer_idx}")?>
+							<?=wg_generate_toggle_icon_link(($peer['enabled'] == 'yes'), 'peer', "?act=toggle&peer={$peer_idx}")?>
 							<a class="fa fa-trash text-danger" title="<?=gettext('Delete Peer')?>" href="<?="?act=delete&peer={$peer_idx}"?>" usepost></a>
 						</td>
 					</tr>
@@ -209,19 +209,19 @@ endif;
 
 <script type="text/javascript">
 //<![CDATA[
+events.push(function() {
+
 	$('.pubkey').click(function () {
 
 		navigator.clipboard.writeText($(this).attr('title'));
 
 	});
+
+});
 //]]>
 </script>
 
-<?php 
-
+<?php
+include('wireguard/includes/wg_foot.inc');
 include('foot.inc');
-
-// Must be included last
-include('wireguard/wg_foot.inc');
-
 ?>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers_edit.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers_edit.php
@@ -32,8 +32,8 @@ require_once('functions.inc');
 require_once('guiconfig.inc');
 
 // WireGuard includes
-require_once('wireguard/wg.inc');
-require_once('wireguard/wg_guiconfig.inc');
+require_once('wireguard/includes/wg.inc');
+require_once('wireguard/includes/wg_guiconfig.inc');
 
 global $wgg;
 
@@ -159,8 +159,8 @@ $form->addGlobal(new Form_Input(
 
 $section->addInput(new Form_Checkbox(
 	'enabled',
-	'Peer Enabled',
-	gettext('Enable'),
+	'Enable',
+	gettext('Enable Peer'),
 	$pconfig['enabled'] == 'yes'
 ))->setHelp('<span class="text-danger">Note: </span>Uncheck this option to disable this peer without removing it from the list.');
 
@@ -188,25 +188,28 @@ $section->addInput(new Form_Checkbox(
 
 $group = new Form_Group('Endpoint');
 
+// Used for hiding/showing the group via JS
+$group->addClass("endpoint");
+
 $group->add(new Form_Input(
 	'endpoint',
 	'Endpoint',
 	'text',
 	$pconfig['endpoint']
-))->setWidth(5)
-	->setHelp('Hostname, IPv4, or IPv6 address of this peer.<br />
-			Leave endpoint and port blank if unknown (dynamic endpoints).');
+))->addClass('trim')
+  ->setHelp('Hostname, IPv4, or IPv6 address of this peer.<br />
+	     Leave endpoint and port blank if unknown (dynamic endpoints).')
+  ->setWidth(5);
 
 $group->add(new Form_Input(
 	'port',
 	'Endpoint Port',
 	'text',
 	$pconfig['port']
-))->setWidth(3)
-	->setHelp("Port used by this peer.<br />
-			Leave blank for default ({$wgg['default_port']}).");
-
-$group->addClass("endpoint");
+))->addClass('trim')
+  ->setHelp("Port used by this peer.<br />
+	     Leave blank for default ({$wgg['default_port']}).")
+  ->setWidth(3);
 
 $section->add($group);
 
@@ -214,9 +217,11 @@ $section->addInput(new Form_Input(
 	'persistentkeepalive',
 	'Keep Alive',
 	'text',
-	$pconfig['persistentkeepalive']
-))->setHelp('Interval (in seconds) for Keep Alive packets sent to this peer.<br />
-		Default is empty (disabled).');
+	$pconfig['persistentkeepalive'],
+	['placeholder' => 'Keep Alive']
+))->addClass('trim')
+  ->setHelp('Interval (in seconds) for Keep Alive packets sent to this peer.<br />
+	     Default is empty (disabled).');
 
 $section->addInput(new Form_Input(
 	'publickey',
@@ -224,7 +229,8 @@ $section->addInput(new Form_Input(
 	'text',
 	$pconfig['publickey'],
 	['placeholder' => 'Public Key']
-))->setHelp('WireGuard public key for this peer.');
+))->addClass('trim')
+  ->setHelp('WireGuard public key for this peer.');
 
 $group = new Form_Group('Pre-shared Key');
 
@@ -233,7 +239,8 @@ $group->add(new Form_Input(
 	'Pre-shared Key',
 	wg_secret_input_type(),
 	$pconfig['presharedkey']
-))->setHelp('Optional pre-shared key for this tunnel. (<a id="copypsk" style="cursor: pointer;" data-success-text="Copied" data-timeout="3000">Copy</a>)');
+))->addClass('trim')
+  ->setHelp('Optional pre-shared key for this tunnel. (<a id="copypsk" style="cursor: pointer;" data-success-text="Copied" data-timeout="3000">Copy</a>)');
 
 $group->add(new Form_Button(
 	'genpsk',
@@ -241,15 +248,13 @@ $group->add(new Form_Button(
 	null,
 	'fa-key'
 ))->addClass('btn-primary btn-sm')
-	->setHelp('New Pre-shared Key');
+  ->setHelp('New Pre-shared Key');
 
 $section->add($group);
 
 $form->add($section);
 
 $section = new Form_Section('Address Configuration');
-
-$section->setAttribute('id', 'allowedips');
 
 // Init the addresses array if necessary
 if (!is_array($pconfig['allowedips']['row']) || empty($pconfig['allowedips']['row'])) {
@@ -274,10 +279,10 @@ foreach ($pconfig['allowedips']['row'] as $counter => $item) {
 		'Allowed Subnet or Host',
 		$item['address'],
 		'BOTH'
-	))->AddClass('address')
-		->setHelp($counter == $last ? 'IPv4 or IPv6 subnet or host reachable via this peer.' : '')
-		->addMask("address_subnet{$counter}", $item['mask'], 128, 0)
-		->setWidth(4);
+	))->addClass('trim')
+	  ->setHelp($counter == $last ? 'IPv4 or IPv6 subnet or host reachable via this peer.' : '')
+	  ->addMask("address_subnet{$counter}", $item['mask'], 128, 0)
+	  ->setWidth(4);
 
 	$group->add(new Form_Input(
 		"address_descr{$counter}",
@@ -285,7 +290,7 @@ foreach ($pconfig['allowedips']['row'] as $counter => $item) {
 		'text',
 		$item['descr']
 	))->setHelp($counter == $last ? 'Description for administrative reference (not parsed).' : '')
-		->setWidth(4);
+	  ->setWidth(4);
 
 	$group->add(new Form_Button(
 		"deleterow{$counter}",
@@ -334,6 +339,8 @@ events.push(function() {
 	// Supress "Delete" button if there are fewer than two rows
 	checkLastRow();
 
+	wgRegTrimHandler();
+
 	$('#copypsk').click(function () {
 
 		var $this = $(this);
@@ -361,7 +368,7 @@ events.push(function() {
 
 	// Request a new pre-shared key
 	$('#genpsk').click(function(event) {
-		if ($('#presharedkey').val().length == 0 || confirm("<?=$genkeywarning?>")) {
+		if ($('#presharedkey').val().length == 0 || confirm(<?=json_encode($genkeywarning)?>)) {
 			ajaxRequest = $.ajax({
 				url: "/wg/vpn_wg_peers_edit.php",
 				type: "post",
@@ -373,19 +380,13 @@ events.push(function() {
 				}
 			});
 		}
-
-	});
-
-	// Trim any whitespace from allowedips input
-	$('#allowedips').on('change', 'input.address', function () {
-
-		$(this).val($(this).val().replace(/\s/g, ''));
-
 	});
 
 	// Save the form
 	$('#saveform').click(function () {
+
 		$(form).submit();
+
 	});
 
 	$('#dynamic').click(function () {
@@ -407,10 +408,6 @@ events.push(function() {
 </script>
 
 <?php
-
+include('wireguard/includes/wg_foot.inc');
 include('foot.inc');
-
-// Must be included last
-include('wireguard/wg_foot.inc');
-
 ?>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_settings.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_settings.php
@@ -32,12 +32,10 @@ require_once('functions.inc');
 require_once('guiconfig.inc');
 
 // WireGuard includes
-require_once('wireguard/wg.inc');
-require_once('wireguard/wg_guiconfig.inc');
+require_once('wireguard/includes/wg.inc');
+require_once('wireguard/includes/wg_guiconfig.inc');
 
 global $wgg;
-
-wg_globals();
 
 $save_success = false;
 
@@ -81,7 +79,13 @@ if ($_POST) {
 
 				$pconfig = $res['pconfig'];
 
-				$save_success = (empty($input_errors) && $res['changes']);
+				if (empty($input_errors) && $res['changes']) {
+
+					wg_toggle_wireguard();
+
+					$save_success = true;
+
+				}
 
 				break;
 
@@ -98,15 +102,13 @@ if ($_POST) {
 
 }
 
-// Defaults for new installations
+$s = fn($x) => $x;
 
-$pconfig['keep_conf'] = isset($wgg['config']['keep_conf']) ? $wgg['config']['keep_conf'] : 'yes';
+// Just to make sure defaults are properly assigned if anything is missing
+wg_defaults_install();
 
-$pconfig['hide_secrets'] = isset($wgg['config']['hide_secrets']) ? $wgg['config']['hide_secrets'] : 'yes';
-
-$pconfig['resolve_interval'] = isset($wgg['config']['resolve_interval']) ? $wgg['config']['default_resolve_interval'] : $wgg['resolve_interval'];
-
-$pconfig['resolve_interval_track'] = isset($wgg['config']['resolve_interval_track']) ? $wgg['config']['resolve_interval_track'] : 'no';
+// Grab current configuration from the XML
+$pconfig = $wgg['config'];
 
 $shortcut_section = 'wireguard';
 
@@ -121,13 +123,13 @@ $tab_array[] = array(gettext('Status'), false, '/wg/status_wireguard.php');
 
 include('head.inc');
 
+wg_print_service_warning();
+
 if ($save_success) {
 
 	print_info_box(gettext('The changes have been applied successfully.'), 'success');
 	
 }
-
-wg_print_service_warning();
 
 if (isset($_POST['apply'])) {
 
@@ -147,49 +149,85 @@ display_top_tabs($tab_array);
 
 $form = new Form(false);
 
-$section = new Form_Section('General Settings');
+$section = new Form_Section(gettext('General Settings'));
+
+$wg_enable = new Form_Checkbox(
+	'enable',
+	gettext('Enable'),
+	gettext('Enable WireGuard'),
+	wg_is_service_enabled()
+);
+
+$wg_enable->setHelp("<span class=\"text-danger\">{$s(gettext('Note:'))} </span>
+		     {$s(gettext('WireGuard cannot be disabled when one or more tunnels is assigned to a pfSense interface.'))}");
+
+if (wg_is_wg_assigned()) {
+
+	$wg_enable->setDisabled();
+
+	// We still want to POST this field, make it a hidden field now
+	$form->addGlobal(new Form_Input(
+		'enable',
+		'',
+		'hidden',
+		(wg_is_service_enabled() ? 'yes' : 'no')
+	));
+
+}
+
+$section->addInput($wg_enable);
 
 $section->addInput(new Form_Checkbox(
 	'keep_conf',
-	'Keep Configuration',
+	gettext('Keep Configuration'),
 	gettext('Enable'),
 	$pconfig['keep_conf'] == 'yes'
-))->setHelp("<span class=\"text-danger\">Note: </span>
-		With 'Keep Configurations' enabled (default), all tunnel configurations and package settings will persist on install/de-install."
-);
+))->setHelp("<span class=\"text-danger\">{$s(gettext('Note:'))} </span>
+	     {$s(gettext("With 'Keep Configurations' enabled (default), all tunnel configurations and package settings will persist on install/de-install."))}");
 
-$group = new Form_Group('Endpoint Hostname Resolve Interval');
+$group = new Form_Group(gettext('Endpoint Hostname Resolve Interval'));
 
 $group->add(new Form_Input(
 	'resolve_interval',
-	'Endpoint Hostname Resolve Interval',
+	gettext('Endpoint Hostname Resolve Interval'),
 	'text',
 	wg_get_endpoint_resolve_interval(),
 	['placeholder' => wg_get_endpoint_resolve_interval()]
-))->setHelp("Interval (in seconds) for re-resolving endpoint host/domain names.<br />
-		<span class=\"text-danger\">Note: </span> The default is {$wgg['default_resolve_interval']} seconds (0 to disable).");
+))->addClass('trim')
+  ->setHelp("{$s(gettext('Interval (in seconds) for re-resolving endpoint host/domain names.'))}<br />
+	     <span class=\"text-danger\">{$s(gettext('Note:'))} </span> {$s(sprintf('The default is %s seconds (0 to disable).', $wgg['default_resolve_interval']))}");
 
 $group->add(new Form_Checkbox(
 	'resolve_interval_track',
 	null,
 	gettext('Track System Resolve Interval'),
 	($pconfig['resolve_interval_track'] == 'yes')
-))->setHelp("Tracks the system 'Aliases Hostnames Resolve Interval' setting.<br />
-		<span class=\"text-danger\">Note: </span> See System / Advanced / <a href=\"..\..\system_advanced_firewall.php\">Firewall & NAT</a>");
+))->setHelp("{$s(gettext("Tracks the system 'Aliases Hostnames Resolve Interval' setting."))}<br />
+	     <span class=\"text-danger\">{$s(gettext('Note:'))} </span> See System / Advanced / <a href=\"..\..\system_advanced_firewall.php\">Firewall & NAT</a>");
 
 $section->add($group);
 
+$interface_group_list = array('all' => gettext('All Tunnels'), 'unassigned' => gettext('Only Unassigned Tunnels'), 'none' => gettext('None'));
+
+$section->addInput($input = new Form_Select(
+	'interface_group',
+	gettext('Interface Group Membership'),
+	$pconfig['interface_group'],
+	$interface_group_list
+))->setHelp("{$s(gettext('Configures which WireGuard tunnels are members of the WireGuard interface group.'))}<br />
+	     <span class=\"text-danger\">{$s(gettext('Note:'))} </span> {$s(sprintf(gettext("Group firewall rules are evaluated before interface firewall rules. Default is '%s.'"), $interface_group_list['all']))}");
+
 $form->add($section);
 
-$section = new Form_Section('User Interface Settings');
+$section = new Form_Section(gettext('User Interface Settings'));
 
 $section->addInput(new Form_Checkbox(
 	'hide_secrets',
-	'Hide Secrets',
+	gettext('Hide Secrets'),
     	gettext('Enable'),
     	$pconfig['hide_secrets'] == 'yes'
-))->setHelp("<span class=\"text-danger\">Note: </span>
-		With 'Hide Secrets' enabled, all secrets (private and pre-shared keys) are hidden in the user interface.");
+))->setHelp("<span class=\"text-danger\">{$s(gettext('Note:'))} </span>
+		{$s(gettext("With 'Hide Secrets' enabled, all secrets (private and pre-shared keys) are hidden in the user interface."))}");
 
 $form->add($section);
 
@@ -214,6 +252,8 @@ print($form);
 <script type="text/javascript">
 //<![CDATA[
 events.push(function() {
+
+	wgRegTrimHandler();
 
 	// Save the form
 	$('#saveform').click(function () {
@@ -240,11 +280,7 @@ events.push(function() {
 //]]>
 </script>
 
-<?php 
-
+<?php
+include('wireguard/includes/wg_foot.inc');
 include('foot.inc');
-
-// Must be included last
-include('wireguard/wg_foot.inc');
-
 ?>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_tunnels.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_tunnels.php
@@ -34,8 +34,8 @@ require_once('pfsense-utils.inc');
 require_once('service-utils.inc');
 
 // WireGuard includes
-require_once('wireguard/wg.inc');
-require_once('wireguard/wg_guiconfig.inc');
+require_once('wireguard/includes/wg.inc');
+require_once('wireguard/includes/wg_guiconfig.inc');
 
 global $wgg;
 
@@ -169,7 +169,7 @@ display_top_tabs($tab_array);
 						<th><?=gettext("Public Key")?></th>
 						<th><?=gettext("Address / Assignment")?></th>
 						<th><?=gettext("Listen Port")?></th>
-						<th><?=gettext("# Peers")?></th>
+						<th><?=gettext("Peers")?></th>
 						<th><?=gettext("Actions")?></th>
 					</tr>
 				</thead>
@@ -196,7 +196,7 @@ if (is_array($wgg['tunnels']) && count($wgg['tunnels']) > 0):
 							<a class="fa fa-user-plus" title="<?=gettext('Add Peer')?>" href="<?="vpn_wg_peers_edit.php?tun={$tunnel['name']}"?>"></a>
 							<a class="fa fa-pencil" title="<?=gettext('Edit Tunnel')?>" href="<?="vpn_wg_tunnels_edit.php?tun={$tunnel['name']}"?>"></a>
 							<a class="fa fa-download" title="<?=gettext('Download Configuration')?>" href="<?="?act=download&tun={$tunnel['name']}"?>" usepost></a>
-							<?=wg_generate_toggle_icon_link($tunnel, 'Click to toggle enabled/disabled status', "?act=toggle&tun={$tunnel['name']}")?>
+							<?=wg_generate_toggle_icon_link(($tunnel['enabled'] == 'yes'), 'tunnel', "?act=toggle&tun={$tunnel['name']}")?>
 							<a class="fa fa-trash text-danger" title="<?=gettext('Delete Tunnel')?>" href="<?="?act=delete&tun={$tunnel['name']}"?>" usepost></a>
 						</td>
 					</tr>
@@ -273,15 +273,20 @@ endif;
 <script type="text/javascript">
 //<![CDATA[
 events.push(function() {
+
 	var peershidden = true;
+
 	var keyshidden = true;
 
 	hideClass('peer-entries', peershidden);
 
 	// Toggle peer visibility
 	$('#showpeers').click(function () {
+
 		peershidden = !peershidden;
+
 		hideClass('peer-entries', peershidden);
+
 	});
 
 	$('.pubkey').click(function () {
@@ -294,11 +299,7 @@ events.push(function() {
 //]]>
 </script>
 
-<?php 
-
+<?php
+include('wireguard/includes/wg_foot.inc');
 include('foot.inc');
-
-// Must be included last
-include('wireguard/wg_foot.inc');
-
 ?>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_tunnels_edit.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_tunnels_edit.php
@@ -32,8 +32,8 @@ require_once('functions.inc');
 require_once('guiconfig.inc');
 
 // WireGuard includes
-require_once('wireguard/wg.inc');
-require_once('wireguard/wg_guiconfig.inc');
+require_once('wireguard/includes/wg.inc');
+require_once('wireguard/includes/wg_guiconfig.inc');
 
 global $wgg;
 
@@ -48,7 +48,7 @@ if (isset($_REQUEST['tun'])) {
 
 	$tun = $_REQUEST['tun'];
 
-	$tun_idx = wg_get_tunnel_array_index($_REQUEST['tun']);
+	$tun_idx = wg_tunnel_get_array_idx($_REQUEST['tun']);
 
 }
 
@@ -186,6 +186,8 @@ if ($_POST) {
 
 }
 
+$s = fn($x) => $x;
+
 // Looks like we are editing an existing tunnel
 if (isset($tun_idx) && is_array($wgg['tunnels'][$tun_idx])) {
 
@@ -251,8 +253,8 @@ $form->addGlobal(new Form_Input(
 
 $tun_enable = new Form_Checkbox(
 	'enabled',
-	'Tunnel Enabled',
-	gettext('Enable'),
+	'Enable',
+	gettext('Enable Tunnel'),
 	$pconfig['enabled'] == 'yes'
 );
 
@@ -291,7 +293,8 @@ $section->addInput(new Form_Input(
 	'text',
 	$pconfig['listenport'],
 	['placeholder' => next_wg_port()]
-))->setHelp('Port used by this tunnel to communicate with peers.');
+))->addClass('trim')
+  ->setHelp('Port used by this tunnel to communicate with peers.');
 
 $group = new Form_Group('*Interface Keys');
 
@@ -300,14 +303,16 @@ $group->add(new Form_Input(
 	'Private Key',
 	wg_secret_input_type(),
 	$pconfig['privatekey']
-))->setHelp('Private key for this tunnel. (Required)');
+))->addClass('trim')
+  ->setHelp('Private key for this tunnel. (Required)');
 
 $group->add(new Form_Input(
 	'publickey',
 	'Public Key',
 	'text',
 	$pconfig['publickey']
-))->setHelp('Public key for this tunnel. (<a id="copypubkey" style="cursor: pointer;" data-success-text="Copied" data-timeout="3000">Copy</a>)')->setReadonly();
+))->addClass('trim')
+  ->setHelp('Public key for this tunnel. (<a id="copypubkey" style="cursor: pointer;" data-success-text="Copied" data-timeout="3000">Copy</a>)')->setReadonly();
 
 $group->add(new Form_Button(
 	'genkeys',
@@ -315,8 +320,8 @@ $group->add(new Form_Button(
 	null,
 	'fa-key'
 ))->addClass('btn-primary btn-sm')
-	->setHelp('New Keys')
-	->setWidth(1);
+  ->setHelp('New Keys')
+  ->setWidth(1);
 
 $section->add($group);
 
@@ -366,10 +371,10 @@ if (!is_wg_tunnel_assigned($pconfig['name'])) {
 			'Interface Address',
 			$item['address'],
 			'BOTH'
-		))->addClass('address')
-			->setHelp($counter == $last ? 'IPv4 or IPv6 address assigned to the tunnel interface.' : '')
-			->addMask("address_subnet{$counter}", $item['mask'])
-			->setWidth(4);
+		))->addClass('trim')
+		  ->setHelp($counter == $last ? 'IPv4 or IPv6 address assigned to the tunnel interface.' : '')
+		  ->addMask("address_subnet{$counter}", $item['mask'])
+		  ->setWidth(4);
 		
 		$group->add(new Form_Input(
 			"address_descr{$counter}",
@@ -377,7 +382,7 @@ if (!is_wg_tunnel_assigned($pconfig['name'])) {
 			'text',
 			$item['descr']
 		))->setHelp($counter == $last ? 'Description for administrative reference (not parsed).' : '')
-			->setWidth(4);
+		  ->setWidth(4);
 
 		$group->add(new Form_Button(
 			"deleterow{$counter}",
@@ -401,21 +406,19 @@ if (!is_wg_tunnel_assigned($pconfig['name'])) {
 
 	$wg_pfsense_if = wg_get_pfsense_interface_info($pconfig['name']);
 
-	wg_htmlspecialchars($wg_pfsense_if);
-
 	$section->addInput(new Form_StaticText(
 		'Assignment',
-		"<i class='fa fa-sitemap' style='vertical-align: middle;'></i><a style='padding-left: 3px' href='../../interfaces_assign.php'>{$wg_pfsense_if['descr']} ({$wg_pfsense_if['name']})</a>"
+		"<i class='fa fa-sitemap' style='vertical-align: middle;'></i><a style='padding-left: 3px' href='../../interfaces_assign.php'>{$s(htmlspecialchars($wg_pfsense_if['descr']))} ({$s(htmlspecialchars($wg_pfsense_if['name']))})</a>"
 	));
 
 	$section->addInput(new Form_StaticText(
 		'Interface',
-		"<i class='fa fa-ethernet' style='vertical-align: middle;'></i><a style='padding-left: 3px' href='../../interfaces.php?if={$wg_pfsense_if['name']}'>Interface Configuration</a>"
+		"<i class='fa fa-ethernet' style='vertical-align: middle;'></i><a style='padding-left: 3px' href='../../interfaces.php?if={$s(htmlspecialchars($wg_pfsense_if['name']))}'>{$s(gettext('Interface Configuration'))}</a>"
 	));
 
 	$section->addInput(new Form_StaticText(
 		'Firewall Rules',
-		"<i class='fa fa-shield-alt' style='vertical-align: middle;'></i><a style='padding-left: 3px' href='../../firewall_rules.php?if={$wg_pfsense_if['name']}'>Firewall Configuration</a>"
+		"<i class='fa fa-shield-alt' style='vertical-align: middle;'></i><a style='padding-left: 3px' href='../../firewall_rules.php?if={$s(htmlspecialchars($wg_pfsense_if['name']))}'>{$s(gettext('Firewall Configuration'))}</a>"
 	));
 
 }
@@ -479,7 +482,7 @@ print($form);
 					<td><?=htmlspecialchars(wg_format_endpoint(false, $peer))?></td>
 					<td style="cursor: pointer;">
 						<a class="fa fa-pencil" title="<?=gettext('Edit Peer')?>" href="<?="vpn_wg_peers_edit.php?peer={$peer_idx}"?>"></a>
-						<?=wg_generate_toggle_icon_link($peer, 'Click to toggle enabled/disabled status', "?act=toggle&peer={$peer_idx}&tun={$tun}")?>
+						<?=wg_generate_toggle_icon_link(($peer['enabled'] == 'yes'), 'peer', "?act=toggle&peer={$peer_idx}&tun={$tun}")?>
 						<a class="fa fa-trash text-danger" title="<?=gettext('Delete Peer')?>" href="<?="?act=delete&peer={$peer_idx}&tun={$tun}"?>" usepost></a>
 					</td>
 				</tr>
@@ -537,6 +540,8 @@ events.push(function() {
 	// Supress "Delete" button if there are fewer than two rows
 	checkLastRow();
 
+	wgRegTrimHandler();
+
 	$('#copypubkey').click(function () {
 
 		var $this = $(this);
@@ -564,7 +569,7 @@ events.push(function() {
 
 	// Request a new public/private key pair
 	$('#genkeys').click(function(event) {
-		if ($('#privatekey').val().length == 0 || confirm("<?=$genKeyWarning?>")) {
+		if ($('#privatekey').val().length == 0 || confirm(<?=json_encode($genKeyWarning)?>)) {
 			ajaxRequest = $.ajax({
 				url: '/wg/vpn_wg_tunnels_edit.php',
 				type: 'post',
@@ -601,22 +606,11 @@ events.push(function() {
 		$(form).submit();
 	});
 
-	// Trim any whitespace from address input
-	$("#addresses").on("change", "input.address", function () {
-
-		$(this).val($(this).val().replace(/\s/g, ""));
-
-	});
-
 });
 //]]>
 </script>
 
-<?php 
-
+<?php
+include('wireguard/includes/wg_foot.inc');
 include('foot.inc');
-
-// Must be included last
-include('wireguard/wg_foot.inc');
-
 ?>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/widgets/include/wireguard.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/widgets/include/wireguard.inc
@@ -1,0 +1,148 @@
+<?php
+/*
+ * wireguard.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2021 R. Christian McDonald (https://github.com/theonemcdonald)
+ * Copyright (c) 2021 Vajonam
+ * Copyright (c) 2020 Ascrod
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+$wireguard_title = gettext('WireGuard');
+$wireguard_title_link = '/wg/status_wireguard.php';
+
+function wg_do_widget_settings_post($post, $user_settings) {
+	global $wgg;
+
+	$pconfig = array();
+
+	if (isset($post['widgetkey'])) {
+
+		$widgetkey 			= $post['widgetkey'];
+
+		$refresh_interval 		= $post["{$widgetkey}_refresh_interval"];
+
+		$activity_threshold		= $post["{$widgetkey}_activity_threshold"];
+
+		$pconfig['refresh_interval'] 	= $wgg['default_widget_refresh_interval'];
+		
+		$pconfig['activity_threshold']	= $wgg['default_widget_activity_threshold'];
+
+		// Check if the posted refresh interval is valid, if so set it...
+		if (isset($refresh_interval)
+		    && is_numericint($refresh_interval) && in_array($refresh_interval, range(0, 10))) {
+
+			$pconfig['refresh_interval'] = $refresh_interval;
+
+		}
+
+		// Check if the posted activity threshold is valid, if so set it...
+		if (isset($activity_threshold)
+		    && is_numericint($activity_threshold) && ($activity_threshold >= 0)) {
+
+			$pconfig['activity_threshold'] = $activity_threshold;
+
+		}
+
+		// Sync with the configuration backend...
+		$user_settings['widgets'][$widgetkey] = $pconfig;
+
+		// Log entry for write_config()
+		$message = sprintf(gettext('Updated %s widget settings via dashboard.'), $wgg['pkg_name']);
+
+		// Save the widget settings...
+		save_widget_settings($_SESSION['Username'], $user_settings['widgets'], $message);
+	
+	}
+
+}
+
+function wg_compose_widget_body($widgetkey, $wireguard_activity_threshold) {
+	global $wgg;
+
+	/*
+	 * A simple hack to use functions inside heredoc strings
+	 * This also allows translation scripts to pick up strings normally by scraping gettext() calls
+	 * 
+	 * Example: {$s(gettext('my text'))}
+	 * 
+	 */
+
+	$s = fn($x) => $x;
+
+	$a_devices = wg_get_status();
+
+	$current_time = (new DateTimeImmutable)->getTimestamp();
+
+	if (empty($wgg['tunnels'])) {
+
+		$data_html = 	<<<"ROW"
+				<tr>
+					<td colspan="9">{$s(gettext('No WireGuard tunnels have been configured.'))}</td>
+				</tr>
+
+				ROW;
+
+	} elseif (empty($a_devices)) {
+
+		$data_html =	<<<"ROW"
+				<tr>
+					<td colspan="9">{$s(gettext('The WireGuard service is not running.'))}</td>
+				</tr>
+
+				ROW;
+
+	} else {
+
+		$data_html = null;
+
+		foreach ($a_devices as $device_name => $device) {
+
+			$active_peers = array_filter($device['peers'], function ($x) use ($current_time, $wireguard_activity_threshold) {
+
+				/* 
+				 * We need to filter the list of peers for those recently active
+				 * or 0 to disable and show all peers...
+				 */
+
+				return (($wireguard_activity_threshold == 0) || (($current_time - $x['latest_handshake']) <= $wireguard_activity_threshold));
+
+			});
+
+			$data_html .= 	<<<"ROW"
+					<tr>
+						<td>
+							{$s(wg_interface_status_icon($device['status']))}
+							<a href="wg/vpn_wg_tunnels_edit.php?tun={$s(htmlspecialchars($device_name))}">{$s(htmlspecialchars($device_name))}</a>
+						</td>
+						<td>{$s(htmlspecialchars(wg_truncate_pretty($device['config']['descr'], 16)))}</td>
+						<td>{$s(htmlspecialchars(count($active_peers)))}</td>
+						<td>{$s(htmlspecialchars($device['listen_port']))}</td>
+						<td>{$s(htmlspecialchars(format_bytes($device['transfer_rx'])))}</td>
+						<td>{$s(htmlspecialchars(format_bytes($device['transfer_tx'])))}</td>
+					</tr>
+
+					ROW;
+
+		}
+
+	}
+
+	return $data_html;
+
+}
+
+?>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/widgets/widgets/wireguard.widget.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/widgets/widgets/wireguard.widget.php
@@ -1,0 +1,167 @@
+<?php
+/*
+ * wireguard.widget.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2021 R. Christian McDonald (https://github.com/theonemcdonald)
+ * Copyright (c) 2021 Vajonam
+ * Copyright (c) 2020 Ascrod
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// pfSense includes
+require_once('guiconfig.inc');
+require_once('util.inc');
+
+// WireGuard includes
+require_once('wireguard/includes/wg.inc');
+require_once('wireguard/includes/wg_guiconfig.inc');
+require_once('wireguard/includes/wg_service.inc');
+
+// Widget includes
+require_once('/usr/local/www/widgets/include/wireguard.inc');
+
+global $wgg;
+
+wg_globals();
+
+$widgetkey 			= (isset($_POST['widgetkey'])) ? $_POST['widgetkey'] : $widgetkey;
+
+$widget_config			= $user_settings['widgets'][$widgetkey];
+
+// Define default widget behavior
+$wireguard_refresh_interval	= (isset($widget_config['refresh_interval']) && is_numericint($widget_config['refresh_interval'])) ? $widget_config['refresh_interval'] : $wgg['default_widget_refresh_interval'];
+
+$wireguard_activity_threshold	= (isset($widget_config['activity_threshold']) && is_numericint($widget_config['activity_threshold'])) ? $widget_config['activity_threshold'] : $wgg['default_widget_activity_threshold'];
+
+// Are we handling an ajax refresh?
+if (isset($_POST['ajax'])) {
+
+	print(wg_compose_widget_body($widgetkey, $wireguard_activity_threshold));
+
+	// We are done here...
+	exit();
+
+}
+
+// Are we saving the configurable settings?
+if (isset($_POST['save'])) {
+
+	// Process settings post
+	wg_do_widget_settings_post($_POST, $user_settings);
+	
+	// Redirect back to home...
+	header('Location: /');
+	
+	// We are done here...
+	exit();
+
+}
+
+?>
+	<div class="table-responsive">
+		<table class="table table-hover table-striped table-condensed" style="overflow-x: visible;">
+			<thead>
+				<th><?=gettext('Tunnel')?></th>
+				<th><?=gettext('Description')?></th>
+				<th><?=(($wireguard_activity_threshold == 0) ? gettext('Peers') : gettext('Active Peers'))?></th>
+				<th><?=gettext('Listen Port')?></th>
+				<th><?=gettext('RX')?></th>
+				<th><?=gettext('TX')?></th>
+			</thead>
+			<tbody id="<?=htmlspecialchars($widgetkey)?>">
+				<?=wg_compose_widget_body($widgetkey, $wireguard_activity_threshold)?>
+			</tbody>
+		</table>
+	</div>
+</div>
+
+<div id="widget-<?=$widgetkey?>_panel-footer" class="panel-footer collapse">
+
+	<form action="/widgets/widgets/<?=$widgetconfig['basename']?>.widget.php" method="post" class="form-horizontal">
+		<input type="hidden" name="widgetkey" value="<?=htmlspecialchars($widgetkey)?>" />
+		<input type="hidden" name="save" value="save" />
+
+		<div class="form-group">
+			<label for="<?=$widgetkey?>_refresh_interval" class="col-sm-4 control-label"><?=gettext('Refresh Interval')?></label>
+			<div class="col-sm-8">
+				<input type="number" id="<?=$widgetkey?>_refresh_interval" name="<?=$widgetkey?>_refresh_interval" value="<?=htmlspecialchars($wireguard_refresh_interval)?>" placeholder="<?=$wgg['default_widget_refresh_interval']?>" min="0" max="10" class="form-control" />
+				<span class="help-block">
+					<?=gettext('Widget refresh interval (in ticks).')?>
+					<br />
+					<span class="text-danger">Note:</span>
+					<?=sprintf(gettext('The default is %s tick (0 to disable).'), $wgg['default_widget_refresh_interval'])?>
+				</span>
+			</div>
+		</div>
+
+		<div class="form-group">
+			<label for="<?=$widgetkey?>_activity_threshold" class="col-sm-4 control-label">
+				<span><?=gettext('Activity Threshold')?></span>
+			</label>
+			<div class="col-sm-8">
+				<input type="number" id="<?=$widgetkey?>_activity_threshold" name="<?=$widgetkey?>_activity_threshold" value="<?=htmlspecialchars($wireguard_activity_threshold)?>" placeholder="<?=$wgg['default_widget_activity_threshold']?>" min="0" class="form-control" />
+				<span class="help-block">
+					<?=gettext('Peer activity threshold (in seconds).')?>
+					<br />
+					<span class="text-danger">Note:</span>
+					<?=sprintf(gettext('The default is %s seconds (0 to disable).'), $wgg['default_widget_activity_threshold'])?>
+				</span>
+			</div>
+		</div>
+
+		<nav class="action-buttons">
+			<button type="submit" class="btn btn-primary">
+				<i class="fa fa-save icon-embed-btn"></i>
+				<?=gettext('Save')?>
+			</button>
+		</nav>
+	</form>
+
+	<script type="text/javascript">
+	//<![CDATA[
+	events.push(function(){
+
+		var wireguardRefreshInterval = <?=json_encode($wireguard_refresh_interval)?>;
+
+		// Callback function called by refresh system when data is retrieved
+		function wireguard_callback(s) {
+			$(<?=json_encode("#{$widgetkey}")?>).html(s);
+		}
+
+		// POST data to send via AJAX
+		var postdata = {
+			ajax: "ajax",
+			widgetkey: <?=json_encode($widgetkey)?>
+		};
+
+		if (wireguardRefreshInterval > 0) {
+
+			// Create an object defining the widget refresh AJAX call
+			var wireguardObject = new Object();
+			wireguardObject.name = "wireguard";
+			wireguardObject.url = "/widgets/widgets/wireguard.widget.php";
+			wireguardObject.callback = wireguard_callback;
+			wireguardObject.parms = postdata;
+			wireguardObject.freq = wireguardRefreshInterval;
+
+			// Register the AJAX object
+			register_ajax(wireguardObject);
+
+		}
+
+	});
+	//]]>
+	</script>

--- a/net/pfSense-pkg-WireGuard/pkg-plist
+++ b/net/pfSense-pkg-WireGuard/pkg-plist
@@ -1,17 +1,18 @@
 pkg/wireguard.xml
-pkg/wireguard/wg.inc
-pkg/wireguard/wg_api.inc
-pkg/wireguard/wg_foot.inc
-pkg/wireguard/wg_globals.inc
-pkg/wireguard/wg_guiconfig.inc
-pkg/wireguard/wg_install.inc
-pkg/wireguard/wg_service.inc
-pkg/wireguard/wg_validate.inc
+pkg/wireguard/classes/wgconfig.class.php
+pkg/wireguard/includes/wg.inc
+pkg/wireguard/includes/wg_api.inc
+pkg/wireguard/includes/wg_foot.inc
+pkg/wireguard/includes/wg_globals.inc
+pkg/wireguard/includes/wg_guiconfig.inc
+pkg/wireguard/includes/wg_install.inc
+pkg/wireguard/includes/wg_service.inc
+pkg/wireguard/includes/wg_validate.inc
 www/shortcuts/pkg_wireguard.inc
+www/widgets/include/wireguard.inc
+www/widgets/widgets/wireguard.widget.php
 www/wg/js/WireGuardHelpers.js
 www/wg/status_wireguard.php
-www/wg/vpn_wg.php
-www/wg/vpn_wg_edit.php
 www/wg/vpn_wg_peers.php
 www/wg/vpn_wg_peers_edit.php
 www/wg/vpn_wg_settings.php
@@ -20,4 +21,3 @@ www/wg/vpn_wg_tunnels_edit.php
 /etc/inc/priv/wireguard.priv.inc
 %%DATADIR%%/info.xml
 @dir /etc/inc/priv
-@dir /etc/inc


### PR DESCRIPTION
Fixes:
1. Less aggressive config writes to help mitigate UI locking caused by Auto Config Backup.
2. Fixes to several routing issues. NOTE: Still need work on automatic route creation. Users should create static routes or use BGP/OSPF/etc...
3. Disabled peers could sometimes appear as enabled.

Features:
1. Dashboard Widget. Includes two configurable settings: Refresh Interval controls how often the widget updates and Activity Threshold controls the handshake threshold to consider a peer as active or not active (default is 180 seconds).
2. Global 'Enable WireGuard' setting under General Settings.
3. 'Interface Group Membership' setting under General Settings. Default is 'All Tunnels.' Options: All Tunnels, Only Unassigned Tunnels, or None.
4. Backend work to support importing WireGuard configurations.