### PR TITLE
pfSense-pkg-snort -- Fix Redmine #12263, Pass List save fails when language is not English

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.1.4
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_suppress_edit.php
@@ -113,7 +113,7 @@ if ($_POST['save']) {
 		$s_list = array();
 		$s_list['name'] = $_POST['name'];
 		$s_list['uuid'] = uniqid();
-		$s_list['descr']  =  mb_convert_encoding($_POST['descr'],"HTML-ENTITIES","auto");
+		$s_list['descr'] = $_POST['descr'];
 		if ($_POST['suppresspassthru']) {
 			$s_list['suppresspassthru'] = str_replace("&#8203;", "", $s_list['suppresspassthru']);
 			$s_list['suppresspassthru'] = base64_encode(str_replace("\r\n", "\n", $_POST['suppresspassthru']));

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist_edit.php
@@ -93,7 +93,7 @@ elseif (!empty($pconfig['uuid'])) {
 else
 	$passlist_uuid = $a_passlist[$id]['uuid'];
 
-if ($_POST['save'] == "Save") {
+if ($_POST['save']) {
 	unset($input_errors);
 	$pconfig = array();
 	$p_list = array();

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_passlist_edit.php
@@ -144,7 +144,7 @@ if ($_POST['save']) {
 		$p_list['vips'] = $_POST['vips']? 'yes' : 'no';
 		$p_list['vpnips'] = $_POST['vpnips']? 'yes' : 'no';
 		$p_list['address']['item'] = $addrs;
-		$p_list['descr']  =  mb_convert_encoding($_POST['descr'],"HTML-ENTITIES","auto");
+		$p_list['descr'] = $_POST['descr'];
 
 		if (isset($id) && isset($a_passlist[$id])) {
 			$a_passlist[$id] = $p_list;


### PR DESCRIPTION
### pfSense-pkg-snort-4.1.4_3
This update for the Snort GUI package addresses [Redmine Issue #12263](https://redmine.pfsense.org/issues/12263) where a Pass List cannot be saved when the firewall's language setting is anything other than English.

**New Features:**
None

**Bug Fixes:**
1. [Redmine Issue #12263](https://redmine.pfsense.org/issues/12263). Pass List cannot be saved when the firewall language is set for anything other than English.
2. Fix unicode encoding for the Description field. Use of the _mb_convert_encoding()_ function is not necessary because the XML config logic wraps the field with CDATA tags.