### PR TITLE
pfBlockerNG-devel v3.1.0_3

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG-devel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-pfBlockerNG-devel
 PORTVERSION=	3.1.0
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/etc/inc/priv/pfblockerng.priv.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/etc/inc/priv/pfblockerng.priv.inc
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2008-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng.xml
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng.xml
@@ -9,7 +9,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2015-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Originally based upon pfBlocker by

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AF.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AF.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_AF.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (Africa)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("af-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("af-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_ALL_REGIONS.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_ALL_REGIONS.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_ALL.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (All Regions)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# script_AWS_AP.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region AP (Asia Pacific)
+# (ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("ap-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("ap-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_EAST.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_EAST.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# script_AWS_AP_EAST.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region AP (Asia Pacific - East)
+# (ap-east-1)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("ap-east-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("ap-east-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_NORTHEAST.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_NORTHEAST.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# script_AWS_AP_NORTHEAST.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region AP (Asia Pacific - North East)
+# (ap-northeast-1,ap-northeast-2,ap-northeast-3)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("ap-northeast-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("ap-northeast-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_SOUTH.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_SOUTH.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# script_AWS_AP_SOUTH.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region AP (Asia Pacific - South)
+# (ap-south-1,ap-south-2)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("ap-south-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("ap-south-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_SOUTHEAST.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_SOUTHEAST.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# script_AWS_AP_SOUTHEAST.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region AP (Asia Pacific - Southeast)
+# (ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("ap-southeast-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("ap-southeast-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_CA.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_CA.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_CA.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (Canada - Central)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("ca-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("ca-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_CN.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_CN.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_CN.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (China)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("cn-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("cn-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_CN_NORTH.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_CN_NORTH.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_CN_NORTH.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (China North)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("cn-north-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("cn-north-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_CN_NORTHWEST.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_CN_NORTHWEST.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_CN_NORTHWEST.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (China - Northwest)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("cn-northwest-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("cn-northwest-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_EU.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (Europe)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("eu-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("eu-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_CENTRAL.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_CENTRAL.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_EU_CENTRAL.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (Europe - Central)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("eu-central-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("eu-central-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_NORTH.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_NORTH.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_EU_NORTH.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (Europe - north)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("eu-north-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("eu-north-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_SOUTH.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_SOUTH.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_EU_SOUTH.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (Europe - South)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("eu-south-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("eu-south-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_WEST.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_WEST.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_EU_WEST.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (Europe - West)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("eu-west-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("eu-west-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_IL.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_IL.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_IL.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (IL))
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("il-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("il-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_ME.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_ME.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_ME.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (Middle East)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("me-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("me-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_ME_CENTRAL.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_ME_CENTRAL.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_ME_CENTRAL.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (Middle East - Central)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("me-central-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("me-central-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_ME_SOUTH.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_ME_SOUTH.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_ME_SOUTH.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (Middle East - South)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("me-south-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("me-south-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_SA.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_SA.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_SA.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (South America)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("sa-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("sa-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_US.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_US.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_US.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (United States)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("us-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("us-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_US_EAST.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_US_EAST.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_US_EAST.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (United States - East)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("us-east-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("us-east-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_US_GOV.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_US_GOV.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_US_GOV.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (United States - Gov)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("us-gov-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("us-gov-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_US_WEST.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_US_WEST.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# script_AWS_US_WEST.sh - By BBcan177@gmail.com - 03-20-2022
+# Pre-Script to collect Amazon AWS Region (United States - West)
+# Copyright (c) 2015-2022 BBcan177@gmail.com
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License Version 2 as
+# published by the Free Software Foundation.  You may not use, modify or
+# distribute this program under any other version of the GNU General
+# Public License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Randomize temporary variables
+rvar="$(/usr/bin/jot -r 1 1000 100000)"
+
+tempfile=/tmp/pfbtemp1_$rvar
+alias="${1}"
+prefix="${2}"
+
+if [ "${prefix}" == '_v4' ]; then
+	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("us-west-")) .ip_prefix' | iprange > "${tempfile}"
+else
+	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("us-west-")) .ipv6_prefix' > "${tempfile}"
+fi
+
+if [ -s "${tempfile}" ]; then
+	mv -f "${tempfile}" "${alias}"
+else
+	rm -f "${tempfile}"
+	echo "Failed to process pre-script"
+fi
+exit

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -3,7 +3,7 @@
 
 # part of pfSense (https://www.pfsense.org)
 # Copyright (c) 2015-2022 Rubicon Communications, LLC (Netgate)
-# Copyright (c) 2015-2021 BBcan177@gmail.com
+# Copyright (c) 2015-2022 BBcan177@gmail.com
 # All rights reserved.
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfb_unbound_include.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfb_unbound_include.inc
@@ -5,7 +5,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2015-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2015-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1224,15 +1224,15 @@ EOF;
 }
 	if (file_exists('/usr/local/lib/lighttpd/mod_openssl.so')) {
 		if (!$pfb['dnsbl_py_blacklist'] || $pfb['dnsbl_py_nolog'] == 'on') {
-			$pfb_conf .= 'server.modules			= ( "mod_access", "mod_accesslog", "mod_fastcgi", "mod_rewrite", "mod_openssl" )';
+			$pfb_conf .= 'server.modules			= ( "mod_access", "mod_auth", "mod_accesslog", "mod_fastcgi", "mod_rewrite", "mod_openssl" )';
 		} else {
-			$pfb_conf .= 'server.modules			= ( "mod_fastcgi", "mod_rewrite", "mod_openssl" )';
+			$pfb_conf .= 'server.modules			= ( "mod_auth", "mod_fastcgi", "mod_rewrite", "mod_openssl" )';
 		}
 	} else {
 		if (!$pfb['dnsbl_py_blacklist'] || $pfb['dnsbl_py_nolog'] == 'on') {
-			$pfb_conf .= 'server.modules			= ( "mod_access", "mod_accesslog", "mod_fastcgi", "mod_rewrite" )';
+			$pfb_conf .= 'server.modules			= ( "mod_access", "mod_auth", "mod_accesslog", "mod_fastcgi", "mod_rewrite" )';
 		} else {
-			$pfb_conf .= 'server.modules			= ( "mod_fastcgi", "mod_rewrite" )';
+			$pfb_conf .= 'server.modules			= ( "mod_auth", "mod_fastcgi", "mod_rewrite" )';
 		}
 	}
 
@@ -3727,16 +3727,25 @@ function pfb_tracker($alias, $int, $text) {
 		$pfbtracker += @ord($line[$i]);
 	}
 
-	// If duplicate Tracker ID found, pre-define a Tracker ID (Starts at 1770000010)
+	$pfbtracker = '177' . str_pad($pfbtracker, 7, '0', STR_PAD_LEFT);
+	if (strlen($pfbtracker) > 10) {
+        	$pfbtracker = substr($pfbtracker, 0, 10);
+	}
+	
+	// If duplicate Tracker ID found, pre-define a Tracker ID (Starts at 1700000010)
 	if (in_array($pfbtracker, $pfb['trackerids'])) {
 		$pfbtracker = ($pfb['last_trackerid'] + 1);
+		
+		// Increment prefix (digits 1&2) and reset Last_tracker ID after 10 digits
+		if (strlen($pfbtracker) > 10) {
+			$tracker_prefix = substr($pfbtracker, 0, 2);
+			$pfbtracker	= ($tracker_prefix + 1) . '00000010';
+		}
 		$pfb['last_trackerid'] = $pfbtracker;
-		return $pfbtracker;
 	}
-	else {
-		$pfb['trackerids'][] = $pfbtracker;
-		return '177' . str_pad($pfbtracker, 7, '0', STR_PAD_LEFT);
-	}
+	
+	$pfb['trackerids'][] = $pfbtracker;
+	return (int)$pfbtracker;
 }
 
 
@@ -4127,8 +4136,14 @@ function pfb_filterrules() {
 		foreach ($results as $result) {
 			if (substr($result, 0, 1) == '@') {
 
-				$r	= explode(')', $result, 2);
-				$id	= ltrim(strstr($r[0], '(', FALSE), '(');
+				$r = explode(')', $result, 2);
+
+				// pfSense > v2.6 uses an 'ridentifier' string
+				if (strpos($result, 'ridentifier') != FALSE) {
+					$id = trim(strstr(strstr($r[1], 'ridentifier', FALSE), ' ', FALSE));
+				} else {
+					$id = ltrim(strstr($r[0], '(', FALSE), '(');
+				}
 
 				// Find rule descriptions and type for pfBlockerNG Tracker IDs
 				if (strpos($r[1], ' <pfB_') !== FALSE) {
@@ -4540,10 +4555,10 @@ function pfb_collect_localhosts() {
 
 	// Collect dynamic DHCP hostnames/IPs
 	$leasesfile = "{$g['dhcpd_chroot_path']}/var/db/dhcpd.leases";
+
 	if (file_exists("{$leasesfile}")) {
-		$leases = file("{$leasesfile}");
-		if (!empty($leases)) {
-			foreach ($leases as $line) {
+		if (($l_handle = @fopen("{$leasesfile}", 'r')) !== FALSE) {
+			while (($line = @fgets($l_handle)) !== FALSE) {
 				if (strpos($line, '{') !== FALSE) {
 					$end = FALSE;
 					$data = explode(' ', $line);
@@ -4745,6 +4760,9 @@ function pfb_daemon_filterlog() {
 		[18]	= Client Hostname
 		[19]	= Duplicate ID indicator		*/
 
+	// Disable pfctl Tracker ID lookup on too many lookup failures
+	$max_retries = 0;
+	
 	if (($s_handle = @fopen('php://stdin', 'r')) !== FALSE) {
 		syslog(LOG_NOTICE, '[pfBlockerNG] filterlog daemon started');
 		while (!feof($s_handle)) {
@@ -4802,7 +4820,8 @@ function pfb_daemon_filterlog() {
 						$local_hosts	= pfb_collect_localhosts();
 					}
 
-					if ($retries < 5) {
+					if ($retries < 5 && $max_retries < 30) {
+						$max_retries++;
 						sleep(5);
 					} else {
 						$other = TRUE;
@@ -8456,6 +8475,17 @@ function sync_package_pfblockerng($cron='') {
 						// cURL Source Interface (sets CURLOPT_INTERFACE)
 						$srcint = $list['srcint'] ?: FALSE;
 
+						// IP v4/6 Advanced Tunable - (Pre/Post Script processing)
+						$pfb_script_pre = FALSE;
+						if (isset($list['script_pre']) && !empty($list['script_pre'])) {
+							$pfb_script_pre = "/usr/local/pkg/pfblockerng/{$list['script_pre']}";
+						}
+
+						$pfb_script_post = FALSE;
+						if (isset($list['script_post']) && !empty($list['script_post'])) {
+							$pfb_script_post = "/usr/local/pkg/pfblockerng/{$list['script_post']}";
+						}
+
 						// Determine 'list' details (return array $pfbarr)
 						if (isset($list['dnsblip'])) {
 							$list_type = 'pfblockerngdnsblsettings';
@@ -8606,6 +8636,12 @@ function sync_package_pfblockerng($cron='') {
 								} else {
 									$pftype = 'auto';
 								}
+							}
+
+							// IPv4/6 Advanced Tunable - (Pre Script processing)
+							if ($pfb_script_pre && file_exists("{$pfb_script_pre}")) {
+								pfb_logger("\nExecuting pre-script: {$list['script_pre']}\n", 1);
+								exec("{$pfb_script_pre} {$file_dwn}.orig {$list['vtype']} {$elog}");
 							}
 
 							if (($fhandle = @fopen("{$file_dwn}.orig", 'r')) !== FALSE) {
@@ -8770,6 +8806,12 @@ function sync_package_pfblockerng($cron='') {
 							}
 							@fclose($fhandle);
 							pfb_logger("\n", 1);
+
+							// IP v4/6 Advanced Tunable - (Post Script processing)
+							if ($pfb_script_post && file_exists("{$pfb_script_post}")) {
+								pfb_logger("\nExecuting post-script: {$list['script_pre']}\n", 1);
+								exec("{$pfb_script_post} {$file_dwn}.orig {$list['vtype']} {$elog}");
+							}
 
 							if (!$custom) {
 								// Check to see if list actually failed download or has no IPs listed.

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # pfBlockerNG Shell Function Script - By BBcan177@gmail.com - 04-12-14
-# Copyright (c) 2015-2021 BBcan177@gmail.com
+# Copyright (c) 2015-2022 BBcan177@gmail.com
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License Version 2 as

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2015-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2015-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfBlockerNG.js
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfBlockerNG.js
@@ -3,7 +3,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2015-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Originally based upon pfBlocker by
@@ -1318,7 +1318,7 @@ $php_data = <<<EOF
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the \"License\");
@@ -1839,7 +1839,7 @@ $php_rep = <<<'EOF'
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the \"License\");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2015-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Parts based on works from Snort_alerts.php

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -408,13 +408,10 @@ if ($_POST && isset($_POST['save'])) {
 			$config['installedpackages'][$conf_type]['config'][$rowid]['agateway_out']	= $_POST['agateway_out']	?: 'default';
 
 			$config['installedpackages'][$conf_type]['config'][$rowid]['suppression_cidr']	= $_POST['suppression_cidr']	?: 'Disabled';
-<<<<<<< HEAD
 			$config['installedpackages'][$conf_type]['config'][$rowid]['srcint']		= $_POST['srcint']		?: '';
-=======
 			$config['installedpackages'][$conf_type]['config'][$rowid]['script_pre']	= $_POST['script_pre']		?: '';
 			$config['installedpackages'][$conf_type]['config'][$rowid]['script_post']	= $_POST['script_post']		?: '';
 
->>>>>>> bbaa2f754684 (pfBlockerNG-devel v3.1.0_2)
 			$config['installedpackages'][$conf_type]['config'][$rowid]['whois_convert']	= $_POST['whois_convert']	?: '';
 		}
 		else {
@@ -536,12 +533,9 @@ else {
 		$pconfig['agateway_out']	= $rowdata[$rowid]['agateway_out'];
 
 		$pconfig['suppression_cidr']	= $rowdata[$rowid]['suppression_cidr'];
-<<<<<<< HEAD
 		$pconfig['srcint']		= $rowdata[$rowid]['srcint'];
-=======
 		$pconfig['script_pre']		= $rowdata[$rowid]['script_pre'];
 		$pconfig['script_post']		= $rowdata[$rowid]['script_post'];
->>>>>>> bbaa2f754684 (pfBlockerNG-devel v3.1.0_2)
 
 		$pconfig['whois_convert']	= $rowdata[$rowid]['whois_convert'];
 	}
@@ -1198,110 +1192,10 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 		$section->add($group);
 		$form->add($section);
 	}
-
-<<<<<<< HEAD
-	if ($gtype == 'ipv4' || $gtype == 'ipv6') {
-=======
-	// Collect pre/post processing scripts
-	$listpre = $listpost = array();
-	$indexdir = '/usr/local/pkg/pfblockerng/';
-	if (is_dir("{$indexdir}")) {
-		
-		if ($gtype == 'ipv4' || $gtype == 'ipv6') {
-			$list_prefix = 'ip';
-		} else {
-			$list_prefix = 'dnsbl';
-		}
-
-		$list = glob("{$indexdir}/{$list_prefix}_pre_*.{sh,py}", GLOB_BRACE);
-		if (!empty($list)) {
-			foreach ($list as $line) {
-				$file = pathinfo($line, PATHINFO_BASENAME);
-				$l = array($file => $file);
-				$listpre = array_merge($listpre, $l);
-			}
-		}
-
-		$list = glob("{$indexdir}/{$list_prefix}_post_*.{sh,py}", GLOB_BRACE);
-		if (!empty($list)) {
-			foreach ($list as $line) {
-				$file = pathinfo($line, PATHINFO_BASENAME);
-				$l = array($file => $file);
-				$listpost = array_merge($listpost, $l);
-			}
-		}
-	}
-
-	$listpre = array_merge(array('' => 'None'), $listpre);
-	$listpre_size = count($listpre) ?: '1';
-
-	$listpost = array_merge(array('' => 'None'), $listpost);
-	$listpost_size = count($listpost) ?: '1';
-
-	if ($gtype == 'ipv4') {
->>>>>>> bbaa2f754684 (pfBlockerNG-devel v3.1.0_2)
-
-		// Print Advanced Tunables section
-		$section = new Form_Section('Advanced Tuneables', 'advancedtunable', COLLAPSIBLE|SEC_CLOSED);
-		$section->addInput(new Form_StaticText(
-			NULL,
-			'These are \'Advanced\' settings and are typically best left at Default settings!')
-		);
-		
-		$interfaces_list = get_interface_list();
-		$src_interfaces = array('lo0' => 'Localhost');
-		foreach ($interfaces_list as $key => $value) {
-			$src_interfaces = array_merge(array($key => strtoupper($interfaces_list[$key]['friendly'])), $src_interfaces);
-		}
-		$src_interfaces = array_merge(array('' => 'Default'), $src_interfaces);
-	
-		if ($gtype == 'ipv4') {
-
-			$list = array('Disabled' => 'Disabled') + array_combine(range(1, 17, -1), range(1, 17, -1));
-			$section->addInput(new Form_Select(
-				'suppression_cidr',
-				'Suppression CIDR Limit',
-				$pconfig['suppression_cidr'],
-				$list
-			))->setHelp('When suppression is enabled, this option will limit the CIDR block for this entire IPv4 Alias'
-					. '(Excluding the Custom List IP addresses)<br />Default: <strong>Disabled</strong> (No CIDR limit)')
-			  ->setAttribute('style', 'width: auto');
-		}
-		
-		if ($gtype == 'ipv4' || $gtype == 'ipv6') {
-			$section->addInput(new Form_Select(
-				'srcint',
-				'cURL Interface',
-				$pconfig['srcint'],
-				$src_interfaces
-			))->setHelp('Use this interface when downloadling lists. This option sets <code>CURLOPT_INTERFACE</code> to the value selected above for all Feeds in this Alias.')
-		 	 ->setAttribute('style', 'width: auto');
-		}
-
-		$section->addInput(new Form_Select(
-			'script_pre',
-			'Pre-process Script',
-			$pconfig['script_pre'],
-			$listpre
-		))->sethelp("Pre-processing Shell script after download.<br />"
-		  	. "Script location: /usr/local/pkg/pfblockerng/<strong>ip_pre_SCRIPT NAME.sh|py</strong> or <strong>dnsbl_pre_SCRIPT NAME.sh|py</strong>")
-		  ->setAttribute('style', 'width: auto')
-		  ->setAttribute('size', $listpre_size);
-
-		$section->addInput(new Form_Select(
-			'script_post',
-			'Post-process Script',
-			$pconfig['script_post'],
-			$listpost
-		))->sethelp("Post-processing Shell script after download.<br />"
-			. "Script location: /usr/local/pkg/pfblockerng/<strong>ip_post_SCRIPT NAME.sh|py</strong> or <strong>dnsbl_post_SCRIPT name.sh|py</strong>")
-		  ->setAttribute('style', 'width: auto')
-		  ->setAttribute('size', $listpost_size);
-
-		$form->add($section);
-	}
 }
-else {
+
+if ($gtype == 'dnsbl') {
+
 	$section->addInput(new Form_Select(
 		'order',
 		'Group Order',
@@ -1352,6 +1246,104 @@ else {
 
 	$form->add($section);
 }
+
+// Print Advanced Tunables section
+$section = new Form_Section('Advanced Tuneables', 'advancedtunable', COLLAPSIBLE|SEC_CLOSED);
+$section->addInput(new Form_StaticText(
+	NULL,
+	'These are \'Advanced\' settings and are typically best left at Default settings!')
+);
+
+if ($gtype == 'ipv4') {
+
+	$list = array('Disabled' => 'Disabled') + array_combine(range(1, 17, -1), range(1, 17, -1));
+	$section->addInput(new Form_Select(
+		'suppression_cidr',
+		'Suppression CIDR Limit',
+		$pconfig['suppression_cidr'],
+		$list
+	))->setHelp('When suppression is enabled, this option will limit the CIDR block for this entire IPv4 Alias'
+		. '(Excluding the Custom List IP addresses)<br />Default: <strong>Disabled</strong> (No CIDR limit)')
+	  ->setAttribute('style', 'width: auto');
+}
+
+if ($gtype == 'ipv4' || $gtype == 'ipv6') {
+
+	$interfaces_list	= get_interface_list();
+	$src_interfaces		= array('lo0' => 'Localhost');
+
+	foreach ($interfaces_list as $key => $value) {
+		$src_interfaces = array_merge(array($key => strtoupper($interfaces_list[$key]['friendly'])), $src_interfaces);
+	}
+	$src_interfaces = array_merge(array('' => 'Default'), $src_interfaces);
+	
+	$section->addInput(new Form_Select(
+		'srcint',
+		'cURL Interface',
+		$pconfig['srcint'],
+		$src_interfaces
+	))->setHelp('Use this interface when downloadling lists. This option sets <code>CURLOPT_INTERFACE</code>'
+		. ' to the value selected above for all Feeds in this Alias.')
+	  ->setAttribute('style', 'width: auto');
+}
+
+// Collect pre/post processing scripts
+$listpre = $listpost = array();
+$indexdir = '/usr/local/pkg/pfblockerng/';
+if (is_dir("{$indexdir}")) {
+
+	if ($gtype == 'ipv4' || $gtype == 'ipv6') {
+		$list_prefix = 'ip';
+	} else {
+		$list_prefix = 'dnsbl';
+	}
+
+	$list = glob("{$indexdir}/{$list_prefix}_pre_*.{sh,py}", GLOB_BRACE);
+	if (!empty($list)) {
+		foreach ($list as $line) {
+			$file = pathinfo($line, PATHINFO_BASENAME);
+			$l = array($file => $file);
+			$listpre = array_merge($listpre, $l);
+		}
+	}
+
+	$list = glob("{$indexdir}/{$list_prefix}_post_*.{sh,py}", GLOB_BRACE);
+	if (!empty($list)) {
+		foreach ($list as $line) {
+			$file = pathinfo($line, PATHINFO_BASENAME);
+			$l = array($file => $file);
+			$listpost = array_merge($listpost, $l);
+		}
+	}
+}
+
+$listpre = array_merge(array('' => 'None'), $listpre);
+$listpre_size = count($listpre) ?: '1';
+
+$listpost = array_merge(array('' => 'None'), $listpost);
+$listpost_size = count($listpost) ?: '1';
+
+$section->addInput(new Form_Select(
+	'script_pre',
+	'Pre-process Script',
+	$pconfig['script_pre'],
+	$listpre
+))->sethelp("Pre-processing Shell script after download.<br />"
+	. "Script location: /usr/local/pkg/pfblockerng/<strong>ip_pre_SCRIPT NAME.sh|py</strong> or <strong>dnsbl_pre_SCRIPT NAME.sh|py</strong>")
+  ->setAttribute('style', 'width: auto')
+  ->setAttribute('size', $listpre_size);
+
+$section->addInput(new Form_Select(
+	'script_post',
+	'Post-process Script',
+	$pconfig['script_post'],
+	$listpost
+))->sethelp("Post-processing Shell script after download.<br />"
+	. "Script location: /usr/local/pkg/pfblockerng/<strong>ip_post_SCRIPT NAME.sh|py</strong> or <strong>dnsbl_post_SCRIPT name.sh|py</strong>")
+  ->setAttribute('style', 'width: auto')
+  ->setAttribute('size', $listpost_size);
+
+$form->add($section);
 
 if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -3,7 +3,7 @@
  * pfblockerng_category_edit.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2016-2021 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2015-2021 BBcan177@gmail.com
  * All rights reserved.
  *
@@ -20,7 +20,6 @@
  * limitations under the License.
  */
 
-require_once('util.inc');
 require_once('guiconfig.inc');
 require_once('globals.inc');
 require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
@@ -408,7 +407,6 @@ if ($_POST && isset($_POST['save'])) {
 			$config['installedpackages'][$conf_type]['config'][$rowid]['agateway_out']	= $_POST['agateway_out']	?: 'default';
 
 			$config['installedpackages'][$conf_type]['config'][$rowid]['suppression_cidr']	= $_POST['suppression_cidr']	?: 'Disabled';
-			$config['installedpackages'][$conf_type]['config'][$rowid]['srcint']		= $_POST['srcint']		?: '';
 			$config['installedpackages'][$conf_type]['config'][$rowid]['whois_convert']	= $_POST['whois_convert']	?: '';
 		}
 		else {
@@ -530,7 +528,6 @@ else {
 		$pconfig['agateway_out']	= $rowdata[$rowid]['agateway_out'];
 
 		$pconfig['suppression_cidr']	= $rowdata[$rowid]['suppression_cidr'];
-		$pconfig['srcint']		= $rowdata[$rowid]['srcint'];
 
 		$pconfig['whois_convert']	= $rowdata[$rowid]['whois_convert'];
 	}
@@ -1188,7 +1185,7 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 		$form->add($section);
 	}
 
-	if ($gtype == 'ipv4' || $gtype == 'ipv6') {
+	if ($gtype == 'ipv4') {
 
 		// Print Advanced Tunables section
 		$section = new Form_Section('Advanced Tuneables', 'advancedtunable', COLLAPSIBLE|SEC_CLOSED);
@@ -1196,36 +1193,17 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 			NULL,
 			'These are \'Advanced\' settings and are typically best left at Default settings!')
 		);
-		
-		$interfaces_list = get_interface_list();
-		$src_interfaces = array('lo0' => 'Localhost');
-		foreach ($interfaces_list as $key => $value) {
-			$src_interfaces = array_merge(array($key => strtoupper($interfaces_list[$key]['friendly'])), $src_interfaces);
-		}
-		$src_interfaces = array_merge(array('' => 'Default'), $src_interfaces);
-	
-		if ($gtype == 'ipv4') {
 
-			$list = array('Disabled' => 'Disabled') + array_combine(range(1, 17, -1), range(1, 17, -1));
-			$section->addInput(new Form_Select(
-				'suppression_cidr',
-				'Suppression CIDR Limit',
-				$pconfig['suppression_cidr'],
-				$list
-			))->setHelp('When suppression is enabled, this option will limit the CIDR block for this entire IPv4 Alias'
-					. '(Excluding the Custom List IP addresses)<br />Default: <strong>Disabled</strong> (No CIDR limit)')
-			  ->setAttribute('style', 'width: auto');
-		}
-		
-		if ($gtype == 'ipv4' || $gtype == 'ipv6') {
-			$section->addInput(new Form_Select(
-				'srcint',
-				'cURL Interface',
-				$pconfig['srcint'],
-				$src_interfaces
-			))->setHelp('Use this interface when downloadling lists. This option sets <code>CURLOPT_INTERFACE</code> to the value selected above for all Feeds in this Alias.')
-		 	 ->setAttribute('style', 'width: auto');
-		}
+		$list = array('Disabled' => 'Disabled') + array_combine(range(1, 17, -1), range(1, 17, -1));
+
+		$section->addInput(new Form_Select(
+			'suppression_cidr',
+			'Suppression CIDR Limit',
+			$pconfig['suppression_cidr'],
+			$list
+		))->setHelp('When suppression is enabled, this option will limit the CIDR block for this entire IPv4 Alias'
+				. '(Excluding the Custom List IP addresses)<br />Default: <strong>Disabled</strong> (No CIDR limit)')
+		  ->setAttribute('style', 'width: auto');
 
 		$form->add($section);
 	}

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the \"License\");
@@ -2530,12 +2530,12 @@ $section->addInput(new Form_Checkbox(
 
 $form->add($section);
 
-$section = new Form_Section('DNSBL Whitelist', 'DNSBL_Whitelist_customlist', COLLAPSIBLE|SEC_CLOSED);
-
 // Create page anchor for DNSBL Whitelist
 $section->addInput(new Form_StaticText(
 	NULL,
 	'<div id="Whitelist"></div>'));
+
+$form->add($section);
 
 $suppression_text = 'No Regex Entries Allowed!&emsp;
 			<div class="infoblock">
@@ -2552,6 +2552,7 @@ $suppression_text = 'No Regex Entries Allowed!&emsp;
 				&emsp; ie: \'drill @8.8.8.8 example.com\'
 			</div>';
 
+$section = new Form_Section('DNSBL Whitelist', 'DNSBL_Whitelist_customlist', COLLAPSIBLE|SEC_CLOSED);
 $section->addInput(new Form_Textarea(
 	'suppression',
 	NULL,

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.json
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.json
@@ -6,7 +6,7 @@
 			"*",
 			"* part of pfSense (https://www.pfsense.org)",
 			"* Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)",
-			"* Copyright (c) 2015-2021 BBcan177@gmail.com",
+			"* Copyright (c) 2015-2022 BBcan177@gmail.com",
 			"* All rights reserved.",
 			"*",
 			"* Licensed under the Apache License, Version 2.0 (the \"License\")",
@@ -855,6 +855,20 @@
 					"header":	"BlockListDE_Strong"
 				}
 			]
+		},
+		"AWS_4": {
+			"info":		"IP ranges for Amazon AWS. Use the IPv4 Advanced Tunable to configure a Pre-Script to collect the AWS Region IPs",
+			"description":	"IP ranges for Amazon AWS.",
+			"action":	"permit",
+			"cron":		"Weekly",
+			"feeds": [
+				{
+					"feed":		"AWS",
+					"website":	"https://docs.aws.amazon.com/general/latest/gr/aws-ip-ranges.html",
+					"url":		"https://ip-ranges.amazonaws.com/ip-ranges.json",
+					"header":	"AWS"
+				}
+			]
 		}
 	},
 	"ipv6": {
@@ -979,6 +993,20 @@
 					"website":	"https://github.com/ejrv/VPNs",
 					"url":		"https://raw.githubusercontent.com/ejrv/VPNs/master/vpn-ipv6.txt",
 					"header":	"Ejrv_VPNv6"
+				}
+			]
+		},
+		"AWS_6": {
+			"info":		"IP ranges for Amazon AWS. Use the IPv6 Advanced Tunable to configure a Pre-Script to collect the AWS Region IPs",
+			"description":	"IP ranges for Amazon AWS.",
+			"action":	"permit",
+			"cron":		"Weekly",
+			"feeds": [
+				{
+					"feed":		"AWS",
+					"website":	"https://docs.aws.amazon.com/general/latest/gr/aws-ip-ranges.html",
+					"url":		"https://ip-ranges.amazonaws.com/ip-ranges.json",
+					"header":	"AWS6"
 				}
 			]
 		}
@@ -1372,8 +1400,8 @@
 				{
 					"feed":		"Malware Patrol",
 					"website":	"https://lists.malwarepatrol.net/",
-					"register":	"https://www.malwarepatrol.net/signup-free.shtml",
-					"url":		"https://lists.malwarepatrol.net/cgi/getfile?receipt=_API_KEY_&product=8&list=mozilla_adblock",
+					"register":	"https://malwareblocklist.org/",
+					"url":		"https://lists.malwarepatrol.net/cgi/getfile?receipt=_API_KEY_&product=37&list=pfblockerng",
 					"header":	"MPatrol"
 				},
 				{

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the \"License\");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the \"License\");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Portions of this code are based on original work done for the

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_safesearch.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_safesearch.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2020-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_sync.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_sync.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the \"License\");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_threats.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_threats.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the \"License\");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Portions of this code are based on original work done for

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/www/dnsbl_default.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/www/dnsbl_default.php
@@ -3,7 +3,7 @@
 
  part of pfSense (https://www.pfsense.org)
  Copyright (c) 2015-2022 Rubicon Communications, LLC (Netgate)
- Copyright (c) 2015-2021 BBcan177@gmail.com
+ Copyright (c) 2015-2022 BBcan177@gmail.com
  All rights reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/www/index.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/www/index.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2015-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/widgets/include/widget-pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/widgets/include/widget-pfblockerng.inc
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2014-2021 BBcan177@gmail.com
+ * Copyright (c) 2014-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/widgets/javascript/pfblockerng.js
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/widgets/javascript/pfblockerng.js
@@ -3,7 +3,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Javascript and Integration modifications by J. Nieuwenhuizen and J. Van Breedam

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Originally based Upon pfBlocker
@@ -593,15 +593,15 @@ function pfBlockerNG_get_header($mode='') {
 	$widget_head = 	array ( array (	'Deny'		=> '',
 					'Pass'		=> '',
 					'Match'		=> '',
-					'Suppression'	=> "{$pfb['supptxt']}"),
+					'Suppression'	=> "{$pfb['ipconfig']['v4suppression']}"),
 
 				array (	'DNSBL'		=> '',
 					'Queries'	=> '',
 					'Percent'	=> '',
-					'Whitelist'	=> "{$pfb['dnsbl_supptxt']}"));
+					'Whitelist'	=> "{$pfb['dnsblconfig']['suppression']}"));
 
 	foreach ($widget_head as $key => $line) {
-		foreach ($line as $type => $file_path) {
+		foreach ($line as $type => $config_path) {
 
 			$stats[$key][$type] = 0;
 			if ($type == 'DNSBL') {
@@ -612,9 +612,15 @@ function pfBlockerNG_get_header($mode='') {
 				}
 			}
 
-			elseif (($type == 'Suppression' || $type == 'Whitelist') && file_exists("{$file_path}")) {
+			elseif ($type == 'Suppression' || $type == 'Whitelist') {
 
-				$gcount = exec("{$pfb['grep']} -c ^ {$file_path} 2>&1");
+				$gcount = 0;
+				foreach (pfbng_text_area_decode($config_path, TRUE, FALSE, TRUE) as $cline) {
+					if (substr(trim($cline), 0, 1) != '#' && !empty($cline)) {
+						$gcount++;
+					}
+				}
+
 				if (is_numeric($gcount)) {
 					$stats[$key][$type] = number_format( $gcount, 0, '', ',' ) ?: 0;
 				} else {

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/wizards/pfblockerng_wizard.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/wizards/pfblockerng_wizard.inc
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2004-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -185,9 +185,12 @@ ZXRnYXRlLmNvbQ0K
 			$add['description']	= $info['description'];
 
 			foreach($info['feeds'] as $row) {
-				if (isset($row['register'])) {
+
+				// Remove Feeds that require Registration and Discontinued Feeds
+				if (isset($row['register']) || (isset($row['status']) && $row['status'] == 'discontinued')) {
 					continue;
 				}
+
 				if (!is_array($add['row'])) {
 					$add['row'] = array();
 				}

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/wizards/pfblockerng_wizard.xml
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/wizards/pfblockerng_wizard.xml
@@ -6,7 +6,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2004-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2015-2021 BBcan177@gmail.com
+ * Copyright (c) 2015-2022 BBcan177@gmail.com
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
* Fix IP Logging due to change in pfSense Firewall filter.log (ridentifier)
* Change IP Firewall Rule tracker IDs from a string to integer
* Improve Tracker ID maximum length  overrun and potential overlap
* Wizard - Do not add "discontinued" Feeds
* Improve parsing of large DHCP lease files for Hostname search
* Fix Malware Patrol Feed URLs
* Change copyright info
* Add "mod_auth" module to squelch warning messages in lighttpd
* Improve Widget counters for DNSBL Whitelist entry count
* Add new Feature to execute a user-defined script (sh or python) on a downloaded Feed. Useful to process Amazon Web Services IP Range feed for specific Regions.
* Add Amazon Web Services IP Range Feed