### PR TITLE
Telegraf: add "devfs" to ignore_fs

### DIFF
--- a/net-mgmt/pfSense-pkg-Telegraf/Makefile
+++ b/net-mgmt/pfSense-pkg-Telegraf/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-Telegraf
 PORTVERSION=	0.9
-PORTREVISION=	5
+PORTREVISION=	6
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.inc
+++ b/net-mgmt/pfSense-pkg-Telegraf/files/usr/local/pkg/telegraf.inc
@@ -82,7 +82,7 @@ function telegraf_resync_config() {
 	fielddrop = ["time_*"]
 
 [[inputs.disk]]
-	ignore_fs = ["tmpfs", "devtmpfs"]
+	ignore_fs = ["tmpfs", "devtmpfs", "devfs"]
 
 [[inputs.diskio]]
 


### PR DESCRIPTION
https://redmine.pfsense.org/issues/12462

The Netgate XG-1537 has the following disk paths at 100% utilization:
/dev
/var/dhcpd/dev
/var/unbound/dev
All three of the above disks use`devfs` as the filesystem.

The current issue with the telegraf package is that when you save from the Services -> Telegraf page, it overwrites whatever you put into `/usr/local/etc/telegraf.conf` with the following:

```txt
[[inputs.disk]]
ignore_fs = ["tmpfs", "devtmpfs"]
```

The package needs to be updated to also include `devfs` in that list like so:

```txt
[[inputs.disk]]
ignore_fs = ["tmpfs", "devtmpfs", "devfs"]
```