### PR TITLE
Add support for bi-directional flow in softflowd

### DIFF
--- a/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.inc
+++ b/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.inc
@@ -59,6 +59,9 @@ function sync_package_softflowd() {
 			if (is_numericint($cf['sample']) && ($cf['sample'] > 0)) {
 				$start .= " -s " . escapeshellarg($cf['sample']);
 			}
+			if ($cf['biflows'] != "") {
+				$start .= " -b ";
+			}
 			if ($cf['version'] != "") {
 				$start .= " -v " . escapeshellarg($cf['version']);
 			}
@@ -121,6 +124,9 @@ function validate_form_softflowd($post, &$input_errors) {
 	}
 	if (!in_array($post['version'], array(1, 5, 9, 10, 'psamp'))) {
 		$input_errors[] = 'You must specify a netflow version';
+	}
+	if ($post['biflows'] and $post['version'] != 10) {
+		$input_errors[] = 'You must specify IPFIX(10) netflow version for using bidirectional flows';
 	}
 	if (!in_array($post['flowtracking'], array("ether", "vlan", "full", "proto", "ip"))) {
 		$input_errors[] = 'You must specify a valid flow tracking selection';

--- a/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.inc
+++ b/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.inc
@@ -59,7 +59,7 @@ function sync_package_softflowd() {
 			if (is_numericint($cf['sample']) && ($cf['sample'] > 0)) {
 				$start .= " -s " . escapeshellarg($cf['sample']);
 			}
-			if ($cf['biflows'] != "") {
+			if ($cf['biflows']) {
 				$start .= " -b ";
 			}
 			if ($cf['version'] != "") {

--- a/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.xml
+++ b/net-mgmt/pfSense-pkg-softflowd/files/usr/local/pkg/softflowd.xml
@@ -123,6 +123,12 @@
 			<required/>
 		</field>
 		<field>
+			<fielddescr>Birectional Flow</fielddescr>
+			<fieldname>biflows</fieldname>
+			<description>Use bidirectional flows. Only possible with IPFIX</description>
+			<type>checkbox</type>
+		</field>
+		<field>
 			<fielddescr>Flow Tracking Level</fielddescr>
 			<fieldname>flowtracking</fieldname>
 			<description>

--- a/net-mgmt/softflowd/Makefile
+++ b/net-mgmt/softflowd/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	softflowd
 PORTVERSION=	1.0.0
+PORTREVISION=   1
 DISTVERSIONPREFIX=	softflowd-
 CATEGORIES=	net-mgmt
 


### PR DESCRIPTION
This patch allows to configure bi-directional flows when IPFIX version is selected. 

Associated Redmine ticket: https://redmine.pfsense.org/issues/12507