### PR TITLE
pfSense-pkg-snort-4.1.4_1 -- Bug fix update for Redmine #12001 and #12137.

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.1.4
-PORTREVISION=	0
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -2330,11 +2330,9 @@ function snort_get_auto_category_mods($categories, $sid_mods, $action, $log_resu
 	$matchcount = 0;
 
 	// Get a list of all possible categories by loading all rules files
-	foreach (array( VRT_FILE_PREFIX, ET_OPEN_FILE_PREFIX, ET_PRO_FILE_PREFIX, GPL_FILE_PREFIX, OPENAPPID_FILE_PREFIX ) as $prefix) {
-		$files = glob("{$snortdir}/rules/{$prefix}*.rules");
-		foreach ($files as $file)
-			$all_cats[] = basename($file);
-	}
+	$files = glob("{$snortdir}/rules/*.rules");
+	foreach ($files as $file)
+		$all_cats[] = basename($file);
 
 	// Walk the SID mod tokens and decode looking for rule
 	// category enable/disable changes.

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -3229,7 +3229,9 @@ function snort_create_rc() {
 	$snortlogdir = SNORTLOGDIR;
 	$snortbindir = SNORT_BINDIR;
 	$rcdir = RCFILEPREFIX;	
+	$no_enabled_interface = TRUE;
 
+	init_config_arr(array('installedpackages', 'snortglobal', 'rule'));
 	$snortconf = $config['installedpackages']['snortglobal']['rule'];
 
 	// If no interfaces are configured for Snort, exit
@@ -3247,6 +3249,7 @@ function snort_create_rc() {
 	// At least one interface is configured, so OK
 	$start_snort_iface_start = array();
 	$start_snort_iface_stop = array();
+	$no_enabled_interface = FALSE;
 
 	// Loop thru each configured interface and build
 	// the shell script.
@@ -3377,9 +3380,14 @@ esac
 
 EOD;
 
-	/* write out snort.sh */
-	@file_put_contents("{$rcdir}snort.sh", $snort_sh_text);
-	@chmod("{$rcdir}snort.sh", 0755);
+	/* write out snort.sh if enabled interfaces are present */
+	if (!$no_enabled_interface) {
+		// Write out the snort.sh script file
+		@file_put_contents("{$rcdir}snort.sh", $snort_sh_text);
+		@chmod("{$rcdir}snort.sh", 0755);
+	} else {
+		unlink_if_exists("{$rcdir}snort.sh");
+	}
 }
 
 function snort_prepare_rule_files($snortcfg, $snortcfgdir) {

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -443,6 +443,7 @@ $update_errors = false;
 
 /* Save current state (running/not running) for each enabled Snort interface */
 $active_interfaces = array();
+init_config_arr(array('installedpackages', 'snortglobal', 'rule'));
 foreach ($config['installedpackages']['snortglobal']['rule'] as $id => $value) {
 	$if_real = get_real_interface($value['interface']);
 


### PR DESCRIPTION
### pfSense-pkg-snort-4.1.4_1
This update addresses three reported bug in the Snort GUI package.

**New Features:**
None

 **Bug Fixes:**
1. PHP _foreach()_ warning error if rules update is run before a Snort interface is configured. [Redmine Issue #12137](https://redmine.pfsense.org/issues/12137).
2. Remove the _snort.sh_ shell script from _/usr/local/etc/rc.d/_ when no enabled Snort interfaces are present. [Redmine Issue #12001](https://redmine.pfsense.org/issues/12001).
3. Fix Feodotracker rules and some others not working when using SID MGMT features.