### PR TITLE
ACME: Update easyDNS API Key Sign Up URL

### DIFF
--- a/security/pfSense-pkg-acme/Makefile
+++ b/security/pfSense-pkg-acme/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-acme
 PORTVERSION=	0.7.1
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
@@ -684,7 +684,7 @@ $acme_domain_validation_method['dns_dynu'] = array('name' => "DNS-Dynu",
 $acme_domain_validation_method['dns_easydns'] = array('name' => "DNS-easyDNS",
 	'fields' => array(
 		'EASYDNS_Key' => array('name' => "easydns_key", 'columnheader' => "API Key", 'type' => "textbox",
-			'description' => "easyDNS API Key. Sign up for a key at http://docs.sandbox.rest.easydns.net/beta_signup.php"
+			'description' => "easyDNS API Key. Sign up for a key at https://cp.easydns.com/manage/security/api/signup.php"
 		),
 		'EASYDNS_Token' => array('name' => "easydns_token", 'columnheader' => "Token", 'type' => "textbox",
 			'description' => "easyDNS API Token"


### PR DESCRIPTION
The current link lands on a legacy api page, which gives the impression that perhaps the integration for easyDNS isn't up to date even though it is and works great.
[Redmine #13050](https://redmine.pfsense.org/issues/13050)