### PR TITLE
pfSense-pkg suricata-6.0.0_12

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.0
-PORTREVISION=	11
+PORTREVISION=	12
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -71,6 +71,10 @@ function suricata_stop($suricatacfg, $if_real) {
 		syslog(LOG_NOTICE, "[Suricata] Suricata STOP for {$suricatacfg['descr']}({$if_real})...");
 		killbypid("{$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid");
 	}
+
+	// Give the Suricata daemon some to actually stop and cleanup before returning
+	sleep(10);
+
 	// Make sure the PID file is actually deleted so Suricata will restart without error
 	unlink_if_exists("{$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid");
 }
@@ -3705,6 +3709,7 @@ case $1 in
 		;;
 	restart)
 		rc_stop
+		sleep 5
 		rc_start
 		;;
 esac

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -3571,14 +3571,17 @@ function suricata_create_rc() {
 	$suricatadir = SURICATADIR;
 	$suricatalogdir = SURICATALOGDIR;
 	$suricatabindir = SURICATA_PBI_BINDIR;
-	$rcdir = RCFILEPREFIX;	
+	$rcdir = RCFILEPREFIX;
+	$no_enabled_interface = TRUE;
 
 	// If no interfaces are configured for Suricata, exit
 	if (!is_array($config['installedpackages']['suricata']['rule'])) {
+		unlink_if_exists("{$rcdir}suricata.sh");
 		return;
 	}
 	$suricataconf = $config['installedpackages']['suricata']['rule'];
 	if (empty($suricataconf)) {
+		unlink_if_exists("{$rcdir}suricata.sh");
 		return;
 	}
 
@@ -3600,6 +3603,9 @@ function suricata_create_rc() {
 		if (($value['enable'] != 'on') || ($if_real == "")) {
 			continue;
 		}
+
+		// We have at least one enabled Suricata interface
+		$no_enabled_interface = FALSE;
 		$suricata_uuid = $value['uuid'];
 		$run_mode = $value['ips_mode'] == 'ips_mode_inline' && $value['blockoffenders'] == 'on' ? '--netmap' : '-i ' . $if_real;
 
@@ -3705,9 +3711,14 @@ esac
 
 EOD;
 
-	// Write out the suricata.sh script file
-	@file_put_contents("{$rcdir}suricata.sh", $suricata_sh_text);
-	@chmod("{$rcdir}suricata.sh", 0755);
+	if (!$no_enabled_interface) {
+		// Write out the suricata.sh script file
+		@file_put_contents("{$rcdir}suricata.sh", $suricata_sh_text);
+		@chmod("{$rcdir}suricata.sh", 0755);
+	} else {
+		unlink_if_exists("{$rcdir}suricata.sh");
+	}
+
 	unset($suricata_sh_text);
 }
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -2245,11 +2245,9 @@ function suricata_get_auto_category_mods($categories, $sid_mods, $action, $log_r
 	$matchcount = 0;
 
 	// Get a list of all possible categories by loading all rules files
-	foreach (array( VRT_FILE_PREFIX, ET_OPEN_FILE_PREFIX, ET_PRO_FILE_PREFIX, GPL_FILE_PREFIX ) as $prefix) {
-		$files = glob(SURICATA_RULES_DIR . "{$prefix}*.rules");
-		foreach ($files as $file) {
-			$all_cats[] = basename($file);
-		}
+	$files = glob(SURICATA_RULES_DIR . "*.rules");
+	foreach ($files as $file) {
+		$all_cats[] = basename($file);
 	}
 
 	// Walk the SID mod tokens and decode looking for rule

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -826,6 +826,7 @@ if ($snortdownload == 'on' || $emergingthreats == 'on' || $snortcommunityrules =
 					suricata_update_status(gettext("Restarting Suricata to activate the new set of rules for " . convert_friendly_interface_to_friendly_descr($value['interface']) . "..."));
 					error_log(gettext("\tRestarting Suricata to activate the new set of rules for " . convert_friendly_interface_to_friendly_descr($value['interface']) . "...\n"), 3, SURICATA_RULES_UPD_LOGFILE);
 					suricata_stop($value, $if_real);
+					sleep(5);
 					suricata_start($value, $if_real);
 					suricata_update_status(gettext(" done.") . "\n");
 					syslog(LOG_NOTICE, gettext("[Suricata] Suricata has restarted with your new set of rules for " . convert_friendly_interface_to_friendly_descr($value['interface']) . "..."));

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -429,6 +429,9 @@ error_log(gettext("Starting rules update...  Time: " . date("Y-m-d H:i:s") . "\n
 $last_curl_error = "";
 $update_errors = false;
 
+/* Ensure our basic config array of interfaces exists to prevent PHP foreach() errors */
+init_config_arr(array('installedpackages', 'suricata', 'rule'));
+
 /* Save current state (running/not running) for each enabled Suricatat interface */
 $active_interfaces = array();
 foreach ($config['installedpackages']['suricata']['rule'] as $value) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2020 Bill Meeks
+ * Copyright (C) 2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -507,6 +507,10 @@ if ($suricatacfg['eve_log_sip'] == 'on') {
 
 if ($suricatacfg['eve_log_snmp'] == 'on') {
 	$eve_out_types .= "\n        - snmp";
+}
+
+if ($suricatacfg['eve_log_mqtt'] == 'on') {
+	$eve_out_types .= "\n        - mqtt";
 }
 
 if ($suricatacfg['eve_log_smtp'] == 'on') {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -128,7 +128,10 @@ if (!empty($suricatacfg['runmode']))
 	$runmode = $suricatacfg['runmode'];
 else
 	$runmode = "autofp";
-
+if (!empty($suricatacfg['autofp_scheduler']))
+	$autofp_scheduler = $suricatacfg['autofp_scheduler'];
+else
+	$autofp_scheduler = "hash";
 if (!empty($suricatacfg['max_pending_packets']))
 	$max_pend_pkts = $suricatacfg['max_pending_packets'];
 else

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -991,7 +991,7 @@ if (!empty($suricatacfg['tls_ja3_fingerprint'])) {
 	$tls_ja3 = $suricatacfg['tls_ja3_fingerprint'];
 }
 else {
-	$tls_ja3 = "no";
+	$tls_ja3 = "auto";
 }
 if (!empty($suricatacfg['tls_encrypt_handling'])) {
 	$tls_encrypt_handling = $suricatacfg['tls_encrypt_handling'];

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -512,9 +512,10 @@ if ($suricatacfg['eve_log_snmp'] == 'on') {
 	$eve_out_types .= "\n        - snmp";
 }
 
-if ($suricatacfg['eve_log_mqtt'] == 'on') {
-	$eve_out_types .= "\n        - mqtt";
-}
+// Disable MQTT Eve logging for now as it is a 6.x binary feature
+//if ($suricatacfg['eve_log_mqtt'] == 'on') {
+//	$eve_out_types .= "\n        - mqtt";
+//}
 
 if ($suricatacfg['eve_log_smtp'] == 'on') {
 	$eve_out_types .= "\n        - smtp:";

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -597,7 +597,7 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['tls_ja3_fingerprint'])) {
-		$pconfig['tls_ja3_fingerprint'] = "off";
+		$pconfig['tls_ja3_fingerprint'] = "auto";
 		$updated_cfg = true;
 	}
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -890,6 +890,15 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 		$pconfig['ips_netmap_threads'] = 'auto';
 	}
 
+	/**********************************************************/
+	/* Add new 'autofp-scheduler' parameter for the interface */
+	/* when using 'autofp" runmode.                           */
+	/**********************************************************/
+	if (!isset($pconfig['autofp_scheduler'])) {
+		$updated_cfg = true;
+		$pconfig['autofp_scheduler'] = 'hash';
+	}
+
 	// Save the new configuration data into the $config array pointer
 	$r = $pconfig;
 }

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -20,7 +20,7 @@ runmode: {$runmode}
 host-mode: auto
 
 # Specifies the kind of flow load balancer used by the flow pinned autofp mode.
-autofp-scheduler: active-packets
+autofp-scheduler: {$autofp_scheduler}
 
 # Daemon working directory
 daemon-directory: {$suricatacfgdir}

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
@@ -255,7 +255,7 @@ elseif ($_POST['ResetAll']) {
 	$pconfig['tls_parser'] = "yes";
 	$pconfig['tls_detect_ports'] = "443";
 	$pconfig['tls_encrypt_handling'] = "default";
-	$pconfig['tls_ja3_fingerprint'] = "off";
+	$pconfig['tls_ja3_fingerprint'] = "auto";
 	$pconfig['smtp_parser'] = "yes";
 	$pconfig['smtp_parser_decode_mime'] = "off";
 	$pconfig['smtp_parser_decode_base64'] = "on";
@@ -690,7 +690,7 @@ if ($importalias) {
 	$section->addInput(new Form_Checkbox(
 		'tls_ja3_fingerprint',
 		'JA3/JA3S Fingerprint',
-		'Suricata will generate JA3/JA3S fingerprint from client hello. Default is Not Checked.',
+		'Suricata will generate JA3/JA3S fingerprint from client hello. Default is Not Checked, which disables fingerprinting unless required by the rules.',
 		$pconfig['tls_ja3_fingerprint'] == 'on' ? true:false,
 		'on'
 	));

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2020 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -262,6 +262,9 @@ if (empty($pconfig['eve_log_drop'])) {
 if (empty($pconfig['eve_log_snmp'])) {
 	$pconfig['eve_log_snmp'] = "on";
 }
+if (empty($pconfig['eve_log_mqtt'])) {
+	$pconfig['eve_log_mqtt'] = "on";
+}
 if (empty($pconfig['eve_log_http_extended']))
 	$pconfig['eve_log_http_extended'] = $pconfig['http_log_extended'];
 if (empty($pconfig['eve_log_tls_extended']))
@@ -489,6 +492,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['eve_log_flow'] == "on") { $natent['eve_log_flow'] = 'on'; }else{ $natent['eve_log_flow'] = 'off'; }
 		if ($_POST['eve_log_netflow'] == "on") { $natent['eve_log_netflow'] = 'on'; }else{ $natent['eve_log_netflow'] = 'off'; }
 		if ($_POST['eve_log_snmp'] == "on") { $natent['eve_log_snmp'] = 'on'; }else{ $natent['eve_log_snmp'] = 'off'; }
+		if ($_POST['eve_log_mqtt'] == "on") { $natent['eve_log_mqtt'] = 'on'; }else{ $natent['eve_log_mqtt'] = 'off'; }
 		if ($_POST['eve_log_stats_totals'] == "on") { $natent['eve_log_stats_totals'] = 'on'; }else{ $natent['eve_log_stats_totals'] = 'off'; }
 		if ($_POST['eve_log_stats_deltas'] == "on") { $natent['eve_log_stats_deltas'] = 'on'; }else{ $natent['eve_log_stats_deltas'] = 'off'; }
 		if ($_POST['eve_log_stats_threads'] == "on") { $natent['eve_log_stats_threads'] = 'on'; }else{ $natent['eve_log_stats_threads'] = 'off'; }
@@ -1267,6 +1271,14 @@ $group->add(new Form_Checkbox(
 	'on'
 ));
 
+$group->add(new Form_Checkbox(
+	'eve_log_mqtt',
+	'MQTT',
+	'MQTT',
+	$pconfig['eve_log_mqtt'] == 'on' ? true:false,
+	'on'
+));
+
 $group->setHelp('Choose the information to log via EVE JSON output.');
 $section->add($group)->addClass('eve_log_info');
 
@@ -1406,9 +1418,8 @@ $section->addInput(new Form_Input(
 	'Netmap Threads',
 	'text',
 	$pconfig['ips_netmap_threads']
-))->setHelp('Enter the number of netmap threads to use. Default is "auto". When set to a numeric value corresponding to the netmap TX/RX queues registered by the NIC, performance can be substantially increased. ' . 
-	    'The NIC hosting this interface registered ' . suricata_get_supported_netmap_queues($if_real) . ' queue(s) with the kernel. Note that with some network cards, using half of the queues value may ' . 
-		'actually be the best choice. For example, if the NIC reports 4 TX/RX queues, using only 2 may work better. The value entered here must be either "auto", or a whole number, and cannot exceed the number of TX/RX queues reported by the NIC.');
+))->setHelp('Enter the number of netmap threads to use. Default is "auto". When set to a value matching the netmap TX/RX queues registered by the NIC, performance can be greatly increased. ' . 
+	    'The NIC hosting this interface registered ' . suricata_get_supported_netmap_queues($if_real) . ' queue(s) with the kernel.');
 
 $section->addInput(new Form_Checkbox(
 	'blockoffenderskill',
@@ -1944,7 +1955,9 @@ events.push(function(){
 		disableInput('eve_log_info', disable);
 		disableInput('eve_log_alerts', disable);
 		disableInput('eve_log_alerts_payload', disable);
+		disableInput('eve_log_alerts_metadata', disable);
 		disableInput('eve_log_anomaly', disable);
+		disableInput('eve_log_anomaly_type_applayer', disable);
 		disableInput('eve_log_http', disable);
 		disableInput('eve_log_dns', disable);
 		disableInput('eve_log_nfs', disable);
@@ -1959,6 +1972,8 @@ events.push(function(){
 		disableInput('eve_log_dhcp', disable);
 		disableInput('eve_log_ssh', disable);
 		disableInput('eve_log_smtp', disable);
+		disableInput('eve_log_snmp', disable);
+		disableInput('eve_log_mqtt', disable);
 		disableInput('eve_log_flow', disable);
 		disableInput('eve_log_netflow', disable);
 		disableInput('eve_log_drop', disable);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1906,6 +1906,7 @@ events.push(function(){
 		disableInput('blockoffendersip', disable);
 		disableInput('ips_netmap_threads', disable);
 		disableInput('performance', disable);
+		disableInput('runmode', disable);
 		disableInput('max_pending_packets', disable);
 		disableInput('detect_eng_profile', disable);
 		disableInput('inspect_recursion_limit', disable);
@@ -1957,7 +1958,10 @@ events.push(function(){
 		disableInput('eve_log_alerts_payload', disable);
 		disableInput('eve_log_alerts_metadata', disable);
 		disableInput('eve_log_anomaly', disable);
+		disableInput('eve_log_anomaly_type_decode', disable);
+		disableInput('eve_log_anomaly_type_stream', disable);
 		disableInput('eve_log_anomaly_type_applayer', disable);
+		disableInput('eve_log_anomaly_packethdr', disable);
 		disableInput('eve_log_http', disable);
 		disableInput('eve_log_dns', disable);
 		disableInput('eve_log_nfs', disable);
@@ -2185,7 +2189,6 @@ events.push(function(){
 	});
 
 	// ---------- On initial page load ------------------------------------------------------------
-	enable_change();
 	enable_blockoffenders();
 	toggle_system_log();
 	toggle_enable_stats();
@@ -2207,6 +2210,7 @@ events.push(function(){
 	toggle_eve_log_tls_extended();
 	toggle_eve_log_http_extended();
 	toggle_eve_log_smtp_extended();
+	enable_change();
 
 });
 //]]>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1926,6 +1926,7 @@ events.push(function(){
 		disableInput('ips_netmap_threads', disable);
 		disableInput('performance', disable);
 		disableInput('runmode', disable);
+		disableInput('autofp_scheduler', disable);
 		disableInput('max_pending_packets', disable);
 		disableInput('detect_eng_profile', disable);
 		disableInput('inspect_recursion_limit', disable);


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.0_12
This update corrects reported bugs in the GUI package. The binary remains at versoin 5.0.6 for now.

**New Features:**
1. Add control for parameter 'autofp_scheduler' to the INTERFACE SETTINGS tab. This parameter is only applicabe when runmode 'autofp' is selected.

**Bug Fixes:**
1. Fix a GUI controls state inconsistency issue on the INTERFACE SETTTINGS tab.
2. Change default value for JA3 Fingerprints on the APP PARSERS tab from "off" to "auto".
3. Fix new Feodotracker and SSL Blacklist rules not working with SID MGMT.
4. Remove the _suricata.sh_ shell script from _/usr/local/etc/rc.d/_ when no enabled Suricata interfaces remain. This addresses [Redmine Issue #12001](https://redmine.pfsense.org/issues/12001).
5. Initialize config interface array in rules update code. Fixes [Redmine Issue #12137](https://redmine.pfsense.org/issues/12137).
6. Insert a sleep interval between consecutive calls to _suricata_stop()_ and _suricata_start()_ to allow time for the Suricata daemon to get stopped and clean up.