### PR TITLE
pfBlockerNG: kill unbound process after 30s timeout. Issue #11398

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2753,6 +2753,13 @@ function pfb_stop_start_unbound($type) {
 			break;
 		}
 	}
+	// if it still hasn't responded to the TERM, KILL it
+	if (is_process_running('unbound')) {
+		pfb_logger("\nUnbound does not respond to the TERM signal, killing..", 1);
+		sigkillbypid("{$g['varrun_path']}/unbound.pid", 'KILL');
+		sleep(1);
+		pfb_logger('.', 1);
+	}
 
 	// Add/Remove additional python mounts
 	if (file_exists('/var/unbound/pfb_unbound_include.inc')) {

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -416,7 +416,7 @@ if (file_exists('/var/db/pfblockerng/dnsbl_info') &&
 unlink_if_exists('/var/db/pfblockerng/dnsbl_info');
 
 // Move dnsbl_levent.sqlite -> /var/unbound folder
-$u_found = FALSE;
+$ufound = FALSE;
 if (file_exists('/var/db/pfblockerng/dnsbl_levent.sqlite') && !file_exists($pfb['dnsbl_resolver'])) {
 	$ufound = TRUE;
 	@copy('/var/db/pfblockerng/dnsbl_levent.sqlite', $pfb['dnsbl_resolver']);


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/11398
- [X] Ready for review

1) Kill unbound after 30s timeout
2) `pfblockerng_install.inc` typo fix