### PR TITLE
pfSense-pkg-suricata-6.0.4 - Update for 6.0.4 Suricata binary and add new http2 and mqtt built-in rules.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,8 +1,8 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	6.0.3
-PORTREVISION=	4
+PORTVERSION=	6.0.4
+PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=6.0.3:security/suricata
+RUN_DEPENDS=	suricata>=6.0.4:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -302,6 +302,30 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 	}
 
 	/***********************************************************/
+	/* Add the new 'dhcp-events.rules' file to the rulesets.    */
+	/***********************************************************/
+	if (strpos($pconfig['rulesets'], "dhcp-events.rules") === FALSE) {
+		$pconfig['rulesets'] = rtrim($pconfig['rulesets'], "||") . "||dhcp-events.rules";	
+		$updated_cfg = true;
+	}
+
+	/***********************************************************/
+	/* Add the new 'http2-events.rules' file to the rulesets.    */
+	/***********************************************************/
+	if (strpos($pconfig['rulesets'], "http2-events.rules") === FALSE) {
+		$pconfig['rulesets'] = rtrim($pconfig['rulesets'], "||") . "||http2-events.rules";	
+		$updated_cfg = true;
+	}
+
+	/***********************************************************/
+	/* Add the new 'mqtt-events.rules' file to the rulesets.    */
+	/***********************************************************/
+	if (strpos($pconfig['rulesets'], "mqtt-events.rules") === FALSE) {
+		$pconfig['rulesets'] = rtrim($pconfig['rulesets'], "||") . "||mqtt-events.rules";	
+		$updated_cfg = true;
+	}
+
+	/***********************************************************/
 	/* Add new run mode value and default it to 'autofp'.      */
 	/***********************************************************/
 	if (empty($pconfig['runmode'])) {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1180,7 +1180,7 @@ $group->add(new Form_Checkbox(
 	'eve_log_http2',
 	'HTTP2',
 	'HTTP2',
-	$pconfig['eve_log_sip'] == 'on' ? true:false,
+	$pconfig['eve_log_http2'] == 'on' ? true:false,
 	'on'
 ));
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -33,8 +33,8 @@ $suricata_rules_dir = SURICATA_RULES_DIR;
 $flowbit_rules_file = FLOWBITS_FILENAME;
 
 // Array of default events rules for Suricata
-$default_rules = array( "app-layer-events.rules", "decoder-events.rules", "dnp3-events.rules", "dns-events.rules", "files.rules", "http-events.rules", "ipsec-events.rules", "kerberos-events.rules", 
-			"modbus-events.rules", "nfs-events.rules", "ntp-events.rules", "smb-events.rules", "smtp-events.rules", "stream-events.rules", "tls-events.rules" );
+$default_rules = array( "app-layer-events.rules", "decoder-events.rules", "dhcp-events.rules", "dnp3-events.rules", "dns-events.rules", "files.rules", "http-events.rules", "http2-events.rules", "ipsec-events.rules",
+						"kerberos-events.rules", "modbus-events.rules", "mqtt-events.rules", "nfs-events.rules", "ntp-events.rules", "smb-events.rules", "smtp-events.rules", "stream-events.rules", "tls-events.rules" );
 
 if (!is_array($config['installedpackages']['suricata']['rule'])) {
 	$config['installedpackages']['suricata']['rule'] = array();


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.4
This updates the Suricata GUI package to support the latest 6.0.4 binary from upstream.

**New Features:**
1. DHCP, HTTP2, and MQTT default rules are added to the built-in rules package.

**Bug Fixes:**
1. Correct typo in checkbox variable name for HTTP2 EVE logging parameter.