### PR TITLE
Ticket# 13467: acme NameSilo DNS bug fix - bump to latest commit from official repo

### DIFF
--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/dnsapi/dns_namesilo.sh
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/dnsapi/dns_namesilo.sh
@@ -110,7 +110,7 @@ _get_root() {
       return 1
     fi
 
-    if _contains "$response" "<domain>$host"; then
+    if _contains "$response" ">$host</domain>"; then
       _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-$p)
       _domain="$host"
       return 0


### PR DESCRIPTION
Bumping to latest official repo commit https://github.com/acmesh-official/acme.sh/commit/3dde83d8a0b911bf7740fa86db2997aa66cd9522 to fix the DNS domain name not found issue described here: https://github.com/acmesh-official/acme.sh/issues/4268

Changing `acme/dnsapi/dns_namesilo.sh` to properly handle the returned domain name from NameSilo when using issuing a certificate via DNS.

Redmine bug entry:
https://redmine.pfsense.org/issues/13467