### PR TITLE
pfSense-pkg-snort-4.1.5 -- update the Snort GUI package to support the 2.9.19 binary

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -1,8 +1,8 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-snort
-PORTVERSION=	4.1.4
-PORTREVISION=	3
+PORTVERSION=	4.1.5
+PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package snort
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	snort>=2.9.18_1:security/snort
+RUN_DEPENDS=	snort>=2.9.19:security/snort
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -301,13 +301,13 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
 		if (is_array($list['address']['item']) && count($list['address']['item']) > 0) {
 			foreach ($list['address']['item'] as $addr) {
 				if (!$whitelist) {
-					if (is_alias($addr)) {
+					if (is_alias($addr) && (alias_get_type($addr) == "host" || alias_get_type($addr) == "network")) {
 						$home_net = array_merge($home_net, explode(" ", trim(filter_expand_alias($addr))));
 					} elseif (is_ipaddr($addr) || is_subnet($addr)) {
 						$home_net[] = $addr;
 					}
 				} elseif ($whitelist) {
-					if (is_alias($addr)) {
+					if (is_alias($addr) && (alias_get_type($addr) == "host" || alias_get_type($addr) == "network")) {
 						$tmp = trim(filter_expand_alias($addr));
 						if ($tmp <> "") {
 							$home_net = array_merge($home_net, explode(" ", $tmp));
@@ -513,13 +513,16 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
 		}
 	}
 
+	// Validate the HOME_NET entries
 	$valresult = array();
 	foreach ($home_net as $vald) { 
-		if (empty($vald))
+		if (empty($vald) || (!is_subnet($vald) && !is_ipaddr($vald) && !is_alias($vald))) {
 			continue;
+		}
 		$vald = trim($vald);
-		if (empty($valresult[$vald]))
+		if (empty($valresult[$vald])) {
 			$valresult[$vald] = $vald;
+		}
 	}
 
 	/* Release memory no longer required */

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -582,10 +582,17 @@ function snort_start($snortcfg, $if_real, $background=FALSE) {
 
 		// Adjust the interface specification and DAQ type according to operating mode
 		if ($snortcfg['ips_mode'] == "ips_mode_inline" && $snortcfg['blockoffenders7'] == "on") {
-			$iface = $if_real . "^:" . $if_real;
-			$daq_type = "-Q --daq netmap";
-		}
-		else {
+			// For VLAN interfaces, need to actually run Snort
+			// on the parent interface, so override interface name.
+			if (interface_is_vlan($if_real)) {
+				$intf_list = get_parent_interface($if_real);
+				$iface = $intf_list[0] . "^:" . $intf_list[0];
+				syslog(LOG_WARNING, "[Snort] WARNING: interface '{$if_real}' is a VLAN, so configuring Snort to run on the parent interface, '{$intf_list[0]}', instead.");
+			} else {
+				$iface = $if_real . "^:" . $if_real;
+				$daq_type = "-Q --daq netmap";
+			}
+		} else {
 			$iface = $if_real;
 			$daq_type = "--daq pcap --daq-mode passive --treat-drop-as-alert";
 		}
@@ -3271,10 +3278,16 @@ function snort_create_rc() {
 
 		// Adjust the interface specification and DAQ type according to operating mode
 		if ($value['ips_mode'] == "ips_mode_inline" && $value['blockoffenders7'] == "on") {
-			$iface = $if_real . "^:" . $if_real;
-			$daq_type = "-Q --daq netmap";
-		}
-		else {
+			// For VLAN interfaces, need to actually run Snort
+			// on the parent interface, so override interface name.
+			if (interface_is_vlan($if_real)) {
+				$intf_list = get_parent_interface($if_real);
+				$iface = $intf_list[0] . "^:" . $intf_list[0];
+			} else {
+				$iface = $if_real . "^:" . $if_real;
+				$daq_type = "-Q --daq netmap";
+			}
+		} else {
 			$iface = $if_real;
 			$daq_type = "--daq pcap --daq-mode passive --treat-drop-as-alert";
 		}

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -582,17 +582,10 @@ function snort_start($snortcfg, $if_real, $background=FALSE) {
 
 		// Adjust the interface specification and DAQ type according to operating mode
 		if ($snortcfg['ips_mode'] == "ips_mode_inline" && $snortcfg['blockoffenders7'] == "on") {
-			// For VLAN interfaces, need to actually run Snort
-			// on the parent interface, so override interface name.
-			if (interface_is_vlan($if_real)) {
-				$intf_list = get_parent_interface($if_real);
-				$iface = $intf_list[0] . "^:" . $intf_list[0];
-				syslog(LOG_WARNING, "[Snort] WARNING: interface '{$if_real}' is a VLAN, so configuring Snort to run on the parent interface, '{$intf_list[0]}', instead.");
-			} else {
-				$iface = $if_real . "^:" . $if_real;
-				$daq_type = "-Q --daq netmap";
-			}
-		} else {
+			$iface = $if_real . "^:" . $if_real;
+			$daq_type = "-Q --daq netmap";
+		}
+		else {
 			$iface = $if_real;
 			$daq_type = "--daq pcap --daq-mode passive --treat-drop-as-alert";
 		}
@@ -3278,16 +3271,10 @@ function snort_create_rc() {
 
 		// Adjust the interface specification and DAQ type according to operating mode
 		if ($value['ips_mode'] == "ips_mode_inline" && $value['blockoffenders7'] == "on") {
-			// For VLAN interfaces, need to actually run Snort
-			// on the parent interface, so override interface name.
-			if (interface_is_vlan($if_real)) {
-				$intf_list = get_parent_interface($if_real);
-				$iface = $intf_list[0] . "^:" . $intf_list[0];
-			} else {
-				$iface = $if_real . "^:" . $if_real;
-				$daq_type = "-Q --daq netmap";
-			}
-		} else {
+			$iface = $if_real . "^:" . $if_real;
+			$daq_type = "-Q --daq netmap";
+		}
+		else {
 			$iface = $if_real;
 			$daq_type = "--daq pcap --daq-mode passive --treat-drop-as-alert";
 		}

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_defs.inc
@@ -47,7 +47,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 		define("SNORT_BIN_VERSION", $matches[0]);
 	}
 	else {
-		define("SNORT_BIN_VERSION", "2.9.18");
+		define("SNORT_BIN_VERSION", "2.9.19");
 	}
 }
 

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rulesets.php
@@ -635,7 +635,7 @@ if ($snortdownload == "on") {
 					<?php endif; ?>
 					<?php if ($openappid_rulesdownload == 'on' && !$no_openappid_files): ?>
 						<th><?=gettext("Enable"); ?></th>
-						<th><?=gettext('Ruleset: Snort OPENAPPI Rules');?></th>
+						<th><?=gettext('Ruleset: Snort OPENAPPID Rules');?></th>
 						<?php else: ?>
 						<th colspan="4"><?=gettext("Snort OPENAPPID rules {$msg_snort}"); ?></th>
 					<?php endif; ?>


### PR DESCRIPTION
### pfSense-pkg-snort-4.1.5
This updates the Snort GUI package to provide support for the latest upstream release of Snort version 2.9.19. Two bug fixes are also included in this update.

**New Features:**
none

**Bug Fixes:**
1. Correct typo in name of OpenAppID ruleset name on the CATEGORIES tab.
2. Incorporate the fix for [Redmine Issue #12476](https://redmine.pfsense.org/issues/12476) from Suricata into Snort as the Snort GUI had the same code bug.