### PR TITLE
Suricata: skip incorrect HOME_NET entries. Fixes #12322

### DIFF
--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -575,7 +575,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 
 	$valresult = array();
 	foreach ($home_net as $vald) { 
-		if (empty($vald)) {
+		if (empty($vald) || !is_subnet($vald)) {
 			continue;
 		}
 		$vald = trim($vald);


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/12322
- [X] Ready for review

can be merged with https://github.com/pfsense/FreeBSD-ports/pull/1103