### PR TITLE
pfSense-pkg-suricata-6.0.6 -- Update the Suricata GUI package to support 6.0.6 and add bug fixes and features.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,8 +1,8 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	6.0.4
-PORTREVISION=	1
+PORTVERSION=	6.0.6
+PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=6.0.4:security/suricata
+RUN_DEPENDS=	suricata>=6.0.6:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2021 Bill Meeks
+ * Copyright (C) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -2458,7 +2458,7 @@ function suricata_modify_sid_state(&$rule_map, $sid_mods, $action, $log_results 
 		}
 		// Test the SID token for the PCRE: keyword
 		elseif (preg_match('/(^pcre\:)(.+)/i', $tok, $matches)) {
-			$regex = '/' . preg_quote($matches[2], '/') . '/i';
+			$regex = '/' . $matches[2] . '/i';
 
 			// Now search through the $rule_map in the 'rule'
 			// element for any matches to the regex and get

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2021 Bill Meeks
+ * Copyright (C) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -80,6 +80,12 @@ if (!defined('SURICATA_SID_MODS_PATH'))
 	define('SURICATA_SID_MODS_PATH', "{$g['vardb_path']}/suricata/sidmods/");
 if (!defined('SURICATA_IPREP_PATH'))
 	define('SURICATA_IPREP_PATH', "{$g['vardb_path']}/suricata/iprep/");
+
+// Define an array consisting of Suricata default events rules
+if (!defined("SURICATA_DEFAULT_RULES"))
+	define("SURICATA_DEFAULT_RULES", array( "app-layer-events.rules", "decoder-events.rules", "dhcp-events.rules", "dnp3-events.rules", "dns-events.rules", "files.rules", "http-events.rules", "http2-events.rules", "ipsec-events.rules",
+						"kerberos-events.rules", "modbus-events.rules", "mqtt-events.rules", "nfs-events.rules", "ntp-events.rules", "smb-events.rules", "smtp-events.rules", "ssh-events.rules", "stream-events.rules",
+						"tls-events.rules" ));
 
 // Rule set download URLs, filenames and prefixes
 if (!defined("VRT_DNLD_URL"))

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2021 Bill Meeks
+ * Copyright (C) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -958,6 +958,12 @@ if (!empty($suricatacfg['dns_request_flood_limit']))
 else
 	$dns_request_flood_limit = "500";
 
+/* ENIP Parser */
+if (!empty($suricatacfg['enip_parser']))
+	$enip_parser = $suricatacfg['enip_parser'];
+else
+	$enip_parser = "yes";
+
 /* HTTP Parser */
 if (!empty($suricatacfg['http_parser']))
 	$http_parser = $suricatacfg['http_parser'];
@@ -967,6 +973,12 @@ if (!empty($suricatacfg['http_parser_memcap']))
 	$http_parser_memcap = $suricatacfg['http_parser_memcap'];
 else
 	$http_parser_memcap = "67108864";
+
+/* MQTT Parser */
+if (!empty($suricatacfg['mqtt_parser']))
+	$mqtt_parser = $suricatacfg['mqtt_parser'];
+else
+	$mqtt_parser = "yes";
 
 /* SMTP Parser */
 if (!empty($suricatacfg['smtp_parser'])) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2019-2022 Rubicon Communications, LLC (Netgate)
- * Copyright (C) 2021 Bill Meeks
+ * Copyright (C) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -711,6 +711,14 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 	}
 	if (empty($pconfig['rfb_parser'])) {
 		$pconfig['rfb_parser'] = "yes";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['enip_parser'])) {
+		$pconfig['enip_parser'] = "yes";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['mqtt_parser'])) {
+		$pconfig['mqtt_parser'] = "yes";
 		$updated_cfg = true;
 	}
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -326,6 +326,14 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 	}
 
 	/***********************************************************/
+	/* Add the new 'ssh-events.rules' file to the rulesets.    */
+	/***********************************************************/
+	if (strpos($pconfig['rulesets'], "ssh-events.rules") === FALSE) {
+		$pconfig['rulesets'] = rtrim($pconfig['rulesets'], "||") . "||ssh-events.rules";	
+		$updated_cfg = true;
+	}
+
+	/***********************************************************/
 	/* Add new run mode value and default it to 'autofp'.      */
 	/***********************************************************/
 	if (empty($pconfig['runmode'])) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -333,6 +333,8 @@ app-layer:
         enabled: {$dns_parser_udp}
         detection-ports:
           dp: {$dns_parser_udp_port}
+    enip:
+      enabled: {$enip_parser}
     ftp:
       enabled: {$ftp_parser}
     ftp-data:
@@ -352,6 +354,8 @@ app-layer:
       detection-ports:
         dp: 502
       stream-depth: 0
+    mqtt:
+      enabled: {$mqtt_parser}
     msn:
       enabled: {$msn_parser}
     nfs:

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2021 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -251,6 +251,7 @@ elseif ($_POST['ResetAll']) {
 	$pconfig['dns_parser_udp_ports'] = "53";
 	$pconfig['dns_parser_tcp'] = "yes";
 	$pconfig['dns_parser_tcp_ports'] = "53";
+	$pconfig['enip_parser'] = "yes";
 	$pconfig['http_parser'] = "yes";
 	$pconfig['tls_parser'] = "yes";
 	$pconfig['tls_detect_ports'] = "443";
@@ -280,6 +281,7 @@ elseif ($_POST['ResetAll']) {
 	$pconfig['snmp_parser'] = "yes";
 	$pconfig['http2_parser'] = "yes";
 	$pconfig['rfb_parser'] = "yes";
+	$pconfig['mqtt_parser'] = "yes";
 
 	/* Log a message at the top of the page to inform the user */
 	$savemsg = gettext("All flow and stream settings on this page have been reset to their defaults.  Click APPLY if you wish to keep these new settings.");
@@ -474,6 +476,8 @@ elseif ($_POST['save'] || $_POST['apply']) {
 		$natent['snmp_parser'] = $_POST['snmp_parser'];
 		$natent['http2_parser'] = $_POST['http2_parser'];
 		$natent['rfb_parser'] = $_POST['rfb_parser'];
+		$natent['enip_parser'] = $_POST['enip_parser'];
+		$natent['mqtt_parser'] = $_POST['mqtt_parser'];
 
 		/**************************************************/
 		/* If we have a valid rule ID, save configuration */
@@ -733,6 +737,12 @@ if ($importalias) {
 		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
 	))->setHelp('Choose the parser/detection setting for DHCP. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
 	$section->addInput(new Form_Select(
+		'enip_parser',
+		'ENIP Parser',
+		$pconfig['enip_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for ENIP. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
 		'http2_parser',
 		'HTTP2 Parser',
 		$pconfig['http2_parser'],
@@ -756,6 +766,12 @@ if ($importalias) {
 		$pconfig['krb5_parser'],
 		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
 	))->setHelp('Choose the parser/detection setting for Kerberos. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
+		'mqtt_parser',
+		'MQTT Parser',
+		$pconfig['mqtt_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for MQTT. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
 	$section->addInput(new Form_Select(
 		'msn_parser',
 		'MSN Parser',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2021 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -548,10 +548,11 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$savemsg1 = gettext("EVE Output to syslog requires Suricata alerts to be copied to the system log, so 'Send Alerts to System Log' has been auto-enabled.");
 		}
 
-		// Check if Inline IPS mode is enabled and display a message about potential
-		// incompatibilities with Netmap and some NIC hardware drivers.
+		// Check if Inline IPS mode is enabled. Auto-enable 'Live Rule Swap' and display a message
+		// about potential incompatibilities with Netmap and some NIC hardware drivers.
 		if ($natent['ips_mode'] == "ips_mode_inline") {
-			$savemsg2 = gettext("Inline IPS Mode is selected.  Not all hardware NIC drivers support Netmap operation which is required for Inline IPS Mode.  If problems are experienced, switch to Legacy Mode instead.");
+			$savemsg2 = gettext("Inline IPS Mode is selected. Live Rule Swap will be automatically enabled to prevent netmap interfaces from cycling offline/online during future rules updates.  Please note that not all hardware NIC drivers support Netmap operation which is required for Inline IPS Mode.  If problems are experienced, switch to Legacy Mode instead.");
+			$config['installedpackages']['suricata']['config'][0]['live_swap_updates'] = "on";
 		}
 
 		$if_real = get_real_interface($natent['interface']);
@@ -682,8 +683,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$natent['libhtp_policy']['item'][] = $default;
 
 			// Enable the basic default rules for the interface
-			$natent['rulesets'] = "app-layer-events.rules||decoder-events.rules||dnp3-events.rules||dns-events.rules||files.rules||http-events.rules||ipsec-events.rules||kerberos-events.rules||" . 
-					      "modbus-events.rules||nfs-events.rules||ntp-events.rules||smb-events.rules||smtp-events.rules||stream-events.rules||tls-events.rules";
+			$natend['rulesets'] = implode("||", SURICATA_DEFAULT_RULES);
 
 			// Adding a new interface, so set flag to build new rules
 			$rebuild_rules = true;

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -683,7 +683,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$natent['libhtp_policy']['item'][] = $default;
 
 			// Enable the basic default rules for the interface
-			$natend['rulesets'] = implode("||", SURICATA_DEFAULT_RULES);
+			$natent['rulesets'] = implode("||", SURICATA_DEFAULT_RULES);
 
 			// Adding a new interface, so set flag to build new rules
 			$rebuild_rules = true;

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2021 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -189,7 +189,7 @@ if (isset($_POST["save"])) {
 
 	// Remove all but the default events and files rules
 	$enabled_rulesets_array = array();
-	$enabled_rulesets_array = implode("||", $default_rules);
+	$enabled_rulesets_array = $default_rules;
 
 	$savemsg = gettext("All rule categories have been de-selected.  ");
 	if ($_POST['ips_policy_enable'] == "on")

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -34,7 +34,8 @@ $flowbit_rules_file = FLOWBITS_FILENAME;
 
 // Array of default events rules for Suricata
 $default_rules = array( "app-layer-events.rules", "decoder-events.rules", "dhcp-events.rules", "dnp3-events.rules", "dns-events.rules", "files.rules", "http-events.rules", "http2-events.rules", "ipsec-events.rules",
-						"kerberos-events.rules", "modbus-events.rules", "mqtt-events.rules", "nfs-events.rules", "ntp-events.rules", "smb-events.rules", "smtp-events.rules", "stream-events.rules", "tls-events.rules" );
+						"kerberos-events.rules", "modbus-events.rules", "mqtt-events.rules", "nfs-events.rules", "ntp-events.rules", "smb-events.rules", "smtp-events.rules", "ssh-events.rules", "stream-events.rules",
+						"tls-events.rules" );
 
 if (!is_array($config['installedpackages']['suricata']['rule'])) {
 	$config['installedpackages']['suricata']['rule'] = array();

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -33,9 +33,7 @@ $suricata_rules_dir = SURICATA_RULES_DIR;
 $flowbit_rules_file = FLOWBITS_FILENAME;
 
 // Array of default events rules for Suricata
-$default_rules = array( "app-layer-events.rules", "decoder-events.rules", "dhcp-events.rules", "dnp3-events.rules", "dns-events.rules", "files.rules", "http-events.rules", "http2-events.rules", "ipsec-events.rules",
-						"kerberos-events.rules", "modbus-events.rules", "mqtt-events.rules", "nfs-events.rules", "ntp-events.rules", "smb-events.rules", "smtp-events.rules", "ssh-events.rules", "stream-events.rules",
-						"tls-events.rules" );
+$default_rules = SURICATA_DEFAULT_RULES;
 
 if (!is_array($config['installedpackages']['suricata']['rule'])) {
 	$config['installedpackages']['suricata']['rule'] = array();
@@ -677,6 +675,8 @@ else:
 			<table class="table table-striped table-hover table-condensed">
 				<thead>
 					<tr>
+						<th><?=gettext("Enabled"); ?></th>
+						<th><?=gettext("Ruleset: Default Rules"); ?></th>
 					<?php if ($emergingdownload == 'on' && !$no_emerging_files): ?>
 						<th><?=gettext("Enabled"); ?></th>
 						<th><?=gettext('Ruleset: ET Open Rules');?></th>
@@ -719,19 +719,65 @@ else:
 					}
 				}
 
+				sort($default_rules);
 				sort($emergingrules);
 				sort($snortrules);
-				$i = count($emergingrules);
 
+				// Find the largest array to determine the max number of rows
+				$i = count($default_rules);
+				if ($i < count($emergingrules))
+					$i = count($emergingrules);
 				if ($i < count($snortrules))
 					$i = count($snortrules);
 
 				// Walk the rules file names arrays and output the
 				// the file names and associated form controls in
 				// an HTML table.
-
 				for ($j = 0; $j < $i; $j++) {
 					echo "<tr>\n";
+				/* Begin DEFAULT RULES */
+					if (!empty($default_rules[$j])) {
+						$file = $default_rules[$j];
+						echo "<td>";
+						if(is_array($enabled_rulesets_array)) {
+							if(in_array($file, $enabled_rulesets_array) && !isset($cat_mods[$file]))
+								$CHECKED = " checked=\"checked\"";
+							else
+								$CHECKED = "";
+						} else
+							$CHECKED = "";
+
+						// If the rule category file is covered by a SID mgmt configuration,
+						// place an appropriate icon beside the category.
+						if (isset($cat_mods[$file])) {
+							// If the category is part of the enabled rulesets array,
+							// make sure we include a hidden field to reference it
+							// so we do not unset it during a post-back.
+							if (in_array($file, $enabled_rulesets_array))
+								echo "<input type='hidden' name='toenable[]' value='{$file}' />\n";
+							if ($cat_mods[$file] == 'enabled') {
+								$CHECKED = "enabled";
+								echo "	\n<i class=\"fa fa-adn text-success\" title=\"" . gettext('Auto-enabled by settings on SID Mgmt tab') . "\"></i>\n";
+							}
+							elseif ($cat_mods[$file] == 'disabled') {
+								echo "	\n<i class=\"fa fa-adn text-danger\" title=\"" . gettext('Auto-disabled by settings on SID Mgmt tab') . "\"></i>\n";
+							}
+						}
+						else {
+							echo "	\n<input type=\"checkbox\" name=\"toenable[]\" value=\"{$file}\" {$CHECKED} />\n";
+						}
+						echo "</td>\n";
+						echo "<td>\n";
+						if (empty($CHECKED))
+							echo "<a href='suricata_rules_edit.php?id={$id}&openruleset=" . urlencode($file) . "' target='_blank' rel='noopener noreferrer'>{$file}</a>\n";
+						else
+							echo "<a href='suricata_rules.php?id={$id}&openruleset=" . urlencode($file) . "'>{$file}</a>\n";
+						echo "</td>\n";
+					} else
+						echo "<td colspan='2'><br/></td>\n";
+				/* End DEFAULT RULES */
+
+				/* Begin EMERGING THREATS RULES */
 					if (!empty($emergingrules[$j])) {
 						$file = $emergingrules[$j];
 						echo "<td>";
@@ -771,7 +817,9 @@ else:
 						echo "</td>\n";
 					} else
 						echo "<td colspan='2'><br/></td>\n";
+				/* End EMERGING THREATS RULES */
 
+				/* Begin SNORT VRT RULES */
 					if (!empty($snortrules[$j])) {
 						$file = $snortrules[$j];
 						echo "<td>";
@@ -812,6 +860,7 @@ else:
 						echo "</td>\n";
 					} else
 						echo "<td colspan='2'><br/></td>\n";
+				/* End SNORT VRT RULES */
 
 					echo "</tr>\n";
 				}


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.6
This updates the Suricata GUI package to support the latest 6.0.6 binary from upstream. Four new features and two bug fixes are included in this release.

**New Features:**
1. Add MQTT and ENIP app-layer-protocol configuration controls on the APP PARSERS tab.
2. Improve the configuration options available in the GUI for the Suricata default events rules on the CATEGORIES tab.
3. Add the new _ssh-events.rules_ file to the list of default Suricata events rules.
4. Add column sorting and improve the functionality of the BLOCKS tab (used for Legacy Blocking Mode). [Redmine Feature Request #12748](https://redmine.pfsense.org/issues/12748).

**Bug Fixes:**
1. Fix [Redmine Issue #12956](https://redmine.pfsense.org/issues/12956) - revert the use of preg_quote() to wrap the user-supplied PCRE argument from the SID MGMT tab logic.
2. Fix [Redmine Issue #13333](https://redmine.pfsense.org/issues/13333) - string passed where an array was expected on the CATEGORIES tab when unselecting all categories.
3. Auto-enable _Live Rule Swap_ on the GLOBAL SETTINGS tab whenever an interface is configured for Inline IPS operation. This will keep netmap from cycling the physical interface down and back up each time Suricata is restarted (such as during a rules update).
