### PR TITLE
Update widget-apcupsd.inc

### DIFF
--- a/sysutils/pfSense-pkg-apcupsd/files/usr/local/www/widgets/include/widget-apcupsd.inc
+++ b/sysutils/pfSense-pkg-apcupsd/files/usr/local/www/widgets/include/widget-apcupsd.inc
@@ -21,6 +21,6 @@
 
 //set variable for custom title
 $apcupsd_title = gettext("Apcupsd");
-$apcupsd_title_link = "apcupsd.widget.php";
+$apcupsd_title_link = "apcupsd_status.php";
 $apcupsd_allow_multiple_widget_copies = false;
 ?>


### PR DESCRIPTION
Fixes an issue where clicking on the title linked you to the widget instead of the UPS status page