### PR TITLE
Suricata rules/categories notifications. Implements #10809

### DIFF
--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -46,6 +46,8 @@ else {
 	$pconfig['autoruleupdatetime'] = htmlentities($config['installedpackages']['suricata']['config'][0]['autoruleupdatetime']);
 	$pconfig['live_swap_updates'] = $config['installedpackages']['suricata']['config'][0]['live_swap_updates'] == "on" ? 'on' : 'off';
 	$pconfig['log_to_systemlog'] = $config['installedpackages']['suricata']['config'][0]['log_to_systemlog'] == "on" ? 'on' : 'off';
+	$pconfig['update_notify'] = $config['installedpackages']['suricata']['config'][0]['update_notify'] == "on" ? 'on' : 'off';
+	$pconfig['rule_categories_notify'] = $config['installedpackages']['suricata']['config'][0]['rule_categories_notify'] == "on" ? 'on' : 'off';
 	$pconfig['log_to_systemlog_facility'] = $config['installedpackages']['suricata']['config'][0]['log_to_systemlog_facility'];
 	$pconfig['log_to_systemlog_priority'] = $config['installedpackages']['suricata']['config'][0]['log_to_systemlog_priority'];
 	$pconfig['forcekeepsettings'] = $config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] == "on" ? 'on' : 'off';
@@ -227,6 +229,8 @@ if (!$input_errors) {
 			$config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'] = str_pad(html_entity_decode($_POST['autoruleupdatetime']), 4, "0", STR_PAD_LEFT);
 		}
 		$config['installedpackages']['suricata']['config'][0]['log_to_systemlog'] = $_POST['log_to_systemlog'] ? 'on' : 'off';
+		$config['installedpackages']['suricata']['config'][0]['update_notify'] = $_POST['update_notify'] ? 'on' : 'off';
+		$config['installedpackages']['suricata']['config'][0]['rule_categories_notify'] = $_POST['rule_categories_notify'] ? 'on' : 'off';
 		$config['installedpackages']['suricata']['config'][0]['log_to_systemlog_facility'] = $_POST['log_to_systemlog_facility'];
 		$config['installedpackages']['suricata']['config'][0]['log_to_systemlog_priority'] = $_POST['log_to_systemlog_priority'];
 		$config['installedpackages']['suricata']['config'][0]['live_swap_updates'] = $_POST['live_swap_updates'] ? 'on' : 'off';
@@ -590,6 +594,33 @@ $section->addInput(new Form_Checkbox(
 	'on'
 ));
 $form->add($section);
+
+$section = new Form_Section('Notifications');
+
+$section->addInput(new Form_StaticText(
+	null,
+	'E-Mail/Telegram/Pushover notifications. Delivery settings are configured under System -> Advanced, ' .
+        'on the Notifications tab.',
+));
+
+$section->addInput(new Form_Checkbox(
+	'update_notify',
+	'Update',
+	'Rules, GeoIP and IQRisk update notifications.',
+	$pconfig['update_notify'] == 'on' ? true:false,
+	'off'
+));
+
+$section->addInput(new Form_Checkbox(
+	'rule_categories_notify',
+	'Rule Categories',
+	'Send notifications when new rule categories appear.',
+	$pconfig['rule_categories_notify'] == 'on' ? true:false,
+	'off'
+));
+
+$form->add($section);
+
 print $form;
 ?>
 </div>


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10809
- [X] Ready for review

Send rules update and new rules categories notification via email/telegram/pushover

sample message:
```
Suricata rules update started: 2021-08-21 13:00:09
- Emerging Threats Open rules rules were updated.
- Snort VRT rules will not be updated, md5 download failed!
- Snort GPLv2 Community Rules rules were updated.
- Feodo Tracker Botnet C2 IP rules were updated.
- ABUSE.ch SSL Blacklist rules were updated.
- Extra malsilo rules were updated.
- Extra positive rules were updated.
- Extra hunting rules were updated.
----- New rule categories are available -----
- Emerging Threats Open rules: 3coresec.rules, botcc.portgrouped.rules, botcc.rules, ciarmy.rules
Suricata rules update finished: 2021-08-21 13:01:26
```

can be merged with https://github.com/pfsense/FreeBSD-ports/pull/1097