### PR TITLE
pfSense-pkg-suricata-6.0.3 -- Update for 6.0.3 binary plus new features and bug fixes

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,8 +1,8 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	6.0.0
-PORTREVISION=	14
+PORTVERSION=	6.0.3
+PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=5.0.6:security/suricata
+RUN_DEPENDS=	suricata>=6.0.3:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
@@ -118,7 +118,7 @@ if (!defined("ET_OPEN_FILE_PREFIX"))
 	define("ET_OPEN_FILE_PREFIX", "emerging-");
 if (!defined("ET_PRO_FILE_PREFIX"))
 	define("ET_PRO_FILE_PREFIX", "etpro-");
-if (!defined("EXTRARULES_FILE_PREFIX"))
+if (!defined("EXTRARULE_FILE_PREFIX"))
 	define("EXTRARULE_FILE_PREFIX", "extrarule-");
 if (!defined('SURICATA_ENFORCING_RULES_FILENAME'))
 	define('SURICATA_ENFORCING_RULES_FILENAME', 'suricata.rules');

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -512,10 +512,9 @@ if ($suricatacfg['eve_log_snmp'] == 'on') {
 	$eve_out_types .= "\n        - snmp";
 }
 
-// Disable MQTT Eve logging for now as it is a 6.x binary feature
-//if ($suricatacfg['eve_log_mqtt'] == 'on') {
-//	$eve_out_types .= "\n        - mqtt";
-//}
+if ($suricatacfg['eve_log_mqtt'] == 'on') {
+	$eve_out_types .= "\n        - mqtt";
+}
 
 if ($suricatacfg['eve_log_smtp'] == 'on') {
 	$eve_out_types .= "\n        - smtp:";

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -512,6 +512,18 @@ if ($suricatacfg['eve_log_snmp'] == 'on') {
 	$eve_out_types .= "\n        - snmp";
 }
 
+if ($suricatacfg['eve_log_ftp'] == 'on') {
+	$eve_out_types .= "\n        - ftp";
+}
+
+if ($suricatacfg['eve_log_http2'] == 'on') {
+	$eve_out_types .= "\n        - http2";
+}
+
+if ($suricatacfg['eve_log_rfb'] == 'on') {
+	$eve_out_types .= "\n        - rfb";
+}
+
 if ($suricatacfg['eve_log_mqtt'] == 'on') {
 	$eve_out_types .= "\n        - mqtt";
 }
@@ -876,6 +888,15 @@ if (!empty($suricatacfg['dhcp_parser']))
 	$dhcp_parser = $suricatacfg['dhcp_parser'];
 else
 	$dhcp_parser = "yes";
+
+if (!empty($suricatacfg['http2_parser']))
+	$http2_parser = $suricatacfg['http2_parser'];
+else
+	$http2_parser = "no";
+if (!empty($suricatacfg['rfb_parser']))
+	$rfb_parser = $suricatacfg['rfb_parser'];
+else
+	$rfb_parser = "yes";
 
 /* DNS Parser */
 if (!empty($suricatacfg['dns_parser_tcp']))

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -375,6 +375,18 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 		$pconfig['eve_log_tls'] = "on";
 		$updated_cfg = true;
 	}
+	if (!isset($pconfig['eve_log_ftp'])) {
+		$pconfig['eve_log_ftp'] = "on";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_http2'])) {
+		$pconfig['eve_log_http2'] = "on";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['eve_log_rfb'])) {
+		$pconfig['eve_log_rfb'] = "on";
+		$updated_cfg = true;
+	}
 	if (!isset($pconfig['eve_log_dhcp'])) {
 		$pconfig['eve_log_dhcp'] = "on";
 		$updated_cfg = true;
@@ -646,6 +658,14 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 	}
 	if (empty($pconfig['sip_parser'])) {
 		$pconfig['sip_parser'] = "yes";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['http2_parser'])) {
+		$pconfig['http2_parser'] = "yes";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['rfb_parser'])) {
+		$pconfig['rfb_parser'] = "yes";
 		$updated_cfg = true;
 	}
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2020 Bill Meeks
+ * Copyright (c) 2021 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -88,6 +88,7 @@ unlink_if_exists(SURICATA_RULES_DIR . VRT_FILE_PREFIX . "*.rules");
 unlink_if_exists(SURICATA_RULES_DIR . ET_OPEN_FILE_PREFIX . "*.rules");
 unlink_if_exists(SURICATA_RULES_DIR . ET_PRO_FILE_PREFIX . "*.rules");
 unlink_if_exists(SURICATA_RULES_DIR . GPL_FILE_PREFIX . "*.rules");
+unlink_if_exists(SURICATA_RULES_DIR . EXTRARULE_FILE_PREFIX . "*.rules");
 unlink_if_exists("/usr/local/share/suricata/GeoLite2/GeoLite2-Country.mmdb");
 rmdir_recursive("/usr/local/share/suricata/GeoLite2");
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -387,6 +387,12 @@ app-layer:
       enabled: {$sip_parser}
     snmp:
       enabled: {$snmp_parser}
+    http2:
+      enabled: {$http2_parser}
+    rfb:
+      enabled: {$rfb_parser}
+      detection-ports:
+        dp: 5900, 5901, 5902, 5903, 5904, 5905, 5906, 5907, 5908, 5909
 
 ###########################################################################
 # Configure libhtp.

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
@@ -277,6 +277,8 @@ elseif ($_POST['ResetAll']) {
 	$pconfig['rdp_parser'] = "yes";
 	$pconfig['sip_parser'] = "yes";
 	$pconfig['snmp_parser'] = "yes";
+	$pconfig['http2_parser'] = "yes";
+	$pconfig['rfb_parser'] = "yes";
 
 	/* Log a message at the top of the page to inform the user */
 	$savemsg = gettext("All flow and stream settings on this page have been reset to their defaults.  Click APPLY if you wish to keep these new settings.");
@@ -468,6 +470,8 @@ elseif ($_POST['save'] || $_POST['apply']) {
 		$natent['rdp_parser'] = $_POST['rdp_parser'];
 		$natent['sip_parser'] = $_POST['sip_parser'];
 		$natent['snmp_parser'] = $_POST['snmp_parser'];
+		$natent['http2_parser'] = $_POST['http2_parser'];
+		$natent['rfb_parser'] = $_POST['rfb_parser'];
 
 		/**************************************************/
 		/* If we have a valid rule ID, save configuration */
@@ -717,6 +721,12 @@ if ($importalias) {
 		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
 	))->setHelp('Choose the parser/detection setting for FTP. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
 	$section->addInput(new Form_Select(
+		'http2_parser',
+		'HTTP2 Parser',
+		$pconfig['http2_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for HTTP2. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
 		'ikev2_parser',
 		'IKEv2 Parser',
 		$pconfig['ikev2_parser'],
@@ -753,6 +763,18 @@ if ($importalias) {
 		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
 	))->setHelp('Choose the parser/detection setting for NTP. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
 	$section->addInput(new Form_Select(
+		'rdp_parser',
+		'RDP Parser',
+		$pconfig['rdp_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for RDP. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
+		'rfb_parser',
+		'RFB Parser',
+		$pconfig['rfb_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for RFB. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
 		'smb_parser',
 		'SMB Parser',
 		$pconfig['smb_parser'],
@@ -770,12 +792,6 @@ if ($importalias) {
 		$pconfig['tftp_parser'],
 		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
 	))->setHelp('Choose the parser/detection setting for TFTP. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
-	$section->addInput(new Form_Select(
-		'rdp_parser',
-		'RDP Parser',
-		$pconfig['rdp_parser'],
-		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
-	))->setHelp('Choose the parser/detection setting for RDP. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
 	$section->addInput(new Form_Select(
 		'sip_parser',
 		'SIP Parser',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -51,7 +51,7 @@ else {
 	$pconfig['forcekeepsettings'] = $config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] == "on" ? 'on' : 'off';
 	$pconfig['snortcommunityrules'] = $config['installedpackages']['suricata']['config'][0]['snortcommunityrules'] == "on" ? 'on' : 'off';
 	$pconfig['snort_rules_file'] = htmlentities($config['installedpackages']['suricata']['config'][0]['snort_rules_file']);
-	$pconfig['autogeoipupdate'] = $config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] == "off" ? 'off' : 'on';
+	$pconfig['autogeoipupdate'] = $config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] == "on" ? 'on' : 'off';
 	$pconfig['maxmind_geoipdb_key'] = htmlentities($config['installedpackages']['suricata']['config'][0]['maxmind_geoipdb_key']);
 	$pconfig['hide_deprecated_rules'] = $config['installedpackages']['suricata']['config'][0]['hide_deprecated_rules'] == "on" ? 'on' : 'off';
 	$pconfig['enable_etopen_custom_url'] = $config['installedpackages']['suricata']['config'][0]['enable_etopen_custom_url'] == "on" ? 'on' : 'off';

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -618,6 +618,7 @@ events.push(function(){
 	function enable_et_rules() {
 		var hide = $('#enable_etopen_rules').prop('checked');
 		$('#enable_etopen_custom_url').prop('disabled', !hide);
+		hideInput('etprocode', true);
 		if (hide && $('#enable_etopen_custom_url').prop('checked')) {
 			hideInput('etopen_custom_rule_url', false);
 		}
@@ -641,13 +642,14 @@ events.push(function(){
 		}
 		else {
 			hideInput('etpro_custom_rule_url', true);
-			hideInput('etprocode', false);
+			hideInput('etprocode', hide);
 
 		}
 		if (!hide && $('#enable_etopen_rules').prop('checked')) {
 			$('#enable_etopen_rules').prop('checked', false);
 			$('#enable_etopen_custom_url').prop('disabled', !hide);
 			hideInput('etopen_custom_rule_url', !hide);
+			hideInput('etprocode', false);
 		}
 	}
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1244,6 +1244,9 @@ $group->add(new Form_Checkbox(
 	'on'
 ));
 
+// The control below is a dummy placeholder to maintain Form Group spacing.
+// There must be the same number of Form Group controls on each row for
+// consistent spacing.
 $group->add(new Form_StaticText(
 	null,
 	null
@@ -1254,58 +1257,10 @@ $section->add($group)->addClass('eve_log_info');
 
 $group = new Form_Group('EVE Logged Info');
 $group->add(new Form_Checkbox(
-	'eve_log_tls',
-	'TLS Handshakes',
-	'TLS Handshakes',
-	$pconfig['eve_log_tls'] == 'on' ? true:false,
-	'on'
-));
-
-$group->add(new Form_Checkbox(
-	'eve_log_ssh',
-	'SSH Handshakes',
-	'SSH Handshakes',
-	$pconfig['eve_log_ssh'] == 'on' ? true:false,
-	'on'
-));
-
-$group->add(new Form_Checkbox(
 	'eve_log_dhcp',
 	'DHCP Messages',
 	'DHCP Messages',
 	$pconfig['eve_log_dhcp'] == 'on' ? true:false,
-	'on'
-));
-
-$group->add(new Form_Checkbox(
-	'eve_log_files',
-	'Tracked Files',
-	'Tracked Files',
-	$pconfig['eve_log_files'] == 'on' ? true:false,
-	'on'
-));
-
-$group->add(new Form_Checkbox(
-	'eve_log_stats',
-	'Perf Stats',
-	'Perf Stats',
-	$pconfig['eve_log_stats'] == 'on' ? true:false,
-	'on'
-));
-
-$group->add(new Form_Checkbox(
-	'eve_log_flow',
-	'Flows',
-	'Flows',
-	$pconfig['eve_log_flow'] == 'on' ? true:false,
-	'on'
-));
-
-$group->add(new Form_Checkbox(
-	'eve_log_netflow',
-	'Net Flows',
-	'Net Flows',
-	$pconfig['eve_log_netflow'] == 'on' ? true:false,
 	'on'
 ));
 
@@ -1318,10 +1273,10 @@ $group->add(new Form_Checkbox(
 ));
 
 $group->add(new Form_Checkbox(
-	'eve_log_snmp',
-	'SNMP',
-	'SNMP',
-	$pconfig['eve_log_snmp'] == 'on' ? true:false,
+	'eve_log_flow',
+	'Flows',
+	'Flows',
+	$pconfig['eve_log_flow'] == 'on' ? true:false,
 	'on'
 ));
 
@@ -1331,6 +1286,77 @@ $group->add(new Form_Checkbox(
 	'MQTT',
 	$pconfig['eve_log_mqtt'] == 'on' ? true:false,
 	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_netflow',
+	'Net Flows',
+	'Net Flows',
+	$pconfig['eve_log_netflow'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_stats',
+	'Perf Stats',
+	'Perf Stats',
+	$pconfig['eve_log_stats'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_snmp',
+	'SNMP',
+	'SNMP',
+	$pconfig['eve_log_snmp'] == 'on' ? true:false,
+	'on'
+));
+
+$section->add($group)->addClass('eve_log_info');
+$group = new Form_Group(false);
+
+$group->add(new Form_Checkbox(
+	'eve_log_ssh',
+	'SSH Handshakes',
+	'SSH Handshakes',
+	$pconfig['eve_log_ssh'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_tls',
+	'TLS Handshakes',
+	'TLS Handshakes',
+	$pconfig['eve_log_tls'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_files',
+	'Tracked Files',
+	'Tracked Files',
+	$pconfig['eve_log_files'] == 'on' ? true:false,
+	'on'
+));
+
+// The controls below are dummy placeholders to maintain Form Group spacing.
+// There must be the same number of Form Group controls on each row for
+// consistent spacing.
+$group->add(new Form_StaticText(
+	null,
+	null
+));
+$group->add(new Form_StaticText(
+	null,
+	null
+));
+$group->add(new Form_StaticText(
+	null,
+	null
+));
+$group->add(new Form_StaticText(
+	null,
+	null
 ));
 
 $group->setHelp('Choose the information to log via EVE JSON output.');

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -270,6 +270,15 @@ if (empty($pconfig['eve_log_snmp'])) {
 if (empty($pconfig['eve_log_mqtt'])) {
 	$pconfig['eve_log_mqtt'] = "on";
 }
+if (empty($pconfig['eve_log_ftp'])) {
+	$pconfig['eve_log_ftp'] = "on";
+}
+if (empty($pconfig['eve_log_http2'])) {
+	$pconfig['eve_log_http2'] = "on";
+}
+if (empty($pconfig['eve_log_rfb'])) {
+	$pconfig['eve_log_rfb'] = "on";
+}
 if (empty($pconfig['eve_log_http_extended']))
 	$pconfig['eve_log_http_extended'] = $pconfig['http_log_extended'];
 if (empty($pconfig['eve_log_tls_extended']))
@@ -501,6 +510,9 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['eve_log_netflow'] == "on") { $natent['eve_log_netflow'] = 'on'; }else{ $natent['eve_log_netflow'] = 'off'; }
 		if ($_POST['eve_log_snmp'] == "on") { $natent['eve_log_snmp'] = 'on'; }else{ $natent['eve_log_snmp'] = 'off'; }
 		if ($_POST['eve_log_mqtt'] == "on") { $natent['eve_log_mqtt'] = 'on'; }else{ $natent['eve_log_mqtt'] = 'off'; }
+		if ($_POST['eve_log_ftp'] == "on") { $natent['eve_log_ftp'] = 'on'; }else{ $natent['eve_log_ftp'] = 'off'; }
+		if ($_POST['eve_log_http2'] == "on") { $natent['eve_log_http2'] = 'on'; }else{ $natent['eve_log_http2'] = 'off'; }
+		if ($_POST['eve_log_rfb'] == "on") { $natent['eve_log_rfb'] = 'on'; }else{ $natent['eve_log_rfb'] = 'off'; }
 		if ($_POST['eve_log_stats_totals'] == "on") { $natent['eve_log_stats_totals'] = 'on'; }else{ $natent['eve_log_stats_totals'] = 'off'; }
 		if ($_POST['eve_log_stats_deltas'] == "on") { $natent['eve_log_stats_deltas'] = 'on'; }else{ $natent['eve_log_stats_deltas'] = 'off'; }
 		if ($_POST['eve_log_stats_threads'] == "on") { $natent['eve_log_stats_threads'] = 'on'; }else{ $natent['eve_log_stats_threads'] = 'off'; }
@@ -1125,14 +1137,6 @@ $section->add($group)->addClass('eve_log_anomaly_details');
 $group = new Form_Group('EVE Logged Traffic');
 
 $group->add(new Form_Checkbox(
-	'eve_log_http',
-	'HTTP',
-	'HTTP',
-	$pconfig['eve_log_http'] == 'on' ? true:false,
-	'on'
-));
-
-$group->add(new Form_Checkbox(
 	'eve_log_dns',
 	'DNS',
 	'DNS',
@@ -1141,34 +1145,26 @@ $group->add(new Form_Checkbox(
 ));
 
 $group->add(new Form_Checkbox(
-	'eve_log_smtp',
-	'SMTP',
-	'SMTP',
-	$pconfig['eve_log_smtp'] == 'on' ? true:false,
+	'eve_log_ftp',
+	'FTP',
+	'FTP',
+	$pconfig['eve_log_ftp'] == 'on' ? true:false,
 	'on'
 ));
 
 $group->add(new Form_Checkbox(
-	'eve_log_nfs',
-	'NFS',
-	'NFS',
-	$pconfig['eve_log_nfs'] == 'on' ? true:false,
+	'eve_log_http',
+	'HTTP',
+	'HTTP',
+	$pconfig['eve_log_http'] == 'on' ? true:false,
 	'on'
 ));
 
 $group->add(new Form_Checkbox(
-	'eve_log_smb',
-	'SMB',
-	'SMB',
-	$pconfig['eve_log_smb'] == 'on' ? true:false,
-	'on'
-));
-
-$group->add(new Form_Checkbox(
-	'eve_log_krb5',
-	'Kerberos',
-	'Kerberos',
-	$pconfig['eve_log_krb5'] == 'on' ? true:false,
+	'eve_log_http2',
+	'HTTP2',
+	'HTTP2',
+	$pconfig['eve_log_sip'] == 'on' ? true:false,
 	'on'
 ));
 
@@ -1181,12 +1177,24 @@ $group->add(new Form_Checkbox(
 ));
 
 $group->add(new Form_Checkbox(
-	'eve_log_tftp',
-	'TFTP',
-	'TFTP',
-	$pconfig['eve_log_tftp'] == 'on' ? true:false,
+	'eve_log_krb5',
+	'Kerberos',
+	'Kerberos',
+	$pconfig['eve_log_krb5'] == 'on' ? true:false,
 	'on'
 ));
+
+$group->add(new Form_Checkbox(
+	'eve_log_nfs',
+	'NFS',
+	'NFS',
+	$pconfig['eve_log_nfs'] == 'on' ? true:false,
+	'on'
+));
+
+$section->add($group)->addClass('eve_log_info');
+
+$group = new Form_Group(false);
 
 $group->add(new Form_Checkbox(
 	'eve_log_rdp',
@@ -1197,11 +1205,48 @@ $group->add(new Form_Checkbox(
 ));
 
 $group->add(new Form_Checkbox(
+	'eve_log_rfb',
+	'RFB',
+	'RFB',
+	$pconfig['eve_log_rfb'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
 	'eve_log_sip',
 	'SIP',
 	'SIP',
 	$pconfig['eve_log_sip'] == 'on' ? true:false,
 	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_smb',
+	'SMB',
+	'SMB',
+	$pconfig['eve_log_smb'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_smtp',
+	'SMTP',
+	'SMTP',
+	$pconfig['eve_log_smtp'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_Checkbox(
+	'eve_log_tftp',
+	'TFTP',
+	'TFTP',
+	$pconfig['eve_log_tftp'] == 'on' ? true:false,
+	'on'
+));
+
+$group->add(new Form_StaticText(
+	null,
+	null
 ));
 
 $group->setHelp('Choose the traffic types to log via EVE JSON output.');
@@ -1998,6 +2043,9 @@ events.push(function(){
 		disableInput('eve_log_tftp', disable);
 		disableInput('eve_log_rdp', disable);
 		disableInput('eve_log_sip', disable);
+		disableInput('eve_log_ftp', disable);
+		disableInput('eve_log_http2', disable);
+		disableInput('eve_log_rfb', disable);
 		disableInput('eve_log_tls', disable);
 		disableInput('eve_log_files', disable);
 		disableInput('eve_log_dhcp', disable);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -100,6 +100,11 @@ if (isset($id) && isset($a_rule[$id])) {
 		$pconfig['enable'] = "off";
 	}
 }
+elseif (isset($_POST['interface']) && !isset($a_rule[$id])) {
+	// Saving first Suricata interface
+	$pconfig['interface'] = $_POST['interface'];
+	$if_friendly = convert_friendly_interface_to_friendly_descr($pconfig['interface']);
+}
 elseif (isset($id) && !isset($a_rule[$id])) {
     // Must be a new interface, so try to pick next available physical interface to use
 	$ifaces = get_configured_interface_list();

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1503,8 +1503,8 @@ $section->addInput(new Form_Input(
 	'Netmap Threads',
 	'text',
 	$pconfig['ips_netmap_threads']
-))->setHelp('Enter the number of netmap threads to use. Default is "auto". When set to a value matching the netmap TX/RX queues registered by the NIC, performance can be greatly increased. ' . 
-	    'The NIC hosting this interface registered ' . suricata_get_supported_netmap_queues($if_real) . ' queue(s) with the kernel.');
+))->setHelp('Enter the number of netmap threads to use. Default is "auto" and is recommended. When set to "auto", Suricata will query the system for the number of supported netmap queues, ' . 
+	    ' and it will use a matching number of netmap theads. The NIC hosting this interface registered ' . suricata_get_supported_netmap_queues($if_real) . ' queue(s) with the kernel.');
 
 $section->addInput(new Form_Checkbox(
 	'blockoffenderskill',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
@@ -168,7 +168,7 @@ if ($_POST['save']) {
 		$p_list['vpnips'] = $_POST['vpnips']? 'yes' : 'no';
 
 		$p_list['address'] = $_POST['address'];
-		$p_list['descr']  =  mb_convert_encoding(str_replace("\r\n", "\n", $_POST['descr']),"HTML-ENTITIES","auto");
+		$p_list['descr']  =  str_replace("\r\n", "\n", $_POST['descr']);
 		$p_list['detail'] = $final_address_details;
 
 		if (isset($id) && $a_passlist[$id])

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress_edit.php
@@ -101,7 +101,7 @@ if ($_POST['save']) {
 		$s_list = array();
 		$s_list['name'] = $_POST['name'];
 		$s_list['uuid'] = uniqid();
-		$s_list['descr']  =  mb_convert_encoding($_POST['descr'],"HTML-ENTITIES","auto");
+		$s_list['descr'] = $_POST['descr'];
 		if ($_POST['suppresspassthru']) {
 			$s_list['suppresspassthru'] = str_replace("&#8203;", "", $s_list['suppresspassthru']);
 			$s_list['suppresspassthru'] = base64_encode($_POST['suppresspassthru']);


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.3
This package update provides support for the latest 6.0.3 Suricata binary from upstream. It also adds two new features and corrects six reported bugs.

**New Features:**
1. Support is added for FTP, HTTP2 and RFB event logging via the EVE JSON log system.
2. Support is added for HTTP2 and RFB application protocol parsing on the APP PARSERS tab.

**Bug Fixes:**
1. Default GeoIP2 database download to 'off' during a greenfield install.
2. When saving Suppress and Pass Lists, there is no need to call _mb_convert_encoding()_ for the description field ['desc'], because the _config.xml_ code automatically wraps that field with CDATA tags.
3. On INTERFACE SETTINGS tab, when enabling File Store in a greenfield install, the default filestore logging directory name is incomplete (missing the UUID portion).
4. On GLOBAL SETTINGS tab, a cosmetic issue exists where ET-Pro Subscription Code field is not always hidden when ET-Pro Rules download is not enabled.
5. Correct issues around initial selection and configuration of the first Suricata interface on a greenfield install on the INTERFACE SETTINGS tab.
6. Reorder the EVE Log Info parameters on the INTERFACE SETTINGS tab to improve asthetics and usability.