### PR TITLE
Regression #12160: An invalid configuration is generated when choosing TLS as the default protocol

### DIFF
--- a/sysutils/pfSense-pkg-syslog-ng/Makefile
+++ b/sysutils/pfSense-pkg-syslog-ng/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-syslog-ng
 PORTVERSION=	1.15
-PORTREVISION=	8
+PORTREVISION=	9
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
+++ b/sysutils/pfSense-pkg-syslog-ng/files/usr/local/pkg/syslog-ng.inc
@@ -135,10 +135,6 @@ function syslogng_build_default_objects($settings) {
 		safe_mkdir(SYSLOGNG_DIR);
 		safe_mkdir(SYSLOGNG_DIR . "/ca.d");
 		syslogng_build_cert($settings);
-		$default_objects[0]['objectparameters'] .= " tls(
-		    key-file('/var/etc/syslog-ng/syslog-ng.key')
-		    cert-file('/var/etc/syslog-ng/syslog-ng.cert')
-		    ca-dir('/var/etc/syslog-ng/ca.d'))";
 	} else {
 		rmdir_recursive(SYSLOGNG_DIR);
 	}
@@ -146,7 +142,11 @@ function syslogng_build_default_objects($settings) {
 	foreach (explode(",", $interfaces) as $interface) {
 		$interface_address = syslogng_get_real_interface_address($interface);
 		if ($interface_address[0]) {
-			$default_objects[0]['objectparameters'] .= " syslog(transport($default_protocol) port($default_port) ip({$interface_address[0]}));";
+			$default_objects[0]['objectparameters'] .= " syslog(transport($default_protocol) port($default_port) ip({$interface_address[0]})";
+			if ($settings['default_protocol'] == 'tls') {
+				$default_objects[0]['objectparameters'] .= " tls(key-file('/var/etc/syslog-ng/syslog-ng.key') cert-file('/var/etc/syslog-ng/syslog-ng.cert') ca-dir('/var/etc/syslog-ng/ca.d'))";
+			}
+			$default_objects[0]['objectparameters'] .= ");";
 		}
 	}
 	$default_objects[0]['objectparameters'] .= " };";


### PR DESCRIPTION
The corresponding issue can be found [here](https://redmine.pfsense.org/issues/12160).