### PR TITLE
Fix: Bug #13214 AttributeError: 'NoneType' object has no attribute 'text'

### DIFF
--- a/sysutils/pfSense-pkg-node_exporter/Makefile
+++ b/sysutils/pfSense-pkg-node_exporter/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-node_exporter
 PORTVERSION=	0.18.1
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-node_exporter/files/usr/local/share/pfSense-pkg-node_exporter/interface-collector.py
+++ b/sysutils/pfSense-pkg-node_exporter/files/usr/local/share/pfSense-pkg-node_exporter/interface-collector.py
@@ -26,7 +26,11 @@ root = ET.parse('/conf/config.xml')
 for elem in root.find("interfaces"):
 	pf_name = elem.tag
 	if_name = elem.find('if').text
-	descr = elem.find('descr').text
+	node = elem.find('descr')
+	if node is not None:
+		descr = elem.find('descr').text
+	else:
+		descr = ""
 	enabled = 1 if elem.find('enable') is not None else 0
 	metrics['up'].add(enabled, name=pf_name)
 	metrics['info'].add(enabled, description=descr, interface=if_name, name=pf_name)


### PR DESCRIPTION
This fix resolves bug [#13214](https://redmine.pfsense.org/issues/13214)

I was seeing this error on my pfsense install with ArpWatch enabled

This code checks the element exists before trying to assign the text value, if it does not exist an empty string is assigned instead.