### PR TITLE
pfSense-pkg-suricata-6.0.3_4 - Support multiple host and network aliases in a Pass List.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.3
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -299,7 +299,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 	/* The default is to build a HOME_NET variable unless      */
 	/* '$passlist' is set to 'true' when calling.              */
 	/*                                                         */
-	/* When '$whitelist' is TRUE, a Pass List is built.        */
+	/* When '$passlist' is TRUE, a Pass List is built.         */
 	/* When '$externalist' is TRUE, the EXTERNAL_NET variable  */
 	/* is built.                                               */
 	/***********************************************************/

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -297,7 +297,11 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 
 	/***********************************************************/
 	/* The default is to build a HOME_NET variable unless      */
-	/* '$passlist' is set to 'true' when calling.             */
+	/* '$passlist' is set to 'true' when calling.              */
+	/*                                                         */
+	/* When '$whitelist' is TRUE, a Pass List is built.        */
+	/* When '$externalist' is TRUE, the EXTERNAL_NET variable  */
+	/* is built.                                               */
 	/***********************************************************/
 
 	global $config, $g, $aliastable, $filterdns;
@@ -337,8 +341,33 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 		$wandns = $list['wandnsips'];
 		$vips = $list['vips'];
 		$vpns = $list['vpnips'];
-		if (!empty($list['address']) && is_alias($list['address'])) {
-			$home_net = explode(" ", trim(filter_expand_alias($list['address'])));
+
+		// Process any custom IPs or aliases defined for the list.
+		// We allow dynamically updated aliases only for a Pass
+		// List. So for Pass Lists, we test for null strings from
+		// filter_expand_alias() and assume the passed alias is a
+		// FQDN or other dynamically updated alias.
+		if (is_array($list['address']['item']) && count($list['address']['item']) > 0) {
+			foreach ($list['address']['item'] as $addr) {
+				if (!$passlist) {
+					if (is_alias($addr) && (alias_get_type($addr) == "host" || alias_get_type($addr) == "network")) {
+						$home_net = array_merge($home_net, explode(" ", trim(filter_expand_alias($addr))));
+					} elseif (is_ipaddr($addr) || is_subnet($addr)) {
+						$home_net[] = $addr;
+					}
+				} elseif ($passlist) {
+					if (is_alias($addr) && (alias_get_type($addr) == "host" || alias_get_type($addr) == "network")) {
+						$tmp = trim(filter_expand_alias($addr));
+						if (strlen($tmp) > 0) {
+							$home_net = array_merge($home_net, explode(" ", $tmp));
+						} elseif (!in_array($addr, $home_net)) {
+							$home_net[] = $addr;
+						}
+					} elseif (is_ipaddr($addr) || is_subnet($addr)) {
+						$home_net[] = $addr;
+					}
+				}
+			}
 		}
 	}
 
@@ -574,9 +603,10 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 		}
 	}
 
+	// Validate the HOME_NET entries
 	$valresult = array();
 	foreach ($home_net as $vald) { 
-		if (empty($vald) || (!is_subnet($vald) && !is_ipaddr($vald))) {
+		if (empty($vald) || (!is_subnet($vald) && !is_ipaddr($vald) && !is_alias($vald))) {
 			continue;
 		}
 		$vald = trim($vald);

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -730,6 +730,16 @@ if ($suricatacfg['enable_async_sessions'] == 'on')
 else
 	$stream_enable_async = "false";
 
+if ($suricatacfg['stream_bypass'] == 'yes' || $suricatacfg['tls_encrypt_handling'] == 'bypass')
+	$stream_bypass_enable = "yes";
+else
+	$stream_bypass_enable = "no";
+
+if ($suricatacfg['stream_drop_invalid'] == 'yes')
+	$stream_drop_invalid_enable = "yes";
+else
+	$stream_drop_invalid_enable = "no";
+
 // Add the OS-specific host policies if configured, otherwise
 // just set default to BSD for all networks.
 $host_os_policy = "";
@@ -1023,6 +1033,12 @@ else {
 }
 if (!empty($suricatacfg['tls_encrypt_handling'])) {
 	$tls_encrypt_handling = $suricatacfg['tls_encrypt_handling'];
+
+	// If TLS encryption bypass is enabled, then stream bypass
+	// must also be forced to "yes" for bypass to happen.
+	if ($tls_encrypt_handling == "bypass") {
+		$stream_bypass_enable = "yes";
+	}
 }
 else {
 	$tls_encrypt_handling = "default";

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -717,6 +717,14 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 		$pconfig['max_synack_queued'] = "5";
 		$updated_cfg = true;
 	}
+	if (!isset($pconfig['stream_bypass'])) {
+		$pconfig['stream_bypass'] = "no";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['stream_drop_invalid'])) {
+		$pconfig['stream_drop_invalid'] = "no";
+		$updated_cfg = true;
+	}
 
 	/**********************************************************/
 	/* Create new interface IPS mode setting if not set       */

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -230,6 +230,27 @@ if (isset($config['installedpackages']['suricata']['config'][0]['files_json_log_
 	$updated_cfg = true;
 }
 
+/**********************************************************/
+/* Add new multiple alias & custom IP assignment feature  */
+/* for Pass Lists by converting existing <address>        */
+/* element for existing entries into an array. Migrate    */
+/* any existing <address> to the new array structure.     */
+/**********************************************************/
+if (is_array($config['installedpackages']['suricata']['passlist']['item'])) {
+	foreach ($config['installedpackages']['suricata']['passlist']['item'] as &$wlisti) {
+		if (!is_array($wlisti['address']) && !is_array($wlisti['address']['item']) && !empty($wlisti['address'])) {
+			$tmp = $wlisti['address'];
+			$wlisti['address'] = array();
+			$wlisti['address']['item'] = array();
+			$wlisti['address']['item'][] = $tmp;
+			$updated_cfg = true;
+		}
+	}
+
+	// Release reference to whitelist array
+	unset($wlisti);
+}
+
 // Now process the interface-specific settings
 foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -224,6 +224,8 @@ stream:
   midstream: {$stream_enable_midstream}
   async-oneside: {$stream_enable_async}
   max-synack-queued: {$max_synack_queued}
+  bypass: {$stream_bypass_enable}
+  drop-invalid: {$stream_drop_invalid_enable}
   reassembly:
     memcap: {$reassembly_memcap}
     depth: {$reassembly_depth}

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
@@ -253,7 +253,7 @@ elseif ($_POST['ResetAll']) {
 
 	// The default 'stream_memcap' value must be calculated as follows:
 	// 216 * prealloc_sessions * number of threads = memory use in bytes
-	// 64 MB is a decent all-around default, but some setups need more.
+	// 128 MB is a decent all-around default, but some setups need more.
 	$pconfig['stream_prealloc_sessions'] = '32768';
 	$pconfig['stream_memcap'] = '131217728';
 	$pconfig['reassembly_memcap'] = '131217728';
@@ -263,6 +263,8 @@ elseif ($_POST['ResetAll']) {
 	$pconfig['enable_midstream_sessions'] = 'off';
 	$pconfig['enable_async_sessions'] = 'off';
 	$pconfig['max_synack_queued'] = '5';
+	$pconfig['stream_bypass'] = "no";
+	$pconfig['stream_drop_invalid'] = "no";
 
 	/* Log a message at the top of the page to inform the user */
 	$savemsg = gettext("All flow and stream settings have been reset to their defaults.  Click APPLY to save the changes.");
@@ -307,6 +309,8 @@ elseif ($_POST['save'] || $_POST['apply']) {
 		if ($_POST['stream_prealloc_sessions'] != "") { $natent['stream_prealloc_sessions'] = $_POST['stream_prealloc_sessions']; }else{ $natent['stream_prealloc_sessions'] = "32768"; }
 		if ($_POST['enable_midstream_sessions'] == "on") { $natent['enable_midstream_sessions'] = 'on'; }else{ $natent['enable_midstream_sessions'] = 'off'; }
 		if ($_POST['enable_async_sessions'] == "on") { $natent['enable_async_sessions'] = 'on'; }else{ $natent['enable_async_sessions'] = 'off'; }
+		if ($_POST['stream_bypass'] == "yes") { $natent['stream_bypass'] = 'yes'; }else{ $natent['stream_bypass'] = 'no'; }
+		if ($_POST['stream_drop_invalid'] == "yes") { $natent['stream_drop_invalid'] = 'yes'; }else{ $natent['stream_drop_invalid'] = 'no'; }
 		if ($_POST['reassembly_memcap'] != "") { $natent['reassembly_memcap'] = $_POST['reassembly_memcap']; }else{ $natent['reassembly_memcap'] = "131217728"; }
 		if ($_POST['reassembly_depth'] != "") { $natent['reassembly_depth'] = $_POST['reassembly_depth']; }else{ $natent['reassembly_depth'] = "1048576"; }
 		if ($_POST['reassembly_to_server_chunk'] != "") { $natent['reassembly_to_server_chunk'] = $_POST['reassembly_to_server_chunk']; }else{ $natent['reassembly_to_server_chunk'] = "2560"; }
@@ -775,6 +779,20 @@ $section->addInput(new Form_Checkbox(
 	'Suricata will track asynchronous one-sided streams. Default is Not Checked.',
 	$pconfig['enable_async_sessions'] == 'on' ? true:false,
 	'on'
+));
+$section->addInput(new Form_Checkbox(
+	'stream_bypass',
+	'Bypass Packets',
+	'Suricata will bypass packets when stream reassembly depth (configured below) is reached. Default is Not Checked.',
+	$pconfig['stream_bypass'] == 'yes' ? true:false,
+	'yes'
+));
+$section->addInput(new Form_Checkbox(
+	'stream_drop_invalid',
+	'Drop Invalid Packets',
+	'When using Inline mode, Suricata will drop packets that are invalid with regards to streaming engine. Default is Not Checked.',
+	$pconfig['stream_drop_invalid'] == 'yes' ? true:false,
+	'yes'
 ));
 $section->addInput(new Form_Input(
 	'reassembly_memcap',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -620,6 +620,8 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$natent['max_synack_queued'] = '5';
 			$natent['enable_midstream_sessions'] = 'off';
 			$natent['enable_async_sessions'] = 'off';
+			$natent['stream_bypass'] = "no";
+			$natent['stream_drop_invalid'] = "no";
 			$natent['delayed_detect'] = 'off';
 			$natent['intf_promisc_mode'] = 'on';
 			$natent['intf_snaplen'] = '1518';

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist.php
@@ -145,7 +145,7 @@ display_top_tabs($tab_array, true);
 					<tr>
 						<th>&nbsp;</th>
 						<th>List Name</th>
-						<th>Assigned Alias</th>
+						<th>Assigned</th>
 						<th>Description</th>
 						<th>Actions</th>
 					</tr>
@@ -159,14 +159,9 @@ display_top_tabs($tab_array, true);
 					<td>
 						<?=htmlspecialchars($list['name'])?>
 					</td>
-					<?php if (!empty($list['address'])) : ?>
-					<td title="<?=filter_expand_alias($list['address'])?>">
-						<?=gettext($list['address'])?>
-					</td>
-					<?php else : ?>
 					<td>
+						<?php suricata_is_passlist_used($list['name']) ? print(gettext("Yes")) : print(gettext("No"));?>
 					</td>
-					<?php endif; ?>
 					<td>
 						<?=htmlspecialchars($list['descr'])?>
 					</td>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
@@ -26,15 +26,16 @@
 require_once("guiconfig.inc");
 require_once("/usr/local/pkg/suricata/suricata.inc");
 
-if ($_POST['cancel']) {
-	header("Location: /suricata/suricata_passlist.php");
-	exit;
-}
+$pconfig = array();
+
+// Arbitrary limit for IP or Alias entries per Pass List.
+$max_addresses = 1000;
 
 if (!is_array($config['installedpackages']['suricata']['passlist']))
 	$config['installedpackages']['suricata']['passlist'] = array();
 if (!is_array($config['installedpackages']['suricata']['passlist']['item']))
 	$config['installedpackages']['suricata']['passlist']['item'] = array();
+
 $a_passlist = &$config['installedpackages']['suricata']['passlist']['item'];
 
 if (isset($_POST['id']) && is_numericint($_POST['id']))
@@ -50,46 +51,28 @@ if (is_null($id)) {
 
 if (isset($id) && isset($a_passlist[$id])) {
 	/* Retrieve saved settings */
-	$pconfig['name'] = $a_passlist[$id]['name'];
-	$pconfig['uuid'] = $a_passlist[$id]['uuid'];
-	$pconfig['address'] = $a_passlist[$id]['address'];
-	$pconfig['descr'] = html_entity_decode($a_passlist[$id]['descr']);
-	$pconfig['localnets'] = $a_passlist[$id]['localnets'];
-	$pconfig['wanips'] = $a_passlist[$id]['wanips'];
-	$pconfig['wangateips'] = $a_passlist[$id]['wangateips'];
-	$pconfig['wandnsips'] = $a_passlist[$id]['wandnsips'];
-	$pconfig['vips'] = $a_passlist[$id]['vips'];
-	$pconfig['vpnips'] = $a_passlist[$id]['vpnips'];
+	$pconfig = $a_passlist[$id];
 }
 
-if (isset($id) && !isset($a_passlist[$id])) {
-	/* This is a new list, so set sensible defaults */
-	$pconfig['localnets'] = 'yes';
-	$pconfig['wanips'] = 'yes';
-	$pconfig['wangateips'] = 'yes';
-	$pconfig['wandnsips'] = 'yes';
-	$pconfig['vips'] = 'yes';
-	$pconfig['vpnips'] = 'yes';
+// Set defaults for any non-initialized values
+if (!isset($pconfig['localnets'])) {
+	$pconfig['localnets'] = "yes";
 }
-
-// Check for returned "selected alias" if action is import
-if ($_GET['act'] == "import") {
-
-	// Retrieve previously typed values we passed to SELECT ALIAS page
-	$pconfig['name'] = htmlspecialchars($_GET['name']);
-	$pconfig['uuid'] = htmlspecialchars($_GET['uuid']);
-	$pconfig['address'] = htmlspecialchars($_GET['address']);
-	$pconfig['descr'] = htmlspecialchars($_GET['descr']);
-	$pconfig['localnets'] = htmlspecialchars($_GET['localnets'])? 'yes' : 'no';
-	$pconfig['wanips'] = htmlspecialchars($_GET['wanips'])? 'yes' : 'no';
-	$pconfig['wangateips'] = htmlspecialchars($_GET['wangateips'])? 'yes' : 'no';
-	$pconfig['wandnsips'] = htmlspecialchars($_GET['wandnsips'])? 'yes' : 'no';
-	$pconfig['vips'] = htmlspecialchars($_GET['vips'])? 'yes' : 'no';
-	$pconfig['vpnips'] = htmlspecialchars($_GET['vpnips'])? 'yes' : 'no';
-
-	// Now retrieve the "selected alias" returned from SELECT ALIAS page
-	if ($_GET['varname'] == "address" && isset($_GET['varvalue']))
-		$pconfig[$_GET['varname']] = htmlspecialchars($_GET['varvalue']);
+if (!isset($pconfig['wangateips'])) {
+	$pconfig['wangateips'] = "yes";
+}
+if (!isset($pconfig['wandnsips'])) {
+	$pconfig['wandnsips'] = "yes";
+}
+if (!isset($pconfig['vips'])) {
+	$pconfig['vips'] = "yes";
+}
+if (!isset($pconfig['vpnips'])) {
+	$pconfig['vpnips'] = "yes";
+}
+if (!is_array($pconfig['address'])) {
+	$pconfig['address'] = array();
+	$pconfig['address']['item'] = array();
 }
 
 /* If no entry for this passlist, then create a UUID and treat it like a new list */
@@ -102,87 +85,91 @@ if (!isset($a_passlist[$id]['uuid']) && empty($pconfig['uuid'])) {
 	}
 }
 elseif (!empty($pconfig['uuid'])) {
-	$passlist_uuid = $pconfig['uuid'];
+	$passlist_uuid = $pconfig['uuid'];	
 }
 else
 	$passlist_uuid = $a_passlist[$id]['uuid'];
 
-/* returns true if $name is a valid name for a pass list file name or ip */
-function is_validpasslistname($name) {
-	if (!is_string($name))
-		return false;
-
-	if (!preg_match("/[^a-zA-Z0-9\_\.\/]/", $name))
-		return true;
-
-	return false;
-}
-
 if ($_POST['save']) {
 	unset($input_errors);
-	$pconfig = $_POST;
+	$pconfig = array();
+	$p_list = array();
 
 	/* input validation */
 	$reqdfields = explode(" ", "name");
 	$reqdfieldsn = explode(",", "Name");
 
-	$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-	if ($pf_version < 2.1)
-		$input_errors = eval('do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors); return $input_errors;');
-	else
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if(strtolower($_POST['name']) == "defaultpasslist")
-		$input_errors[] = gettext("Pass List file names may not be named defaultpasslist.");
-
-	if (is_validpasslistname($_POST['name']) == false)
-		$input_errors[] = gettext("Pass List file name may only consist of the characters \"a-z, A-Z, 0-9 and _\". Note: No Spaces or dashes. Press Cancel to reset.");
+		$input_errors[] = gettext("Pass List file names may not be named 'defaultpasslist' as that is a reserved name.");
 
 	/* check for name conflicts */
-	foreach ($a_passlist as $p_list) {
-		if (isset($id) && ($a_passlist[$id]) && ($a_passlist[$id] === $p_list))
+	foreach ($a_passlist as $k) {
+		if (isset($id) && isset($a_passlist[$id]) && ($a_passlist[$id] === $k))
 			continue;
 
-		if ($p_list['name'] == $_POST['name']) {
-			$input_errors[] = gettext("A Pass List file name with this name already exists.");
+		if ($k['name'] == $_POST['name']) {
+			$input_errors[] = gettext("A Pass List with this name already exists.");
 			break;
 		}
 	}
 
-	if ($_POST['address']) {
-		if (!is_alias($_POST['address']))
-			$input_errors[] = gettext("A valid alias must be provided");
-		if (is_alias($_POST['address']) && trim(filter_expand_alias($_POST['address'])) == "")
-			$input_errors[] = gettext("FQDN aliases are not supported in Suricata.");
+	// Iterate and validate the returned $_POST['address'] values (these will be "addressX" where "X" is a number from 0 - 999).
+	$addrs = array();
+	for ($x = 0; $x < ($max_addresses - 1); $x++) {
+		if ($_POST["address{$x}"] <> "") {
+
+			// Verify the entry is a valid IP address, subnet or alias name
+			if (is_ipaddroralias($_POST["address{$x}"]) || is_subnet($_POST["address{$x}"])) {
+				$addrs[] = $_POST["address{$x}"];
+				if (is_alias($_POST["address{$x}"])) {
+					if (alias_get_type($_POST["address{$x}"]) != "host" && alias_get_type($_POST["address{$x}"]) != "network") {
+						$input_errors[] = gettext("Custom Address entry '" . $_POST["address{$x}"] . "' is not a Host or Network Alias!");
+					}
+				}
+			} else {
+				$input_errors[] = gettext("Custom Address entry '" . $_POST["address{$x}"] . "' is not a valid IP address, IP subnet or Alias name!");
+				$addrs[] = $_POST["address{$x}"];
+			}
+		}
 	}
+
 	if (!$input_errors) {
-		$p_list = array();
+
 		/* post user input */
 		$p_list['name'] = $_POST['name'];
 		$p_list['uuid'] = $passlist_uuid;
 		$p_list['localnets'] = $_POST['localnets']? 'yes' : 'no';
-		$p_list['wanips'] = $_POST['wanips']? 'yes' : 'no';
 		$p_list['wangateips'] = $_POST['wangateips']? 'yes' : 'no';
 		$p_list['wandnsips'] = $_POST['wandnsips']? 'yes' : 'no';
 		$p_list['vips'] = $_POST['vips']? 'yes' : 'no';
 		$p_list['vpnips'] = $_POST['vpnips']? 'yes' : 'no';
+		$p_list['address']['item'] = $addrs;
+		$p_list['descr'] = $_POST['descr'];
 
-		$p_list['address'] = $_POST['address'];
-		$p_list['descr']  =  str_replace("\r\n", "\n", $_POST['descr']);
-		$p_list['detail'] = $final_address_details;
-
-		if (isset($id) && $a_passlist[$id])
+		if (isset($id) && isset($a_passlist[$id])) {
 			$a_passlist[$id] = $p_list;
-		else
+		} else {
 			$a_passlist[] = $p_list;
+		}
+
+		$pconfig = $p_list;
 
 		write_config("Suricata pkg: modified PASS LIST {$p_list['name']}.");
 
-		/* create pass list and homenet file, then sync files */
+		/* create pass list file, then sync file with configured partners */
 		sync_suricata_package_config();
-
-		header("Location: /suricata/suricata_passlist.php");
-		exit;
+	} else {
+		$pconfig['name'] = $_POST['name'];
+		$pconfig['uuid'] = $passlist_uuid;
+		$pconfig['localnets'] = $_POST['localnets']? 'yes' : 'no';
+		$pconfig['wangateips'] = $_POST['wangateips']? 'yes' : 'no';
+		$pconfig['wandnsips'] = $_POST['wandnsips']? 'yes' : 'no';
+		$pconfig['vips'] = $_POST['vips']? 'yes' : 'no';
+		$pconfig['vpnips'] = $_POST['vpnips']? 'yes' : 'no';
+		$pconfig['descr']  =  mb_convert_encoding($_POST['descr'],"HTML-ENTITIES","auto");
+		$pconfig['address']['item'] = $addrs;
 	}
 }
 
@@ -211,7 +198,25 @@ $tab_array[] = array(gettext("Sync"), false, "/pkg_edit.php?xml=suricata/suricat
 $tab_array[] = array(gettext("IP Lists"), false, "/suricata/suricata_ip_list_mgmt.php");
 display_top_tabs($tab_array, true);
 
-$form = new Form(FALSE);
+$pattern_str = array(	'network' => '[a-zA-Z0-9_:.-]+(/[0-9]+)?( [a-zA-Z0-9_:.-]+(/[0-9]+)?)*',	// Alias Name, Host Name, IP Address, FQDN, Network or IP Address Range
+			'host'	  => '[\pL0-9_:.-]+(/[0-9]+)?( [a-zA-Z0-9_:.-]+(/[0-9]+)?)*'		// Alias Name, Host Name, IP Address, FQDN
+);
+$help = gettext("Enter as many IP addresses or alias names as desired. Enter ONLY an IP address, IP subnet or alias name! Do NOT enter a FQDN (fully qualified domain name) directly! " . 
+		"To use a FQDN, first create the necessary firewall alias, and then provide the alias name here. FQDN aliases are periodically re-resolved and updated by the firewall. " . 
+		"You can also provide an IP subnet with a proper netmask of the form network/mask such as 1.2.3.0/24.");
+
+$form = new Form();
+
+// Include the Pass List ID in a hidden form field with any $_POST
+if (isset($id)) {
+	$form->addGlobal(new Form_Input(
+		'id',
+		'id',
+		'hidden',
+		$id
+	));
+}
+
 $section = new Form_Section('General Information');
 $section->addInput(new Form_Input(
 	'name',
@@ -231,131 +236,146 @@ $section = new Form_Section('Auto-Generated IP Addresses');
 $section->addInput(new Form_Checkbox(
 	'localnets',
 	'Local Networks',
-	'Add firewall Locally-Attached Networks to the list (excluding WAN).  Default is checked (but see warning below).',
+	'Add firewall Locally-Attached Networks to the list (excluding WAN). Default is Checked.',
 	$pconfig['localnets'] == 'yes' ? true:false,
 	'yes'
-))->setHelp('If creating a custom HOME_NET list, then this box should usually be checked.');
-$section->addInput(new Form_Checkbox(
-	'wanips',
-	'WAN IP',
-	'Add WAN interface IP to the list.  Default is checked).',
-	$pconfig['wanips'] == 'yes' ? true:false,
-	'yes'
-))->setHelp('If creating a custom HOME_NET list and using NAT, then this box should usually be checked.');
+));
 $section->addInput(new Form_Checkbox(
 	'wangateips',
 	'WAN Gateways',
-	'Add WAN Gateways to the list.  Default is checked.',
+	'Add WAN Gateways to the list. Default is Checked.',
 	$pconfig['wangateips'] == 'yes' ? true:false,
 	'yes'
 ));
 $section->addInput(new Form_Checkbox(
 	'wandnsips',
 	'WAN DNS Servers',
-	'Add WAN DNS servers to the list.  Default is checked.',
+	'Add WAN DNS servers to the list. Default is Checked.',
 	$pconfig['wandnsips'] == 'yes' ? true:false,
 	'yes'
 ));
 $section->addInput(new Form_Checkbox(
 	'vips',
 	'Virtual IP Addresses',
-	'Add Virtual IP Addresses to the list.  Default is checked.',
+	'Add Virtual IP Addresses to the list. Default is Checked.',
 	$pconfig['vips'] == 'yes' ? true:false,
 	'yes'
 ));
 $section->addInput(new Form_Checkbox(
 	'vpnips',
 	'VPN Addresses',
-	'Add VPN Addresses to the list.  Default is checked.',
+	'Add VPN Addresses to the list. Default is Checked.',
 	$pconfig['vpnips'] == 'yes' ? true:false,
 	'yes'
-))->setHelp('If creating a custom HOME_NET list, then this box should usually be checked.');
-$form->add($section);
-
-$section = new Form_Section('Custom IP Address from Configured Alias');
-$group = new Form_Group('Assigned Alias');
-$group->add(new Form_Input(
-	'address',
-	'Assigned Alias',
-	'text',
-	$pconfig['address']
-))->setHelp('Enter the name of an existing Alias in order to further customize IP addresses included on this Pass List.')->setAttribute('title', trim(filter_expand_alias($pconfig['address'])));
-$group->add(new Form_Button(
-	'btnSelectAlias',
-	'Aliases',
-	'javascript:selectAlias();',
-	'fa-search-plus'
-))->removeClass('btn-default')->addClass('btn-sm btn-success')->setAttribute('title', gettext('View and select from available aliases'));
-$section->add($group);
-$form->add($section);
-
-$section = new Form_Section('');
-$btnsave = new Form_Button(
-	'save',
-	'Save',
-	null,
-	'fa-save'
-);
-$btncancel = new Form_Button(
-	'cancel',
-	'Cancel'
-);
-$btnsave->addClass('btn-primary')->addClass('btn-default');
-$btncancel->removeClass('btn-primary')->addClass('btn-default')->addClass('btn-warning');
-
-$section->addInput(new Form_StaticText(
-	null,
-	$btnsave . $btncancel
 ));
 $form->add($section);
 
-// Include the Pass List ID in a hidden form field with any $_POST
-if (isset($id)) {
-	$form->addGlobal(new Form_Input(
-		'id',
-		'id',
-		'hidden',
-		$id
+$section = new Form_Section('Custom IP Addresses and Configured Firewall Aliases');
+
+// Make somewhere to park the help text, and give it a class so we can update it later if desired
+$section->addInput(new Form_StaticText(
+	'Hint',
+	'<span class="helptext">' . $help . '</span>'
+));
+
+// Iterate any defined IPs or Aliases defined for this list, otherwise
+// create a single empty initial empty row.
+if (count($pconfig['address']['item']) > 0) {
+	$counter = 0;
+	while ($counter < count($pconfig['address']['item'])) {
+		$group = new Form_Group('IP or Alias');
+		$group->addClass('repeatable');
+
+		$group->add(new Form_IpAddress(
+			'address' . $counter,
+			'Address',
+			$pconfig['address']['item'][$counter],
+			'ALIASV4V6'
+		));
+
+		$group->add(new Form_Button(
+			'deleterow' . $counter,
+			'Delete',
+			null,
+			'fa-trash'
+		))->addClass('btn-warning btn-sm nowarn')->setAttribute('title', "Delete this entry from list");
+
+		$section->add($group);
+		$counter++;
+	}
+} else {
+	$group = new Form_Group('IP or Alias');
+	$group->addClass('repeatable');
+
+	$group->add(new Form_IpAddress(
+		'address0',
+		'Address',
+		'',
+		'ALIASV4V6'
 	));
+
+	$group->add(new Form_Button(
+		'deleterow0',
+		'Delete',
+		null,
+		'fa-trash'
+	))->addClass('btn-warning btn-sm nowarn')->setAttribute('title', "Delete this entry from list");
+
+	$section->add($group);
 }
+$form->add($section);
+
+$form->addGlobal(new Form_Button(
+	'addrow',
+	'Add IP',
+	null,
+	'fa-plus'
+))->addClass('btn-success addbtn')->setAttribute('title', "Add new IP address, subnet or alias name row");
 
 print($form);
 ?>
 
 <script type="text/javascript">
 //<![CDATA[
-
-function selectAlias() {
-
-	var loc;
-	var fields = [ "name", "descr", "localnets", "wanips", "wangateips", "wandnsips", "vips", "vpnips", "address" ];
-
-	// Scrape current form field values and add to
-	// the select alias URL as a query string.
-	var loc = '/suricata/suricata_select_alias.php?id=<?=$id;?>&act=import&type=host|network';
-	loc = loc + '&varname=address&multi_ip=yes';
-	loc = loc + '&returl=<?=urlencode($_SERVER['PHP_SELF']);?>';
-	loc = loc + '&uuid=<?=$passlist_uuid;?>';
-
-	// Iterate over just the specific form fields we want to pass to
-	// the select alias URL.
-	fields.forEach(function(entry) {
-		var tmp = $('#' + entry).serialize();
-		if (tmp.length > 0)
-			loc = loc + '&' + tmp;
-	});
-	
-	window.parent.location = loc; 
-}
+// ---------- Autocomplete --------------------------------------------------------------------
+var addressarray = <?= json_encode(get_alias_list(array("host", "network"))) ?>;
 
 events.push(function() {
 
-	// ---------- Autocomplete --------------------------------------------------------------------
+	// Hide and disable all rows >= that specified
+	function hideRowsAfter(row, hide) {
+		var idx = 0;
 
-	var addressarray = <?= json_encode(get_alias_list(array("host", "network", "openvpn"))) ?>;
+		$('.repeatable').each(function(el) {
+			if (idx >= row) {
+				hideRow(idx, hide);
+			}
 
-	$('#address').autocomplete({
-		source: addressarray
+			idx++;
+		});
+	}
+
+	function hideRow(row, hide) {
+		if (hide) {
+			$('#deleterow' + row).parent('div').parent().addClass('hidden');
+		} else {
+			$('#deleterow' + row).parent('div').parent().removeClass('hidden');
+		}
+
+		// We need to disable the elements so they are not submitted in the POST
+		$('#address' + row).prop("disabled", hide);
+		$('#deleterow' + row).prop("disabled", hide);
+	}
+
+	checkLastRow();
+
+	// Autocomplete
+	$('[id^=address]').each(function() {
+		if (this.id.substring(0, 8) != "address_") {
+			$(this).autocomplete({
+				source: addressarray
+			});
+		}
 	});
 });
 //]]>


### PR DESCRIPTION
**pfSense-pkg-suricata-6.0.3_4**
This update to the Suricata GUI package adds support for entering multiple host and network aliases (including FQDN aliases) to a Pass List. This mimics the same feature added to the Snort GUI package back in February of 2021.

**New Features:**
1. Added the ability to specify multiple IP addresses, network subnets, or host and network aliases (including fully-qualified-domain-name aliases) to a Pass List.

**Bug Fixes:**
None