### PR TITLE
Suricata extra rulesets. Implements #11210

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.0
-PORTREVISION=	12
+PORTREVISION=	13
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
@@ -118,6 +118,8 @@ if (!defined("ET_OPEN_FILE_PREFIX"))
 	define("ET_OPEN_FILE_PREFIX", "emerging-");
 if (!defined("ET_PRO_FILE_PREFIX"))
 	define("ET_PRO_FILE_PREFIX", "etpro-");
+if (!defined("EXTRARULES_FILE_PREFIX"))
+	define("EXTRARULE_FILE_PREFIX", "extrarule-");
 if (!defined('SURICATA_ENFORCING_RULES_FILENAME'))
 	define('SURICATA_ENFORCING_RULES_FILENAME', 'suricata.rules');
 if (!defined('FLOWBITS_FILENAME'))

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
@@ -37,6 +37,9 @@ $etpro = $config['installedpackages']['suricata']['config'][0]['enable_etpro_rul
 $snortcommunityrules = $config['installedpackages']['suricata']['config'][0]['snortcommunityrules'];
 $feodotracker_rules = $config['installedpackages']['suricata']['config'][0]['enable_feodo_botnet_c2_rules'];
 $sslbl_rules = $config['installedpackages']['suricata']['config'][0]['enable_abuse_ssl_blacklist_rules'];
+$enable_extra_rules = $config['installedpackages']['suricata']['config'][0]['enable_extra_rules'] == "on" ? 'on' : 'off';
+init_config_arr(array('installedpackages', 'suricata' ,'config', 0, 'extra_rules', 'rule'));
+$extra_rules = $config['installedpackages']['suricata']['config'][0]['extra_rules']['rule'];
 
 /* Get last update information if available */
 if (file_exists(SURICATADIR . "rulesupd_status")) {
@@ -166,6 +169,7 @@ if ($_REQUEST['updatemode']) {
 		unlink_if_exists("{$suricatadir}{$snort_rules_file}.md5");
 		unlink_if_exists("{$suricatadir}{$feodotracker_rules_filename}.md5");
 		unlink_if_exists("{$suricatadir}{$sslbl_rules_filename}.md5");
+		unlink_if_exists("{$suricatadir}" . EXTRARULE_FILE_PREFIX . "*.md5");
 	}
 
 	// Launch a background process to download the updates
@@ -294,6 +298,50 @@ include_once("head.inc");
 		</div>
 	</div>
 </div>
+<?php
+if (($enable_extra_rules == 'on') && !empty($extra_rules)) {
+?>
+<div class="panel panel-default">
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext("EXTRA RULE SET MD5 SIGNATURES")?></h2></div>
+	<div class="panel-body">
+		<div class="content table-responsive">
+			<table class="table table-striped table-condensed">
+				<thead>
+					<tr>
+						<th><?=gettext("Rule Set Name");?></th>
+						<th><?=gettext("MD5 Signature Hash");?></th>
+						<th><?=gettext("MD5 Signature Date");?></th>
+					</tr>
+				</thead>
+				<tbody>
+<?php
+foreach ($extra_rules as $exrule) {
+	$format = (substr($exrule['url'], strrpos($exrule['url'], 'rules')) == 'rules') ? ".rules" : ".tar.gz";
+	$rulesfilename = EXTRARULE_FILE_PREFIX . $exrule['name'] . $format;
+	if (file_exists("{$suricatadir}{$rulesfilename}.md5")) {
+		$extra_sig_chk_local = trim(file_get_contents("{$suricatadir}{$rulesfilename}.md5"));
+		$extra_sig_date = date(DATE_RFC850, filemtime("{$suricatadir}{$rulesfilename}.md5"));
+	} else {
+		$extra_sig_chk_local = 'Not Downloaded';
+		$extra_sig_date = 'Not Downloaded';
+	}
+?>
+				<tr>
+					<td><?=$exrule['name'];?></td>
+					<td><?=$extra_sig_chk_local;?></td>
+					<td><?=gettext($extra_sig_date);?></td>
+				</tr>
+<?php
+}
+?>
+				</tbody>
+			</table>
+		</div>
+	</div>
+</div>
+<?php
+}
+?>
 <div class="panel panel-default">
 	<div class="panel-heading"><h2 class="panel-title"><?=gettext("UPDATE YOUR RULE SET")?></h2></div>
 	<div class="panel-body">
@@ -303,7 +351,7 @@ include_once("head.inc");
 				<strong><?=gettext("Result:");?></strong> <?=$last_rule_upd_status?>
 			</p>
 			<p>
-				<?php if ($snortdownload != 'on' && $emergingthreats != 'on' && $etpro != 'on'): ?>
+				<?php if ($snortdownload != 'on' && $emergingthreats != 'on' && $etpro != 'on' && $enable_extra_rules != 'on'): ?>
 					<br/><button class="btn btn-primary" disabled>
 						<i class="fa fa-check icon-embed-btn"></i>
 						<?=gettext("Update"); ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -64,6 +64,9 @@ $etpro = $config['installedpackages']['suricata']['config'][0]['enable_etpro_rul
 $snortcommunitydownload = $config['installedpackages']['suricata']['config'][0]['snortcommunityrules'] == 'on' ? 'on' : 'off';
 $feodotrackerdownload = $config['installedpackages']['suricata']['config'][0]['enable_feodo_botnet_c2_rules'] == 'on' ? 'on' : 'off';
 $sslbldownload = $config['installedpackages']['suricata']['config'][0]['enable_abuse_ssl_blacklist_rules'] == 'on' ? 'on' : 'off';
+$enable_extra_rules = $config['installedpackages']['suricata']['config'][0]['enable_extra_rules'] == "on" ? 'on' : 'off';
+init_config_arr(array('installedpackages', 'suricata' ,'config', 0, 'extra_rules', 'rule'));
+$extra_rules = $config['installedpackages']['suricata']['config'][0]['extra_rules']['rule'];
 
 $no_emerging_files = false;
 $no_snort_files = false;
@@ -241,6 +244,12 @@ if (isset($_POST["save"])) {
 	/* Include the Snort rules only if enabled and no IPS policy is set */
 	if ($snortdownload == 'on' && empty($_POST['ips_policy_enable'])) {
 		$files = glob("{$suricata_rules_dir}" . VRT_FILE_PREFIX . "*.rules");
+		foreach ($files as $file)
+			$enabled_rulesets_array[] = basename($file);
+	}
+
+	if ($enable_extra_rules == 'on') {
+		$files = glob("{$suricata_rules_dir}" . EXTRARULE_FILE_PREFIX . "*.rules");
 		foreach ($files as $file)
 			$enabled_rulesets_array[] = basename($file);
 	}
@@ -808,6 +817,102 @@ else:
 				</tbody>
 			</table>
 		</div>
+<?php
+if (($enable_extra_rules == 'on') && !empty($extra_rules)) {
+?>
+		<div class="table-responsive col-sm-12">
+			<table class="table table-striped table-hover table-condensed">
+<?php
+foreach ($extra_rules as $exrule) {
+	$format = (substr($exrule['url'], strrpos($exrule['url'], 'rules')) == 'rules') ? ".rules" : ".tar.gz";
+	$rulesfilename = EXTRARULE_FILE_PREFIX . $exrule['name'] . $format;
+?>
+				<thead>
+					<tr>
+						<th><?=gettext("Enabled"); ?></th>
+						<th><?=gettext("Extra Ruleset: {$exrule['name']}");?></th>
+					</tr>
+				</thead>
+				<tbody>
+<?php
+				$extrarules = array();
+				if (empty($isrulesfolderempty)) {
+					$dh  = opendir("{$suricatadir}suricata_{$suricata_uuid}_{$if_real}/rules/");
+				} else {
+					$dh  = opendir("{$suricata_rules_dir}");
+				}
+
+				while (false !== ($filename = readdir($dh))) {
+					$filename = basename($filename);
+					if (substr($filename, -5) != "rules") {
+						continue;
+					}
+					preg_match("/" . EXTRARULE_FILE_PREFIX . "([A-Za-z0-9_]+)/", $filename, $matches);
+					if ($exrule['name'] == $matches[1]) {
+						$extrarules[] = $filename;
+					}
+				}
+
+				sort($extrarules);
+				$i = count($extrarules);
+
+				// Walk the rules file names arrays and output the
+				// the file names and associated form controls in
+				// an HTML table.
+
+				for ($j = 0; $j < $i; $j++) {
+					echo "<tr>\n";
+					if (!empty($extrarules[$j])) {
+						$file = $extrarules[$j];
+						echo "<td>";
+						if(is_array($enabled_rulesets_array)) {
+							if(in_array($file, $enabled_rulesets_array) && !isset($cat_mods[$file]))
+								$CHECKED = " checked=\"checked\"";
+							else
+								$CHECKED = "";
+						} else
+							$CHECKED = "";
+
+						// If the rule category file is covered by a SID mgmt configuration,
+						// place an appropriate icon beside the category.
+						if (isset($cat_mods[$file])) {
+							// If the category is part of the enabled rulesets array,
+							// make sure we include a hidden field to reference it
+							// so we do not unset it during a post-back.
+							if (in_array($file, $enabled_rulesets_array))
+								echo "<input type='hidden' name='toenable[]' value='{$file}' />\n";
+							if ($cat_mods[$file] == 'enabled') {
+								$CHECKED = "enabled";
+								echo "	\n<i class=\"fa fa-adn text-success\" title=\"" . gettext('Auto-enabled by settings on SID Mgmt tab') . "\"></i>\n";
+							}
+							elseif ($cat_mods[$file] == 'disabled') {
+								echo "	\n<i class=\"fa fa-adn text-danger\" title=\"" . gettext('Auto-disabled by settings on SID Mgmt tab') . "\"></i>\n";
+							}
+						}
+						else {
+							echo "	\n<input type=\"checkbox\" name=\"toenable[]\" value=\"{$file}\" {$CHECKED} />\n";
+						}
+						echo "</td>\n";
+						echo "<td>\n";
+						if (empty($CHECKED))
+							echo "<a href='suricata_rules_edit.php?id={$id}&openruleset=" . urlencode($file) . "' target='_blank' rel='noopener noreferrer'>{$file}</a>\n";
+						else
+							echo "<a href='suricata_rules.php?id={$id}&openruleset=" . urlencode($file) . "'>{$file}</a>\n";
+						echo "</td>\n";
+					} else
+						echo "<td colspan='2'><br/></td>\n";
+					echo "</tr>\n";
+				}
+			?>
+				</tbody>
+<?php
+}
+?>
+			</table>
+		</div>
+<?php
+}
+?>
 	</div>
 </div>
 


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/11210
- [X] Ready for review

rules for testing:
https://github.com/OISF/suricata-intel-index/blob/master/index.yaml
https://raw-data.gitlab.io/post/feeds/

also I found that `suricata_check_rule_md5()` doesn't work correctly without `trim()`,
```php
			$md5_check_new = file_get_contents($file_dst);
			$md5_check_old = file_get_contents("{$suricatadir}{$filename_md5}");
```
must be:
```php
			$md5_check_new = trim(file_get_contents($file_dst));
			$md5_check_old = trim(file_get_contents("{$suricatadir}{$filename_md5}"));
```