### PR TITLE
Update manifest.inc

### DIFF
--- a/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches/manifest.inc
+++ b/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches/manifest.inc
@@ -65,7 +65,7 @@ $recommended_patches = [
 ],
 [
   'uniqid' => 'fd30b9eda98900eb5f1a0c37d600ef4deaf582ad',
-  'versions' => ['2.6.0', '22.01', '2.7.0', '22.05'],
+  'versions' => ['2.6.0', '22.01'],
   'descr' => 'Fix Captive Portal handling of non-TCP traffic after login',
   'links' => [
       [ 'text' => 'Redmine #12834',


### PR DESCRIPTION
as per @jim-p 's [redmine comment](https://redmine.pfsense.org/issues/12834#note-12), patch [`fd30b9eda98900eb5f1a0c37d600ef4deaf582ad`](https://github.com/pfsense/FreeBSD-ports/blob/1a4f1fdbd14484e4ea4630fe4cd16ac777a32f5a/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches/manifest.inc#L68) (captive portal workaround) no longer applies to 2.7 / 22.05 since there's a new method being used