### PR TITLE
pfSense-pkg-snort-4.1.5_3 - Fix Redmine Issues #13095 and #13096

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.1.5
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -430,7 +430,11 @@ safe_mkdir("{$snortiprepdir}");
 /* See if we need to automatically clear the Update Log based on 1024K size limit */
 if (file_exists(SNORT_RULES_UPD_LOGFILE)) {
 	if (1048576 < filesize(SNORT_RULES_UPD_LOGFILE))
-		unlink_if_exists("{SNORT_RULES_UPD_LOGFILE}");
+		file_put_contents(SNORT_RULES_UPD_LOGFILE, "");
+}
+else {
+	/* Create the file if not already present */
+	file_put_contents(SNORT_RULES_UPD_LOGFILE, "");
 }
 
 /* Sleep for random number of seconds between 0 and 35 to spread load on rules site */

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_check_for_rule_updates.php
@@ -392,7 +392,7 @@ function snort_untar($mode, $tarFile, $outputFolder = null, $extra = null){
 	$success = $ret === 0;
 	if(!$success) {
 		$err_msg = gettext("Failed to extract a rules-update archive. Some snort rules might still be out-of-date. Make sure there is enough free disk space and try again. Tar file:") . $tarFile;
-		error_log('\t' . $err_msg . '\n', 3, SNORT_RULES_UPD_LOGFILE);
+		error_log("\t" . $err_msg . "\n", 3, SNORT_RULES_UPD_LOGFILE);
 		syslog(LOG_ERR, '[Snort] ' . $err_msg);
 	}
 	return $success;
@@ -404,7 +404,7 @@ function snort_copy($srcFilePathPattern, $destPath){
 	$success = $ret === 0;
 	if(!$success) {
 		$err_msg = gettext("Failed to copy some files from the rules-update archive. Some snort rules might still be out-of-date. Make sure there is enough free disk space and try again. File(s):") . $srcFilePathPattern;
-		error_log('\t' . $err_msg . '\n', 3, SNORT_RULES_UPD_LOGFILE);
+		error_log("\t" . $err_msg . "\n", 3, SNORT_RULES_UPD_LOGFILE);
 		syslog(LOG_ERR, '[Snort] ' . $err_msg);
 	}
 	return $success;
@@ -625,6 +625,7 @@ if ($snortdownload == 'on') {
 		/* extract SO rules */
 		$snort_arch = php_uname("m");
 		$nosorules = true;
+		safe_mkdir("{$tmpfname}/so_rules");
 
 		/****************************************************************************/
 		/* Snort SO rules only exist for Intel/AMD 64-bit architecture on FreeBSD,  */
@@ -632,9 +633,12 @@ if ($snortdownload == 'on') {
 		/****************************************************************************/
 		if ($snort_arch == 'amd64') {
 			error_log(gettext("\tUsing Snort Subscriber precompiled SO rules for {$freebsd_version_so} ...\n"), 3, SNORT_RULES_UPD_LOGFILE);
-			if(snort_untar("xzf", "{$tmpfname}/{$snort_filename}", "{$tmpfname}", "so_rules/precompiled/{$freebsd_version_so}/x86_64/{$snort_version}/")) {
-				snort_copy("{$tmpfname}/so_rules/precompiled/{$freebsd_version_so}/x86_64/{$snort_version}/*.so", "{$snortlibdir}/snort_dynamicrules/");
+			if(snort_untar("xzf", "{$tmpfname}/{$snort_filename}", "{$tmpfname}/so_rules", "--strip-components 5 so_rules/precompiled/{$freebsd_version_so}*")) {
+				snort_copy("{$tmpfname}/so_rules/*.so", "{$snortlibdir}/snort_dynamicrules/");
 				$nosorules = false;
+			}
+			else {
+				error_log(gettext("\tAn error occurred extracting the Snort Subscriber precompiled SO rules. They have not been updated ...\n"), 3, SNORT_RULES_UPD_LOGFILE);
 			}
 		}
 		rmdir_recursive("{$tmpfname}/so_rules/");


### PR DESCRIPTION
### pfSense-pkg-snort-4.1.5_3
This GUI package update fixes one bug and implements one feature request for the Snort package.

**New Features:**
1. Improve robustness of Snort Rules Update Logfile size limit code by changing the logic to match that used in the Suricata package. [Redmine Issue #13096](https://redmine.pfsense.org/issues/13096).

**Bug Fixes:**
1. Fix [Redmine Issue #13095](https://redmine.pfsense.org/issues/13095) where a path name change in the Snort VRT rules archive results in Shared Object (SO) rules not being extracted and updated. The fix makes the new code more flexible in dealing with future internal path name changes in the rules archive tarball.
