### PR TITLE
Suricata instance reload on suppress list change fix. Issue #12506

### DIFF
--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -546,7 +546,7 @@ if (($_POST['mode'] == 'addsuppress_srcip' || $_POST['mode'] == 'addsuppress_dst
 				$suppress = "suppress gen_id {$_POST['gen_id']}, sig_id {$_POST['sidid']}\n";
 			else
 				$suppress = "#{$_POST['descr']}\nsuppress gen_id {$_POST['gen_id']}, sig_id {$_POST['sidid']}\n";
-			$success = gettext("An entry for 'suppress gen_id {$_POST['gen_id']}, sig_id {$_POST['sidid']}' has been added to the Suppress List.");
+			$success = gettext("An entry for 'suppress gen_id {$_POST['gen_id']}, sig_id {$_POST['sidid']}' has been added to the Suppress List.  Suricata is 'live-reloading' the new rules list.  Please wait at least 15 secs for the process to complete before toggling additional rule actions.");
 			break;
 		case "by_src":
 		case "by_dst":
@@ -556,7 +556,7 @@ if (($_POST['mode'] == 'addsuppress_srcip' || $_POST['mode'] == 'addsuppress_dst
 					$suppress = "suppress gen_id {$_POST['gen_id']}, sig_id {$_POST['sidid']}, track {$method}, ip {$_POST['ip']}\n";
 				else
 					$suppress = "#{$_POST['descr']}\nsuppress gen_id {$_POST['gen_id']}, sig_id {$_POST['sidid']}, track {$method}, ip {$_POST['ip']}\n";
-				$success = gettext("An entry for 'suppress gen_id {$_POST['gen_id']}, sig_id {$_POST['sidid']}, track {$method}, ip {$_POST['ip']}' has been added to the Suppress List.");
+				$success = gettext("An entry for 'suppress gen_id {$_POST['gen_id']}, sig_id {$_POST['sidid']}, track {$method}, ip {$_POST['ip']}' has been added to the Suppress List.  Suricata is 'live-reloading' the new rules list.  Please wait at least 15 secs for the process to complete before toggling additional rule actions.");
 			}
 			else {
 				header("Location: /suricata/suricata_alerts.php");
@@ -571,6 +571,12 @@ if (($_POST['mode'] == 'addsuppress_srcip' || $_POST['mode'] == 'addsuppress_dst
 	/* Add the new entry to the Suppress List and signal Suricata to reload config */
 	if (suricata_add_supplist_entry($suppress)) {
 		suricata_reload_config($a_instance[$instanceid]);
+		foreach ($a_instance as $insid => $insconf) {
+			if (($insid != $instanceid) &&
+			    ($a_instance[$instanceid]['suppresslistname'] == $insconf['suppresslistname'])) {
+				suricata_reload_config($a_instance[$insid]);
+			}
+		}
 		$savemsg = $success;
 
 		// Sync to configured CARP slaves if any are enabled

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_filecheck.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_filecheck.php
@@ -122,6 +122,11 @@ if ($savemsg) {
 					<td><a target="_blank" href="https://opentip.kaspersky.com/<?=$file_hash;?>/">
 						<?=gettext("Kaspersky Threat Intelligence Portal");?></a></td>
 				</tr>
+				<tr>
+					<td><i class="fa fa-globe pull-right"></i></td>	
+					<td><a target="_blank" href="https://beta.virusbay.io/sample/browse?q=<?=$file_hash;?>">
+						<?=gettext("VirusBay");?></a></td>
+				</tr>
 			</tbody>
 		</table>
 	</div>


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/12506
- [X] Ready for review

1) Reload all instances that use the same suppression list
2) Add "Please wait at least 15 secs for the process to complete before toggling additional rule actions." to suppress list change save messages
3) Add VirusBay link to `suricata_filecheck.php`


Can be merged with https://github.com/pfsense/FreeBSD-ports/pull/1122

