### PR TITLE
pfBlockerNG: Add the option to specify CURLOPT_INTERFACE for IPv4/IPv6 lists (Feature #12882)

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3308,7 +3308,7 @@ function find_reported_header($ip, $pfbfolder, $geoip=FALSE) {
 
 
 // Function to download feeds
-function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $logtype, $vtype='', $timeout=300, $type='', $username='', $password='') {
+function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $logtype, $vtype='', $timeout=300, $type='', $username='', $password='', $srcint=FALSE) {
 	global $pfb;
 	$http_status = '';
 	$elog = ">> {$pfb['log']} 2>&1";
@@ -3381,6 +3381,10 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				curl_setopt($ch, CURLOPT_FILE, $fhandle);	// Add $fhandle setting to cURL
 				curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);	// Set cURL download timeout
 				curl_setopt($ch, CURLOPT_ENCODING, 'gzip');	// Request 'gzip' encoding from server if available
+				if ($srcint) {
+					curl_setopt($ch, CURLOPT_INTERFACE, $srcint);	// Use a specific interface when downloading lists
+					pfb_logger("\nList: ${header} will be downloaded via interface: {$srcint}\n", 1);
+				}
 
 				if (!empty($username) && !empty($password)) {
 					curl_setopt($ch, CURLOPT_USERPWD, "{$username}:{$password}");
@@ -7401,7 +7405,7 @@ function sync_package_pfblockerng($cron='') {
 									} else {
 										// Download file
 										if (!pfb_download($row['url'], $file_dwn, $pflex, $header,
-											$row['format'], 1)) {
+											$row['format'], 1, '', '', '', '', '', $srcint)) {
 
 											// Determine reason for download failure
 											pfb_download_failure($alias, $header, $pfbfolder, $row['url']);
@@ -8416,6 +8420,9 @@ function sync_package_pfblockerng($cron='') {
 						if (isset($list['suppression_cidr'])) {
 							$pfbcidr = "{$list['suppression_cidr']}";
 						}
+						
+						// cURL Source Interface (sets CURLOPT_INTERFACE)
+						$srcint = $list['srcint'] ?: FALSE;
 
 						// Determine 'list' details (return array $pfbarr)
 						if (isset($list['dnsblip'])) {
@@ -8500,7 +8507,7 @@ function sync_package_pfblockerng($cron='') {
 								else {
 									// Download list
 									if (!pfb_download($row['url'], $file_dwn, $pflex, $header, $row['format'],
-										1, $list['vtype'])) {
+										1, $list['vtype'], '', '', '', '', $srcint)) {
 
 										// Determine reason for download failure
 										pfb_download_failure($alias, $header, $pfbfolder, $row['url']);

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -960,9 +960,7 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 			<br />Click here for more info -->
 			<div class=\"infoblock alert-info clearfix\">
 				Select the <strong>Action</strong> for Firewall Rules on lists you have selected.<br /><br />
-
 				<strong><u>'Disabled' Rules:</u></strong> Disables selection and does nothing to selected Alias.<br /><br />
-
 				<strong><u>'Deny' Rules:</u></strong><br />
 				'Deny' rules create high priority 'block' or 'reject' rules on the stated interfaces. They don't change the 'pass' rules on other
 				interfaces. Typical uses of 'Deny' rules are:<br />
@@ -979,7 +977,6 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 							sessions to be created in the other direction.
 						</li>
 					</ul>
-
 				<strong><u>'Permit' Rules:</u></strong><br />
 				'Permit' rules create high priority 'pass' rules on the stated interfaces. They are the opposite of Deny rules, and don't create
 				any 'blocking' effect anywhere. They have priority over all Deny rules. Typical uses of 'Permit' rules are:<br />
@@ -991,7 +988,6 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 							or pre-created blocklist blocks a few IPs that should be accessible.
 						</li>
 					</ul>
-
 				<strong><u>'Match' Rules:</u></strong><br />
 				'Match' or 'Log' only the traffic on the stated interfaces. This does not Block or Reject. It just Logs the traffic.
 				<ul>
@@ -1001,7 +997,6 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 					<li><strong>Match Inbound/Match Outbound</strong> - Matches all traffic in one direction only.
 					</li>
 				</ul>
-
 				<strong><u>'Alias' Rules:</u></strong><br />
 				<strong>'Alias'</strong> rules create an <a href=\"/firewall_aliases.php\">alias</a> for the list (and do nothing else).
 				This enables a pfBlockerNG list to be used by name, in any firewall rule or pfSense function, as desired.
@@ -1010,7 +1005,6 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 						<li>'Alias Deny' can use De-Duplication and Reputation Processes if configured.</li>
 						<li>'Alias Permit' and 'Alias Match' will be saved in the Same folder as the other Permit/Match Auto-Rules</li>
 						<li>'Alias Native' lists are kept in their Native format without any modifications.</li></ul>
-
 				<span class=\"text-danger\">Note: </span><ul>
 					When manually creating 'Alias' type firewall rules; Prefix the Firewall rule Description with <strong>pfb_</strong>
 					This will ensure that that Dashboard widget reports those statistics correctly. <strong>Do not</strong> 
@@ -1194,7 +1188,7 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 		$form->add($section);
 	}
 
-	if ($gtype == 'ipv4') {
+	if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 
 		// Print Advanced Tunables section
 		$section = new Form_Section('Advanced Tuneables', 'advancedtunable', COLLAPSIBLE|SEC_CLOSED);
@@ -1202,59 +1196,38 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 			NULL,
 			'These are \'Advanced\' settings and are typically best left at Default settings!')
 		);
-
-		$list = array('Disabled' => 'Disabled') + array_combine(range(1, 17, -1), range(1, 17, -1));
-
-		$section->addInput(new Form_Select(
-			'suppression_cidr',
-			'Suppression CIDR Limit',
-			$pconfig['suppression_cidr'],
-			$list
-		))->setHelp('When suppression is enabled, this option will limit the CIDR block for this entire IPv4 Alias'
-				. '(Excluding the Custom List IP addresses)<br />Default: <strong>Disabled</strong> (No CIDR limit)')
-		  ->setAttribute('style', 'width: auto');
-
+		
 		$interfaces_list = get_interface_list();
 		$src_interfaces = array('lo0' => 'Localhost');
-		foreach($interfaces_list as $key => $value) {
+		foreach ($interfaces_list as $key => $value) {
 			$src_interfaces = array_merge(array($key => strtoupper($interfaces_list[$key]['friendly'])), $src_interfaces);
 		}
-		$src_interfaces = array_merge(array('' => 'any'), $src_interfaces);
-		$section->addInput(new Form_Select(
-			'srcint',
-			'cURL Interface',
-			$pconfig['srcint'],
-			$src_interfaces
-		))->setHelp('Use this interface when downloadling lists. This option sets <code>CURLOPT_INTERFACE</code> to the value selected above.')
-		  ->setAttribute('style', 'width: auto');
+		$src_interfaces = array_merge(array('' => 'Default'), $src_interfaces);
+	
+		if ($gtype == 'ipv4') {
+
+			$list = array('Disabled' => 'Disabled') + array_combine(range(1, 17, -1), range(1, 17, -1));
+			$section->addInput(new Form_Select(
+				'suppression_cidr',
+				'Suppression CIDR Limit',
+				$pconfig['suppression_cidr'],
+				$list
+			))->setHelp('When suppression is enabled, this option will limit the CIDR block for this entire IPv4 Alias'
+					. '(Excluding the Custom List IP addresses)<br />Default: <strong>Disabled</strong> (No CIDR limit)')
+			  ->setAttribute('style', 'width: auto');
+		}
+		
+		if ($gtype == 'ipv4' || $gtype == 'ipv6') {
+			$section->addInput(new Form_Select(
+				'srcint',
+				'cURL Interface',
+				$pconfig['srcint'],
+				$src_interfaces
+			))->setHelp('Use this interface when downloadling lists. This option sets <code>CURLOPT_INTERFACE</code> to the value selected above for all Feeds in this Alias.')
+		 	 ->setAttribute('style', 'width: auto');
+		}
 
 		$form->add($section);
-	}
-
-	if ($gtype == 'ipv6') {
-
-		// Print Advanced Tunables section
-		$section = new Form_Section('Advanced Tuneables', 'advancedtunable', COLLAPSIBLE|SEC_CLOSED);
-                $section->addInput(new Form_StaticText(
-                        NULL,
-                        'These are \'Advanced\' settings and are typically best left at Default settings!')
-                );
-
-                $interfaces_list = get_interface_list();
-                $src_interfaces = array('lo0' => 'Localhost');
-                foreach($interfaces_list as $key => $value) {
-                        $src_interfaces = array_merge(array($key => strtoupper($interfaces_list[$key]['friendly'])), $src_interfaces);
-                }
-		$src_interfaces = array_merge(array('' => 'any'), $src_interfaces);
-                $section->addInput(new Form_Select(
-                        'srcint',
-                        'cURL Interface',
-                        $pconfig['srcint'],
-                        $src_interfaces
-                ))->setHelp('Use this interface when downloadling lists. This option sets <code>CURLOPT_INTERFACE</code> to the value selected above.')
-                  ->setAttribute('style', 'width: auto');     
-
-                $form->add($section);
 	}
 }
 else {

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -20,6 +20,7 @@
  * limitations under the License.
  */
 
+require_once('util.inc');
 require_once('guiconfig.inc');
 require_once('globals.inc');
 require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
@@ -407,6 +408,7 @@ if ($_POST && isset($_POST['save'])) {
 			$config['installedpackages'][$conf_type]['config'][$rowid]['agateway_out']	= $_POST['agateway_out']	?: 'default';
 
 			$config['installedpackages'][$conf_type]['config'][$rowid]['suppression_cidr']	= $_POST['suppression_cidr']	?: 'Disabled';
+			$config['installedpackages'][$conf_type]['config'][$rowid]['srcint']		= $_POST['srcint']		?: '';
 			$config['installedpackages'][$conf_type]['config'][$rowid]['whois_convert']	= $_POST['whois_convert']	?: '';
 		}
 		else {
@@ -528,6 +530,7 @@ else {
 		$pconfig['agateway_out']	= $rowdata[$rowid]['agateway_out'];
 
 		$pconfig['suppression_cidr']	= $rowdata[$rowid]['suppression_cidr'];
+		$pconfig['srcint']		= $rowdata[$rowid]['srcint'];
 
 		$pconfig['whois_convert']	= $rowdata[$rowid]['whois_convert'];
 	}
@@ -1211,7 +1214,47 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 				. '(Excluding the Custom List IP addresses)<br />Default: <strong>Disabled</strong> (No CIDR limit)')
 		  ->setAttribute('style', 'width: auto');
 
+		$interfaces_list = get_interface_list();
+		$src_interfaces = array('lo0' => 'Localhost');
+		foreach($interfaces_list as $key => $value) {
+			$src_interfaces = array_merge(array($key => strtoupper($interfaces_list[$key]['friendly'])), $src_interfaces);
+		}
+		$src_interfaces = array_merge(array('' => 'any'), $src_interfaces);
+		$section->addInput(new Form_Select(
+			'srcint',
+			'cURL Interface',
+			$pconfig['srcint'],
+			$src_interfaces
+		))->setHelp('Use this interface when downloadling lists. This option sets <code>CURLOPT_INTERFACE</code> to the value selected above.')
+		  ->setAttribute('style', 'width: auto');
+
 		$form->add($section);
+	}
+
+	if ($gtype == 'ipv6') {
+
+		// Print Advanced Tunables section
+		$section = new Form_Section('Advanced Tuneables', 'advancedtunable', COLLAPSIBLE|SEC_CLOSED);
+                $section->addInput(new Form_StaticText(
+                        NULL,
+                        'These are \'Advanced\' settings and are typically best left at Default settings!')
+                );
+
+                $interfaces_list = get_interface_list();
+                $src_interfaces = array('lo0' => 'Localhost');
+                foreach($interfaces_list as $key => $value) {
+                        $src_interfaces = array_merge(array($key => strtoupper($interfaces_list[$key]['friendly'])), $src_interfaces);
+                }
+		$src_interfaces = array_merge(array('' => 'any'), $src_interfaces);
+                $section->addInput(new Form_Select(
+                        'srcint',
+                        'cURL Interface',
+                        $pconfig['srcint'],
+                        $src_interfaces
+                ))->setHelp('Use this interface when downloadling lists. This option sets <code>CURLOPT_INTERFACE</code> to the value selected above.')
+                  ->setAttribute('style', 'width: auto');     
+
+                $form->add($section);
 	}
 }
 else {


### PR DESCRIPTION
This PR adds the ability to specify `CURLOPT_INTERFACE` when downloading lists. (Feature [#12282](https://redmine.pfsense.org/issues/12882))