### PR TITLE
The NiX Spam feed has moved from www.dnsbl.manitu.net to www.nixspam.net

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.json
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.json
@@ -655,6 +655,9 @@
 					"feed":		"Nix Spam",
 					"website":	"https://www.heise.de/ix/NiX-Spam-DNSBL-and-blacklist-for-download-499637.html",
 					"url":		"https://www.nixspam.net/download/nixspam-ip.dump.gz",
+					"past_urls": [
+								"http://www.dnsbl.manitu.net/download/nixspam-ip.dump.gz"
+					],
 					"header":	"Nix_Spam"
 				},
 				{

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.json
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.json
@@ -654,7 +654,7 @@
 				{
 					"feed":		"Nix Spam",
 					"website":	"https://www.heise.de/ix/NiX-Spam-DNSBL-and-blacklist-for-download-499637.html",
-					"url":		"http://www.dnsbl.manitu.net/download/nixspam-ip.dump.gz",
+					"url":		"https://www.nixspam.net/download/nixspam-ip.dump.gz",
 					"header":	"Nix_Spam"
 				},
 				{


### PR DESCRIPTION
Attempts to access the feed file via the old URL return a 301 (Moved Permanently), however the redirect goes to the base of the new domain (HTML text) rather than to the feed file. The result is that the download succeeds, but the downloaded
file does not contain the list of IP addresses.