### PR TITLE
pfSense-pkg-suricata-6.0.3_3 -- Fix netmap VLAN issue, add verbose logging option, increase stream memcap.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.3
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -91,8 +91,9 @@ function suricata_start($suricatacfg, $if_real) {
 		// Truncate suricata.log file for this interface.
 		file_put_contents("{$suricatalogdir}/suricata.log", '');
 		$run_mode = $suricatacfg['ips_mode'] == 'ips_mode_inline' && $suricatacfg['blockoffenders'] == 'on' ? '--netmap' : '-i ' . $if_real;
+		$verbose_logging = $suricatacfg['enable_verbose_logging'] == 'on' ? "-vv" : "";
 		syslog(LOG_NOTICE, "[Suricata] Suricata START for {$suricatacfg['descr']}({$if_real})...");
-		mwexec_bg("{$suricatabindir}suricata {$run_mode} -D -c {$suricatadir}suricata_{$suricata_uuid}_{$if_real}/suricata.yaml --pidfile {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid");
+		mwexec_bg("{$suricatabindir}suricata {$run_mode} -D -c {$suricatadir}suricata_{$suricata_uuid}_{$if_real}/suricata.yaml --pidfile {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid {$verbose_logging}");
 	} else {
 		return;
 	}
@@ -3612,6 +3613,7 @@ function suricata_create_rc() {
 		$no_enabled_interface = FALSE;
 		$suricata_uuid = $value['uuid'];
 		$run_mode = $value['ips_mode'] == 'ips_mode_inline' && $value['blockoffenders'] == 'on' ? '--netmap' : '-i ' . $if_real;
+		$verbose_logging = $value['enable_verbose_logging'] == 'on' ? "-vv" : "";
 
 		$start_suricata_iface_start[] = <<<EOE
 
@@ -3625,7 +3627,7 @@ function suricata_create_rc() {
 	if [ -z \$pid ]; then
 		/bin/cp /dev/null {$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/suricata.log
 		/usr/bin/logger -p daemon.info -i -t SuricataStartup "Suricata START for {$value['descr']}({$suricata_uuid}_{$if_real})..."
-		{$suricatabindir}suricata {$run_mode} -D -c {$suricatadir}suricata_{$suricata_uuid}_{$if_real}/suricata.yaml --pidfile {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid > /dev/null 2>&1
+		{$suricatabindir}suricata {$run_mode} -D -c {$suricatadir}suricata_{$suricata_uuid}_{$if_real}/suricata.yaml --pidfile {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid {$verbose_logging} > /dev/null 2>&1
 	fi
 
 	sleep 1

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -688,7 +688,7 @@ else
 if (!empty($suricatacfg['stream_memcap']))
 	$stream_memcap = $suricatacfg['stream_memcap'];
 else
-	$stream_memcap = "67108864";
+	$stream_memcap = "131217728";
 
 if (!empty($suricatacfg['stream_prealloc_sessions']))
 	$stream_prealloc_sessions = $suricatacfg['stream_prealloc_sessions'];
@@ -698,7 +698,7 @@ else
 if (!empty($suricatacfg['reassembly_memcap']))
 	$reassembly_memcap = $suricatacfg['reassembly_memcap'];
 else
-	$reassembly_memcap = "67108864";
+	$reassembly_memcap = "131217728";
 
 if (!empty($suricatacfg['reassembly_depth']) || $suricatacfg['reassembly_depth'] == '0')
 	$reassembly_depth = $suricatacfg['reassembly_depth'];

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -1126,6 +1126,16 @@ if ($suricatacfg['ips_mode'] == 'ips_mode_inline' && $suricatacfg['blockoffender
 		$netmap_threads_param = $suricatacfg['ips_netmap_threads'];
 	}
 
+	$if_netmap = $if_real;
+
+	// For VLAN interfaces, need to actually run Suricata
+	// on the parent interface, so override interface name.
+	if (interface_is_vlan($if_real)) {
+		$intf_list = get_parent_interface($if_real);
+		$if_netmap = $intf_list[0];
+		syslog(LOG_WARNING, "[suricata] WARNING: interface '{$if_real}' is a VLAN, so configuring Suricata to run on the parent interface, '{$if_netmap}', instead.");
+	}
+
 	// Note -- Netmap promiscuous mode logic is backwards from pcap
 	$netmap_intf_promisc_mode = $intf_promisc_mode == 'yes' ? 'no' : 'yes';
 	$suricata_ips_mode = <<<EOD
@@ -1136,10 +1146,14 @@ netmap:
    copy-mode: ips
    disable-promisc: {$netmap_intf_promisc_mode}
    checksum-checks: auto
- - interface: {$if_real}
-   copy-iface: {$if_real}^
- - interface: {$if_real}^
-   copy-iface: {$if_real}
+ - interface: {$if_netmap}
+   threads: {$netmap_threads_param}
+   copy-mode: ips
+   copy-iface: {$if_netmap}^
+ - interface: {$if_netmap}^
+   threads: {$netmap_threads_param}
+   copy-mode: ips
+   copy-iface: {$if_netmap}
 EOD;
 }
 else {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
@@ -255,8 +255,8 @@ elseif ($_POST['ResetAll']) {
 	// 216 * prealloc_sessions * number of threads = memory use in bytes
 	// 64 MB is a decent all-around default, but some setups need more.
 	$pconfig['stream_prealloc_sessions'] = '32768';
-	$pconfig['stream_memcap'] = '67108864';
-	$pconfig['reassembly_memcap'] = '67108864';
+	$pconfig['stream_memcap'] = '131217728';
+	$pconfig['reassembly_memcap'] = '131217728';
 	$pconfig['reassembly_depth'] = '1048576';
 	$pconfig['reassembly_to_server_chunk'] = '2560';
 	$pconfig['reassembly_to_client_chunk'] = '2560';
@@ -303,11 +303,11 @@ elseif ($_POST['save'] || $_POST['apply']) {
 		if ($_POST['flow_icmp_emerg_new_timeout'] != "") { $natent['flow_icmp_emerg_new_timeout'] = $_POST['flow_icmp_emerg_new_timeout']; }else{ $natent['flow_icmp_emerg_new_timeout'] = "10"; }
 		if ($_POST['flow_icmp_emerg_established_timeout'] != "") { $natent['flow_icmp_emerg_established_timeout'] = $_POST['flow_icmp_emerg_established_timeout']; }else{ $natent['flow_icmp_emerg_established_timeout'] = "100"; }
 
-		if ($_POST['stream_memcap'] != "") { $natent['stream_memcap'] = $_POST['stream_memcap']; }else{ $natent['stream_memcap'] = "67108864"; }
+		if ($_POST['stream_memcap'] != "") { $natent['stream_memcap'] = $_POST['stream_memcap']; }else{ $natent['stream_memcap'] = "131217728"; }
 		if ($_POST['stream_prealloc_sessions'] != "") { $natent['stream_prealloc_sessions'] = $_POST['stream_prealloc_sessions']; }else{ $natent['stream_prealloc_sessions'] = "32768"; }
 		if ($_POST['enable_midstream_sessions'] == "on") { $natent['enable_midstream_sessions'] = 'on'; }else{ $natent['enable_midstream_sessions'] = 'off'; }
 		if ($_POST['enable_async_sessions'] == "on") { $natent['enable_async_sessions'] = 'on'; }else{ $natent['enable_async_sessions'] = 'off'; }
-		if ($_POST['reassembly_memcap'] != "") { $natent['reassembly_memcap'] = $_POST['reassembly_memcap']; }else{ $natent['reassembly_memcap'] = "67108864"; }
+		if ($_POST['reassembly_memcap'] != "") { $natent['reassembly_memcap'] = $_POST['reassembly_memcap']; }else{ $natent['reassembly_memcap'] = "131217728"; }
 		if ($_POST['reassembly_depth'] != "") { $natent['reassembly_depth'] = $_POST['reassembly_depth']; }else{ $natent['reassembly_depth'] = "1048576"; }
 		if ($_POST['reassembly_to_server_chunk'] != "") { $natent['reassembly_to_server_chunk'] = $_POST['reassembly_to_server_chunk']; }else{ $natent['reassembly_to_server_chunk'] = "2560"; }
 		if ($_POST['reassembly_to_client_chunk'] != "") { $natent['reassembly_to_client_chunk'] = $_POST['reassembly_to_client_chunk']; }else{ $natent['reassembly_to_client_chunk'] = "2560"; }
@@ -755,7 +755,7 @@ $section->addInput(new Form_Input(
 	'Stream Memory Cap',
 	'text',
 	$pconfig['stream_memcap']
-))->setHelp('Max memory to be used by stream engine. Default is 67,108,864 bytes (64MB). Sets the maximum amount of memory, in bytes, to be used by the stream engine. This number will likely need to be increased beyond the default value in systems with more than 4 processor cores. If Suricata fails to start and logs a memory allocation error, increase this value in 4 MB chunks until Suricata starts successfully.');
+))->setHelp('Max memory to be used by stream engine. Default is 131,217,728 bytes (128MB). Sets the maximum amount of memory, in bytes, to be used by the stream engine. This number will likely need to be increased beyond the default value in systems with more than 4 processor cores. If Suricata fails to start and logs a memory allocation error, increase this value in 4 MB chunks until Suricata starts successfully.');
 $section->addInput(new Form_Input(
 	'stream_prealloc_sessions',
 	'Preallocated Sessions',
@@ -781,7 +781,7 @@ $section->addInput(new Form_Input(
 	'Reassembly Memory Cap',
 	'text',
 	$pconfig['reassembly_memcap']
-))->setHelp('Max memory to be used for stream reassembly. Default is 67,108,864 bytes (64MB). Sets the maximum amount of memory, in bytes, to be used for stream reassembly.');
+))->setHelp('Max memory to be used for stream reassembly. Default is 131,217,728 bytes (128MB). Sets the maximum amount of memory, in bytes, to be used for stream reassembly.');
 $section->addInput(new Form_Input(
 	'reassembly_depth',
 	'Reassembly Depth',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -611,9 +611,9 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$natent['flow_icmp_emerg_new_timeout'] = '10';
 			$natent['flow_icmp_emerg_established_timeout'] = '100';
 
-			$natent['stream_memcap'] = '67108864';
+			$natent['stream_memcap'] = '131217728';
 			$natent['stream_prealloc_sessions'] = '32768';
-			$natent['reassembly_memcap'] = '67108864';
+			$natent['reassembly_memcap'] = '131217728';
 			$natent['reassembly_depth'] = '1048576';
 			$natent['reassembly_to_server_chunk'] = '2560';
 			$natent['reassembly_to_client_chunk'] = '2560';

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -437,6 +437,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		$natent['uuid'] = $pconfig['uuid'];
 
 		if ($_POST['descr']) $natent['descr'] =  htmlspecialchars($_POST['descr']); else $natent['descr'] = strtoupper($natent['interface']);
+		if ($_POST['enable_verbose_logging'] == "on") { $natent['enable_verbose_logging'] = 'on'; }else{ $natent['enable_verbose_logging'] = 'off'; }
 		if ($_POST['max_pcap_log_size']) $natent['max_pcap_log_size'] = $_POST['max_pcap_log_size']; else unset($natent['max_pcap_log_size']);
 		if ($_POST['max_pcap_log_files']) $natent['max_pcap_log_files'] = $_POST['max_pcap_log_files']; else unset($natent['max_pcap_log_files']);
 		if ($_POST['enable_stats_collection'] == "on") { $natent['enable_stats_collection'] = 'on'; }else{ $natent['enable_stats_collection'] = 'off'; }
@@ -960,6 +961,14 @@ $section->addInput(new Form_Input(
 	'text',
 	$pconfig['max_pcap_log_files']
 ))->setHelp('Enter maximum number of packet log files to maintain. Default is 1000. When the number of packet log files reaches the set limit, the oldest file will be overwritten.');
+
+$section->addInput(new Form_Checkbox(
+	'enable_verbose_logging',
+	'Enable Verbose Logging',
+	'Suricata will log additional information to the suricata.log file when starting up and shutting down. Default is Not Checked.',
+	$pconfig['enable_verbose_logging'] == 'on' ? true:false,
+	'on'
+));
 
 $form->add($section);
 
@@ -2001,6 +2010,7 @@ events.push(function(){
 		disableInput('alertsystemlog', disable);
 		disableInput('alertsystemlog_facility', disable);
 		disableInput('alertsystemlog_priority', disable);
+		disableInput('enable_verbose_logging', disable);
 		disableInput('blockoffenders', disable);
 		disableInput('ips_mode', disable);
 		disableInput('blockoffenderskill', disable);


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.3_3
This update to the Suricata GUI package fixes a reported issue with netmap use in IPS mode on VLAN interfaces, adds an option for increasing the verbosity of startup/shutdown logging, and increases the greenfield default for the TCP stream memcap value from 64 MB to 128 MB.

**New Features:**
1. Add option to the INTERFACE SETTINGS tab for enabing more verbose logging in the _suricata.log_ file from Suricata when starting up and shutting down an interface instance.

**Bug Fixes:**
1. When using Inline IPS Mode with VLANs, because the netmap device cannot process VLAN tags, Suricata should pass the VLAN's parent interface as the physical interface where netmap will operate.
2. The default value for TCP Stream Memcap (on the FLOW/STREAM tab) for greenfield installs is increased from 64 MB to 128 MB. This higher value is more likely to be needed with modern higher core-count processors. Note this change only impacts a new greenfield install! Existing installations will not be modified! The user should make their own modifications to any existing Suricata installation.