### PR TITLE
pfSense-pkg-suricata-6.0.6_1 - Fix PHP8 compatibility issues. Redmine Issue #13531.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.6
-PORTREVISION=	0
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -3777,7 +3777,7 @@ function suricata_remove_dead_rules() {
 	// Now remove any dead rules files from the interface configurations
 	if (!empty($cats)) {
 		$a_ifaces = config_get_path('installedpackages/suricata/rule', []);
-		foreach ($a_ifaces as $iface) {
+		foreach ($a_ifaces as &$iface) {
 			$enabled_rules = explode("||", $iface['rulesets']);
 			foreach ($enabled_rules as $k => $v) {
 				foreach ($cats as $d) {
@@ -3807,7 +3807,7 @@ function suricata_sync_on_changes() {
 		return;
 	}
 
-	if (config_get_path('installedpackages/suricatasync/config')) {
+	if (config_get_path('installedpackages/suricatasync/config/0')) {
 		$suricata_sync = config_get_path('installedpackages/suricatasync/config/0');
 		$synconchanges = $suricata_sync['varsynconchanges'];
 		$synctimeout = $suricata_sync['varsynctimeout'] ?: '150';

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -4169,7 +4169,7 @@ function suricata_get_vpns_list() {
 		require_once("ipsec.inc");
 	}
 	if (ipsec_enabled()) {
-		if (config_get_path('ipsec/client') && config_path_enabled('ipsec/client')) {
+		if (config_path_enabled('ipsec/client')) {
 			/* Virtual Address Pool */
 			if (config_path_enabled('ipsec/client', 'pool_address') &&
 			    config_path_enabled('ipsec/client', 'pool_netbits')) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -37,18 +37,16 @@ require_once("xmlrpc_client.inc");
 require_once("openvpn.inc");
 require("/usr/local/pkg/suricata/suricata_defs.inc");
 
-global $g, $config;
+global $g;
 
 // Suricata GUI needs some extra PHP memory space to manipulate large rules arrays
 ini_set("memory_limit", "512M");
 
 function suricata_generate_id() {
-	global $config;
 
-	$suricatacfg = $config['installedpackages']['suricata']['rule'];
 	while (true) {
 		$suricata_uuid = mt_rand(1, 65535);
-		foreach ($suricatacfg as $value) {
+		foreach (config_get_path('installedpackages/suricata/rule', []) as $value) {
 			if ($value['uuid'] == $suricata_uuid) {
 				continue 2;
 			}
@@ -107,14 +105,7 @@ function suricata_start_all_interfaces($background=FALSE) {
 	/* interfaces.                                               */
 	/*************************************************************/
 
-	global $g, $config;
-
-	/* do nothing if no Suricata interfaces active */
-	if (!is_array($config['installedpackages']['suricata']['rule'])) {
-		return;
-	}
-
-	foreach ($config['installedpackages']['suricata']['rule'] as $suricatacfg) {
+	foreach (config_get_path('installedpackages/suricata/rule', []) as $suricatacfg) {
 		if ($suricatacfg['enable'] != 'on' || get_real_interface($suricatacfg['interface']) == "") {
 			continue;
 		}
@@ -128,14 +119,7 @@ function suricata_stop_all_interfaces() {
 	/* This function stops all configured Suricata interfaces.   */
 	/*************************************************************/
 
-	global $g, $config;
-
-	/* do nothing if no Suricata interfaces active */
-	if (!is_array($config['installedpackages']['suricata']['rule'])) {
-		return;
-	}
-
-	foreach ($config['installedpackages']['suricata']['rule'] as $suricatacfg) {
+	foreach (config_get_path('installedpackages/suricata/rule', []) as $suricatacfg) {
 		suricata_stop($suricatacfg, get_real_interface($suricatacfg['interface']));
 	}
 }
@@ -147,10 +131,8 @@ function suricata_restart_all_interfaces() {
 	/* and restarts enabled Suricata interfaces.                 */
 	/*************************************************************/
 
-	global $g, $config;
-
-	/* do nothing if no Suricata interfaces active */
-	if (!is_array($config['installedpackages']['suricata']['rule'])) {
+	/* do nothing if no Suricata interfaces configured */
+	if (count(config_get_path('installedpackages/suricata/rule', [])) < 1) {
 		return;
 	}
 
@@ -273,19 +255,10 @@ function suricata_get_supported_netmap_queues($if_real) {
 	return $threads_param;
 }
 
-/* func builds custom Pass Lists */
+/* func finds custom Suppress or Pass Lists */
 function suricata_find_list($find_name, $type = 'passlist') {
-	global $config;
 
-	$suricataglob = $config['installedpackages']['suricata'];
-	if (!is_array($suricataglob[$type])) {
-		return "";
-	}
-	if (!is_array($suricataglob[$type]['item'])) {
-		return "";
-	}
-
-	foreach ($suricataglob[$type]['item'] as $value) {
+	foreach (config_get_path("installedpackages/suricata/{$type}/item", []) as $value) {
 		if ($value['name'] == $find_name) {
 			return $value;
 		}
@@ -303,11 +276,20 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 	/* When '$passlist' is TRUE, a Pass List is built.         */
 	/* When '$externalist' is TRUE, the EXTERNAL_NET variable  */
 	/* is built.                                               */
+	/*                                                         */
+	/* Returns: an array of IP addresses/subnets               */
 	/***********************************************************/
 
-	global $config, $g, $aliastable, $filterdns;
+	global $g, $aliastable, $filterdns;
 	$home_net = array();
 
+	// If passed an empty interface configuration array, then
+	// exit and return an empty list array. This would be
+	// an unexpected condition.
+	if (empty($suricatacfg))
+		return $home_net;
+
+	// Determine which type of list we are to generate
 	if (!$externallist && ($listname == 'default' || empty($listname))) {
 		// When using inline IPS mode, exclude VPNs, VIPs,
 		// locally-attached network segments and the WAN IP from
@@ -348,25 +330,23 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 		// List. So for Pass Lists, we test for null strings from
 		// filter_expand_alias() and assume the passed alias is a
 		// FQDN or other dynamically updated alias.
-		if (is_array($list['address']['item']) && count($list['address']['item']) > 0) {
-			foreach ($list['address']['item'] as $addr) {
-				if (!$passlist) {
-					if (is_alias($addr) && (alias_get_type($addr) == "host" || alias_get_type($addr) == "network")) {
-						$home_net = array_merge($home_net, explode(" ", trim(filter_expand_alias($addr))));
-					} elseif (is_ipaddr($addr) || is_subnet($addr)) {
+		foreach (array_get_path($list, 'address/item', []) as $addr) {
+			if (!$passlist) {
+				if (is_alias($addr) && (alias_get_type($addr) == "host" || alias_get_type($addr) == "network")) {
+					$home_net = array_merge($home_net, explode(" ", trim(filter_expand_alias($addr))));
+				} elseif (is_ipaddr($addr) || is_subnet($addr)) {
+					$home_net[] = $addr;
+				}
+			} elseif ($passlist) {
+				if (is_alias($addr) && (alias_get_type($addr) == "host" || alias_get_type($addr) == "network")) {
+					$tmp = trim(filter_expand_alias($addr));
+					if (strlen($tmp) > 0) {
+						$home_net = array_merge($home_net, explode(" ", $tmp));
+					} elseif (!in_array($addr, $home_net)) {
 						$home_net[] = $addr;
 					}
-				} elseif ($passlist) {
-					if (is_alias($addr) && (alias_get_type($addr) == "host" || alias_get_type($addr) == "network")) {
-						$tmp = trim(filter_expand_alias($addr));
-						if (strlen($tmp) > 0) {
-							$home_net = array_merge($home_net, explode(" ", $tmp));
-						} elseif (!in_array($addr, $home_net)) {
-							$home_net[] = $addr;
-						}
-					} elseif (is_ipaddr($addr) || is_subnet($addr)) {
-						$home_net[] = $addr;
-					}
+				} elseif (is_ipaddr($addr) || is_subnet($addr)) {
+					$home_net[] = $addr;
 				}
 			}
 		}
@@ -577,17 +557,14 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 	// If the user chose to include Virtual IPs, then do so.
 	if($vips == 'yes') {
 		// iterate all vips and add to passlist
-		init_config_arr(array('virtualip', 'vip'));
-		if (is_array($config['virtualip']) && is_array($config['virtualip']['vip'])) {
-			foreach($config['virtualip']['vip'] as $vip) {
-				if (is_ipaddrv4($vip['subnet'])) {
-					$ip = gen_subnet($vip['subnet'], $vip['subnet_bits']) . "/{$vip['subnet_bits']}";
-				} else {
-					$ip = gen_subnetv6($vip['subnet'], $vip['subnet_bits']) . "/{$vip['subnet_bits']}";
-				}
-				if (!in_array($ip, $home_net)) {
-					$home_net[] = $ip;
-				}
+		foreach(config_get_path('virtualip/vip', []) as $vip) {
+			if (is_ipaddrv4($vip['subnet'])) {
+				$ip = gen_subnet($vip['subnet'], $vip['subnet_bits']) . "/{$vip['subnet_bits']}";
+			} else {
+				$ip = gen_subnetv6($vip['subnet'], $vip['subnet_bits']) . "/{$vip['subnet_bits']}";
+			}
+			if (!in_array($ip, $home_net)) {
+				$home_net[] = $ip;
 			}
 		}
 	}
@@ -644,16 +621,7 @@ function suricata_cron_job_exists($crontask, $match_time=FALSE, $minute="0", $ho
 	 * the $crontask already exists.                            *
 	 ************************************************************/
 
-	global $config, $g;
-
-	if (!is_array($config['cron'])) {
-		$config['cron'] = array();
-	}
-	if (!is_array($config['cron']['item'])) {
-		$config['cron']['item'] = array();
-	}
-
-	foreach($config['cron']['item'] as $item) {
+	foreach(config_get_path('cron/item', []) as $item) {
 		if(strpos($item['command'], $crontask) !== FALSE) {
 			if ($match_time) {
 				if ($item['minute'] != $minute) {
@@ -682,7 +650,6 @@ function suricata_cron_job_exists($crontask, $match_time=FALSE, $minute="0", $ho
 }
 
 function suricata_rules_up_install_cron($should_install=true) {
-	global $config, $g;
 
 	// If called with FALSE as argument, then we're removing 
 	// the existing job.
@@ -694,11 +661,11 @@ function suricata_rules_up_install_cron($should_install=true) {
 	}
 
 	// Get auto-rule update parameter from configuration
-	$suricata_rules_up_info_ck = $config['installedpackages']['suricata']['config'][0]['autoruleupdate'];
+	$suricata_rules_up_info_ck = config_get_path('installedpackages/suricata/config/0/autoruleupdate', '');
 
 	// See if a customized start time has been set for rule file updates
-	if (!empty($config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'])) {
-		$suricata_rules_upd_time = $config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'];
+	if (config_get_path('installedpackages/suricata/config/0/autoruleupdatetime')) {
+		$suricata_rules_upd_time = config_get_path('installedpackages/suricata/config/0/autoruleupdatetime');
 	} else {
 		$suricata_rules_upd_time = "00:" . str_pad(strval(random_int(0,59)), 2, "00", STR_PAD_LEFT);
 	}
@@ -796,7 +763,6 @@ function suricata_loglimit_install_cron($should_install=true) {
 }
 
 function suricata_rm_blocked_install_cron($should_install) {
-	global $config, $g;
 	$suri_pf_table = SURICATA_PF_TABLE;
 
 	// See if simply removing existing "expiretable" job for Suricata
@@ -807,7 +773,7 @@ function suricata_rm_blocked_install_cron($should_install) {
 		return;
 	}
 
-	$suricata_rm_blocked_info_ck = $config['installedpackages']['suricata']['config'][0]['rm_blocked'];
+	$suricata_rm_blocked_info_ck = config_get_path('installedpackages/suricata/config/0/rm_blocked', '');
 
 	if ($suricata_rm_blocked_info_ck == "15m_b") {
 		$suricata_rm_blocked_min = "*/1";
@@ -905,7 +871,7 @@ function suricata_rm_blocked_install_cron($should_install) {
 }
 
 function sync_suricata_package_config() {
-	global $config, $g;
+	global $g;
 
 	$suricatadir = SURICATADIR;
 	$rcdir = RCFILEPREFIX;
@@ -916,12 +882,11 @@ function sync_suricata_package_config() {
 	safe_mkdir(SURICATA_SID_MODS_PATH);
 
 	// Do not start config build if there are no Suricata-configured interfaces
-	if (!is_array($config['installedpackages']['suricata']['rule']) || count($config['installedpackages']['suricata']['rule']) < 1) {
+	if (count(config_get_path('installedpackages/suricata/rule', [])) < 1) {
 		return;
 	}
 
-	$suricataconf = $config['installedpackages']['suricata']['rule'];
-	foreach ($suricataconf as $value) {
+	foreach (config_get_path('installedpackages/suricata/rule', []) as $value) {
 		/* Skip configuration of any disabled instance or */
 		/* an instance whose assigned physical interface  */
 		/* has been removed.                              */
@@ -940,10 +905,10 @@ function sync_suricata_package_config() {
 	suricata_loglimit_install_cron(true);
 
 	// setup the suricata rules update job if enabled
-	suricata_rules_up_install_cron($config['installedpackages']['suricata']['config'][0]['autoruleupdate'] != "never_up" ? true : false);
+	suricata_rules_up_install_cron(config_get_path('installedpackages/suricata/config/0/autoruleupdate', '') != "never_up" ? true : false);
 
 	// set the suricata blocked hosts time
-	suricata_rm_blocked_install_cron($config['installedpackages']['suricata']['config'][0]['rm_blocked'] != "never_b" ? true : false);
+	suricata_rm_blocked_install_cron(config_get_path('installedpackages/suricata/config/0/rm_blocked', '') != "never_b" ? true : false);
 
 	// Do not attempt package sync if reinstalling package or booting
 	if (!isset($g['suricata_postinstall']) && !$g['booting']) {
@@ -952,8 +917,6 @@ function sync_suricata_package_config() {
 }
 
 function suricata_load_suppress_sigs($suricatacfg, $track_by=false) {
-
-	global $config;
 
 	/**********************************************************/
 	/* This function loads the GEN_ID and SIG_ID for all the  */
@@ -975,18 +938,7 @@ function suricata_load_suppress_sigs($suricatacfg, $track_by=false) {
 
 	$suppress = array();
 
-	if (!is_array($config['installedpackages']['suricata'])) {
-		return;
-	}
-	if (!is_array($config['installedpackages']['suricata']['suppress'])) {
-		return;
-	}
-	if (!is_array($config['installedpackages']['suricata']['suppress']['item'])) {
-		return;
-	}
-	$a_suppress = $config['installedpackages']['suricata']['suppress']['item'];
-
-	foreach ($a_suppress as $a_id => $alist) {
+	foreach (config_get_path('installedpackages/suricata/suppress/item', []) as $a_id => $alist) {
 		if ($alist['name'] == $suricatacfg['suppresslistname']) {
 			if (!empty($alist['suppresspassthru'])) {
 				$tmplist = str_replace("\r", "", base64_decode($alist['suppresspassthru']));
@@ -1011,7 +963,7 @@ function suricata_load_suppress_sigs($suricatacfg, $track_by=false) {
 							if (!is_array($suppress[$genid][$sigid])) {
 								$suppress[$genid][$sigid] = array();
 							}
-							$suppress[$genid][$sigid] = "suppress";
+							array_set_path($suppress, "{$genid}/{$sigid}", "suppress");
 						}
 					}
 
@@ -1024,19 +976,7 @@ function suricata_load_suppress_sigs($suricatacfg, $track_by=false) {
 							$whichip = trim($matches[3]);
 							$ip = $matches[4];
 							if (!empty($genid) && !empty($sigid) && !empty($whichip) && !empty($ip)) {
-								if (!is_array($suppress[$genid])) {
-									$suppress[$genid] = array();
-								}
-								if (!is_array($suppress[$genid][$sigid])) {
-									$suppress[$genid][$sigid] = array();
-								}
-								if (!is_array($suppress[$genid][$sigid][$whichip])) {
-									$suppress[$genid][$sigid][$whichip] = array();
-								}
-								if (!is_array($suppress[$genid][$sigid][$whichip][$ip])) {
-									$suppress[$genid][$sigid][$whichip][$ip] = array();
-								}
-								$suppress[$genid][$sigid][$whichip][$ip] = "suppress";
+								array_set_path($suppress, "{$genid}/{$sigid}/{$whichip}/{$ip}", "suppress");
 							}
 						}
 						/* See if entry suppresses only by SRC or DST IPv6 address */
@@ -1046,19 +986,7 @@ function suricata_load_suppress_sigs($suricatacfg, $track_by=false) {
 							$whichip = trim($matches[3]);
 							$ip = trim($matches[4]);
 							if (!empty($genid) && !empty($sigid) && !empty($whichip) && !empty($ip)) {
-								if (!is_array($suppress[$genid])) {
-									$suppress[$genid] = array();
-								}
-								if (!is_array($suppress[$genid][$sigid])) {
-									$suppress[$genid][$sigid] = array();
-								}
-								if (!is_array($suppress[$genid][$sigid][$whichip])) {
-									$suppress[$genid][$sigid][$whichip] = array();
-								}
-								if (!is_array($suppress[$genid][$sigid][$whichip][$ip])) {
-									$suppress[$genid][$sigid][$whichip][$ip] = array();
-								}
-								$suppress[$genid][$sigid][$whichip][$ip] = "suppress";
+								array_set_path($suppress, "{$genid}/{$sigid}/{$whichip}/{$ip}", "suppress");
 							}
 						}
 					}
@@ -1068,7 +996,6 @@ function suricata_load_suppress_sigs($suricatacfg, $track_by=false) {
 			break;
 		}
 	}
-	unset($alist);
 	return $suppress;
 }
 
@@ -1964,23 +1891,22 @@ function suricata_parse_sidconf_file($sidconf_file,$split_lines=TRUE) {
 	/*                    SID modifier tokens     */
 	/**********************************************/
 
-	global $config;
 	$buf = "";
 	$sid_mods = array();
 	$list = array();
 
 	// Find the list we need
-	if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists'])) {
-		$config['installedpackages']['suricata']['sid_mgmt_lists'] = array();
-	}
-	if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists']['item'])) {
-		$config['installedpackages']['suricata']['sid_mgmt_lists']['item'] = array();
-	}
-	foreach($config['installedpackages']['suricata']['sid_mgmt_lists']['item'] as $item) {
+	foreach(config_get_path('installedpackages/suricata/sid_mgmt_lists/item', []) as $item) {
 		if ($item['name'] == $sidconf_file) {
 			$list = $item;
 			break;
 		}
+	}
+
+	// If for some unexpected reason we fail to find the list, bail and
+	// return an emtpy array.
+	if (count($list) < 1) {
+		return $sid_mods;
 	}
 
 	// Decode the list contents into a PHP temp buffer
@@ -2048,16 +1974,7 @@ function suricata_sid_mgmt_list_exist($sid_mgmt_list) {
 	/*                                                  */
 	/****************************************************/
 
-	global $config, $g;
-
-	if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists'])) {
-		$config['installedpackages']['suricata']['sid_mgmt_lists'] = array();
-	}
-	if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists']['item'])) {
-		$config['installedpackages']['suricata']['sid_mgmt_lists']['item'] = array();
-	}
-
-	foreach($config['installedpackages']['suricata']['sid_mgmt_lists']['item'] as $list) {
+	foreach(config_get_path('installedpackages/suricata/sid_mgmt_lists/item', []) as $list) {
 		if ($list['name'] == $sid_mgmt_list) {
 			return TRUE;
 		}
@@ -2099,14 +2016,13 @@ function suricata_sid_mgmt_auto_categories($suricatacfg, $log_results = FALSE) {
 	/*                                                  */
 	/****************************************************/
 
-	global $config;
 	$sid_mods = array();
 	$enables = array();
 	$disables = array();
 	$drops = array();
 
 	// Check if auto-mgmt of SIDs is enabled, exit if not
-	if ($config['installedpackages']['suricata']['config'][0]['auto_manage_sids'] != 'on') {
+	if (config_get_path('installedpackages/suricata/config/0/auto_manage_sids', '')!= 'on') {
 		return array();
 	}
 	if (empty($suricatacfg['disable_sid_file']) && empty($suricatacfg['enable_sid_file']) && empty($suricatacfg['drop_sid_file'])) {
@@ -2956,7 +2872,6 @@ function suricata_auto_sid_mgmt(&$rule_map, $suricatacfg, $log_results = FALSE) 
 	/*                   otherwise FALSE              */
 	/**************************************************/
 
-	global $config;
 	$result = FALSE;
 
 	// Configure the interface's logging subdirectory if log results is enabled
@@ -2968,7 +2883,7 @@ function suricata_auto_sid_mgmt(&$rule_map, $suricatacfg, $log_results = FALSE) 
 
 	// Check if auto-mgmt of SIDs is enabled and files are specified
 	// for the interface.
-	if ($config['installedpackages']['suricata']['config'][0]['auto_manage_sids'] == 'on' &&
+	if (config_get_path('installedpackages/suricata/config/0/auto_manage_sids', '') == 'on' &&
 	    (!empty($suricatacfg['disable_sid_file']) || !empty($suricatacfg['enable_sid_file']) || 
 	    !empty($suricatacfg['modify_sid_file']) || !empty($suricatacfg['drop_sid_file']))) {
 		if ($log_results == TRUE) {
@@ -3323,7 +3238,7 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 	/*                  to be written.                         */
 	/***********************************************************/
 
-	global $config, $rebuild_rules;
+	global $rebuild_rules;
 
 	$flowbit_rules_file = FLOWBITS_FILENAME;
 	$suricata_enforcing_rules_file = SURICATA_ENFORCING_RULES_FILENAME;
@@ -3481,7 +3396,7 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 		}
 	}
 	// If no rule categories were enabled, then use auto-SID management if enabled, since it may enable some rules
-	elseif ($config['installedpackages']['suricata']['config'][0]['auto_manage_sids'] == 'on' &&
+	elseif (config_get_path('installedpackages/suricata/config/0/auto_manage_sids', '') == 'on' &&
 		(!empty($suricatacfg['disable_sid_file']) || !empty($suricatacfg['enable_sid_file']) || 
 		!empty($suricatacfg['modify_sid_file']))) {
 
@@ -3606,7 +3521,7 @@ function suricata_create_rc() {
 	/* after any changes to suricata.conf saved in the GUI.     */
 	/************************************************************/
 
-	global $config, $g;
+	global $g;
 
 	$suricatadir = SURICATADIR;
 	$suricatalogdir = SURICATALOGDIR;
@@ -3614,13 +3529,9 @@ function suricata_create_rc() {
 	$rcdir = RCFILEPREFIX;
 	$no_enabled_interface = TRUE;
 
-	// If no interfaces are configured for Suricata, exit
-	if (!is_array($config['installedpackages']['suricata']['rule'])) {
-		unlink_if_exists("{$rcdir}suricata.sh");
-		return;
-	}
-	$suricataconf = $config['installedpackages']['suricata']['rule'];
-	if (empty($suricataconf)) {
+	// If no interfaces are configured for Suricata, remove any
+	// existing shell script and exit.
+	if (count(config_get_path('installedpackages/suricata/rule', [])) < 1) {
 		unlink_if_exists("{$rcdir}suricata.sh");
 		return;
 	}
@@ -3631,7 +3542,7 @@ function suricata_create_rc() {
 
 	// Loop thru each configured interface and build
 	// the shell script.
-	foreach ($suricataconf as $value) {
+	foreach (config_get_path('installedpackages/suricata/rule', []) as $value) {
 
 		// Attempt to grab physical interface
 		// for this Suricata instance.
@@ -3781,7 +3692,7 @@ function suricata_generate_yaml($suricatacfg) {
 	/*                           file.                          */
 	/************************************************************/
 
-	global $config, $g;
+	global $g;
 
 	$suricatadir = SURICATADIR;
 	$suricatalogdir = SURICATALOGDIR;
@@ -3791,7 +3702,8 @@ function suricata_generate_yaml($suricatacfg) {
 	$suricata_uuid = $suricatacfg['uuid'];
 	$suricatacfgdir = "{$suricatadir}suricata_{$suricata_uuid}_{$if_real}";
 
-	if (!is_array($config['installedpackages']['suricata']['rule'])) {
+	// Nothing to do if no Suricata interfaces configured, so exit
+	if (count(config_get_path('installedpackages/suricata/rule', [])) < 1) {
 		return;
 	}
 
@@ -3820,7 +3732,6 @@ function suricata_remove_dead_rules() {
 	/* to determine which rules files to remove.             */
 	/*********************************************************/
 
-	global $config;
 	$rulesdir = SURICATADIR . "rules/";
 	$count = 0;
 	$cats = array();
@@ -3864,8 +3775,9 @@ function suricata_remove_dead_rules() {
 	syslog(LOG_NOTICE, gettext("[Suricata] Removed {$count} obsoleted rules category files."));
 
 	// Now remove any dead rules files from the interface configurations
-	if (!empty($cats) && is_array($config['installedpackages']['suricata']['rule'])) {
-		foreach ($config['installedpackages']['suricata']['rule'] as &$iface) {
+	if (!empty($cats)) {
+		$a_ifaces = config_get_path('installedpackages/suricata/rule', []);
+		foreach ($a_ifaces as $iface) {
 			$enabled_rules = explode("||", $iface['rulesets']);
 			foreach ($enabled_rules as $k => $v) {
 				foreach ($cats as $d) {
@@ -3876,6 +3788,9 @@ function suricata_remove_dead_rules() {
 			}
 			$iface['rulesets'] = implode("||", $enabled_rules);
 		}
+
+		// Write the updated ruleset configuration
+		config_set_path('installedpackages/suricata/rule', $a_ifaces);
 	}
 
 	// Clean up
@@ -3884,7 +3799,7 @@ function suricata_remove_dead_rules() {
 
 /* Uses XMLRPC to synchronize the changes to a remote node */
 function suricata_sync_on_changes() {
-	global $config, $g;
+	global $g;
 
 	/* Do not attempt a package sync while booting up or installing package */
 	if ($g['booting'] || $g['suricata_postinstall'] == TRUE) {
@@ -3892,8 +3807,8 @@ function suricata_sync_on_changes() {
 		return;
 	}
 
-	if (is_array($config['installedpackages']['suricatasync']['config'])) {
-		$suricata_sync = $config['installedpackages']['suricatasync']['config'][0];
+	if (config_get_path('installedpackages/suricatasync/config')) {
+		$suricata_sync = config_get_path('installedpackages/suricatasync/config/0');
 		$synconchanges = $suricata_sync['varsynconchanges'];
 		$synctimeout = $suricata_sync['varsynctimeout'] ?: '150';
 		$syncdownloadrules = $suricata_sync['vardownloadrules'];
@@ -3907,20 +3822,20 @@ function suricata_sync_on_changes() {
 				}
 				break;
 			case "auto":
-				if (is_array($config['hasync'])) {
-					$system_carp = $config['hasync'];
+				if (config_get_path('hasync')) {
+					$system_carp = config_get_path('hasync');
 					$rs[0]['varsyncipaddress'] = $system_carp['synchronizetoip'];
 					$rs[0]['varsyncusername'] = $system_carp['username'];
 					$rs[0]['varsyncpassword'] = $system_carp['password'];
 					$rs[0]['varsyncsuricatastart'] = FALSE;
 					$rs[0]['varsyncdestinenable'] = FALSE;
 					// XMLRPC sync is currently only supported over connections using the same protocol and port as this system
-					if ($config['system']['webgui']['protocol'] == "http") {
+					if (config_get_path('system/webgui/protocol', '') == "http") {
 						$rs[0]['varsyncprotocol'] = "http";
-						$rs[0]['varsyncport'] = $config['system']['webgui']['port'] ?: '80';
+						$rs[0]['varsyncport'] = config_get_path('system/webgui/port') ?: '80';
 					} else {
 						$rs[0]['varsyncprotocol'] = "https";
-						$rs[0]['varsyncport'] = $config['system']['webgui']['port'] ?: '443';
+						$rs[0]['varsyncport'] = config_get_path('system/webgui/port') ?: '443';
 					}
 					if ($system_carp['synchronizetoip'] == "") {
 						syslog(LOG_NOTICE, "[suricata] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
@@ -3986,7 +3901,7 @@ if(!function_exists('pf_version')) {
 
 /* Do the actual XMLRPC sync */
 function suricata_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol, $username, $password, $synctimeout, $syncstartsuricata) {
-	global $config, $g;
+	global $g;
 
 	/* Do not attempt a package sync while booting up or installing package */
 	if ($g['booting'] || isset($g['suricata_postinstall'])) {
@@ -4004,7 +3919,7 @@ function suricata_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protoc
 	/* $xml will hold the section to sync.            */
 	/**************************************************/
 	$xml = array();
-	$xml['suricata'] = $config['installedpackages']['suricata'];
+	$xml['suricata'] = config_get_path('installedpackages/suricata');
 	
 	$downloadrulescmd = "";
 	if ($syncdownloadrules == "yes") {
@@ -4245,7 +4160,6 @@ EOD;
 }
 
 function suricata_get_vpns_list() {
-	global $config;
 
 	$vpns = "";
 	$vpns_arr = array();
@@ -4255,26 +4169,26 @@ function suricata_get_vpns_list() {
 		require_once("ipsec.inc");
 	}
 	if (ipsec_enabled()) {
-		if (is_array($config['ipsec']['client']) && isset($config['ipsec']['client']['enable'])) {
+		if (config_get_path('ipsec/client') && config_path_enabled('ipsec/client')) {
 			/* Virtual Address Pool */
-			if (isset($config['ipsec']['client']['pool_address']) &&
-			    isset($config['ipsec']['client']['pool_netbits'])) {
-				$client_subnet = "{$config['ipsec']['client']['pool_address']}/{$config['ipsec']['client']['pool_netbits']}";
+			if (config_path_enabled('ipsec/client', 'pool_address') &&
+			    config_path_enabled('ipsec/client', 'pool_netbits')) {
+				$client_subnet = config_get_path('ipsec/client/pool_address') . '/' . config_get_path('ipsec/client/pool_netbits');
 				if (is_subnetv4($client_subnet)) {
 					 $vpns_arr[] = $client_subnet;
 				}
 			}
 			/* Virtual IPv6 Address Pool */
-			if (isset($config['ipsec']['client']['pool_address_v6']) &&
-			    isset($config['ipsec']['client']['pool_netbits_v6'])) {
-				$client_subnet = "{$config['ipsec']['client']['pool_address_v6']}/{$config['ipsec']['client']['pool_netbits_v6']}";
+			if (config_path_enabled('ipsec/client', 'pool_address_v6') &&
+			    config_path_enabled('ipsec/client', 'pool_netbits_v6')) {
+				$client_subnet = config_get_path('ipsec/client/pool_address_v6') . '/' . config_get_path('ipsec/client/pool_netbits_v6');
 				if (is_subnetv6($client_subnet)) {
 					$vpns_arr[] = text_to_compressed_ip6($client_subnet);
 				}
 			}
 			/* Mobile warriors */
-			if (isset($config['ipsec']['mobilekey'])) {
-				foreach ($config['ipsec']['mobilekey'] as $key) {
+			if (config_path_enabled('ipsec', 'mobilekey')) {
+				foreach (config_get_path('ipsec/mobilekey') as $key) {
 					if (!empty($key['pool_address']) &&
 					    !empty($key['pool_netbits'])) {
 						$vpns_subnet = "{$key['pool_address']}/{$key['pool_netbits']}";
@@ -4286,11 +4200,11 @@ function suricata_get_vpns_list() {
 			}
 		}
 		/* Site-to-Site IPsec */
-		if (is_array($config['ipsec']['phase2'])) {
-			foreach ($config['ipsec']['phase2'] as $ph2ent) {
+		if (config_get_path('ipsec/phase2')) {
+			foreach (config_get_path('ipsec/phase2', []) as $ph2ent) {
 				if ((!$ph2ent['mobile']) && ($ph2ent['mode'] != 'transport') &&
 				    !isset($ph2ent['disabled'])) {
-					if (!is_array($ph2ent['remoteid'])) {
+					if (!array_get_path($ph2ent, 'remoteid')) {
 						continue;
 					}
 					$ph2ent['remoteid']['mode'] = $ph2ent['mode'];
@@ -4307,37 +4221,35 @@ function suricata_get_vpns_list() {
 	}
 	/* OpenVPN */
 	foreach (array('client', 'server') as $type) {
-		if (is_array($config['openvpn']["openvpn-$type"])) {
-			foreach ($config['openvpn']["openvpn-$type"] as $settings) {
-				if (is_array($settings)) {
-					if (!isset($settings['disable'])) {
-						$remote_networks = explode(',', $settings['remote_network']);
+		foreach (config_get_path("openvpn/openvpn-{$type}", []) as $settings) {
+			if (is_array($settings)) {
+				if (!array_path_enabled($settings, 'disable')) {
+					$remote_networks = explode(',', $settings['remote_network']);
+					foreach ($remote_networks as $remote_network) {
+						if (function_exists('openvpn_gen_tunnel_network')) {
+							$vpns_arr[] = implode('/', openvpn_gen_tunnel_network($remote_network));
+						} elseif (is_subnetv4($remote_network)) {
+							$vpns_arr[] = $remote_network;
+						}
+					}
+					if (function_exists('openvpn_gen_tunnel_network')) {
+						$vpns_arr[] = implode('/', openvpn_gen_tunnel_network($settings['tunnel_network']));
+					} elseif (is_subnetv4($settings['tunnel_network'])) {
+						$vpns_arr[] = $settings['tunnel_network'];
+					}
+					if (isset($settings['remote_networkv6'])) {
+						$remote_networks = explode(',', $settings['remote_networkv6']);
 						foreach ($remote_networks as $remote_network) {
 							if (function_exists('openvpn_gen_tunnel_network')) {
 								$vpns_arr[] = implode('/', openvpn_gen_tunnel_network($remote_network));
-							} elseif (is_subnetv4($remote_network)) {
-								$vpns_arr[] = $remote_network;
+							} elseif (is_subnetv6($remote_network)) {
+								$vpns_arr[] = text_to_compressed_ip6($remote_network);
 							}
 						}
 						if (function_exists('openvpn_gen_tunnel_network')) {
-							$vpns_arr[] = implode('/', openvpn_gen_tunnel_network($settings['tunnel_network']));
-						} elseif (is_subnetv4($settings['tunnel_network'])) {
-							$vpns_arr[] = $settings['tunnel_network'];
-						}
-						if (isset($settings['remote_networkv6'])) {
-							$remote_networks = explode(',', $settings['remote_networkv6']);
-							foreach ($remote_networks as $remote_network) {
-								if (function_exists('openvpn_gen_tunnel_network')) {
-									$vpns_arr[] = implode('/', openvpn_gen_tunnel_network($remote_network));
-								} elseif (is_subnetv6($remote_network)) {
-									$vpns_arr[] = text_to_compressed_ip6($remote_network);
-								}
-							}
-							if (function_exists('openvpn_gen_tunnel_network')) {
-								$vpns_arr[] = implode('/', openvpn_gen_tunnel_network($settings['tunnel_networkv6']));
-							} elseif (is_subnetv6($settings['tunnel_networkv6'])) {
-								$vpns_arr[] = text_to_compressed_ip6($settings['tunnel_networkv6']);
-							}
+							$vpns_arr[] = implode('/', openvpn_gen_tunnel_network($settings['tunnel_networkv6']));
+						} elseif (is_subnetv6($settings['tunnel_networkv6'])) {
+							$vpns_arr[] = text_to_compressed_ip6($settings['tunnel_networkv6']);
 						}
 					}
 				}
@@ -4345,41 +4257,38 @@ function suricata_get_vpns_list() {
 		}
 	}
 	// OpenVPN CSO
-	init_config_arr(array('openvpn', 'openvpn-csc'));
-	foreach ($config['openvpn']['openvpn-csc'] as $ovpnent) {
-		if (is_array($ovpnent) && !isset($ovpnent['disable'])) {
+	foreach (config_get_path('openvpn/openvpn-csc', []) as $ovpnent) {
+		if (is_array($ovpnent) && !config_path_enabled($ovpnent, 'disable')) {
 			if (!empty($ovpnent['tunnel_network'])) {
 				if (function_exists('openvpn_gen_tunnel_network')) {
 					$vpns_arr[] = implode('/', openvpn_gen_tunnel_network($ovpnent['tunnel_network']));
 				} else {
-					$vpns_arr[] = $settings['tunnel_network'];
+					$vpns_arr[] = $ovpnent['tunnel_network'];
 				}
 			}
 			if (!empty($ovpnent['tunnel_networkv6'])) {
 				if (function_exists('openvpn_gen_tunnel_network')) {
 					$vpns_arr[] = implode('/', openvpn_gen_tunnel_network($ovpnent['tunnel_networkv6']));
 				} else {
-					$vpns_arr[] = $settings['tunnel_networkv6'];
+					$vpns_arr[] = $ovpnent['tunnel_networkv6'];
 				}
 			}
 		}
 	}
 	/* PPPoE Server */
- 	if (is_array($config['pppoes']['pppoe'])) {
-		foreach ($config['pppoes']['pppoe'] as $pppoe) {
-			if ($pppoe['mode'] == "server") {
-				if (is_ipaddrv4($pppoe['remoteip'])) {
-					$pppoesub = gen_subnetv4($pppoe['remoteip'], $pppoe['pppoe_subnet']);
-					if (is_subnetv4($pppoesub)) {
-						$vpns_arr[] = $pppoesub;
-					}
+	foreach (config_get_path('pppoes/pppoe', []) as $pppoe) {
+		if ($pppoe['mode'] == "server") {
+			if (is_ipaddrv4($pppoe['remoteip'])) {
+				$pppoesub = gen_subnetv4($pppoe['remoteip'], $pppoe['pppoe_subnet']);
+				if (is_subnetv4($pppoesub)) {
+					$vpns_arr[] = $pppoesub;
 				}
 			}
 		}
 	}
 	/* L2TP Server */
-	if ($config['l2tp']['mode'] == "server") {
-		$l2tp_net = "{$config['l2tp']['remoteip']}/{$config['l2tp']['l2tp_subnet']}";
+	if (config_get_path('l2tp/mode') == "server") {
+		$l2tp_net = config_get_path('l2tp/remoteip') . '/' . config_get_path('l2tp/l2tp_subnet');
 		if (is_subnetv4($l2tp_net)) {
 			$vpns_arr[] = $l2tp_net;
 		}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2020 Bill Meeks
+ * Copyright (C) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,7 @@
 
 require_once("/usr/local/pkg/suricata/suricata.inc");
 
-global $g, $config;
+global $g;
 
 function suricata_folderSize($dir) {
 
@@ -56,7 +56,7 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 	 *                                   in megabytes       *
 	 ********************************************************/
 
-	global $g, $config;
+	global $g;
 
 	// Convert Log Limit Size setting from MB to KB
 	$suricataloglimitsizeKB = round($suricataloglimitsize * 1024);
@@ -69,7 +69,7 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 		$logs = array ( "alerts.log", "block.log", "dns.log", "eve.json", "http.log", "sid_changes.log", "stats.log", "tls.log" );
 
 		// Clean-up the rotated logs for each configured Suricata instance
-		foreach ($config['installedpackages']['suricata']['rule'] as $value) {
+		foreach (config_get_path('installedpackages/suricata/rule', []) as $value) {
 			$if_real = get_real_interface($value['interface']);
 
 			// Skip instances where pfSense physical interface
@@ -129,7 +129,7 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 
 		// Clean-up active logs for each configured Suricata instance
 		// until we get below the configured Directory Size Limit.
-		foreach ($config['installedpackages']['suricata']['rule'] as $value) {
+		foreach (config_get_path('installedpackages/suricata/rule', []) as $value) {
 			$if_real = get_real_interface($value['interface']);
 
 			// Skip instances where pfSense physical interface
@@ -337,30 +337,30 @@ if ($g['booting'] == true)
 	return;
 
 // If no interfaces defined, there is nothing to clean up
-if (!is_array($config['installedpackages']['suricata']['rule']))
+if (!config_get_path('installedpackages/suricata/rule'))
 	return;
 
 $logs = array ();
 
 // Build an arry of files to check and limits to check them against from our saved configuration
-$logs['alerts.log']['limit'] = $config['installedpackages']['suricata']['config'][0]['alert_log_limit_size'];
-$logs['alerts.log']['retention'] = $config['installedpackages']['suricata']['config'][0]['alert_log_retention'];
-$logs['block.log']['limit'] = $config['installedpackages']['suricata']['config'][0]['block_log_limit_size'];
-$logs['block.log']['retention'] = $config['installedpackages']['suricata']['config'][0]['block_log_retention'];
-$logs['eve.json']['limit'] = $config['installedpackages']['suricata']['config'][0]['eve_log_limit_size'];
-$logs['eve.json']['retention'] = $config['installedpackages']['suricata']['config'][0]['eve_log_retention'];
-$logs['http.log']['limit'] = $config['installedpackages']['suricata']['config'][0]['http_log_limit_size'];
-$logs['http.log']['retention'] = $config['installedpackages']['suricata']['config'][0]['http_log_retention'];
-$logs['sid_changes.log']['limit'] = $config['installedpackages']['suricata']['config'][0]['sid_changes_log_limit_size'];
-$logs['sid_changes.log']['retention'] = $config['installedpackages']['suricata']['config'][0]['sid_changes_log_retention'];
-$logs['stats.log']['limit'] = $config['installedpackages']['suricata']['config'][0]['stats_log_limit_size'];
-$logs['stats.log']['retention'] = $config['installedpackages']['suricata']['config'][0]['stats_log_retention'];
-$logs['tls.log']['limit'] = $config['installedpackages']['suricata']['config'][0]['tls_log_limit_size'];
-$logs['tls.log']['retention'] = $config['installedpackages']['suricata']['config'][0]['tls_log_retention'];
+$logs['alerts.log']['limit'] = config_get_path('installedpackages/suricata/config/0/alert_log_limit_size');
+$logs['alerts.log']['retention'] = config_get_path('installedpackages/suricata/config/0/alert_log_retention');
+$logs['block.log']['limit'] = config_get_path('installedpackages/suricata/config/0/block_log_limit_size');
+$logs['block.log']['retention'] = config_get_path('installedpackages/suricata/config/0/block_log_retention');
+$logs['eve.json']['limit'] = config_get_path('installedpackages/suricata/config/0/eve_log_limit_size');
+$logs['eve.json']['retention'] = config_get_path('installedpackages/suricata/config/0/eve_log_retention');
+$logs['http.log']['limit'] = config_get_path('installedpackages/suricata/config/0/http_log_limit_size');
+$logs['http.log']['retention'] = config_get_path('installedpackages/suricata/config/0/http_log_retention');
+$logs['sid_changes.log']['limit'] = config_get_path('installedpackages/suricata/config/0/sid_changes_log_limit_size');
+$logs['sid_changes.log']['retention'] = config_get_path('installedpackages/suricata/config/0/sid_changes_log_retention');
+$logs['stats.log']['limit'] = config_get_path('installedpackages/suricata/config/0/stats_log_limit_size');
+$logs['stats.log']['retention'] = config_get_path('installedpackages/suricata/config/0/stats_log_retention');
+$logs['tls.log']['limit'] = config_get_path('installedpackages/suricata/config/0/tls_log_limit_size');
+$logs['tls.log']['retention'] = config_get_path('installedpackages/suricata/config/0/tls_log_retention');
 
 // Check log limits and retention in the interface logging directories if enabled
-if ($config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 'on') {
-	foreach ($config['installedpackages']['suricata']['rule'] as $value) {
+if (config_get_path('installedpackages/suricata/config/0/enable_log_mgmt') == 'on') {
+	foreach (config_get_path('installedpackages/suricata/rule', []) as $value) {
 		$if_real = get_real_interface($value['interface']);
 
 		// Skip instances where pfSense physical interface
@@ -382,37 +382,37 @@ if ($config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 
 
 		// Prune aged-out File Store captured files if any exist
 		if (is_dir("{$suricata_log_dir}/filestore") &&
-		    $config['installedpackages']['suricata']['config'][0]['file_store_retention'] > 0) {
+		    config_get_path('installedpackages/suricata/config/0/file_store_retention') > 0) {
 
-			$prune_count = suricata_check_prune_filestore_files("{$suricata_log_dir}/filestore", $config['installedpackages']['suricata']['config'][0]['file_store_retention']);
+			$prune_count = suricata_check_prune_filestore_files("{$suricata_log_dir}/filestore", config_get_path('installedpackages/suricata/config/0/file_store_retention'));
 			if ($prune_count > 0)
 				syslog(LOG_NOTICE, gettext("[Suricata] File Store captured files cleanup job removed {$prune_count} file(s) from '{$suricata_log_dir}/filestore/' path..."));
 		}
 
 		// Check File Store captured files storage limit and prune if necessary
 		if (is_dir("{$suricata_log_dir}/filestore") && 
-		    $config['installedpackages']['suricata']['config'][0]['file_store_limit_size'] > 0 && 
-		    (intval(suricata_folderSize("{$suricata_log_dir}/filestore")/1000000) >= $config['installedpackages']['suricata']['config'][0]['file_store_limit_size'])) {
-			suricata_check_filestore_limit_size("{$suricata_log_dir}/filestore", $config['installedpackages']['suricata']['config'][0]['file_store_limit_size']);
+		    config_get_path('installedpackages/suricata/config/0/file_store_limit_size') > 0 && 
+		    (intval(suricata_folderSize("{$suricata_log_dir}/filestore")/1000000) >= config_get_path('installedpackages/suricata/config/0/file_store_limit_size'))) {
+			suricata_check_filestore_limit_size("{$suricata_log_dir}/filestore", config_get_path('installedpackages/suricata/config/0/file_store_limit_size'));
 		}
 
 		// If a user-customized file store directory is set, check it, too
 		if (isset($value['file_store_logdir'])) {
 			if (is_dir($value['file_store_logdir']) && 
-			    $config['installedpackages']['suricata']['config'][0]['file_store_limit_size'] > 0 && 
-			    (intval(suricata_folderSize($value['file_store_logdir'])/1000000) >= $config['installedpackages']['suricata']['config'][0]['file_store_limit_size'])) {
-				suricata_check_filestore_limit_size($value['file_store_logdir'], $config['installedpackages']['suricata']['config'][0]['file_store_limit_size']);
+			    config_get_path('installedpackages/suricata/config/0/file_store_limit_size') > 0 && 
+			    (intval(suricata_folderSize($value['file_store_logdir'])/1000000) >= config_get_path('installedpackages/suricata/config/0/file_store_limit_size'))) {
+				suricata_check_filestore_limit_size($value['file_store_logdir'], config_get_path('installedpackages/suricata/config/0/file_store_limit_size'));
 			}
 		}
 
 		// Prune aged-out TLS Certs Store files if any exist
 		if (is_dir("{$suricata_log_dir}/certs") &&
-		    $config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'] > 0) {
+		    config_get_path('installedpackages/suricata/config/0/tls_certs_store_retention') > 0) {
 			$now = time();
 			$files = glob("{$suricata_log_dir}/certs/*.*");
 			$prune_count = 0;
 			foreach ($files as $f) {
-				if (($now - filemtime($f)) > ($config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'] * 3600)) {
+				if (($now - filemtime($f)) > (config_get_path('installedpackages/suricata/config/0/tls_certs_store_retention') * 3600)) {
 					$prune_count++;
 					unlink_if_exists($f);
 				}
@@ -444,8 +444,8 @@ if ($config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 
 }
 
 // Check the overall log directory limit (if enabled) and prune if necessary
-if ($config['installedpackages']['suricata']['config'][0]['suricataloglimit'] == 'on') {
-	suricata_check_dir_size_limit($config['installedpackages']['suricata']['config'][0]['suricataloglimitsize']);
+if (config_get_path('installedpackages/suricata/config/0/suricataloglimit') == 'on') {
+	suricata_check_dir_size_limit(config_get_path('installedpackages/suricata/config/0/suricataloglimitsize'));
 }
 
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -390,17 +390,18 @@ if (config_get_path('installedpackages/suricata/config/0/enable_log_mgmt') == 'o
 		}
 
 		// Check File Store captured files storage limit and prune if necessary
-		if (is_dir("{$suricata_log_dir}/filestore") && 
-		    config_get_path('installedpackages/suricata/config/0/file_store_limit_size') > 0 && 
-		    (intval(suricata_folderSize("{$suricata_log_dir}/filestore")/1000000) >= config_get_path('installedpackages/suricata/config/0/file_store_limit_size'))) {
+		if (is_dir("{$suricata_log_dir}/filestore") &&
+		    config_get_path('installedpackages/suricata/config/0/file_store_limit_size') > 0 &&
+		    (intval(suricata_folderSize("{$suricata_log_dir}/filestore")/1000000) >= config_get_path('installedpackages/suricata/config/0/file_store_limit_size'))
+		   ) {
 			suricata_check_filestore_limit_size("{$suricata_log_dir}/filestore", config_get_path('installedpackages/suricata/config/0/file_store_limit_size'));
 		}
 
 		// If a user-customized file store directory is set, check it, too
 		if (isset($value['file_store_logdir'])) {
-			if (is_dir($value['file_store_logdir']) && 
-			    config_get_path('installedpackages/suricata/config/0/file_store_limit_size') > 0 && 
-			    (intval(suricata_folderSize($value['file_store_logdir'])/1000000) >= config_get_path('installedpackages/suricata/config/0/file_store_limit_size'))) {
+			if (is_dir($value['file_store_logdir']) &&
+			    config_get_path('installedpackages/suricata/config/0/file_store_limit_size') > 0 &&
+			    (intval(suricata_folderSize($value['file_store_logdir'])/1000000) >= (int)_get_path('installedpackages/suricata/config/0/file_store_limit_size'))) {
 				suricata_check_filestore_limit_size($value['file_store_logdir'], config_get_path('installedpackages/suricata/config/0/file_store_limit_size'));
 			}
 		}
@@ -412,7 +413,7 @@ if (config_get_path('installedpackages/suricata/config/0/enable_log_mgmt') == 'o
 			$files = glob("{$suricata_log_dir}/certs/*.*");
 			$prune_count = 0;
 			foreach ($files as $f) {
-				if (($now - filemtime($f)) > (config_get_path('installedpackages/suricata/config/0/tls_certs_store_retention') * 3600)) {
+				if (($now - filemtime($f)) > (int)(config_get_path('installedpackages/suricata/config/0/tls_certs_store_retention') * 3600)) {
 					$prune_count++;
 					unlink_if_exists($f);
 				}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -401,7 +401,7 @@ if (config_get_path('installedpackages/suricata/config/0/enable_log_mgmt') == 'o
 		if (isset($value['file_store_logdir'])) {
 			if (is_dir($value['file_store_logdir']) &&
 			    config_get_path('installedpackages/suricata/config/0/file_store_limit_size') > 0 &&
-			    (intval(suricata_folderSize($value['file_store_logdir'])/1000000) >= (int)_get_path('installedpackages/suricata/config/0/file_store_limit_size'))) {
+			    (intval(suricata_folderSize($value['file_store_logdir'])/1000000) >= (int)config_get_path('installedpackages/suricata/config/0/file_store_limit_size'))) {
 				suricata_check_filestore_limit_size($value['file_store_logdir'], config_get_path('installedpackages/suricata/config/0/file_store_limit_size'));
 			}
 		}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2021 Bill Meeks
+ * Copyright (C) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,27 +38,26 @@ $suricata_rules_dir = SURICATA_RULES_DIR;
 $suri_eng_ver = filter_var(SURICATA_BIN_VERSION, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
 
 /* define checks */
-$oinkid = $config['installedpackages']['suricata']['config'][0]['oinkcode'];
-$snort_filename = $config['installedpackages']['suricata']['config'][0]['snort_rules_file'];
-$etproid = $config['installedpackages']['suricata']['config'][0]['etprocode'];
-$snortdownload = $config['installedpackages']['suricata']['config'][0]['enable_vrt_rules'] == 'on' ? 'on' : 'off';
-$etpro = $config['installedpackages']['suricata']['config'][0]['enable_etpro_rules'] == 'on' ? 'on' : 'off';
-$eto = $config['installedpackages']['suricata']['config'][0]['enable_etopen_rules'] == 'on' ? 'on' : 'off';
-$vrt_enabled = $config['installedpackages']['suricata']['config'][0]['enable_vrt_rules'] == 'on' ? 'on' : 'off';
-$snortcommunityrules = $config['installedpackages']['suricata']['config'][0]['snortcommunityrules'] == 'on' ? 'on' : 'off';
-$feodotracker_rules = $config['installedpackages']['suricata']['config'][0]['enable_feodo_botnet_c2_rules'] == 'on' ? 'on' : 'off';
-$sslbl_rules = $config['installedpackages']['suricata']['config'][0]['enable_abuse_ssl_blacklist_rules'] == 'on' ? 'on' : 'off';
-$enable_extra_rules = $config['installedpackages']['suricata']['config'][0]['enable_extra_rules'] == "on" ? 'on' : 'off';
-init_config_arr(array('installedpackages', 'suricata' ,'config', 0, 'extra_rules', 'rule'));
-$extra_rules = $config['installedpackages']['suricata']['config'][0]['extra_rules']['rule'];
+$oinkid = config_get_path('installedpackages/suricata/config/0/oinkcode');
+$snort_filename = config_get_path('installedpackages/suricata/config/0/snort_rules_file');
+$etproid = config_get_path('installedpackages/suricata/config/0/etprocode');
+$snortdownload = config_get_path('installedpackages/suricata/config/0/enable_vrt_rules') == 'on' ? 'on' : 'off';
+$etpro = config_get_path('installedpackages/suricata/config/0/enable_etpro_rules') == 'on' ? 'on' : 'off';
+$eto = config_get_path('installedpackages/suricata/config/0/enable_etopen_rules') == 'on' ? 'on' : 'off';
+$vrt_enabled = config_get_path('installedpackages/suricata/config/0/enable_vrt_rules') == 'on' ? 'on' : 'off';
+$snortcommunityrules = config_get_path('installedpackages/suricata/config/0/snortcommunityrules') == 'on' ? 'on' : 'off';
+$feodotracker_rules = config_get_path('installedpackages/suricata/config/0/enable_feodo_botnet_c2_rules') == 'on' ? 'on' : 'off';
+$sslbl_rules = config_get_path('installedpackages/suricata/config/0/enable_abuse_ssl_blacklist_rules') == 'on' ? 'on' : 'off';
+$enable_extra_rules = config_get_path('installedpackages/suricata/config/0/enable_extra_rules') == "on" ? 'on' : 'off';
+$extra_rules = config_get_path('installedpackages/suricata/config/0/extra_rules/rule', []);
 
 /* Working directory for downloaded rules tarballs */
 $tmpfname = "{$g['tmp_path']}/suricata_rules_up";
 
 /* Snort Rules filenames and URL */
-if ($config['installedpackages']['suricata']['config'][0]['enable_snort_custom_url'] == 'on') {
-	$snort_rule_url = trim(substr($config['installedpackages']['suricata']['config'][0]['snort_custom_url'], 0, strrpos($config['installedpackages']['suricata']['config'][0]['snort_custom_url'], '/') + 1));
-	$snort_filename = trim(substr($config['installedpackages']['suricata']['config'][0]['snort_custom_url'], strrpos($config['installedpackages']['suricata']['config'][0]['snort_custom_url'], '/') + 1));
+if (config_get_path('installedpackages/suricata/config/0/enable_snort_custom_url') == 'on') {
+	$snort_rule_url = trim(substr(config_get_path('installedpackages/suricata/config/0/snort_custom_url'), 0, strrpos(config_get_path('installedpackages/suricata/config/0/snort_custom_url'), '/') + 1));
+	$snort_filename = trim(substr(config_get_path('installedpackages/suricata/config/0/snort_custom_url'), strrpos(config_get_path('installedpackages/suricata/config/0/snort_custom_url'), '/') + 1));
 	$snort_filename_md5 = "{$snort_filename}.md5";
 }
 else {
@@ -67,10 +66,10 @@ else {
 }
 
 /* Snort GPLv2 Community Rules filenames and URL */
-if ($config['installedpackages']['suricata']['config'][0]['enable_gplv2_custom_url'] == 'on') {
-	$snort_community_rules_filename = trim(substr($config['installedpackages']['suricata']['config'][0]['gplv2_custom_url'], strrpos($config['installedpackages']['suricata']['config'][0]['gplv2_custom_url'], '/') + 1));
+if (config_get_path('installedpackages/suricata/config/0/enable_gplv2_custom_url') == 'on') {
+	$snort_community_rules_filename = trim(substr(config_get_path('installedpackages/suricata/config/0/gplv2_custom_url'), strrpos(config_get_path('installedpackages/suricata/config/0/gplv2_custom_url'), '/') + 1));
 	$snort_community_rules_filename_md5 = $snort_community_rules_filename . ".md5";
-	$snort_community_rules_url = trim(substr($config['installedpackages']['suricata']['config'][0]['gplv2_custom_url'], 0, strrpos($config['installedpackages']['suricata']['config'][0]['gplv2_custom_url'], '/') + 1));
+	$snort_community_rules_url = trim(substr(config_get_path('installedpackages/suricata/config/0/gplv2_custom_url'), 0, strrpos(config_get_path('installedpackages/suricata/config/0/gplv2_custom_url'), '/') + 1));
 }
 else {
 	$snort_community_rules_filename = GPLV2_DNLD_FILENAME;
@@ -79,13 +78,13 @@ else {
 }
 
 /* Set up ABUSE.ch Feodo Tracker and SSL Blacklist rules filenames and URLs */
-if ($config['installedpackages']['suricata']['config'][0]['enable_feodo_botnet_c2_rules'] == 'on') {
+if (config_get_path('installedpackages/suricata/config/0/enable_feodo_botnet_c2_rules') == 'on') {
 	$feodotracker_rules_filename = FEODO_TRACKER_DNLD_FILENAME;
 	$feodotracker_rules_filename_md5 = FEODO_TRACKER_DNLD_FILENAME . ".md5";
 	$feodotracker_rules_url = FEODO_TRACKER_DNLD_URL;
 
 }
-if ($config['installedpackages']['suricata']['config'][0]['enable_abuse_ssl_blacklist_rules'] == 'on') {
+if (config_get_path('installedpackages/suricata/config/0/enable_abuse_ssl_blacklist_rules') == 'on') {
 	$sslbl_rules_filename = ABUSE_SSLBL_DNLD_FILENAME;
 	$sslbl_rules_filename_md5 = ABUSE_SSLBL_DNLD_FILENAME . ".md5";
 	$sslbl_rules_url = ABUSE_SSLBL_DNLD_URL;
@@ -95,9 +94,9 @@ if ($config['installedpackages']['suricata']['config'][0]['enable_abuse_ssl_blac
 /* Set up Emerging Threats rules filenames and URL */
 if ($etpro == "on") {
 	$et_name = "Emerging Threats Pro";
-	if ($config['installedpackages']['suricata']['config'][0]['enable_etpro_custom_url'] == 'on') {
-		$emergingthreats_url = trim(substr($config['installedpackages']['suricata']['config'][0]['etpro_custom_rule_url'], 0, strrpos($config['installedpackages']['suricata']['config'][0]['etpro_custom_rule_url'], '/') + 1));
-		$emergingthreats_filename = trim(substr($config['installedpackages']['suricata']['config'][0]['etpro_custom_rule_url'], strrpos($config['installedpackages']['suricata']['config'][0]['etpro_custom_rule_url'], '/') + 1));
+	if (config_get_path('installedpackages/suricata/config/0/enable_etpro_custom_url') == 'on') {
+		$emergingthreats_url = trim(substr(config_get_path('installedpackages/suricata/config/0/etpro_custom_rule_url'), 0, strrpos(config_get_path('installedpackages/suricata/config/0/etpro_custom_rule_url'), '/') + 1));
+		$emergingthreats_filename = trim(substr(config_get_path('installedpackages/suricata/config/0/etpro_custom_rule_url'), strrpos(config_get_path('installedpackages/suricata/config/0/etpro_custom_rule_url'), '/') + 1));
 		$emergingthreats_filename_md5 = $emergingthreats_filename . ".md5";
 		$et_md5_remove = ET_DNLD_FILENAME . ".md5";
 	}
@@ -112,9 +111,9 @@ if ($etpro == "on") {
 }
 else {
 	$et_name = "Emerging Threats Open";
-	if ($config['installedpackages']['suricata']['config'][0]['enable_etopen_custom_url'] == 'on') {
-		$emergingthreats_url = trim(substr($config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url'], 0, strrpos($config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url'], '/') + 1));
-		$emergingthreats_filename = trim(substr($config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url'], strrpos($config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url'], '/') + 1));
+	if (config_get_path('installedpackages/suricata/config/0/enable_etopen_custom_url') == 'on') {
+		$emergingthreats_url = trim(substr(config_get_path('installedpackages/suricata/config/0/etopen_custom_rule_url'), 0, strrpos(config_get_path('installedpackages/suricata/config/0/etopen_custom_rule_url'), '/') + 1));
+		$emergingthreats_filename = trim(substr(config_get_path('installedpackages/suricata/config/0/etopen_custom_rule_url'), strrpos(config_get_path('installedpackages/suricata/config/0/etopen_custom_rule_url'), '/') + 1));
 		$emergingthreats_filename_md5 = $emergingthreats_filename . ".md5";
 		$et_md5_remove = ETPRO_DNLD_FILENAME . ".md5";
 	}
@@ -164,7 +163,7 @@ function suricata_download_file_url($url, $file_out) {
 	/* It provides logging of returned CURL errors. */
 	/************************************************/
 
-	global $g, $config, $last_curl_error, $fout, $ch;
+	global $g, $last_curl_error, $fout, $ch;
 
 	$rfc2616 = array(
 			100 => "100 Continue",
@@ -231,7 +230,7 @@ function suricata_download_file_url($url, $file_out) {
 		curl_setopt($ch, CURLOPT_TCP_KEEPALIVE, 1);
 
 		// Honor any system restrictions on sending USERAGENT info
-		if (!isset($config['system']['do_not_send_host_uuid'])) {
+		if (config_path_enabled('system', 'do_not_send_host_uuid')) {
 			curl_setopt($ch, CURLOPT_USERAGENT, $g['product_name'] . '/' . $g['product_version'] . ' : ' . get_single_sysctl('kern.hostuuid'));
 		}
 		else {
@@ -239,14 +238,14 @@ function suricata_download_file_url($url, $file_out) {
 		}
 
 		// Use the system proxy server setttings if configured
-		if (!empty($config['system']['proxyurl'])) {
-			curl_setopt($ch, CURLOPT_PROXY, $config['system']['proxyurl']);
-			if (!empty($config['system']['proxyport'])) {
-				curl_setopt($ch, CURLOPT_PROXYPORT, $config['system']['proxyport']);
+		if (!empty(config_get_path('system/proxyurl'))) {
+			curl_setopt($ch, CURLOPT_PROXY, config_get_path('system/proxyurl'));
+			if (!empty(config_get_path('system/proxyport'))) {
+				curl_setopt($ch, CURLOPT_PROXYPORT, config_get_path('system/proxyport'));
 			}
-			if (!empty($config['system']['proxyuser']) && !empty($config['system']['proxypass'])) {
+			if (!empty(config_get_path('system/proxyuser')) && !empty(config_get_path('system/proxypass'))) {
 				@curl_setopt($ch, CURLOPT_PROXYAUTH, CURLAUTH_ANY | CURLAUTH_ANYSAFE);
-				curl_setopt($ch, CURLOPT_PROXYUSERPWD, "{$config['system']['proxyuser']}:{$config['system']['proxypass']}");
+				curl_setopt($ch, CURLOPT_PROXYUSERPWD, config_get_path('system/proxyuser') . ":" . config_get_path('system/proxypass'));
 			}
 		}
 
@@ -445,7 +444,7 @@ init_config_arr(array('installedpackages', 'suricata', 'rule'));
 
 /* Save current state (running/not running) for each enabled Suricatat interface */
 $active_interfaces = array();
-foreach ($config['installedpackages']['suricata']['rule'] as $value) {
+foreach (config_get_path('installedpackages/suricata/rule', []) as $value) {
 	$if_real = get_real_interface($value['interface']);
 
 	/* Skip processing for instances whose underlying physical        */
@@ -474,7 +473,7 @@ if ($emergingthreats == 'on') {
 
 /*  Check for and download any new Snort rule sigs */
 if ($snortdownload == 'on') {
-	$snort_custom_url = $config['installedpackages']['suricata']['config'][0]['enable_snort_custom_url'] == 'on' ? TRUE : FALSE;
+	$snort_custom_url = config_get_path('installedpackages/suricata/config/0/enable_snort_custom_url') == 'on' ? TRUE : FALSE;
 	if (empty($snort_filename)) {
 		syslog(LOG_WARNING, gettext("WARNING: No snortrules-snapshot filename has been set on Snort pkg GLOBAL SETTINGS tab.  Snort rules cannot be updated."));
 		error_log(gettext("\tWARNING-- No snortrules-snapshot filename set on GLOBAL SETTINGS tab. Snort rules cannot be updated!\n"), 3, SURICATA_RULES_UPD_LOGFILE);
@@ -868,7 +867,7 @@ if ($snortcommunityrules == 'on') {
 }
 
 // If removing deprecated rules categories, then do it
-if ($config['installedpackages']['suricata']['config'][0]['hide_deprecated_rules'] == "on") {
+if (config_get_path('installedpackages/suricata/config/0/hide_deprecated_rules') == "on") {
 	syslog(LOG_NOTICE, gettext("[Suricata] Hide Deprecated Rules is enabled.  Removing obsoleted rules categories."));
 	suricata_remove_dead_rules();
 }
@@ -922,8 +921,7 @@ if ($snortdownload == 'on' || $emergingthreats == 'on' || $snortcommunityrules =
 	}
 
 	/* Start the rules rebuild proccess for each configured interface */
-	if (is_array($config['installedpackages']['suricata']['rule']) &&
-	    count($config['installedpackages']['suricata']['rule']) > 0) {
+	if (count(config_get_path('installedpackages/suricata/rule', [])) > 0) {
 
 		/* Set the flag to force rule rebuilds since we downloaded new rules,    */
 		/* except when in post-install mode.  Post-install does its own rebuild. */
@@ -933,7 +931,7 @@ if ($snortdownload == 'on' || $emergingthreats == 'on' || $snortcommunityrules =
 			$rebuild_rules = true;
 
 		/* Create configuration for each active Suricata interface */
-		foreach ($config['installedpackages']['suricata']['rule'] as $value) {
+		foreach (config_get_path('installedpackages/suricata/rule', []) as $value) {
 			$if_real = get_real_interface($value['interface']);
 
 			/* Skip processing for instances whose underlying physical       */
@@ -959,7 +957,7 @@ if ($snortdownload == 'on' || $emergingthreats == 'on' || $snortcommunityrules =
 			if (in_array($value['interface'], $active_interfaces) && !$g['suricata_postinstall']) {
 				// If running and "Live Reload" is enabled, just reload the configuration;
 				// otherwise, start/restart the interface instance of Suricata.
-				if (suricata_is_running($value['uuid'], $if_real) && $config['installedpackages']['suricata']['config'][0]['live_swap_updates'] == 'on') {
+				if (suricata_is_running($value['uuid'], $if_real) && config_get_path('installedpackages/suricata/config/0/live_swap_updates') == 'on') {
 					syslog(LOG_NOTICE, gettext("[Suricata] Live-Reload of rules from auto-update is enabled..."));
 					error_log(gettext("\tLive-Reload of updated rules is enabled...\n"), 3, SURICATA_RULES_UPD_LOGFILE);
 					suricata_update_status(gettext("Signaling Suricata to live-load the new set of rules for " . convert_friendly_interface_to_friendly_descr($value['interface']) . "..."));
@@ -1011,10 +1009,10 @@ else {
 }
 @file_put_contents(SURICATADIR . "rulesupd_status", $status);
 
-if ($config['installedpackages']['suricata']['config'][0]['update_notify'] == 'on') {
+if (config_get_path('installedpackages/suricata/config/0/update_notify') == 'on') {
 	notify_all_remote($notify_message);
 }
-if (($config['installedpackages']['suricata']['config'][0]['rule_categories_notify'] == 'on') &&
+if ((config_get_path('installedpackages/suricata/config/0/rule_categories_notify') == 'on') &&
     ($notify_new_message)) {
 	notify_all_remote("Suricata new rule categories are available:\n" . $notify_new_message);
 }

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
@@ -31,13 +31,10 @@ require_once("pkg-utils.inc");
 /* the "suricata.inc" and "suricata_post_install.php" files.             */
 /*************************************************************************/
 
-global $g, $config;
-
-if (!is_array($config['installedpackages']['suricata']))
-	$config['installedpackages']['suricata'] = array();
+global $g;
 
 /* Get installed package version for display */
-$suricata_package_version = "{$config['installedpackages']['package'][get_package_id("suricata")]['version']}";
+$suricata_package_version = config_get_path('installedpackages/package/' . get_package_id("suricata") . '/version');
 
 // Define the installed package version
 if (!defined('SURICATA_PKG_VER'))

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_etiqrisk_update.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_etiqrisk_update.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2019 Bill Meeks
+ * Copyright (C) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,9 +48,9 @@ function suricata_check_iprep_md5($filename) {
 	/*           error occurred.                              */
 	/**********************************************************/
 
-	global $config, $iqRisk_tmppath, $iprep_path, $notify_message;
+	global $iqRisk_tmppath, $iprep_path, $notify_message;
 	$new_md5 = $old_md5 = "";
-	$et_iqrisk_url = str_replace("_xxx_", $config['installedpackages']['suricata']['config'][0]['iqrisk_code'], ET_IQRISK_DNLD_URL);
+	$et_iqrisk_url = str_replace("_xxx_", config_get_path('installedpackages/suricata/config/0/iqrisk_code'), ET_IQRISK_DNLD_URL);
 
 	if (download_file("{$et_iqrisk_url}{$filename}.md5sum", "{$iqRisk_tmppath}{$filename}.md5", true, 10, 30) == true) {
 		if (file_exists("{$iqRisk_tmppath}{$filename}.md5"))
@@ -73,28 +73,21 @@ function suricata_check_iprep_md5($filename) {
 /**********************************************************************
  * Start of main code                                                 *
  **********************************************************************/
-global $g, $config;
+global $g;
 $iprep_path = SURICATA_IPREP_PATH;
 $iqRisk_tmppath = "{$g['tmp_path']}/IQRisk/";
 $success = FALSE;
 
-if (!is_array($config['installedpackages']['suricata']))
-	$config['installedpackages']['suricata'] = array();
-if (!is_array($config['installedpackages']['suricata']['config']))
-	$config['installedpackages']['suricata']['config'] = array();
-if (!is_array($config['installedpackages']['suricata']['config'][0]))
-	$config['installedpackages']['suricata']['config'][0] = array();
-
 // If auto-updates of ET IQRisk are disabled, then exit
-if ($config['installedpackages']['suricata']['config'][0]['et_iqrisk_enable'] == "off")
+if (config_get_path('installedpackages/suricata/config/0/et_iqrisk_enable') == "off")
 	return(0);
 else
 	syslog(LOG_NOTICE, gettext("[Suricata] Updating the Emerging Threats IQRisk IP List..."));
 	$notify_message = gettext("Suricata Emerging Threats IQRisk IP List update started: " . date("Y-m-d H:i:s") . "\n");
 
 // Construct the download URL using the saved ET IQRisk Subscriber Code
-if (!empty($config['installedpackages']['suricata']['config'][0]['iqrisk_code'])) {
-	$et_iqrisk_url = str_replace("_xxx_", $config['installedpackages']['suricata']['config'][0]['iqrisk_code'], ET_IQRISK_DNLD_URL);
+if (!empty(config_get_path('installedpackages/suricata/config/0/iqrisk_code'))) {
+	$et_iqrisk_url = str_replace("_xxx_", config_get_path('installedpackages/suricata/config/0/iqrisk_code'), ET_IQRISK_DNLD_URL);
 }
 else {
 	syslog(gettext(LOG_ALERT, "[Suricata] ALERT: No IQRisk subscriber code found!  Aborting scheduled update of Emerging Threats IQRisk IP List."));
@@ -165,7 +158,7 @@ $notify_message .= gettext("Suricata Emerging Threats IQRisk IP List update fini
 
 // If successful, signal any running Suricata process to live reload the rules and IP lists
 if ($success == TRUE && is_process_running("suricata")) {
-	foreach ($config['installedpackages']['suricata']['rule'] as $value) {
+	foreach (config_get_path('installedpackages/suricata/rule', []) as $value) {
 		if ($value['enable_iprep'] == "on") {
 			suricata_reload_config($value);
 			sleep(2);
@@ -173,7 +166,7 @@ if ($success == TRUE && is_process_running("suricata")) {
 	}
 }
 
-if ($config['installedpackages']['suricata']['config'][0]['update_notify'] == 'on') {
+if (config_get_path('installedpackages/suricata/config/0/update_notify') == 'on') {
 	notify_all_remote($notify_message);
 }
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -82,16 +82,16 @@ $suricata_servers = array (
 	"sip_servers" => "\$HOME_NET"
 );
 $addr_vars = "";
-	foreach ($suricata_servers as $alias => $avalue) {
-		if (!empty($suricatacfg["def_{$alias}"]) && is_alias($suricatacfg["def_{$alias}"])) {
-			$avalue = trim(filter_expand_alias($suricatacfg["def_{$alias}"]));
-			$avalue = preg_replace('/\s+/', ', ', trim($avalue));
-		}
-		$addr_vars .= "    " . strtoupper($alias) . ": \"{$avalue}\"\n";
+foreach ($suricata_servers as $alias => $avalue) {
+	if (!empty($suricatacfg["def_{$alias}"]) && is_alias($suricatacfg["def_{$alias}"])) {
+		$avalue = trim(filter_expand_alias($suricatacfg["def_{$alias}"]));
+		$avalue = preg_replace('/\s+/', ', ', trim($avalue));
 	}
+	$addr_vars .= "    " . strtoupper($alias) . ": \"{$avalue}\"\n";
+}
 $addr_vars = trim($addr_vars);
-if(is_array($config['system']['ssh']) && isset($config['system']['ssh']['port']))
-        $ssh_port = $config['system']['ssh']['port'];
+if(config_get_path('system/ssh/port'))
+        $ssh_port = config_get_path('system/ssh/port');
 else
         $ssh_port = "22";
 $suricata_ports = array(
@@ -105,13 +105,13 @@ $suricata_ports = array(
 	"sip_ports" => "5060, 5061, 5600"
 );
 $port_vars = "";
-	foreach ($suricata_ports as $alias => $avalue) {
-		if (!empty($suricatacfg["def_{$alias}"]) && is_alias($suricatacfg["def_{$alias}"])) {
-			$avalue = trim(filter_expand_alias($suricatacfg["def_{$alias}"]));
-			$avalue = preg_replace('/\s+/', ', ', trim($avalue));
-		}
-		$port_vars .= "    " . strtoupper($alias) . ": \"{$avalue}\"\n";
+foreach ($suricata_ports as $alias => $avalue) {
+	if (!empty($suricatacfg["def_{$alias}"]) && is_alias($suricatacfg["def_{$alias}"])) {
+		$avalue = trim(filter_expand_alias($suricatacfg["def_{$alias}"]));
+		$avalue = preg_replace('/\s+/', ', ', trim($avalue));
 	}
+	$port_vars .= "    " . strtoupper($alias) . ": \"{$avalue}\"\n";
+}
 $port_vars = trim($port_vars);
 
 // Define a Suppress List (Threshold) if one is configured
@@ -387,15 +387,15 @@ else {
 // EVE log output included information
 $eve_out_types = "";
 
-if (($suricatacfg['eve_log_alerts'] == 'on')) {
+if ($suricatacfg['eve_log_alerts'] == 'on') {
 	$eve_out_types .= "\n        - alert:";
-	$eve_out_types .= "\n            payload: ".($suricatacfg['eve_log_alerts_payload'] == 'on' || $suricatacfg['eve_log_alerts_payload'] == 'only-base64' ?'yes':'no ')."              # enable dumping payload in Base64";
+	$eve_out_types .= "\n            payload: " . (($suricatacfg['eve_log_alerts_payload'] == 'on' || $suricatacfg['eve_log_alerts_payload'] == 'only-base64') ? 'yes':'no ') . "              # enable dumping payload in Base64";
 	$eve_out_types .= "\n            payload-buffer-size: 4kb  # max size of payload buffer to output in eve-log";
-	$eve_out_types .= "\n            payload-printable: ".($suricatacfg['eve_log_alerts_payload'] == 'on' || $suricatacfg['eve_log_alerts_payload'] == 'only-printable' ?'yes':'no ')."    # enable dumping payload in printable (lossy) format";
-	$eve_out_types .= "\n            packet: ".($suricatacfg['eve_log_alerts_packet'] == 'on'?'yes':'no ')."               # enable dumping of packet (without stream segments)";
-	$eve_out_types .= "\n            http-body: ".($suricatacfg['eve_log_alerts_payload'] == 'on'?'yes':'no ' || $suricatacfg['eve_log_alerts_payload'] == 'only-base64' ?'yes':'no ')."            # enable dumping of http body in Base64";
-	$eve_out_types .= "\n            http-body-printable: ".($suricatacfg['eve_log_alerts_payload'] == 'on' || $suricatacfg['eve_log_alerts_payload'] == 'only-printable' ?'yes':'no ')."  # enable dumping of http body in printable format";
-	$eve_out_types .= "\n            metadata: ".($suricatacfg['eve_log_alerts_metadata'] == 'on'?'yes':'no ')."             # enable inclusion of app layer metadata with alert";
+	$eve_out_types .= "\n            payload-printable: " . (($suricatacfg['eve_log_alerts_payload'] == 'on' || $suricatacfg['eve_log_alerts_payload'] == 'only-printable') ? 'yes':'no ') . "    # enable dumping payload in printable (lossy) format";
+	$eve_out_types .= "\n            packet: " . ($suricatacfg['eve_log_alerts_packet'] == 'on' ? 'yes':'no ') . "               # enable dumping of packet (without stream segments)";
+	$eve_out_types .= "\n            http-body: " . (($suricatacfg['eve_log_alerts_payload'] == 'on'|| $suricatacfg['eve_log_alerts_payload'] == 'only-base64') ?'yes':'no ') . "            # enable dumping of http body in Base64";
+	$eve_out_types .= "\n            http-body-printable: " . (($suricatacfg['eve_log_alerts_payload'] == 'on' || $suricatacfg['eve_log_alerts_payload'] == 'only-printable') ? 'yes':'no ') . "  # enable dumping of http body in printable format";
+	$eve_out_types .= "\n            metadata: " . ($suricatacfg['eve_log_alerts_metadata'] == 'on' ? 'yes':'no ') . "             # enable inclusion of app layer metadata with alert";
 	$eve_out_types .= "\n            tagged-packets: yes       # enable logging of tagged packets for rules using the 'tag' keyword";
 }
 
@@ -1131,18 +1131,18 @@ if (file_exists("{$suricatacfgdir}/rules/custom.rules")) {
 $rules_files = ltrim($rules_files, '\n -');
 
 // Add the general logging settings to the configuration (non-interface specific)
-if ($config['installedpackages']['suricata']['config'][0]['log_to_systemlog'] == 'on')
+if (config_get_path('installedpackages/suricata/config/0/log_to_systemlog') == 'on')
 	$suricata_use_syslog = "yes";
 else
 	$suricata_use_syslog = "no";
 
-if (!empty($config['installedpackages']['suricata']['config'][0]['log_to_systemlog_facility']))
-	$suricata_use_syslog_facility = $config['installedpackages']['suricata']['config'][0]['log_to_systemlog_facility'];
+if (!empty(config_get_path('installedpackages/suricata/config/0/log_to_systemlog_facility')))
+	$suricata_use_syslog_facility = config_get_path('installedpackages/suricata/config/0/log_to_systemlog_facility');
 else
 	$suricata_use_syslog_facility = "local1";
 
-if (!empty($config['installedpackages']['suricata']['config'][0]['log_to_systemlog_priority']))
-	$suricata_use_syslog_priority = $config['installedpackages']['suricata']['config'][0]['log_to_systemlog_priority'];
+if (!empty(config_get_path('installedpackages/suricata/config/0/log_to_systemlog_priority')))
+	$suricata_use_syslog_priority = config_get_path('installedpackages/suricata/config/0/log_to_systemlog_priority');
 else
 	$suricata_use_syslog_priority = "notice";
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -233,7 +233,16 @@ foreach (config_get_path('installedpackages/suricata/passlist/item', []) as &$wl
 	}
 }
 
-// Now process the interface-specific settings
+/***********************************************************/
+/* Add new 'clear blocks' setting to remove blocked hosts  */
+/* from the snort2c pf table that were added by the Legacy */
+/* Blocking custom plugin. Default empty value to 'yes'.   */
+/***********************************************************/
+if (!config_path_enabled('installedpackages/suricata/config/0/clearblocks')) {
+	config_set_path('installedpackages/suricata/config/0/clearblocks', 'on');
+}
+
+// Now process the interface-specific migration settings
 $a_rules = config_get_path('installedpackages/suricata/rule', []);
 foreach ($a_rules as $pconfig) {
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -245,7 +245,7 @@ if (!config_path_enabled('installedpackages/suricata/config/0/clearblocks')) {
 
 // Now process the interface-specific migration settings
 $a_rules = config_get_path('installedpackages/suricata/rule', []);
-foreach ($a_rules as $pconfig) {
+foreach ($a_rules as &$pconfig) {
 
 	/***********************************************************/
 	/* Add the new 'dns-events.rules' file to the rulesets.    */

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -30,15 +30,8 @@ require_once("functions.inc");
 /* latest package version.                                                  */
 /****************************************************************************/
 
-global $config;
-
-if (!is_array($config['installedpackages']['suricata']))
-	$config['installedpackages']['suricata'] = array();
-if (!is_array($config['installedpackages']['suricata']['rule']))
-	$config['installedpackages']['suricata']['rule'] = array();
-
 // Just exit if this is a clean install with no saved settings
-if (empty($config['installedpackages']['suricata']['rule']))
+if (count(config_get_path('installedpackages/suricata/rule', [])) < 1)
 	return;
 
 /****************************************************************************/
@@ -51,10 +44,10 @@ syslog(LOG_NOTICE, "[Suricata] Checking configuration settings version...");
 
 // Check the configuration version to see if XMLRPC Sync should be
 // auto-disabled as part of the upgrade due to config format changes.
-if ($config['installedpackages']['suricata']['config'][0]['suricata_config_ver'] < 2 && 
-    ($config['installedpackages']['suricatasync']['config'][0]['varsynconchanges'] == 'auto' ||
-     $config['installedpackages']['suricatasync']['config'][0]['varsynconchanges'] == 'manual')) {
-	$config['installedpackages']['suricatasync']['config'][0]['varsynconchanges'] = "disabled";
+if (config_get_path('installedpackages/suricata/config/0/suricata_config_ver') < 2 && 
+    (config_get_path('installedpackages/suricata/config/0/varsynconchanges') == 'auto' ||
+     config_get_path('installedpackages/suricata/config/0/varsynconchanges') == 'manual')) {
+	config_set_path('installedpackages/suricata/config/0/varsynconchanges', "disabled");
 	syslog(LOG_NOTICE, "[Suricata] Turning off Suricata Sync on this host due to configuration format changes in this update.  Upgrade all Suricata Sync targets to this same Suricata package version before re-enabling Suricata Sync.");
 	$updated_cfg = true;
 }
@@ -62,10 +55,10 @@ if ($config['installedpackages']['suricata']['config'][0]['suricata_config_ver']
 /**********************************************************/
 /* Create new Auto SID Mgmt settings if not set           */
 /**********************************************************/
-if (empty($config['installedpackages']['suricata']['config'][0]['auto_manage_sids'])) {
-	$config['installedpackages']['suricata']['config'][0]['auto_manage_sids'] = "off";
-	$config['installedpackages']['suricata']['config'][0]['sid_changes_log_limit_size'] = "250";
-	$config['installedpackages']['suricata']['config'][0]['sid_changes_log_retention'] = "336";
+if (empty(config_get_path('installedpackages/suricata/config/0/auto_manage_sids'))) {
+	config_set_path('installedpackages/suricata/config/0/auto_manage_sids', "off");
+	config_set_path('installedpackages/suricata/config/0/sid_changes_log_limit_size', "250");
+	config_set_path('installedpackages/suricata/config/0/sid_changes_log_retention', "336");
 	$updated_cfg = true;
 }
 
@@ -74,14 +67,8 @@ if (empty($config['installedpackages']['suricata']['config'][0]['auto_manage_sid
 /* /var/db/suricata/sidmods directory to Base64 encoded   */
 /* strings in SID_MGMT_LIST array in config.xml.          */
 /**********************************************************/
-if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists'])) {
-	$config['installedpackages']['suricata']['sid_mgmt_lists'] = array();
-}
-if (empty($config['installedpackages']['suricata']['config'][0]['sid_list_migration']) && count($config['installedpackages']['suricata']['sid_mgmt_lists']) < 1) {
-	if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists']['item'])) {
-		$config['installedpackages']['suricata']['sid_mgmt_lists']['item'] = array();
-	}
-	$a_list = &$config['installedpackages']['suricata']['sid_mgmt_lists']['item'];
+if (empty(config_get_path('installedpackages/suricata/config/0/sid_list_migration')) && count(config_get_path('installedpackages/suricata/sid_mgmt_lists', [])) < 1) {
+	$a_list = config_get_path('installedpackages/suricata/sid_mgmt_lists/item', []);
 	$sidmodfiles = return_dir_as_array("/var/db/suricata/sidmods/");
 	foreach ($sidmodfiles as $sidfile) {
 		$data = file_get_contents("/var/db/suricata/sidmods/" . $sidfile);
@@ -93,9 +80,9 @@ if (empty($config['installedpackages']['suricata']['config'][0]['sid_list_migrat
 			$a_list[] = $tmp;
 		}
 	}
-	$config['installedpackages']['suricata']['config'][0]['sid_list_migration'] = "1";
+	config_set_path('installedpackages/suricata/sid_mgmt_lists/item', $a_list);
+	config_set_path('installedpackages/suricata/config/0/sid_list_migration', "1");
 	$updated_cfg = true;
-	unset($a_list);
 }
 
 /**********************************************************/
@@ -103,24 +90,24 @@ if (empty($config['installedpackages']['suricata']['config'][0]['sid_list_migrat
 /* to recent MaxMind changes to the GeoLite2 database     */
 /* download permissions.                                  */
 /**********************************************************/
-if (empty($config['installedpackages']['suricata']['config'][0]['autogeoipupdate']) || empty($config['installedpackages']['suricata']['config'][0]['maxmind_geoipdb_key'])) {
-	$config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] = "off";
+if (empty(config_get_path('installedpackages/suricata/config/0/autogeoipupdate')) || empty(config_get_path('installedpackages/suricata/config/0/maxmind_geoipdb_key'))) {
+	config_set_path('installedpackages/suricata/config/0/autogeoipupdate', "off");
 	$updated_cfg = true;
 }
 
 /**********************************************************/
 /* Create new ET IQRisk IP Reputation setting if not set  */
 /**********************************************************/
-if (empty($config['installedpackages']['suricata']['config'][0]['et_iqrisk_enable'])) {
-	$config['installedpackages']['suricata']['config'][0]['et_iqrisk_enable'] = "off";
+if (empty(config_get_path('installedpackages/suricata/config/0/et_iqrisk_enable'))) {
+	config_set_path('installedpackages/suricata/config/0/et_iqrisk_enable', "off");
 	$updated_cfg = true;
 }
 
 /**********************************************************/
 /* Create new HIDE_DEPRECATED_RULES setting if not set    */
 /**********************************************************/
-if (empty($config['installedpackages']['suricata']['config'][0]['hide_deprecated_rules'])) {
-	$config['installedpackages']['suricata']['config'][0]['hide_deprecated_rules'] = "off";
+if (empty(config_get_path('installedpackages/suricata/config/0/hide_deprecated_rules'))) {
+	config_set_path('installedpackages/suricata/config/0/hide_deprecated_rules', "off");
 	$updated_cfg = true;
 }
 
@@ -129,12 +116,12 @@ if (empty($config['installedpackages']['suricata']['config'][0]['hide_deprecated
 /* from the package configuration. The status is now      */
 /* stored in a local file.                                */
 /**********************************************************/
-if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status'])) {
-	unset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_status']);
+if (config_path_enabled('installedpackages/suricata/config/0', 'last_rule_upd_status')) {
+	config_del_path('installedpackages/suricata/config/0/last_rule_upd_status');
 	$updated_cfg = true;
 }
-if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_time'])) {
-	unset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_time']);
+if (config_path_enabled('installedpackages/suricata/config/0', 'last_rule_upd_time')) {
+	config_del_path('installedpackages/suricata/config/0/last_rule_upd_time');
 	$updated_cfg = true;
 }
 
@@ -144,89 +131,89 @@ if (isset($config['installedpackages']['suricata']['config'][0]['last_rule_upd_t
 /* large numbers of pfSense users hitting Snort.org at    */
 /* the same minute past the hour for rules updates.       */
 /**********************************************************/
-if (empty($config['installedpackages']['suricata']['config'][0]['autoruleupdatetime']) || 
-	$config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'] == '00:05' || 
-	strlen($config['installedpackages']['suricata']['config'][0]['autoruleupdatetime']) < 5) {
-	$config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'] = "00:" . str_pad(strval(random_int(0,59)), 2, "00", STR_PAD_LEFT);
+if (empty(config_get_path('installedpackages/suricata/config/0/autoruleupdatetime')) || 
+	config_get_path('installedpackages/suricata/config/0/autoruleupdatetime') == '00:05' || 
+	strlen(config_get_path('installedpackages/suricata/config/0/autoruleupdatetime')) < 5) {
+	config_set_path('installedpackages/suricata/config/0/autoruleupdatetime', "00:" . str_pad(strval(random_int(0,59)), 2, "00", STR_PAD_LEFT));
 	$updated_cfg = true;
 }
 
 /**********************************************************/
 /* Set default log size and retention limits if not set   */
 /**********************************************************/
-if (!isset($config['installedpackages']['suricata']['config'][0]['alert_log_retention']) && $config['installedpackages']['suricata']['config'][0]['alert_log_retention'] != '0') {
-	$config['installedpackages']['suricata']['config'][0]['alert_log_retention'] = "336";
+if (!config_path_enabled('installedpackages/suricata/config/0', 'alert_log_retention')) {
+	config_set_path('installedpackages/suricata/config/0/alert_log_retention', "336");
 	$updated_cfg = true;
 }
-if (!isset($config['installedpackages']['suricata']['config'][0]['alert_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['alert_log_limit_size'] != '0') {
-	$config['installedpackages']['suricata']['config'][0]['alert_log_limit_size'] = "500";
-	$updated_cfg = true;
-}
-
-if (!isset($config['installedpackages']['suricata']['config'][0]['block_log_retention']) && $config['installedpackages']['suricata']['config'][0]['block_log_retention'] != '0') {
-	$config['installedpackages']['suricata']['config'][0]['block_log_retention'] = "336";
-	$updated_cfg = true;
-}
-if (!isset($config['installedpackages']['suricata']['config'][0]['block_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['block_log_limit_size'] != '0') {
-	$config['installedpackages']['suricata']['config'][0]['block_log_limit_size'] = "500";
+if (!config_path_enabled('installedpackages/suricata/config/0', 'alert_log_limit_size')) {
+	config_set_path('installedpackages/suricata/config/0/alert_log_limit_size', "500");
 	$updated_cfg = true;
 }
 
-if (!isset($config['installedpackages']['suricata']['config'][0]['eve_log_retention']) && $config['installedpackages']['suricata']['config'][0]['eve_log_retention'] != '0') {
-	$config['installedpackages']['suricata']['config'][0]['eve_log_retention'] = "168";
+if (!config_path_enabled('installedpackages/suricata/config/0', 'block_log_retention')) {
+	config_set_path('installedpackages/suricata/config/0/block_log_retention', "336");
 	$updated_cfg = true;
 }
-if (!isset($config['installedpackages']['suricata']['config'][0]['eve_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['eve_log_limit_size'] != '0') {
-	$config['installedpackages']['suricata']['config'][0]['eve_log_limit_size'] = "5000";
-	$updated_cfg = true;
-}
-
-if (!isset($config['installedpackages']['suricata']['config'][0]['http_log_retention']) && $config['installedpackages']['suricata']['config'][0]['http_log_retention'] != '0') {
-	$config['installedpackages']['suricata']['config'][0]['http_log_retention'] = "168";
-	$updated_cfg = true;
-}
-if (!isset($config['installedpackages']['suricata']['config'][0]['http_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['http_log_limit_size'] != '0') {
-	$config['installedpackages']['suricata']['config'][0]['http_log_limit_size'] = "1000";
+if (!config_path_enabled('installedpackages/suricata/config/0', 'block_log_limit_size')) {
+	config_set_path('installedpackages/suricata/config/0/block_log_limit_size', "500");
 	$updated_cfg = true;
 }
 
-if (!isset($config['installedpackages']['suricata']['config'][0]['stats_log_retention']) && $config['installedpackages']['suricata']['config'][0]['stats_log_retention'] != '0') {
-	$config['installedpackages']['suricata']['config'][0]['stats_log_retention'] = "168";
+if (!config_path_enabled('installedpackages/suricata/config/0', 'eve_log_retention')) {
+	config_set_path('installedpackages/suricata/config/0/eve_log_retention', "168");
 	$updated_cfg = true;
 }
-if (!isset($config['installedpackages']['suricata']['config'][0]['stats_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['stats_log_limit_size'] != '0') {
-	$config['installedpackages']['suricata']['config'][0]['stats_log_limit_size'] = "500";
-	$updated_cfg = true;
-}
-
-if (!isset($config['installedpackages']['suricata']['config'][0]['tls_log_retention']) && $config['installedpackages']['suricata']['config'][0]['tls_log_retention'] != '0') {
-	$config['installedpackages']['suricata']['config'][0]['tls_log_retention'] = "336";
-	$updated_cfg = true;
-}
-if (!isset($config['installedpackages']['suricata']['config'][0]['tls_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['tls_log_limit_size'] != '0') {
-	$config['installedpackages']['suricata']['config'][0]['tls_log_limit_size'] = "500";
+if (!config_path_enabled('installedpackages/suricata/config/0', 'eve_log_limit_size')) {
+	config_set_path('installedpackages/suricata/config/0/eve_log_limit_size', "5000");
 	$updated_cfg = true;
 }
 
-if (!isset($config['installedpackages']['suricata']['config'][0]['file_store_retention']) && $config['installedpackages']['suricata']['config'][0]['file_store_retention'] != '0') {
-	$config['installedpackages']['suricata']['config'][0]['file_store_retention'] = "168";
+if (!config_path_enabled('installedpackages/suricata/config/0', 'http_log_retention')) {
+	config_set_path('installedpackages/suricata/config/0/http_log_retention', "168");
+	$updated_cfg = true;
+}
+if (!config_path_enabled('installedpackages/suricata/config/0', 'http_log_limit_size')) {
+	config_set_path('installedpackages/suricata/config/0/http_log_limit_size', "1000");
 	$updated_cfg = true;
 }
 
-if (!isset($config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention']) && $config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'] != '0') {
-	$config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'] = "168";
+if (!config_path_enabled('installedpackages/suricata/config/0', 'stats_log_retention')) {
+	config_set_path('installedpackages/suricata/config/0/stats_log_retention', "168");
+	$updated_cfg = true;
+}
+if (!config_path_enabled('installedpackages/suricata/config/0', 'stats_log_limit_size')) {
+	config_set_path('installedpackages/suricata/config/0/stats_log_limit_size', "500");
+	$updated_cfg = true;
+}
+
+if (!config_path_enabled('installedpackages/suricata/config/0', 'tls_log_retention')) {
+	config_set_path('installedpackages/suricata/config/0/tls_log_retention', "336");
+	$updated_cfg = true;
+}
+if (!config_path_enabled('installedpackages/suricata/config/0', 'tls_log_limit_size')) {
+	config_set_path('installedpackages/suricata/config/0/tls_log_limit_size', "500");
+	$updated_cfg = true;
+}
+
+if (!config_path_enabled('installedpackages/suricata/config/0', 'file_store_retention')) {
+	config_set_path('installedpackages/suricata/config/0/file_store_retention', "168");
+	$updated_cfg = true;
+}
+
+if (!config_path_enabled('installedpackages/suricata/config/0', 'tls_certs_store_retention')) {
+	config_set_path('installedpackages/suricata/config/0/tls_certs_store_retention', "168");
 	$updated_cfg = true;
 }
 
 /**********************************************************/
 /* Remove deprecated file-log settings from LOGS MGMT     */
 /**********************************************************/
-if (isset($config['installedpackages']['suricata']['config'][0]['files_json_log_retention'])) {
-	unset($config['installedpackages']['suricata']['config'][0]['files_json_log_retention']);
+if (config_path_enabled('installedpackages/suricata/config/0', 'files_json_log_retention')) {
+	config_del_path('installedpackages/suricata/config/0/files_json_log_retention');
 	$updated_cfg = true;
 }
-if (isset($config['installedpackages']['suricata']['config'][0]['files_json_log_limit_size'])) {
-	unset($config['installedpackages']['suricata']['config'][0]['files_json_log_limit_size']);
+if (config_path_enabled('installedpackages/suricata/config/0', 'files_json_log_limit_size')) {
+	config_del_path('installedpackages/suricata/config/0/files_json_log_limit_size');
 	$updated_cfg = true;
 }
 
@@ -236,100 +223,57 @@ if (isset($config['installedpackages']['suricata']['config'][0]['files_json_log_
 /* element for existing entries into an array. Migrate    */
 /* any existing <address> to the new array structure.     */
 /**********************************************************/
-if (is_array($config['installedpackages']['suricata']['passlist']['item'])) {
-	foreach ($config['installedpackages']['suricata']['passlist']['item'] as &$wlisti) {
-		if (!is_array($wlisti['address']) && !is_array($wlisti['address']['item']) && !empty($wlisti['address'])) {
-			$tmp = $wlisti['address'];
-			$wlisti['address'] = array();
-			$wlisti['address']['item'] = array();
-			$wlisti['address']['item'][] = $tmp;
-			$updated_cfg = true;
-		}
+foreach (config_get_path('installedpackages/suricata/passlist/item', []) as &$wlisti) {
+	if (!is_array($wlisti['address']) && !empty($wlisti['address']) && !is_array($wlisti['address']['item'])) {
+		$tmp = $wlisti['address'];
+		$wlisti['address'] = array();
+		$wlisti['address']['item'] = array();
+		$wlisti['address']['item'][] = $tmp;
+		$updated_cfg = true;
 	}
-
-	// Release reference to whitelist array
-	unset($wlisti);
 }
 
 // Now process the interface-specific settings
-foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
-
-	// Initialize arrays for supported preprocessors if necessary
-	if (!is_array($r['libhtp_policy']))
-		$r['libhtp_policy'] = array();
-	if (!is_array($r['libhtp_policy']['item']))
-		$r['libhtp_policy']['item'] = array();
-
-	$pconfig = array();
-	$pconfig = $r;
-
-	/***********************************************************/
-	/* This setting is deprecated in Suricata 2.0 and higher,  */
-	/* so remove it from the configuration.                    */
-	/***********************************************************/
-	if (isset($pconfig['stream_max_sessions'])) {
-		unset($pconfig['stream_max_sessions']);
-		$updated_cfg = true;
-	}
-
-	/***********************************************************/
-	/* HTTP server personalities for "Apache" and "Apache_2_2" */
-	/* are deprecated and replaced with "Apache_2" in Suricata */
-	/* versions greater than 2.0.                              */
-	/***********************************************************/
-	$http_serv = &$pconfig['libhtp_policy']['item'];
-	foreach ($http_serv as &$policy) {
-		if ($policy['personality'] == "Apache" || $policy['personality'] == "Apache_2_2") {
-			$policy['personality'] = "Apache_2";
-			$updated_cfg = true;
-		}
-		// Set new URI inspect option for Suricata 2.0 and higher
-		if (!isset($policy['uri-include-all'])) {
-			$policy['uri-include-all'] = "no";
-			$updated_cfg = true;
-		}
-	}
-
-	// Release config array references used immediately above
-	unset($http_serv, $policy);
+$a_rules = config_get_path('installedpackages/suricata/rule', []);
+foreach ($a_rules as $pconfig) {
 
 	/***********************************************************/
 	/* Add the new 'dns-events.rules' file to the rulesets.    */
 	/***********************************************************/
-	if (strpos($pconfig['rulesets'], "dns-events.rules") === FALSE) {
-		$pconfig['rulesets'] = rtrim($pconfig['rulesets'], "||") . "||dns-events.rules";	
+	if (strpos(array_get_path($pconfig, 'rulesets', ''), "dns-events.rules") === FALSE) {
+		$pconfig['rulesets'] = rtrim(array_get_path($pconfig, 'rulesets', ''), "||") . "||dns-events.rules";	
 		$updated_cfg = true;
 	}
 
 	/***********************************************************/
-	/* Add the new 'dhcp-events.rules' file to the rulesets.    */
+	/* Add the new 'dhcp-events.rules' file to the rulesets.   */
 	/***********************************************************/
-	if (strpos($pconfig['rulesets'], "dhcp-events.rules") === FALSE) {
-		$pconfig['rulesets'] = rtrim($pconfig['rulesets'], "||") . "||dhcp-events.rules";	
+	if (strpos(array_get_path($pconfig, 'rulesets', ''), "dhcp-events.rules") === FALSE) {
+		$pconfig['rulesets'] = rtrim(array_get_path($pconfig, 'rulesets', ''), "||") . "||dhcp-events.rules";	
 		$updated_cfg = true;
 	}
 
 	/***********************************************************/
-	/* Add the new 'http2-events.rules' file to the rulesets.    */
+	/* Add the new 'http2-events.rules' file to the rulesets.  */
 	/***********************************************************/
-	if (strpos($pconfig['rulesets'], "http2-events.rules") === FALSE) {
-		$pconfig['rulesets'] = rtrim($pconfig['rulesets'], "||") . "||http2-events.rules";	
+	if (strpos(array_get_path($pconfig, 'rulesets', ''), "http2-events.rules") === FALSE) {
+		$pconfig['rulesets'] = rtrim(array_get_path($pconfig, 'rulesets', ''), "||") . "||http2-events.rules";	
 		$updated_cfg = true;
 	}
 
 	/***********************************************************/
-	/* Add the new 'mqtt-events.rules' file to the rulesets.    */
+	/* Add the new 'mqtt-events.rules' file to the rulesets.   */
 	/***********************************************************/
-	if (strpos($pconfig['rulesets'], "mqtt-events.rules") === FALSE) {
-		$pconfig['rulesets'] = rtrim($pconfig['rulesets'], "||") . "||mqtt-events.rules";	
+	if (strpos(array_get_path($pconfig, 'rulesets', ''), "mqtt-events.rules") === FALSE) {
+		$pconfig['rulesets'] = rtrim(array_get_path($pconfig, 'rulesets', ''), "||") . "||mqtt-events.rules";	
 		$updated_cfg = true;
 	}
 
 	/***********************************************************/
 	/* Add the new 'ssh-events.rules' file to the rulesets.    */
 	/***********************************************************/
-	if (strpos($pconfig['rulesets'], "ssh-events.rules") === FALSE) {
-		$pconfig['rulesets'] = rtrim($pconfig['rulesets'], "||") . "||ssh-events.rules";	
+	if (strpos(array_get_path($pconfig, 'rulesets', ''), "ssh-events.rules") === FALSE) {
+		$pconfig['rulesets'] = rtrim(array_get_path($pconfig, 'rulesets', ''), "||") . "||ssh-events.rules";	
 		$updated_cfg = true;
 	}
 
@@ -480,105 +424,6 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 
 	if (!isset($pconfig['eve_log_smtp_extended_fields'])) {
 		$pconfig['eve_log_smtp_extended_fields'] = "received, x-mailer, x-originating-ip, relays, reply-to, bcc";
-		$updated_cfg = true;
-	}
-
-	/******************************************************************/
-	/* SHA1 and SHA256 were added as additional hashing options in    */
-	/* Suricata 3.x, so the old binary on/off MD5 hashing parameter   */
-	/* is now one of three string values: NONE, MD5, SHA1 or SHA256.  */
-	/* It has been moved to a new parameter name and the old one is   */
-	/* now deprecated and removed from the config.                    */
-	/******************************************************************/
-	if (!isset($pconfig['tracked_files_hash'])) {
-		if ($pconfig['enabled_tracked_files_md5'] == "on") {
-			$pconfig['tracked_files_hash'] = "md5";
-		}
-		else {
-			$pconfig['tracked_files_hash'] = "none";
-		}
-		unset($pconfig['enabled_tracked_files_md5']);
-		$updated_cfg = true;
-	}
-
-	/******************************************************************/
-	/* Remove per interface default log size and retention limits     */ 
-	/* if they were set by early bug.                                 */
-	/******************************************************************/
-	if (isset($pconfig['alert_log_retention'])) {
-		unset($pconfig['alert_log_retention']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['alert_log_limit_size'])) {
-		unset($pconfig['alert_log_limit_size']);
-		$updated_cfg = true;
-	}
-
-	if (isset($pconfig['block_log_retention'])) {
-		unset($pconfig['block_log_retention']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['block_log_limit_size'])) {
-		unset($pconfig['block_log_limit_size']);
-		$updated_cfg = true;
-	}
-
-	if (isset($pconfig['dns_log_retention'])) {
-		unset($pconfig['dns_log_retention']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['dns_log_limit_size'])) {
-		unset($pconfig['dns_log_limit_size']);
-		$updated_cfg = true;
-	}
-
-	if (isset($pconfig['eve_log_retention'])) {
-		unset($pconfig['eve_log_retention']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['eve_log_limit_size'])) {
-		unset($pconfig['eve_log_limit_size']);
-		$updated_cfg = true;
-	}
-
-	if (isset($pconfig['files_json_log_retention'])) {
-		unset($pconfig['files_json_log_retention']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['files_json_log_limit_size'])) {
-		unset($pconfig['files_json_log_limit_size']);
-		$updated_cfg = true;
-	}
-
-	if (isset($pconfig['http_log_retention'])) {
-		unset($pconfig['http_log_retention']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['http_log_limit_size'])) {
-		unset($pconfig['http_log_limit_size']);
-		$updated_cfg = true;
-	}
-
-	if (isset($pconfig['stats_log_retention'])) {
-		unset($pconfig['stats_log_retention']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['stats_log_limit_size'])) {
-		unset($pconfig['stats_log_limit_size']);
-		$updated_cfg = true;
-	}
-
-	if (isset($pconfig['tls_log_retention'])) {
-		unset($pconfig['tls_log_retention']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['tls_log_limit_size'])) {
-		unset($pconfig['tls_log_limit_size']);
-		$updated_cfg = true;
-	}
-
-	if (isset($pconfig['file_store_retention'])) {
-		unset($pconfig['file_store_retention']);
 		$updated_cfg = true;
 	}
 
@@ -784,17 +629,6 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 	}
 
 	/**********************************************************/
-	/* Suricata 3.2.1 introduced support for hyperscan as an  */
-	/* option for the multi pattern matcher (MPM) algorithm.  */
-	/* Several older MPM algorithms were also deprecated.     */
-	/**********************************************************/
-	$old_mpm_algos = array('ac-gfbs', 'b2g', 'b2gc', 'b2gm', 'b3g', 'wumanber');
-	if (in_array($pconfig['mpm_algo'], $old_mpm_algos)) {
-		$pconfig['mpm_algo'] = "auto";
-		$updated_cfg = true;
-	}
-
-	/**********************************************************/
 	/* Set default value for new interface snaplen parameter  */
 	/* if one has not been previously configured.             */
 	/**********************************************************/
@@ -987,12 +821,9 @@ foreach ($config['installedpackages']['suricata']['rule'] as &$r) {
 		$updated_cfg = true;
 		$pconfig['autofp_scheduler'] = 'hash';
 	}
-
-	// Save the new configuration data into the $config array pointer
-	$r = $pconfig;
 }
-// Release reference to final array element
-unset($r);
+// Save the updated interfaces configuration
+config_set_path('installedpackages/suricata/rule', $a_rules);
 
 // Log a message indicating what we did
 if ($updated_cfg) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -44,9 +44,10 @@ syslog(LOG_NOTICE, "[Suricata] Checking configuration settings version...");
 
 // Check the configuration version to see if XMLRPC Sync should be
 // auto-disabled as part of the upgrade due to config format changes.
-if (config_get_path('installedpackages/suricata/config/0/suricata_config_ver') < 2 && 
+if (config_get_path('installedpackages/suricata/config/0/suricata_config_ver') < 2 &&
     (config_get_path('installedpackages/suricata/config/0/varsynconchanges') == 'auto' ||
-     config_get_path('installedpackages/suricata/config/0/varsynconchanges') == 'manual')) {
+     config_get_path('installedpackages/suricata/config/0/varsynconchanges') == 'manual')
+   ) {
 	config_set_path('installedpackages/suricata/config/0/varsynconchanges', "disabled");
 	syslog(LOG_NOTICE, "[Suricata] Turning off Suricata Sync on this host due to configuration format changes in this update.  Upgrade all Suricata Sync targets to this same Suricata package version before re-enabling Suricata Sync.");
 	$updated_cfg = true;
@@ -131,8 +132,8 @@ if (config_path_enabled('installedpackages/suricata/config/0', 'last_rule_upd_ti
 /* large numbers of pfSense users hitting Snort.org at    */
 /* the same minute past the hour for rules updates.       */
 /**********************************************************/
-if (empty(config_get_path('installedpackages/suricata/config/0/autoruleupdatetime')) || 
-	config_get_path('installedpackages/suricata/config/0/autoruleupdatetime') == '00:05' || 
+if (empty(config_get_path('installedpackages/suricata/config/0/autoruleupdatetime')) ||
+	config_get_path('installedpackages/suricata/config/0/autoruleupdatetime') == '00:05' ||
 	strlen(config_get_path('installedpackages/suricata/config/0/autoruleupdatetime')) < 5) {
 	config_set_path('installedpackages/suricata/config/0/autoruleupdatetime', "00:" . str_pad(strval(random_int(0,59)), 2, "00", STR_PAD_LEFT));
 	$updated_cfg = true;

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2020 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,7 +35,7 @@ require_once("functions.inc");
 require_once("/usr/local/pkg/suricata/suricata.inc");
 require("/usr/local/pkg/suricata/suricata_defs.inc");
 
-global $config, $g, $rebuild_rules, $pkg_interface, $suricata_gui_include;
+global $g, $rebuild_rules, $pkg_interface, $suricata_gui_include;
 
 // Initialize some common values from defined constants
 $suricatadir = SURICATADIR;
@@ -92,64 +92,21 @@ foreach ($map_files as $f) {
 }
 
 // Download the latest GeoIP DB updates and create cron task if the feature is enabled
-if ($config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] == 'on' && !empty($config['installedpackages']['suricata']['config'][0]['maxmind_geoipdb_key'])) {
+if (config_get_path('installedpackages/suricata/config/0/autogeoipupdate') == 'on' && !empty(config_get_path('installedpackages/suricata/config/0/maxmind_geoipdb_key'))) {
 	syslog(LOG_NOTICE, gettext("[Suricata] Installing free GeoLite2 country IP database file in /usr/local/share/suricata/GeoLite2/..."));
 	include("/usr/local/pkg/suricata/suricata_geoipupdate.php");
 	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_geoipupdate.php", TRUE, 0, 6, "*", "*", "*", "root");
 }
 
 // Download the latest ET IQRisk updates and create cron task if the feature is not disabled
-if ($config['installedpackages']['suricata']['config'][0]['et_iqrisk_enable'] == 'on') {
+if (config_get_path('installedpackages/suricata/config/0/et_iqrisk_enable') == 'on') {
 	syslog(LOG_NOTICE, gettext("[Suricata] Installing Emerging Threats IQRisk IP List..."));
 	include("/usr/local/pkg/suricata/suricata_etiqrisk_update.php");
 	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_etiqrisk_update.php", TRUE, 0, "*/6", "*", "*", "*", "root");
 }
 
-/*********************************************************/
-/* START OF BUG FIX CODE                                 */
-/*                                                       */
-/* Remove any Suricata cron tasks that may have been     */
-/* left from a previous uninstall due to a bug that      */
-/* saved edited cron tasks as new ones while still       */
-/* leaving the original task.  Correct cron task         */
-/* entries will be recreated below if saved settings     */
-/* are detected.                                         */
-/*********************************************************/
-$cron_count = 0;
-$suri_pf_table = SURICATA_PF_TABLE;
-
-while (suricata_cron_job_exists($suri_pf_table, FALSE)) {
-	install_cron_job($suri_pf_table, false);
-	$cron_count++;
-}
-
-if ($cron_count > 0) {
-	syslog(LOG_NOTICE, gettext("[Suricata] Removed {$cron_count} duplicate 'remove_blocked_hosts' cron task(s)."));
-}
-
-/*********************************************************/
-/* END OF BUG FIX CODE                                   */
-/*********************************************************/
-
-// Make sure config variable is an array (PHP7 likes every level to be created individually )
-if (!is_array($config['installedpackages']['suricata'])) {
-	$config['installedpackages']['suricata'] = array();
-}
-
-if (!is_array($config['installedpackages']['suricata']['rule'])) {
-	$config['installedpackages']['suricata']['rule'] = array();
-}
-
-if (!is_array($config['installedpackages']['suricata']['config'])) {
-	$config['installedpackages']['suricata']['config'] = array();
-}
-
-if (!is_array($config['installedpackages']['suricata']['config'][0])) {
-	$config['installedpackages']['suricata']['config'][0] = array();
-}
-
-// remake saved settings if previously flagged
-if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] == 'on') {
+// Remake saved settings if previously flagged to restore them
+if (config_get_path('installedpackages/suricata/config/0/forcekeepsettings') == 'on') {
 	syslog(LOG_NOTICE, gettext("[Suricata] Saved settings detected... rebuilding installation with saved settings."));
 	update_status(gettext("Saved settings detected...") . "\n");
 
@@ -157,13 +114,17 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 	/* Add all the new built-in events rules to each configured     */
 	/* interface.                                                   */
 	/****************************************************************/
-	if (count($config['installedpackages']['suricata']['rule']) > 0) {
+	if (count(config_get_path('installedpackages/suricata/rule', [])) > 0) {
 
-		// Array of default events rules for Suricata
-		$builtin_rules = array( "app-layer-events.rules", "decoder-events.rules", "dnp3-events.rules", "dns-events.rules", "files.rules", "http-events.rules", "ipsec-events.rules", "kerberos-events.rules", 
-					"modbus-events.rules", "nfs-events.rules", "ntp-events.rules", "smb-events.rules", "smtp-events.rules", "stream-events.rules", "tls-events.rules" );
+		// Array of default events rules for Suricata. This array
+		// must be kept in sync with the content of the "/rules"
+		// directory in the Suricata binary source tarball.
+		$builtin_rules = array( "app-layer-events.rules", "decoder-events.rules", "dhcp-events.rules", "dnp3-events.rules", "dns-events.rules", "files.rules", "http-events.rules", "http2-events.rules", "ipsec-events.rules", 
+					"kerberos-events.rules", "modbus-events.rules", "mqtt-events.rules", "nfs-events.rules", "ntp-events.rules", "ssh-events.rules", "smb-events.rules", "smtp-events.rules", "stream-events.rules", 
+					"tls-events.rules" );
 
-		foreach ($config['installedpackages']['suricata']['rule'] as &$suricatacfg) {
+		$a_ifaces = config_get_path('installedpackages/suricata/rule', []);
+		foreach ($a_ifaces as $suricatacfg) {
 			$rulesets = explode("||", $suricatacfg['rulesets']);
 			foreach ($builtin_rules as $name) {
 				if (in_array($name, $rulesets)) {
@@ -176,9 +137,8 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 			// Remove any duplicate ruleset names from earlier bug
 			$suricatacfg['rulesets'] = implode("||", array_keys(array_flip($rulesets)));
 		}
-
-		// Release our config array iterator and other memory
-		unset($suricatacfg, $builtin_rules, $rulesets);
+		// Write updates to configuration
+		config_set_path('installedpackages/suricata/rule', $a_ifaces);
 	}
 	/****************************************************************/
 	/* End of built-in events rules fix.                            */
@@ -193,25 +153,8 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 	update_status(gettext("Generating suricata.yaml configuration file from saved settings.") . "\n");
 	$rebuild_rules = true;
 
-	// Make sure config variable is an array (PHP7 likes every level to be created individually )
-	if (!is_array($config['installedpackages']['suricata'])) {
-		$config['installedpackages']['suricata'] = array();
-	}
-
-	if (!is_array($config['installedpackages']['suricata']['rule'])) {
-		$config['installedpackages']['suricata']['rule'] = array();
-	}
-
-	if (!is_array($config['installedpackages']['suricata']['config'])) {
-		$config['installedpackages']['suricata']['config'] = array();
-	}
-
-	if (!is_array($config['installedpackages']['suricata']['config'][0])) {
-		$config['installedpackages']['suricata']['config'][0] = array();
-	}
-
-	// Create the suricata.yaml files for each enabled interface
-	foreach ($config['installedpackages']['suricata']['rule'] as $suricatacfg) {
+	// Create the suricata.yaml file for each enabled interface
+	foreach (config_get_path('installedpackages/suricata/rule', []) as $suricatacfg) {
 		$if_real = get_real_interface($suricatacfg['interface']);
 
 		/* Skip instance if its real interface is missing in pfSense */
@@ -232,28 +175,28 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 		// (which is defined in the included file).
 		include("/usr/local/pkg/suricata/suricata_yaml_template.inc");
 
-		// Now write out the conf file using $suricata_conf_text contents
+		// Now write out the conf YAML file using $suricata_conf_text contents
 		@file_put_contents("{$suricatacfgdir}/suricata.yaml", $suricata_conf_text);
 		unset($suricata_conf_text);
 		update_status(gettext(" done.") . "\n");
 	}
 
-	// create Suricata bootup file suricata.sh
+	// create Suricata bootup shell script file suricata.sh
 	suricata_create_rc();
 
 	// Set Log Limit, Block Hosts Time and Rules Update Time
 	suricata_loglimit_install_cron(true);
-	suricata_rm_blocked_install_cron($config['installedpackages']['suricata']['config'][0]['rm_blocked'] != "never_b" ? true : false);
-	suricata_rules_up_install_cron($config['installedpackages']['suricata']['config'][0]['autoruleupdate'] != "never_up" ? true : false);
+	suricata_rm_blocked_install_cron(config_get_path('installedpackages/suricata/config/0/rm_blocked') != "never_b" ? true : false);
+	suricata_rules_up_install_cron(config_get_path('installedpackages/suricata/config/0/autoruleupdate') != "never_up" ? true : false);
 
 	// Restore the Dashboard Widget if it was previously enabled and saved
-	if (!empty($config['installedpackages']['suricata']['config'][0]['dashboard_widget']) && !empty($config['widgets']['sequence'])) {
-		if (strpos($config['widgets']['sequence'], "suricata_alerts") === FALSE)
-			$config['widgets']['sequence'] .= "," . $config['installedpackages']['suricata']['config'][0]['dashboard_widget'];
+	if (!empty(config_get_path('installedpackages/suricata/config/0/dashboard_widget')) && !empty(config_get_path('widgets/sequence'))) {
+		if (strpos(config_get_path('widgets/sequence', ''), "suricata_alerts") === FALSE)
+			config_set_path('widgets/sequence', config_get_path('widgets/sequence') . "," . config_get_path('installedpackages/suricata/config/0/dashboard_widget'));
 	}
-	if (!empty($config['installedpackages']['suricata']['config'][0]['dashboard_widget_rows']) && !empty($config['widgets'])) {
-		if (empty($config['widgets']['widget_suricata_display_lines']))
-			$config['widgets']['widget_suricata_display_lines'] = $config['installedpackages']['suricata']['config'][0]['dashboard_widget_rows'];
+	if (!empty(config_get_path('installedpackages/suricata/config/0/dashboard_widget_rows')) && !empty(config_get_path('widgets'))) {
+		if (empty(config_get_path('widgets/widget_suricata_display_lines')))
+			config_set_path('widgets/widget_suricata_display_lines', config_get_path('installedpackages/suricata/config/0/dashboard_widget_rows'));
 	}
 
 	$rebuild_rules = false;
@@ -263,9 +206,9 @@ if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] =
 
 // If this is first install and "forcekeepsettings" is empty,
 // then default it to 'on'.
-if (empty($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'])) {
+if (empty(config_get_path('installedpackages/suricata/config/0/forcekeepsettings'))) {
 	update_status("   " . gettext("\n  Setting up initial configuration.") . "\n");
-	$config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] = 'on';
+	config_set_path('installedpackages/suricata/config/0/forcekeepsettings', 'on');
 }
 
 /**********************************************************/
@@ -274,16 +217,9 @@ if (empty($config['installedpackages']['suricata']['config'][0]['forcekeepsettin
 /* strings in SID_MGMT_LIST array in config.xml if this   */
 /* is a first-time green field install of Suricata.       */
 /**********************************************************/
-if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists'])) {
-	$config['installedpackages']['suricata']['sid_mgmt_lists'] = array();
-}
-if (empty($config['installedpackages']['suricata']['config'][0]['sid_list_migration']) && count($config['installedpackages']['suricata']['sid_mgmt_lists']) < 1) {
-	if (!is_array($config['installedpackages']['suricata']['sid_mgmt_lists']['item'])) {
-		$config['installedpackages']['suricata']['sid_mgmt_lists']['item'] = array();
-	}
-	$a_list = &$config['installedpackages']['suricata']['sid_mgmt_lists']['item'];
-	$sidmodfiles = array("disablesid-sample.conf", "dropsid-sample.conf", "enablesid-sample.conf", "modifysid-sample.conf");
-	foreach ($sidmodfiles as $sidfile) {
+if (empty(config_get_path('installedpackages/suricata/config/0/sid_list_migration')) && count(config_get_path('installedpackages/suricata/sid_mgmt_lists', [])) < 1) {
+	$a_list = config_get_path('installedpackages/suricata/sid_mgmt_lists/item', []);
+	foreach (array("disablesid-sample.conf", "dropsid-sample.conf", "enablesid-sample.conf", "modifysid-sample.conf") as $sidfile) {
 		if (file_exists(SURICATA_SID_MODS_PATH . $sidfile)) {
 			$data = file_get_contents(SURICATA_SID_MODS_PATH . $sidfile);
 			if ($data !== FALSE) {
@@ -295,14 +231,15 @@ if (empty($config['installedpackages']['suricata']['config'][0]['sid_list_migrat
 			}
 		}
 	}
-	$config['installedpackages']['suricata']['config'][0]['sid_list_migration'] = "1";
+	config_set_path('installedpackages/suricata/sid_mgmt_lists/item', $a_list);
+	config_set_path('installedpackages/suricata/config/0/sid_list_migration', "1");
 }
 
 // Update Suricata package version in configuration
 update_status(gettext("  " . "Setting package version in configuration file.") . "\n");
-$config['installedpackages']['suricata']['config'][0]['suricata_config_ver'] = $config['installedpackages']['package'][get_package_id("suricata")]['version'];
+config_set_path('installedpackages/suricata/config/0/suricata_config_ver', config_get_path('installedpackages/package/' . get_package_id("suricata") . '/version'));
 
-write_config("Suricata pkg v{$config['installedpackages']['package'][get_package_id("suricata")]['version']}: post-install configuration saved.");
+write_config("Suricata pkg v" . config_get_path('installedpackages/package/' . get_package_id('suricata') . '/version') . ": post-install configuration saved.");
 
 // Done with post-install, so clear flag
 unset($g['suricata_postinstall']);

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -124,7 +124,7 @@ if (config_get_path('installedpackages/suricata/config/0/forcekeepsettings') == 
 					"tls-events.rules" );
 
 		$a_ifaces = config_get_path('installedpackages/suricata/rule', []);
-		foreach ($a_ifaces as $suricatacfg) {
+		foreach ($a_ifaces as &$suricatacfg) {
 			$rulesets = explode("||", $suricatacfg['rulesets']);
 			foreach ($builtin_rules as $name) {
 				if (in_array($name, $rulesets)) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -94,14 +94,14 @@ foreach ($map_files as $f) {
 // Download the latest GeoIP DB updates and create cron task if the feature is enabled
 if (config_get_path('installedpackages/suricata/config/0/autogeoipupdate') == 'on' && !empty(config_get_path('installedpackages/suricata/config/0/maxmind_geoipdb_key'))) {
 	syslog(LOG_NOTICE, gettext("[Suricata] Installing free GeoLite2 country IP database file in /usr/local/share/suricata/GeoLite2/..."));
-	include("/usr/local/pkg/suricata/suricata_geoipupdate.php");
+	include '/usr/local/pkg/suricata/suricata_geoipupdate.php';
 	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_geoipupdate.php", TRUE, 0, 6, "*", "*", "*", "root");
 }
 
 // Download the latest ET IQRisk updates and create cron task if the feature is not disabled
 if (config_get_path('installedpackages/suricata/config/0/et_iqrisk_enable') == 'on') {
 	syslog(LOG_NOTICE, gettext("[Suricata] Installing Emerging Threats IQRisk IP List..."));
-	include("/usr/local/pkg/suricata/suricata_etiqrisk_update.php");
+	include '/usr/local/pkg/suricata/suricata_etiqrisk_update.php';
 	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_etiqrisk_update.php", TRUE, 0, "*/6", "*", "*", "*", "root");
 }
 
@@ -146,10 +146,10 @@ if (config_get_path('installedpackages/suricata/config/0/forcekeepsettings') == 
 
 	/* Do one-time settings migration for new version configuration */
 	update_status(gettext("Migrating settings to new configuration..."));
-	include('/usr/local/pkg/suricata/suricata_migrate_config.php');
+	include '/usr/local/pkg/suricata/suricata_migrate_config.php';
 	update_status(gettext(" done.") . "\n");
 	syslog(LOG_NOTICE, gettext("[Suricata] Downloading and updating configured rule types."));
-	include('/usr/local/pkg/suricata/suricata_check_for_rule_updates.php');
+	include '/usr/local/pkg/suricata/suricata_check_for_rule_updates.php';
 	update_status(gettext("Generating suricata.yaml configuration file from saved settings.") . "\n");
 	$rebuild_rules = true;
 
@@ -167,13 +167,13 @@ if (config_get_path('installedpackages/suricata/config/0/forcekeepsettings') == 
 
 		// Pull in the PHP code that generates the suricata.yaml file
 		// variables that will be substituted further down below.
-		include("/usr/local/pkg/suricata/suricata_generate_yaml.php");
+		include '/usr/local/pkg/suricata/suricata_generate_yaml.php';
 
 		// Pull in the boilerplate template for the suricata.yaml
 		// configuration file.  The contents of the template along
 		// with substituted variables are stored in $suricata_conf_text
 		// (which is defined in the included file).
-		include("/usr/local/pkg/suricata/suricata_yaml_template.inc");
+		include '/usr/local/pkg/suricata/suricata_yaml_template.inc';
 
 		// Now write out the conf YAML file using $suricata_conf_text contents
 		@file_put_contents("{$suricatacfgdir}/suricata.yaml", $suricata_conf_text);

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
@@ -118,6 +118,12 @@ if (!empty($widgets)) {
 	write_config("Suricata pkg removed Dashboard Alerts widget.");
 }
 
+// See if we are to clear blocked hosts on uninstall
+if (config_get_path('installedpackages/suricata/config/0/clearblocks') == 'on') {
+	syslog(LOG_NOTICE, gettext("[Suricata] Flushing all blocked hosts from <snort2c> table due to package removal..."));
+	mwexec("/sbin/pfctl -t snort2c -T flush");
+}
+
 /* Keep this as a last step */
 if (config_get_path('installedpackages/suricata/config/0/forcekeepsettings') != 'on') {
 	syslog(LOG_NOTICE, gettext("Not saving settings... all Suricata configuration info and logs deleted..."));

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
@@ -131,7 +131,6 @@ if (config_get_path('installedpackages/suricata/config/0/forcekeepsettings') != 
 	config_del_path('installedpackages/suricatasync');
 	unlink_if_exists("{$suricata_rules_upd_log}");
 	rmdir_recursive("{$suricatalogdir}");
-	rmdir_recursive("{$g['vardb_path']}/suricata");
 	write_config("Removing Suricata configuration");
 	syslog(LOG_NOTICE, gettext("[Suricata] The package has been removed from this system..."));
 }

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2021 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,7 @@
 
 require_once("/usr/local/pkg/suricata/suricata.inc");
 
-global $config, $g;
+global $g;
 
 $suricatadir = SURICATADIR;
 $suricatalogdir = SURICATALOGDIR;
@@ -68,7 +68,7 @@ install_cron_job("suricata_geoipupdate.php" , false);
 install_cron_job("suricata_etiqrisk_update.php", false);
 
 /* See if we are to keep Suricata log files on uninstall */
-if ($config['installedpackages']['suricata']['config'][0]['clearlogs'] == 'on') {
+if (config_get_path('installedpackages/suricata/config/0/clearlogs') == 'on') {
 	syslog(LOG_NOTICE, gettext("[Suricata] Clearing all Suricata-related log files..."));
 	unlink_if_exists("{$suricata_rules_upd_log}");
 	rmdir_recursive("{$suricatalogdir}");
@@ -92,39 +92,37 @@ unlink_if_exists(SURICATA_RULES_DIR . EXTRARULE_FILE_PREFIX . "*.rules");
 unlink_if_exists("/usr/local/share/suricata/GeoLite2/GeoLite2-Country.mmdb");
 rmdir_recursive("/usr/local/share/suricata/GeoLite2");
 
-if (is_array($config['installedpackages']['suricata']['rule'])) {
-	foreach ($config['installedpackages']['suricata']['rule'] as $suricatacfg) {
-		rmdir_recursive("{$suricatadir}suricata_" . $suricatacfg['uuid'] . "_" . get_real_interface($suricatacfg['interface']));
-	}
+foreach (config_get_path('installedpackages/suricata/rule', []) as $suricatacfg) {
+	rmdir_recursive("{$suricatadir}suricata_" . $suricatacfg['uuid'] . "_" . get_real_interface($suricatacfg['interface']));
 }
 
 /* Remove our associated Dashboard widget config and files. */
 /* If "save settings" is enabled, then save old widget      */
 /* container settings so we can restore them later.         */
-$widgets = $config['widgets']['sequence'];
+$widgets = config_get_path('widgets/sequence');
 if (!empty($widgets)) {
 	$widgetlist = explode(",", $widgets);
 	foreach ($widgetlist as $key => $widget) {
 		if (strstr($widget, "suricata_alerts")) {
-			if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] == 'on') {
-				$config['installedpackages']['suricata']['config'][0]['dashboard_widget'] = $widget;
-				if ($config['widgets']['widget_suricata_display_lines']) {
-					$config['installedpackages']['suricata']['config'][0]['dashboard_widget_rows'] = $config['widgets']['widget_suricata_display_lines'];
-					unset($config['widgets']['widget_suricata_display_lines']);
+			if (config_get_path('installedpackages/suricata/config/0/forcekeepsettings') == 'on') {
+				config_set_path('installedpackages/suricata/config/0/dashboard_widget', $widget);
+				if (config_get_path('widgets/widget_suricata_display_lines')) {
+					cpnfig_set_path('installedpackages/suricata/config/0/dashboard_widget_rows', config_get_path('widgets/widget_suricata_display_lines'));
+					config_del_path('widgets/widget_suricata_display_lines');
 				}
 			}
 			unset($widgetlist[$key]);
 		}
 	}
-	$config['widgets']['sequence'] = implode(",", $widgetlist);
+	config_set_path('widgets/sequence', implode(",", $widgetlist));
 	write_config("Suricata pkg removed Dashboard Alerts widget.");
 }
 
 /* Keep this as a last step */
-if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] != 'on') {
+if (config_get_path('installedpackages/suricata/config/0/forcekeepsettings') != 'on') {
 	syslog(LOG_NOTICE, gettext("Not saving settings... all Suricata configuration info and logs deleted..."));
-	unset($config['installedpackages']['suricata']);
-	unset($config['installedpackages']['suricatasync']);
+	config_del_path('installedpackages/suricata');
+	config_del_path('installedpackages/suricatasync');
 	unlink_if_exists("{$suricata_rules_upd_log}");
 	rmdir_recursive("{$suricatalogdir}");
 	rmdir_recursive("{$g['vardb_path']}/suricata");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -541,12 +541,12 @@ if ($_POST['mode'] == 'togglesid' && is_numeric($_POST['sidid']) && is_numeric($
 
 	// See if the target SID is in our list of modified SIDs,
 	// and toggle it if present.
-	if (isset($enablesid[$gid][$sid]))
-		unset($enablesid[$gid][$sid]);
-	if (isset($disablesid[$gid][$sid]))
-		unset($disablesid[$gid][$sid]);
-	elseif (!isset($disablesid[$gid][$sid]))
-		$disablesid[$gid][$sid] = "disablesid";
+	array_del_path($enablesid, "{$gid}/{$sid}");
+	if (array_get_path($disablesid, "{$gid}/{$sid}") {
+		array_del_path($disablesid, "{$gid}/{$sid}");
+	} else {
+		array_set_path($disablesid, "{$gid}/{$sid}", 'disablesid');
+	}
 
 	// Write the updated enablesid and disablesid values to the config file.
 	$tmp = "";

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -186,19 +186,9 @@ if ($a_instance['blockoffenders'] == 'on' && ($a_instance['ips_mode'] == 'ips_mo
 }
 
 $pconfig = array();
-if (config_get_path('installedpackages/suricata/alertsblocks')) {
-	$pconfig['arefresh'] = config_get_path('installedpackages/suricata/alertsblocks/arefresh');
-	$pconfig['alertnumber'] = config_get_path('installedpackages/suricata/alertsblocks/alertnumber');
-}
-
-if (empty($pconfig['alertnumber']))
-	$pconfig['alertnumber'] = 250;
-if (empty($pconfig['arefresh']))
-	$pconfig['arefresh'] = 'on';
-$anentries = $pconfig['alertnumber'];
-if (!is_numeric($anentries)) {
-	$anentries = 250;
-}	
+$pconfig['arefresh'] = config_get_path('installedpackages/suricata/alertsblocks/arefresh', 'on');
+$pconfig['alertnumber'] = config_get_path('installedpackages/suricata/alertsblocks/alertnumber', '250');
+$anentries = (int)$pconfig['alertnumber'];
 
 # --- AJAX REVERSE DNS RESOLVE Start ---
 if (isset($_POST['resolve'])) {
@@ -391,63 +381,27 @@ if (isset($_POST['rule_action_save']) && $_POST['mode'] == "toggle_action" && is
 	// action lists.
 	switch ($action) {
 		case "action_default":
-			if (isset($alertsid[$gid][$sid])) {
-				unset($alertsid[$gid][$sid]);
-			}
-			if (isset($dropsid[$gid][$sid])) {
-				unset($dropsid[$gid][$sid]);
-			}
-			if (isset($rejectsid[$gid][$sid])) {
-				unset($rejectsid[$gid][$sid]);
-			}
+			array_del_path($alertsid, "{$gid}/{$sid}");
+			array_del_path($dropsid, "{$gid}/{$sid}");
+			array_del_path($rejectsid, "{$gid}/{$sid}");
 			break;
 
 		case "action_alert":
-			if (!is_array($alertsid[$gid])) {
-				$alertsid[$gid] = array();
-			}
-			if (!is_array($alertsid[$gid][$sid])) {
-				$alertsid[$gid][$sid] = array();
-			}
-			$alertsid[$gid][$sid] = "alertsid";
-			if (isset($dropsid[$gid][$sid])) {
-				unset($dropsid[$gid][$sid]);
-			}
-			if (isset($rejectsid[$gid][$sid])) {
-				unset($rejectsid[$gid][$sid]);
-			}
+			array_set_path($alertsid, "{$gid}/{$sid}", "alertsid");
+			array_del_path($dropsid, "{$gid}/{$sid}");
+			array_del_path($rejectsid, "{$gid}/{$sid}");
 			break;
 
 		case "action_drop":
-			if (!is_array($dropsid[$gid])) {
-				$dropsid[$gid] = array();
-			}
-			if (!is_array($dropsid[$gid][$sid])) {
-				$dropsid[$gid][$sid] = array();
-			}
-			$dropsid[$gid][$sid] = "dropsid";
-			if (isset($alertsid[$gid][$sid])) {
-				unset($alertsid[$gid][$sid]);
-			}
-			if (isset($rejectsid[$gid][$sid])) {
-				unset($rejectsid[$gid][$sid]);
-			}
+			array_set_path($dropsid, "{$gid}/{$sid}", "dropsid");
+			array_del_path($alertsid, "{$gid}/{$sid}");
+			array_del_path($rejectsid, "{$gid}/{$sid}");
 			break;
 
 		case "action_reject":
-			if (!is_array($rejectsid[$gid])) {
-				$rejectsid[$gid] = array();
-			}
-			if (!is_array($rejectsid[$gid][$sid])) {
-				$rejectsid[$gid][$sid] = array();
-			}
-			$rejectsid[$gid][$sid] = "rejectsid";
-			if (isset($alertsid[$gid][$sid])) {
-				unset($alertsid[$gid][$sid]);
-			}
-			if (isset($dropsid[$gid][$sid])) {
-				unset($dropsid[$gid][$sid]);
-			}
+			array_set_path($rejectsid, "{$gid}/{$sid}", "rejectsid");
+			array_del_path($alertsid, "{$gid}/{$sid}");
+			array_del_path($dropsid, "{$gid}/{$sid}");
 			break;
 
 		default:

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2021 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,7 @@
 require_once("guiconfig.inc");
 require_once("/usr/local/pkg/suricata/suricata.inc");
 
-global $g, $config;
+global $g;
 $supplist = array();
 $suri_pf_table = SURICATA_PF_TABLE;
 
@@ -67,34 +67,25 @@ function suricata_add_supplist_entry($suppress) {
 	/*   TRUE if successful or FALSE on failure     */
 	/************************************************/
 
-	global $config, $a_instance, $instanceid;
+	global $a_instance, $instanceid;
 
-	if (!is_array($config['installedpackages']['suricata']['suppress'])) {
-		$config['installedpackages']['suricata']['suppress'] = array();
-	}
-
-	if (!is_array($config['installedpackages']['suricata']['suppress']['item'])) {
-		$config['installedpackages']['suricata']['suppress']['item'] = array();
-	}
-
-	$a_suppress = &$config['installedpackages']['suricata']['suppress']['item'];
-
+	$a_suppress = config_get_path('installedpackages/suricata/suppress/item', []);
 	$found_list = false;
 
 	/* If no Suppress List is set for the interface, then create one with the interface name */
-	if (empty($a_instance[$instanceid]['suppresslistname']) || $a_instance[$instanceid]['suppresslistname'] == 'default') {
+	if (empty($a_instance['suppresslistname']) || $a_instance['suppresslistname'] == 'default') {
 		$s_list = array();
 		$s_list['uuid'] = uniqid();
-		$s_list['name'] = $a_instance[$instanceid]['interface'] . "suppress" . "_" . $s_list['uuid'];
+		$s_list['name'] = $a_instance['interface'] . "suppress" . "_" . $s_list['uuid'];
 		$s_list['descr']  =  "Auto-generated list for Alert suppression";
 		$s_list['suppresspassthru'] = base64_encode($suppress);
 		$a_suppress[] = $s_list;
-		$a_instance[$instanceid]['suppresslistname'] = $s_list['name'];
+		$a_instance['suppresslistname'] = $s_list['name'];
 		$found_list = true;
 	} else {
 		/* If we get here, a Suppress List is defined for the interface so see if we can find it */
 		foreach ($a_suppress as $a_id => $alist) {
-			if ($alist['name'] == $a_instance[$instanceid]['suppresslistname']) {
+			if ($alist['name'] == $a_instance['suppresslistname']) {
 				$found_list = true;
 				if (!empty($alist['suppresspassthru'])) {
 					$tmplist = base64_decode($alist['suppresspassthru']);
@@ -113,6 +104,8 @@ function suricata_add_supplist_entry($suppress) {
 	/* If we created a new list or updated an existing one, save the change */
 	/* and return true; otherwise return false.                             */
 	if ($found_list) {
+		config_set_path("installedpackages/suricata/rule/{$instanceid}", $a_instance);
+		config_set_path('installedpackages/suricata/suppress/item', $a_suppress);
 		write_config("Suricata pkg: saved change to Suppress List " . $s_list['name'] . " from ALERTS tab.");
 		sync_suricata_package_config();
 		return true;
@@ -167,27 +160,25 @@ elseif (isset($_GET['instance']) && is_numericint($_GET['instance']))
 if (is_null($instanceid))
 	$instanceid = 0;
 
-if (!is_array($config['installedpackages']['suricata']['rule']))
-	$config['installedpackages']['suricata']['rule'] = array();
-$a_instance = &$config['installedpackages']['suricata']['rule'];
-$suricata_uuid = $a_instance[$instanceid]['uuid'];
-$if_real = get_real_interface($a_instance[$instanceid]['interface']);
+$a_instance = config_get_path("installedpackages/suricata/rule/{$instanceid}", []);
+$suricata_uuid = $a_instance['uuid'];
+$if_real = get_real_interface($a_instance['interface']);
 $suricatalogdir = SURICATALOGDIR;
 $suricatadir = SURICATADIR;
 
 // Load up the arrays of force-enabled and force-disabled SIDs
-$enablesid = suricata_load_sid_mods($a_instance[$instanceid]['rule_sid_on']);
-$disablesid = suricata_load_sid_mods($a_instance[$instanceid]['rule_sid_off']);
+$enablesid = suricata_load_sid_mods($a_instance['rule_sid_on']);
+$disablesid = suricata_load_sid_mods($a_instance['rule_sid_off']);
 
 // Load up the arrays of forced-alert, forced-drop or forced-reject
 // rules as applicable to the current IPS mode.
-if ($a_instance[$instanceid]['blockoffenders'] == 'on' && ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' || $a_instance[$instanceid]['block_drops_only'] == 'on')) {
-	$alertsid = suricata_load_sid_mods($a_instance[$instanceid]['rule_sid_force_alert']);
-	$dropsid = suricata_load_sid_mods($a_instance[$instanceid]['rule_sid_force_drop']);
+if ($a_instance['blockoffenders'] == 'on' && ($a_instance['ips_mode'] == 'ips_mode_inline' || $a_instance['block_drops_only'] == 'on')) {
+	$alertsid = suricata_load_sid_mods($a_instance['rule_sid_force_alert']);
+	$dropsid = suricata_load_sid_mods($a_instance['rule_sid_force_drop']);
 
 	// REJECT forcing is only applicable to Inline IPS Mode
-	if ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' ) {
-		$rejectsid = suricata_load_sid_mods($a_instance[$instanceid]['rule_sid_force_reject']);
+	if ($a_instance['ips_mode'] == 'ips_mode_inline' ) {
+		$rejectsid = suricata_load_sid_mods($a_instance['rule_sid_force_reject']);
 	}
 	else {
 		$rejectsid = array();
@@ -195,9 +186,9 @@ if ($a_instance[$instanceid]['blockoffenders'] == 'on' && ($a_instance[$instance
 }
 
 $pconfig = array();
-if (is_array($config['installedpackages']['suricata']['alertsblocks'])) {
-	$pconfig['arefresh'] = $config['installedpackages']['suricata']['alertsblocks']['arefresh'];
-	$pconfig['alertnumber'] = $config['installedpackages']['suricata']['alertsblocks']['alertnumber'];
+if (config_get_path('installedpackages/suricata/alertsblocks')) {
+	$pconfig['arefresh'] = config_get_path('installedpackages/suricata/alertsblocks/arefresh');
+	$pconfig['alertnumber'] = config_get_path('installedpackages/suricata/alertsblocks/alertnumber');
 }
 
 if (empty($pconfig['alertnumber']))
@@ -343,7 +334,7 @@ if ($_POST['filterlogentries_submit']) {
 	// Note the order of these fields must match the order decoded from the alerts log
 	$filterfieldsarray = array();
 	$filterfieldsarray['time'] = $_POST['filterlogentries_time'] ? $_POST['filterlogentries_time'] : null;
-	if ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline') {
+	if ($a_instance['ips_mode'] == 'ips_mode_inline') {
 		if ($_POST['filterlogentries_action_drop']) {
 			$filterfieldsarray['action'] = $_POST['filterlogentries_action_drop'] ? $_POST['filterlogentries_action_drop'] : null;
 		}
@@ -376,10 +367,8 @@ if ($_POST['filterlogentries_clear']) {
 }
 
 if ($_POST['save']) {
-	if (!is_array($config['installedpackages']['suricata']['alertsblocks']))
-		$config['installedpackages']['suricata']['alertsblocks'] = array();
-	$config['installedpackages']['suricata']['alertsblocks']['arefresh'] = $_POST['arefresh'] ? 'on' : 'off';
-	$config['installedpackages']['suricata']['alertsblocks']['alertnumber'] = $_POST['alertnumber'];
+	config_set_path('installedpackages/suricata/alertsblocks/arefresh', $_POST['arefresh'] ? 'on' : 'off');
+	config_set_path('installedpackages/suricata/alertsblocks/alertnumber', $_POST['alertnumber']);
 
 	write_config("Suricata pkg: saved change to ALERTS tab configuration.");
 
@@ -475,9 +464,9 @@ if (isset($_POST['rule_action_save']) && $_POST['mode'] == "toggle_action" && is
 		$tmp = rtrim($tmp, "||");
 
 		if (!empty($tmp))
-			$a_instance[$instanceid]['rule_sid_force_alert'] = $tmp;
+			$a_instance['rule_sid_force_alert'] = $tmp;
 		else
-			unset($a_instance[$instanceid]['rule_sid_force_alert']);
+			unset($a_instance['rule_sid_force_alert']);
 
 		$tmp = "";
 		foreach (array_keys($dropsid) as $k1) {
@@ -487,9 +476,9 @@ if (isset($_POST['rule_action_save']) && $_POST['mode'] == "toggle_action" && is
 		$tmp = rtrim($tmp, "||");
 
 		if (!empty($tmp))
-			$a_instance[$instanceid]['rule_sid_force_drop'] = $tmp;
+			$a_instance['rule_sid_force_drop'] = $tmp;
 		else
-			unset($a_instance[$instanceid]['rule_sid_force_drop']);
+			unset($a_instance['rule_sid_force_drop']);
 
 		$tmp = "";
 		foreach (array_keys($rejectsid) as $k1) {
@@ -499,23 +488,24 @@ if (isset($_POST['rule_action_save']) && $_POST['mode'] == "toggle_action" && is
 		$tmp = rtrim($tmp, "||");
 
 		if (!empty($tmp))
-			$a_instance[$instanceid]['rule_sid_force_reject'] = $tmp;
+			$a_instance['rule_sid_force_reject'] = $tmp;
 		else
-			unset($a_instance[$instanceid]['rule_sid_force_reject']);
+			unset($a_instance['rule_sid_force_reject']);
 
 		/* Update the config.xml file. */
-		write_config("Suricata pkg: User-forced rule action override applied for rule {$gid}:{$sid} on ALERTS tab for interface {$a_instance[$instanceid]['interface']}.");
+		config_set_path("installedpackages/suricata/rule/{$instanceid}", $a_instance);
+		write_config("Suricata pkg: User-forced rule action override applied for rule {$gid}:{$sid} on ALERTS tab for interface {$a_instance['interface']}.");
 
 		/*************************************************/
 		/* Update the suricata.yaml file and rebuild the */
 		/* rules for this interface.                     */
 		/*************************************************/
 		$rebuild_rules = true;
-		suricata_generate_yaml($a_instance[$instanceid]);
+		suricata_generate_yaml($a_instance);
 		$rebuild_rules = false;
 
 		/* Signal Suricata to live-load the new rules */
-		suricata_reload_config($a_instance[$instanceid]);
+		suricata_reload_config($a_instance);
 
 		// Sync to configured CARP slaves if any are enabled
 		suricata_sync_on_changes();
@@ -570,11 +560,14 @@ if (($_POST['mode'] == 'addsuppress_srcip' || $_POST['mode'] == 'addsuppress_dst
 
 	/* Add the new entry to the Suppress List and signal Suricata to reload config */
 	if (suricata_add_supplist_entry($suppress)) {
-		suricata_reload_config($a_instance[$instanceid]);
-		foreach ($a_instance as $insid => $insconf) {
+		suricata_reload_config($a_instance);
+
+		// See if this Suppress List is assigned to any other interface
+		// and signal that interface to reload its configuration if true.
+		foreach (config_get_path('installedpackages/suricata/rule', []) as $insid => $insconf) {
 			if (($insid != $instanceid) &&
-			    ($a_instance[$instanceid]['suppresslistname'] == $insconf['suppresslistname'])) {
-				suricata_reload_config($a_instance[$insid]);
+			    ($a_instance['suppresslistname'] == $insconf['suppresslistname'])) {
+				suricata_reload_config($insconf);
 			}
 		}
 		$savemsg = $success;
@@ -584,7 +577,7 @@ if (($_POST['mode'] == 'addsuppress_srcip' || $_POST['mode'] == 'addsuppress_dst
 		sleep(2);
 	}
 	else
-		$input_errors[] = gettext("Suppress List '{$a_instance[$instanceid]['suppresslistname']}' is defined for this interface, but it could not be found!");
+		$input_errors[] = gettext("Suppress List '{$a_instance['suppresslistname']}' is defined for this interface, but it could not be found!");
 }
 
 if ($_POST['mode'] == 'togglesid' && is_numeric($_POST['sidid']) && is_numeric($_POST['gen_id'])) {
@@ -610,9 +603,9 @@ if ($_POST['mode'] == 'togglesid' && is_numeric($_POST['sidid']) && is_numeric($
 	$tmp = rtrim($tmp, "||");
 
 	if (!empty($tmp))
-		$a_instance[$instanceid]['rule_sid_on'] = $tmp;
+		$a_instance['rule_sid_on'] = $tmp;
 	else
-		unset($a_instance[$instanceid]['rule_sid_on']);
+		unset($a_instance['rule_sid_on']);
 
 	$tmp = "";
 	foreach (array_keys($disablesid) as $k1) {
@@ -622,23 +615,24 @@ if ($_POST['mode'] == 'togglesid' && is_numeric($_POST['sidid']) && is_numeric($
 	$tmp = rtrim($tmp, "||");
 
 	if (!empty($tmp))
-		$a_instance[$instanceid]['rule_sid_off'] = $tmp;
+		$a_instance['rule_sid_off'] = $tmp;
 	else
-		unset($a_instance[$instanceid]['rule_sid_off']);
+		unset($a_instance['rule_sid_off']);
 
 	/* Update the config.xml file. */
-	write_config("Suricata pkg: User-forced rule state override applied for rule {$gid}:{$sid} on ALERTS tab for interface {$a_instance[$instanceid]['interface']}.");
+	config_set_path("installedpackages/suricata/rule/{$instanceid}", $a_instance);
+	write_config("Suricata pkg: User-forced rule state override applied for rule {$gid}:{$sid} on ALERTS tab for interface {$a_instance['interface']}.");
 
 	/*************************************************/
 	/* Update the suricata.yaml file and rebuild the */
 	/* rules for this interface.                     */
 	/*************************************************/
 	$rebuild_rules = true;
-	suricata_generate_yaml($a_instance[$instanceid]);
+	suricata_generate_yaml($a_instance);
 	$rebuild_rules = false;
 
 	/* Signal Suricata to live-load the new rules */
-	suricata_reload_config($a_instance[$instanceid]);
+	suricata_reload_config($a_instance);
 
 	// Sync to configured CARP slaves if any are enabled
 	suricata_sync_on_changes();
@@ -657,7 +651,7 @@ if ($_POST['clear']) {
 	}
 
 	// Signal the Suricata instance that logs have been rotated
-	suricata_reload_config($a_instance[$instanceid], "SIGHUP");
+	suricata_reload_config($a_instance, "SIGHUP");
 
 	/* XXX: This is needed if suricata is run as suricata user */
 	mwexec('/bin/chmod 660 {$suricatalogdir}*', true);
@@ -693,14 +687,12 @@ if ($_POST['download']) {
 }
 
 /* Load up an array with the current Suppression List GID,SID values */
-$supplist = suricata_load_suppress_sigs($a_instance[$instanceid], true);
+$supplist = suricata_load_suppress_sigs($a_instance, true);
 
 function build_instance_list() {
-	global $a_instance;
-
 	$list = array();
 
-	foreach ($a_instance as $id => $instance) {
+	foreach (config_get_path('installedpackages/suricata/rule', []) as $id => $instance) {
 		$list[$id] = '(' . convert_friendly_interface_to_friendly_descr($instance['interface']) . ') ' . $instance['descr'];
 	}
 
@@ -909,7 +901,7 @@ $group->add(new Form_Input(
 	$filterfieldsarray['proto']
 ))->setHelp("Protocol");
 
-if ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline') {
+if ($a_instance['ips_mode'] == 'ips_mode_inline') {
 	$group->add(new Form_Checkbox(
 		'filterlogentries_action_drop',
 		'Dropped',
@@ -1030,7 +1022,7 @@ if ($filterlogentries && count($filterfieldsarray)) {
 <div class="panel panel-default">
 	<div class="panel-heading"><h2 class="panel-title"><?=sprintf($sectitle)?></h2></div>
 	<div class="panel-body table-responsive">
-	<?php if ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' || $a_instance[$instanceid]['block_drops_only'] == 'on') : ?>
+	<?php if ($a_instance['ips_mode'] == 'ips_mode_inline' || $a_instance['block_drops_only'] == 'on') : ?>
 		<div class="content table-responsive">
 			<span class="text-info"><b><?=gettext('Note: ');?></b><?=gettext('Alerts triggered by DROP rules that resulted in dropped (blocked) packets are shown with ');?>
 			<span class="text-danger"><?=gettext('highlighted ');?></span><?=gettext('rows below.');?><span>
@@ -1087,7 +1079,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 			$fields['time'] = substr($buf, 0, strpos($buf, '  '));
 
 			// Field 1 is the rule action (value is '**' when mode is not inline IPS or 'block-drops-only')
-			if (($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline'  || $a_instance[$instanceid]['block_drops_only'] == 'on') && preg_match('/\[([A-Z]+)\]\s/i', $buf, $tmp)) {
+			if (($a_instance['ips_mode'] == 'ips_mode_inline'  || $a_instance['block_drops_only'] == 'on') && preg_match('/\[([A-Z]+)\]\s/i', $buf, $tmp)) {
 				$fields['action'] = trim($tmp[1]);
 			}
 			else {
@@ -1165,7 +1157,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 			$alert_proto = $fields['proto'];
 
 			/* Action */
-			if (isset($fields['action']) && $a_instance[$instanceid]['blockoffenders'] == 'on' && ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' || $a_instance[$instanceid]['block_drops_only'] == 'on')) {
+			if (isset($fields['action']) && $a_instance['blockoffenders'] == 'on' && ($a_instance['ips_mode'] == 'ips_mode_inline' || $a_instance['block_drops_only'] == 'on')) {
 
 				switch ($fields['action']) {
 
@@ -1175,7 +1167,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 							$alert_action = '<i class="fa fa-thumbs-down icon-pointer text-danger text-center" title="';
 							$alert_action .= gettext("Rule action is User-Forced to DROP. Click to force a different action for this rule.");
 						}
-						elseif ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' && isset($rejectsid[$fields['gid']][$fields['sid']])) {
+						elseif ($a_instance['ips_mode'] == 'ips_mode_inline' && isset($rejectsid[$fields['gid']][$fields['sid']])) {
 							$alert_action = '<i class="fa fa-hand-stop-o icon-pointer text-warning text-center" title="';
 							$alert_action .= gettext("Rule action is User-Forced to REJECT. Click to force a different action for this rule.");
 						}
@@ -1191,7 +1183,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 				$alert_action .= '" onClick="toggleAction(\'' . $fields['gid'] . '\', \'' . $fields['sid'] . '\');"</i>';
 			}
 			else {
-				if ($a_instance[$instanceid]['blockoffenders'] == 'on' && ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' || $a_instance[$instanceid]['block_drops_only'] == 'on')) {
+				if ($a_instance['blockoffenders'] == 'on' && ($a_instance['ips_mode'] == 'ips_mode_inline' || $a_instance['block_drops_only'] == 'on')) {
 					$alert_action = '<i class="fa fa-exclamation-triangle icon-pointer text-warning text-center" title="' . gettext("Rule action is ALERT.");
 					$alert_action .= '" onClick="toggleAction(\'' . $fields['gid'] . '\', \'' . $fields['sid'] . '\');"</i>';
 				}
@@ -1306,8 +1298,8 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 			}
 
 			/* Add icon for toggling rule action if applicable to current mode */
-			if ($a_instance[$instanceid]['blockoffenders'] == 'on') {
-				if ($a_instance[$instanceid]['block_drops_only'] == 'on' || $a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline') {
+			if ($a_instance['blockoffenders'] == 'on') {
+				if ($a_instance['block_drops_only'] == 'on' || $a_instance['ips_mode'] == 'ips_mode_inline') {
 					$sid_action_link = "<i class=\"fa fa-pencil-square-o icon-pointer text-info\" onClick=\"toggleAction('{$fields['gid']}', '{$fields['sid']}');\"";
 					$sid_action_link .= ' title="' . gettext("Click to force a different action for this rule.") . '"></i>';
 					if (isset($alertsid[$fields['gid']][$fields['sid']])) {
@@ -1362,7 +1354,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 	</div>
 </div>
 
-<?php if ($a_instance[$instanceid]['blockoffenders'] == 'on') : ?>
+<?php if ($a_instance['blockoffenders'] == 'on') : ?>
 	<!-- Modal Rule SID action selector window -->
 	<div class="modal fade" role="dialog" id="sid_action_selector">
 		<div class="modal-dialog">
@@ -1385,7 +1377,7 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 						<input type="radio" form="formalert" name="ruleActionOptions" id="action_drop" value="action_drop"> <span class = "label label-danger">DROP</span>
 					</label>
 
-			<?php if ($a_instance[$instanceid]['ips_mode'] == 'ips_mode_inline' && $a_instance[$instanceid]['blockoffenders'] == 'on') : ?>
+			<?php if ($a_instance['ips_mode'] == 'ips_mode_inline' && $a_instance['blockoffenders'] == 'on') : ?>
 					<label class="radio-inline">
 						<input type="radio" form="formalert" name="ruleActionOptions" id="action_reject" value="action_reject"> <span class = "label label-warning">REJECT</span>
 					</label>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
@@ -42,40 +42,41 @@ init_config_arr( array('installedpackages', 'suricata', 'rule', $id, 'libhtp_pol
 
 // Initialize required array variables as necessary
 init_config_arr( array('aliases', 'alias') );
-$a_aliases = $config['aliases']['alias'];
+$a_aliases = config_get_path('aliases/alias', []);
 
-$a_nat = &$config['installedpackages']['suricata']['rule'];
+$a_nat = config_get_path("installedpackages/suricata/rule/{$id}", []);
 
-$libhtp_engine_next_id = count($a_nat[$id]['libhtp_policy']['item']);
+$libhtp_engine_next_id = count(array_get_path($a_nat, 'libhtp_policy/item', []));
 
 // Build a lookup array of currently used engine 'bind_to' Aliases
 // so we can screen matching Alias names from the list.
 $used = array();
-foreach ($a_nat[$id]['libhtp_policy']['item'] as $v)
+foreach (array_get_path($a_nat, 'libhtp_policy/item', []) as $v)
 	$used[$v['bind_to']] = true;
 
 $pconfig = array();
-if (isset($id) && $a_nat[$id]) {
+if (isset($id) && !empty($a_nat)) {
 	/* Get current values from config for page form fields */
-	$pconfig = $a_nat[$id];
+	$pconfig = $a_nat;
 
 	// See if Host-OS policy engine array is configured and use
 	// it; otherwise create a default engine configuration.
-	if (empty($pconfig['libhtp_policy']['item'])) {
+	if (!array_get_path($pconfig, 'libhtp_policy/item')) {
 		$default = array( "name" => "default", "bind_to" => "all", "personality" => "IDS",
 				  "request-body-limit" => 4096, "response-body-limit" => 4096,
 				  "double-decode-path" => "no", "double-decode-query" => "no",
 				  "uri-include-all" => "no", "meta-field-limit" => 18432 );
 		$pconfig['libhtp_policy']['item'] = array();
 		$pconfig['libhtp_policy']['item'][] = $default;
-		if (!is_array($a_nat[$id]['libhtp_policy']['item']))
-			$a_nat[$id]['libhtp_policy']['item'] = array();
-		$a_nat[$id]['libhtp_policy']['item'][] = $default;
-		write_config("Suricata pkg: created a new default HTTP server configuration for " . convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']));
+		if (!is_array($a_nat['libhtp_policy']['item']))
+			$a_nat['libhtp_policy']['item'] = array();
+		$a_nat['libhtp_policy']['item'][] = $default;
+		config_set_path("installedpackages/suricata/rule/{$id}", $a_nat);
+		write_config("Suricata pkg: created a new default HTTP server configuration for " . convert_friendly_interface_to_friendly_descr($a_nat['interface']));
 		$libhtp_engine_next_id++;
 	}
 	else
-		$pconfig['libhtp_policy'] = $a_nat[$id]['libhtp_policy'];
+		$pconfig['libhtp_policy'] = $a_nat['libhtp_policy'];
 }
 
 // Check for "import or select alias mode" and set flags if TRUE.
@@ -157,18 +158,18 @@ if ($_POST['save_libhtp_policy']) {
 
 		// if no errors, write new entry to conf
 		if (!$input_errors) {
-			if (isset($eng_id) && isset($a_nat[$id]['libhtp_policy']['item'][$eng_id])) {
-				$a_nat[$id]['libhtp_policy']['item'][$eng_id] = $engine;
+			if (isset($eng_id) && isset($a_nat['libhtp_policy']['item'][$eng_id])) {
+				$a_nat['libhtp_policy']['item'][$eng_id] = $engine;
 			}
 			else
-				$a_nat[$id]['libhtp_policy']['item'][] = $engine;
+				$a_nat['libhtp_policy']['item'][] = $engine;
 
 			/* Reorder the engine array to ensure the */
 			/* 'bind_to=all' entry is at the bottom   */
 			/* if it contains more than one entry.	  */
-			if (count($a_nat[$id]['libhtp_policy']['item']) > 1) {
+			if (count($a_nat['libhtp_policy']['item']) > 1) {
 				$i = -1;
-				foreach ($a_nat[$id]['libhtp_policy']['item'] as $f => $v) {
+				foreach ($a_nat['libhtp_policy']['item'] as $f => $v) {
 					if ($v['bind_to'] == "all") {
 						$i = $f;
 						break;
@@ -177,15 +178,16 @@ if ($_POST['save_libhtp_policy']) {
 				/* Only relocate the entry if we  */
 				/* found it, and it's not already */
 				/* at the end.					  */
-				if ($i > -1 && ($i < (count($a_nat[$id]['libhtp_policy']['item']) - 1))) {
-					$tmp = $a_nat[$id]['libhtp_policy']['item'][$i];
-					unset($a_nat[$id]['libhtp_policy']['item'][$i]);
-					$a_nat[$id]['libhtp_policy']['item'][] = $tmp;
+				if ($i > -1 && ($i < (count($a_nat['libhtp_policy']['item']) - 1))) {
+					$tmp = $a_nat['libhtp_policy']['item'][$i];
+					unset($a_nat['libhtp_policy']['item'][$i]);
+					$a_nat['libhtp_policy']['item'][] = $tmp;
 				}
 			}
 
 			// Now write the new engine array to conf
-			write_config("Suricata pkg: saved updated HTTP server configuration for " . convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']));
+			config_set_path("installedpackages/suricata/rule/{$id}", $a_nat);
+			write_config("Suricata pkg: saved updated HTTP server configuration for " . convert_friendly_interface_to_friendly_descr($a_nat['interface']));
 			$add_edit_libhtp_policy = false;
 			header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 			header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
@@ -212,7 +214,7 @@ elseif ($_POST['edit_libhtp_policy']) {
 	if ($_POST['eng_id'] != "") {
 		$add_edit_libhtp_policy = true;
 		$eng_id = $_POST['eng_id'];
-		$pengcfg = $a_nat[$id]['libhtp_policy']['item'][$eng_id];
+		$pengcfg = $a_nat['libhtp_policy']['item'][$eng_id];
 	}
 }
 elseif ($_POST['del_libhtp_policy']) {
@@ -223,9 +225,10 @@ elseif ($_POST['del_libhtp_policy']) {
 		unset($natent['libhtp_policy']['item'][$_POST['eng_id']]);
 		$pconfig = $natent;
 	}
-	if (isset($id) && isset($a_nat[$id])) {
-		$a_nat[$id] = $natent;
-		write_config("Suricata pkg: deleted a HTTP server configuration for " . convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']));
+	if (isset($id) && isset($a_nat)) {
+		$a_nat = $natent;
+		config_set_path("installedpackages/suricata/rule/{$id}", $a_nat);
+		write_config("Suricata pkg: deleted a HTTP server configuration for " . convert_friendly_interface_to_friendly_descr($a_nat['interface']));
 	}
 	$add_edit_libhtp_policy = false;
 	header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
@@ -336,7 +339,7 @@ elseif ($_POST['save_import_alias']) {
 			foreach ($_POST['aliastoimport'] as $item) {
 				$engine['name'] = strtolower($item);
 				$engine['bind_to'] = $item;
-				$a_nat[$id]['libhtp_policy']['item'][] = $engine;
+				$a_nat['libhtp_policy']['item'][] = $engine;
 			}
 		}
 		else {
@@ -349,9 +352,9 @@ elseif ($_POST['save_import_alias']) {
 			// Reorder the engine array to ensure the
 			// 'bind_to=all' entry is at the bottom if
 			// the array contains more than one entry.
-			if (count($a_nat[$id]['libhtp_policy']['item']) > 1) {
+			if (count($a_nat['libhtp_policy']['item']) > 1) {
 				$i = -1;
-				foreach ($a_nat[$id]['libhtp_policy']['item'] as $f => $v) {
+				foreach ($a_nat['libhtp_policy']['item'] as $f => $v) {
 					if ($v['bind_to'] == "all") {
 						$i = $f;
 						break;
@@ -360,16 +363,17 @@ elseif ($_POST['save_import_alias']) {
 				// Only relocate the entry if we
 				// found it, and it's not already
 				// at the end.
-				if ($i > -1 && ($i < (count($a_nat[$id]['libhtp_policy']['item']) - 1))) {
-					$tmp = $a_nat[$id]['libhtp_policy']['item'][$i];
-					unset($a_nat[$id]['libhtp_policy']['item'][$i]);
-					$a_nat[$id]['libhtp_policy']['item'][] = $tmp;
+				if ($i > -1 && ($i < (count($a_nat['libhtp_policy']['item']) - 1))) {
+					$tmp = $a_nat['libhtp_policy']['item'][$i];
+					unset($a_nat['libhtp_policy']['item'][$i]);
+					$a_nat['libhtp_policy']['item'][] = $tmp;
 				}
-				$pconfig['libhtp_policy']['item'] = $a_nat[$id]['libhtp_policy']['item'];
+				$pconfig['libhtp_policy']['item'] = $a_nat['libhtp_policy']['item'];
 			}
 
 			// Write the new engine array to config file
-			write_config("Suricata pkg: saved an updated HTTP server configuration for " . convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']));
+			config_set_path("installedpackages/suricata/rule/{$id}", $a_nat);
+			write_config("Suricata pkg: saved an updated HTTP server configuration for " . convert_friendly_interface_to_friendly_descr($a_nat['interface']));
 			$importalias = false;
 			header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 			header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
@@ -484,9 +488,10 @@ elseif ($_POST['save'] || $_POST['apply']) {
 		/* then update the suricata.conf file for this	  */
 		/* interface.									  */
 		/**************************************************/
-		if (isset($id) && $a_nat[$id]) {
-			$a_nat[$id] = $natent;
-			write_config("Suricata pkg: saved updated app-layer parser configuration for " . convert_friendly_interface_to_friendly_descr($a_nat[$id]['interface']));
+		if (isset($id) && $a_nat) {
+			$a_nat = $natent;
+			config_set_path("installedpackages/suricata/rule/{$id}", $a_nat);
+			write_config("Suricata pkg: saved updated app-layer parser configuration for " . convert_friendly_interface_to_friendly_descr($a_nat['interface']));
 			$rebuild_rules = false;
 			suricata_generate_yaml($natent);
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
@@ -26,23 +26,13 @@
 require_once("guiconfig.inc");
 require_once("/usr/local/pkg/suricata/suricata.inc");
 
-global $g, $config;
+global $g;
 
 $suricatalogdir = SURICATALOGDIR;
 $suri_pf_table = SURICATA_PF_TABLE;
 
-if (!is_array($config['installedpackages']['suricata']['alertsblocks']))
-	$config['installedpackages']['suricata']['alertsblocks'] = array();
-
-$pconfig['brefresh'] = $config['installedpackages']['suricata']['alertsblocks']['brefresh'];
-$pconfig['blertnumber'] = $config['installedpackages']['suricata']['alertsblocks']['blertnumber'];
-
-if (empty($pconfig['blertnumber'])) {
-	$pconfig['blertnumber'] = 500;
-}
-if (empty($pconfig['brefresh'])) {
-	$pconfig['brefresh'] = 'on';
-}
+$pconfig['brefresh'] = config_get_path('installedpackages/suricata/alertsblocks/brefresh', 'on');
+$pconfig['blertnumber'] = config_get_path('installedpackages/suricata/alertsblocks/blertnumber', 500);
 $bnentries = $pconfig['blertnumber'];
 
 # --- AJAX REVERSE DNS RESOLVE Start ---
@@ -155,15 +145,12 @@ if ($_POST['save'])
 {
 	/* no errors */
 	if (!$input_errors) {
-		$config['installedpackages']['suricata']['alertsblocks']['brefresh'] = $_POST['brefresh'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['alertsblocks']['blertnumber'] = $_POST['blertnumber'];
-
+		config_set_path('installedpackages/suricata/alertsblocks/brefresh', $_POST['brefresh'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/alertsblocks/blertnumber', $_POST['blertnumber']);
 		write_config("Suricata pkg: updated BLOCKED tab settings.");
-
 		header("Location: /suricata/suricata_blocked.php");
 		exit;
 	}
-
 }
 
 $pglinks = array("", "/suricata/suricata_interfaces.php", "@self");
@@ -239,7 +226,7 @@ $group->add(new Form_Checkbox(
 	'brefresh',
 	null,
 	'Refresh',
-	(($config['installedpackages']['suricata']['alertsblocks']['brefresh']=="on") || ($config['installedpackages']['suricata']['alertsblocks']['brefresh']=='')),
+	((config_get_path('installedpackages/suricata/alertsblocks/brefresh')=="on") || (config_get_path('installedpackages/suricata/alertsblocks/brefresh')=='')),
 	'on'
 ))->setHelp('Default is ON');
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_define_vars.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_define_vars.php
@@ -50,11 +50,8 @@ $suricata_servers = array (
 	"sip_servers" => "\$HOME_NET"
 );
 
-/* if user has defined a custom ssh port, use it */
-if(config_get_path('system/ssh/port'))
-		$ssh_port = config_get_path('system/ssh/port');
-else
-		$ssh_port = "22";
+/* if user has defined a custom ssh port, use it, else default to '22' */
+$ssh_port = config_get_path('system/ssh/port', '22');
 $suricata_ports = array(
 	"ftp_ports" => "21",
 	"http_ports" => "80",

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_define_vars.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_define_vars.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2021 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,10 +38,7 @@ if (is_null($id)) {
 		exit;
 }
 
-if (!is_array($config['installedpackages']['suricata']['rule'])) {
-	$config['installedpackages']['suricata']['rule'] = array();
-}
-$a_nat = &$config['installedpackages']['suricata']['rule'];
+$a_nat = config_get_path("installedpackages/suricata/rule/{$id}", []);
 
 /* define servers and ports */
 $suricata_servers = array (
@@ -54,8 +51,8 @@ $suricata_servers = array (
 );
 
 /* if user has defined a custom ssh port, use it */
-if(is_array($config['system']['ssh']) && isset($config['system']['ssh']['port']))
-		$ssh_port = $config['system']['ssh']['port'];
+if(config_get_path('system/ssh/port'))
+		$ssh_port = config_get_path('system/ssh/port');
 else
 		$ssh_port = "22";
 $suricata_ports = array(
@@ -74,11 +71,11 @@ $suricata_ports = array(
 ksort($suricata_servers);
 ksort($suricata_ports);
 
-$pconfig = $a_nat[$id];
+$pconfig = $a_nat;
 
 /* convert fake interfaces to real */
 $if_real = get_real_interface($pconfig['interface']);
-$suricata_uuid = $config['installedpackages']['suricata']['rule'][$id]['uuid'];
+$suricata_uuid = config_get_path("installedpackages/suricata/rule/{$id}/uuid");
 
 if ($_POST) {
 
@@ -113,16 +110,17 @@ if ($_POST) {
 				unset($natent["def_{$key}"]);
 		}
 
-		$a_nat[$id] = $natent;
-
+		// Save the updated interface configuration
+		$a_nat = $natent;
+		config_set_path("installedpackages/suricata/rule/{$id}", $a_nat);
 		write_config("Suricata pkg: saved changes for PORT or IP variables.");
 
 		/* Update the suricata.yaml file for this interface. */
 		$rebuild_rules = false;
-		suricata_generate_yaml($a_nat[$id]);
+		suricata_generate_yaml($a_nat);
 
 		/* Soft-restart Suricaa to live-load new variables. */
-		suricata_reload_config($a_nat[$id]);
+		suricata_reload_config($a_nat);
 
 		/* Sync to configured CARP slaves if any are enabled */
 		suricata_sync_on_changes();

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2021 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,15 +31,14 @@ require_once("/usr/local/pkg/suricata/suricata.inc");
 $suricatadir = SURICATADIR;
 $suricata_rules_upd_log = SURICATA_RULES_UPD_LOGFILE;
 
-$snortdownload = $config['installedpackages']['suricata']['config'][0]['enable_vrt_rules'];
-$emergingthreats = $config['installedpackages']['suricata']['config'][0]['enable_etopen_rules'];
-$etpro = $config['installedpackages']['suricata']['config'][0]['enable_etpro_rules'];
-$snortcommunityrules = $config['installedpackages']['suricata']['config'][0]['snortcommunityrules'];
-$feodotracker_rules = $config['installedpackages']['suricata']['config'][0]['enable_feodo_botnet_c2_rules'];
-$sslbl_rules = $config['installedpackages']['suricata']['config'][0]['enable_abuse_ssl_blacklist_rules'];
-$enable_extra_rules = $config['installedpackages']['suricata']['config'][0]['enable_extra_rules'] == "on" ? 'on' : 'off';
-init_config_arr(array('installedpackages', 'suricata' ,'config', 0, 'extra_rules', 'rule'));
-$extra_rules = $config['installedpackages']['suricata']['config'][0]['extra_rules']['rule'];
+$snortdownload = config_get_path('installedpackages/suricata/config/0/enable_vrt_rules');
+$emergingthreats = config_get_path('installedpackages/suricata/config/0/enable_etopen_rules');
+$etpro = config_get_path('installedpackages/suricata/config/0/enable_etpro_rules');
+$snortcommunityrules = config_get_path('installedpackages/suricata/config/0/snortcommunityrules');
+$feodotracker_rules = config_get_path('installedpackages/suricata/config/0/enable_feodo_botnet_c2_rules');
+$sslbl_rules = config_get_path('installedpackages/suricata/config/0/enable_abuse_ssl_blacklist_rules');
+$enable_extra_rules = config_get_path('installedpackages/suricata/config/0/enable_extra_rules') == "on" ? 'on' : 'off';
+$extra_rules = config_get_path('installedpackages/suricata/config/0/extra_rules/rule', []);
 
 /* Get last update information if available */
 if (file_exists(SURICATADIR . "rulesupd_status")) {
@@ -54,22 +53,22 @@ else {
 
 // Check for any custom URLs and extract custom filenames
 // if present, else use package default values.
-if ($config['installedpackages']['suricata']['config'][0]['enable_snort_custom_url'] == 'on') {
-	$snort_rules_file = trim(substr($config['installedpackages']['suricata']['config'][0]['snort_custom_url'], strrpos($config['installedpackages']['suricata']['config'][0]['snort_custom_url'], '/') + 1));
+if (config_get_path('installedpackages/suricata/config/0/enable_snort_custom_url') == 'on') {
+	$snort_rules_file = trim(substr(config_get_path('installedpackages/suricata/config/0/snort_custom_url'), strrpos(config_get_path('installedpackages/suricata/config/0/snort_custom_url'), '/') + 1));
 }
 else {
-	$snort_rules_file = $config['installedpackages']['suricata']['config'][0]['snort_rules_file'];
+	$snort_rules_file = config_get_path('installedpackages/suricata/config/0/snort_rules_file');
 }
-if ($config['installedpackages']['suricata']['config'][0]['enable_gplv2_custom_url'] == 'on') {
-	$snort_community_rules_filename = trim(substr($config['installedpackages']['suricata']['config'][0]['gplv2_custom_url'], strrpos($config['installedpackages']['suricata']['config'][0]['gplv2_custom_url'], '/') + 1));
+if (config_get_path('installedpackages/suricata/config/0/enable_gplv2_custom_url') == 'on') {
+	$snort_community_rules_filename = trim(substr(config_get_path('installedpackages/suricata/config/0/gplv2_custom_url'), strrpos(config_get_path('installedpackages/suricata/config/0/gplv2_custom_url'), '/') + 1));
 }
 else {
 	$snort_community_rules_filename = GPLV2_DNLD_FILENAME;
 }
 if ($etpro == "on") {
 	$et_name = "Emerging Threats Pro Rules";
-	if ($config['installedpackages']['suricata']['config'][0]['enable_etpro_custom_url'] == 'on') {
-		$emergingthreats_filename = trim(substr($config['installedpackages']['suricata']['config'][0]['etpro_custom_rule_url'], strrpos($config['installedpackages']['suricata']['config'][0]['etpro_custom_rule_url'], '/') + 1));
+	if (config_get_path('installedpackages/suricata/config/0/enable_etpro_custom_url') == 'on') {
+		$emergingthreats_filename = trim(substr(config_get_path('installedpackages/suricata/config/0/etpro_custom_rule_url'), strrpos(config_get_path('installedpackages/suricata/config/0/etpro_custom_rule_url'), '/') + 1));
 	}
 	else {
 		$emergingthreats_filename = ETPRO_DNLD_FILENAME;
@@ -77,8 +76,8 @@ if ($etpro == "on") {
 }
 else {
 	$et_name = "Emerging Threats Open Rules";
-	if ($config['installedpackages']['suricata']['config'][0]['enable_etopen_custom_url'] == 'on') {
-		$emergingthreats_filename = trim(substr($config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url'], strrpos($config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url'], '/') + 1));
+	if (config_get_path('installedpackages/suricata/config/0/enable_etopen_custom_url') == 'on') {
+		$emergingthreats_filename = trim(substr(config_get_path('installedpackages/suricata/config/0/etopen_custom_rule_url'), strrpos(config_get_path('installedpackages/suricata/config/0/etopen_custom_rule_url'), '/') + 1));
 	}
 	else {
 		$emergingthreats_filename = ET_DNLD_FILENAME;
@@ -174,7 +173,7 @@ if ($_REQUEST['updatemode']) {
 
 	// Launch a background process to download the updates
 	$upd_pid = 0;
-	$upd_pid = mwexec_bg("/usr/local/bin/php -f /usr/local/pkg/suricata/suricata_check_for_rule_updates.php");
+	$upd_pid = mwexec_bg("/usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_check_for_rule_updates.php");
 	print($upd_pid);
 
 	// If we failed to launch our background process, throw up an error for the user.

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_filecheck.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_filecheck.php
@@ -22,15 +22,11 @@
 require('guiconfig.inc');
 require_once("/usr/local/pkg/suricata/suricata.inc");
 
-global $config;
-
 $file_hash = $_REQUEST['filehash'];
 $uuid = $_REQUEST['uuid'];
 $file_name = urldecode($_REQUEST['filename']);
 $file_size = urldecode($_REQUEST['filesize']);
-
-init_config_arr(array('installedpackages', 'suricata', 'rule'));
-$a_instance = &$config['installedpackages']['suricata']['rule'];
+$a_instance = config_get_path('installedpackages/suricata/rule', []);
 
 foreach ($a_instance as $instance) {
 	if (($instance['uuid'] == $uuid) &&

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2021 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,37 +35,20 @@ elseif (isset($_GET['id']) && is_numericint($_GET['id']))
 if (is_null($id))
 	$id=0;
 
-if (!is_array($config['installedpackages']['suricata']))
-	$config['installedpackages']['suricata'] = array();
-if (!is_array($config['installedpackages']['suricata']['rule']))
-	$config['installedpackages']['suricata']['rule'] = array();
-
-// Initialize required array variables as necessary
-if (!is_array($config['aliases'])) {
-	$config['aliases'] = array();
-}
-if (!is_array($config['aliases']['alias']))
-	$config['aliases']['alias'] = array();
-$a_aliases = $config['aliases']['alias'];
-
-// Initialize Host-OS Policy engine arrays if necessary
-if (!is_array($config['installedpackages']['suricata']['rule'][$id]['host_os_policy']['item']))
-	$config['installedpackages']['suricata']['rule'][$id]['host_os_policy']['item'] = array();
-
-$a_nat = &$config['installedpackages']['suricata']['rule'];
-
-$host_os_policy_engine_next_id = count($a_nat[$id]['host_os_policy']['item']);
+$a_aliases = config_get_path('aliases/alias', []);
+$a_nat = config_get_path("installedpackages/suricata/rule/{$id}", []);
+$host_os_policy_engine_next_id = count(array_get_path($a_nat, 'host_os_policy/item', []));
 
 // Build a lookup array of currently used engine 'bind_to' Aliases
 // so we can screen matching Alias names from the list.
 $used = array();
-foreach ($a_nat[$id]['host_os_policy']['item'] as $v)
+foreach (array_get_path($a_nat, 'host_os_policy/item', []) as $v)
 	$used[$v['bind_to']] = true;
 
 $pconfig = array();
-if (isset($id) && $a_nat[$id]) {
+if (isset($id) && !empty($a_nat)) {
 	/* Get current values from config for page form fields */
-	$pconfig = $a_nat[$id];
+	$pconfig = $a_nat;
 
 	// See if Host-OS policy engine array is configured and use
 	// it; otherwise create a default engine configuration.
@@ -73,14 +56,15 @@ if (isset($id) && $a_nat[$id]) {
 		$default = array( "name" => "default", "bind_to" => "all", "policy" => "bsd" );
 		$pconfig['host_os_policy']['item'] = array();
 		$pconfig['host_os_policy']['item'][] = $default;
-		if (!is_array($a_nat[$id]['host_os_policy']['item']))
-			$a_nat[$id]['host_os_policy']['item'] = array();
-		$a_nat[$id]['host_os_policy']['item'][] = $default;
+		if (!is_array($a_nat['host_os_policy']['item']))
+			$a_nat['host_os_policy']['item'] = array();
+		$a_nat['host_os_policy']['item'][] = $default;
+		config_set_path("installedpackages/suricata/rule/{$id}", $a_nat);
 		write_config("Suricata pkg: saved new default Host_OS_Policy engine.");
 		$host_os_policy_engine_next_id++;
 	}
 	else
-		$pconfig['host_os_policy'] = $a_nat[$id]['host_os_policy'];
+		$pconfig['host_os_policy'] = $a_nat['host_os_policy'];
 }
 
 // Check for "import or select alias mode" and set flags if TRUE.
@@ -145,18 +129,18 @@ if ($_POST['save_os_policy']) {
 
 		// if no errors, write new entry to conf
 		if (!$input_errors) {
-			if (isset($eng_id) && $a_nat[$id]['host_os_policy']['item'][$eng_id]) {
-				$a_nat[$id]['host_os_policy']['item'][$eng_id] = $engine;
+			if (isset($eng_id) && $a_nat['host_os_policy']['item'][$eng_id]) {
+				$a_nat['host_os_policy']['item'][$eng_id] = $engine;
 			}
 			else
-				$a_nat[$id]['host_os_policy']['item'][] = $engine;
+				$a_nat['host_os_policy']['item'][] = $engine;
 
 			/* Reorder the engine array to ensure the */
 			/* 'bind_to=all' entry is at the bottom   */
 			/* if it contains more than one entry.	*/
-			if (count($a_nat[$id]['host_os_policy']['item']) > 1) {
+			if (count($a_nat['host_os_policy']['item']) > 1) {
 				$i = -1;
-				foreach ($a_nat[$id]['host_os_policy']['item'] as $f => $v) {
+				foreach ($a_nat['host_os_policy']['item'] as $f => $v) {
 					if ($v['bind_to'] == "all") {
 						$i = $f;
 						break;
@@ -165,14 +149,15 @@ if ($_POST['save_os_policy']) {
 				/* Only relocate the entry if we  */
 				/* found it, and it's not already */
 				/* at the end.					*/
-				if ($i > -1 && ($i < (count($a_nat[$id]['host_os_policy']['item']) - 1))) {
-					$tmp = $a_nat[$id]['host_os_policy']['item'][$i];
-					unset($a_nat[$id]['host_os_policy']['item'][$i]);
-					$a_nat[$id]['host_os_policy']['item'][] = $tmp;
+				if ($i > -1 && ($i < (count($a_nat['host_os_policy']['item']) - 1))) {
+					$tmp = $a_nat['host_os_policy']['item'][$i];
+					unset($a_nat['host_os_policy']['item'][$i]);
+					$a_nat['host_os_policy']['item'][] = $tmp;
 				}
 			}
 
 			// Now write the new engine array to conf
+			config_set_path("installedpackages/suricata/rule/{$id}", $a_nat);
 			write_config("Suricata pkg: saved new Host_OS_Policy engine.");
 			header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 			header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
@@ -193,7 +178,7 @@ elseif ($_POST['edit_os_policy']) {
 	if ($_POST['eng_id'] != "") {
 		$add_edit_os_policy = true;
 		$eng_id = $_POST['eng_id'];
-		$pengcfg = $a_nat[$id]['host_os_policy']['item'][$eng_id];
+		$pengcfg = $a_nat['host_os_policy']['item'][$eng_id];
 	}
 }
 elseif ($_POST['del_os_policy']) {
@@ -204,8 +189,9 @@ elseif ($_POST['del_os_policy']) {
 		unset($natent['host_os_policy']['item'][$_POST['eng_id']]);
 		$pconfig = $natent;
 	}
-	if (isset($id) && $a_nat[$id]) {
-		$a_nat[$id] = $natent;
+	if (isset($id) && !empty($a_nat)) {
+		$a_nat = $natent;
+		config_set_path("installedpackages/suricata/rule/{$id}", $a_nat);
 		write_config("Suricata pkg: deleted a Host_OS_Policy engine.");
 	}
 	header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
@@ -322,8 +308,9 @@ elseif ($_POST['save'] || $_POST['apply']) {
 		/* then update the suricata.conf file for this	*/
 		/* interface.									 */
 		/**************************************************/
-		if (isset($id) && $a_nat[$id]) {
-			$a_nat[$id] = $natent;
+		if (isset($id) && !empty($a_nat)) {
+			$a_nat = $natent;
+			config_set_path("installedpackages/suricata/rule/{$id}", $a_nat);
 			write_config("Suricata pkg: saved flow or stream configuration changes.");
 			$rebuild_rules = false;
 			suricata_generate_yaml($natent);
@@ -379,7 +366,7 @@ elseif ($_POST['save_import_alias']) {
 			foreach ($_POST['aliastoimport'] as $item) {
 				$engine['name'] = strtolower($item);
 				$engine['bind_to'] = $item;
-				$a_nat[$id]['host_os_policy']['item'][] = $engine;
+				$a_nat['host_os_policy']['item'][] = $engine;
 			}
 		}
 		else {
@@ -392,9 +379,9 @@ elseif ($_POST['save_import_alias']) {
 			// Reorder the engine array to ensure the
 			// 'bind_to=all' entry is at the bottom if
 			// the array contains more than one entry.
-			if (count($a_nat[$id]['host_os_policy']['item']) > 1) {
+			if (count($a_nat['host_os_policy']['item']) > 1) {
 				$i = -1;
-				foreach ($a_nat[$id]['host_os_policy']['item'] as $f => $v) {
+				foreach ($a_nat['host_os_policy']['item'] as $f => $v) {
 					if ($v['bind_to'] == "all") {
 						$i = $f;
 						break;
@@ -403,15 +390,16 @@ elseif ($_POST['save_import_alias']) {
 				// Only relocate the entry if we
 				// found it, and it's not already
 				// at the end.
-				if ($i > -1 && ($i < (count($a_nat[$id]['host_os_policy']['item']) - 1))) {
-					$tmp = $a_nat[$id]['host_os_policy']['item'][$i];
-					unset($a_nat[$id]['host_os_policy']['item'][$i]);
-					$a_nat[$id]['host_os_policy']['item'][] = $tmp;
+				if ($i > -1 && ($i < (count($a_nat['host_os_policy']['item']) - 1))) {
+					$tmp = $a_nat['host_os_policy']['item'][$i];
+					unset($a_nat['host_os_policy']['item'][$i]);
+					$a_nat['host_os_policy']['item'][] = $tmp;
 				}
-				$pconfig['host_os_policy']['item'] = $a_nat[$id]['host_os_policy']['item'];
+				$pconfig['host_os_policy']['item'] = $a_nat['host_os_policy']['item'];
 			}
 
 			// Write the new engine array to config file
+			config_set_path("installedpackages/suricata/rule/{$id}", $a_nat);
 			write_config("Suricata pkg: saved Host_OS_Policy engine created from a defined firewall alias.");
 			$importalias = false;
 			$selectalias = false;

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
@@ -129,7 +129,7 @@ if ($_POST['save_os_policy']) {
 
 		// if no errors, write new entry to conf
 		if (!$input_errors) {
-			if (isset($eng_id) && $a_nat['host_os_policy']['item'][$eng_id]) {
+			if (isset($eng_id) && array_get_path($a_nat, "host_os_policy/item/{$eng_id}")) {
 				$a_nat['host_os_policy']['item'][$eng_id] = $engine;
 			}
 			else
@@ -138,9 +138,9 @@ if ($_POST['save_os_policy']) {
 			/* Reorder the engine array to ensure the */
 			/* 'bind_to=all' entry is at the bottom   */
 			/* if it contains more than one entry.	*/
-			if (count($a_nat['host_os_policy']['item']) > 1) {
+			if (count(array_get_path($a_nat, 'host_os_policy/item', [])) > 1) {
 				$i = -1;
-				foreach ($a_nat['host_os_policy']['item'] as $f => $v) {
+				foreach (array_get_path($a_nat, 'host_os_policy/item', []) as $f => $v) {
 					if ($v['bind_to'] == "all") {
 						$i = $f;
 						break;
@@ -149,9 +149,9 @@ if ($_POST['save_os_policy']) {
 				/* Only relocate the entry if we  */
 				/* found it, and it's not already */
 				/* at the end.					*/
-				if ($i > -1 && ($i < (count($a_nat['host_os_policy']['item']) - 1))) {
-					$tmp = $a_nat['host_os_policy']['item'][$i];
-					unset($a_nat['host_os_policy']['item'][$i]);
+				if ($i > -1 && ($i < (count(array_get_path($a_nat, 'host_os_policy/item', [])) - 1))) {
+					$tmp = array_get_path($a_nat, "host_os_policy/item/{$i}", []);
+					array_del_path($a_nat, "host_os_policy/item/{$i}");
 					$a_nat['host_os_policy']['item'][] = $tmp;
 				}
 			}
@@ -186,7 +186,7 @@ elseif ($_POST['del_os_policy']) {
 	$natent = $pconfig;
 
 	if ($_POST['eng_id'] != "") {
-		unset($natent['host_os_policy']['item'][$_POST['eng_id']]);
+		array_del_path($natent, "host_os_policy/item/{$_POST['eng_id']}");
 		$pconfig = $natent;
 	}
 	if (isset($id) && !empty($a_nat)) {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -51,6 +51,7 @@ else {
 	$pconfig['log_to_systemlog_facility'] = config_get_path('installedpackages/suricata/config/0/log_to_systemlog_facility');
 	$pconfig['log_to_systemlog_priority'] = config_get_path('installedpackages/suricata/config/0/log_to_systemlog_priority');
 	$pconfig['forcekeepsettings'] = config_get_path('installedpackages/suricata/config/0/forcekeepsettings') == "on" ? 'on' : 'off';
+	$pconfig['clearblocks'] = config_get_path('installedpackages/suricata/config/0/clearblocks') == "off" ? 'off' : 'on';
 	$pconfig['snortcommunityrules'] = config_get_path('installedpackages/suricata/config/0/snortcommunityrules') == "on" ? 'on' : 'off';
 	$pconfig['snort_rules_file'] = htmlentities(config_get_path('installedpackages/suricata/config/0/snort_rules_file'));
 	$pconfig['autogeoipupdate'] = config_get_path('installedpackages/suricata/config/0/autogeoipupdate') == "on" ? 'on' : 'off';
@@ -235,6 +236,7 @@ if (!$input_errors) {
 		config_set_path('installedpackages/suricata/config/0/log_to_systemlog_priority', $_POST['log_to_systemlog_priority']);
 		config_set_path('installedpackages/suricata/config/0/live_swap_updates', $_POST['live_swap_updates'] ? 'on' : 'off');
 		config_set_path('installedpackages/suricata/config/0/forcekeepsettings', $_POST['forcekeepsettings'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/clearblocks', $_POST['clearblocks'] ? 'on' : 'off');
 
 		$retval = 0;
 
@@ -591,6 +593,14 @@ $section->addInput(new Form_Checkbox(
 	'Keep Suricata Settings After Deinstall',
 	'Settings will not be removed during package deinstallation.',
 	$pconfig['forcekeepsettings'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Checkbox(
+	'clearblocks',
+	'Clear Blocked Hosts After Deinstall',
+	'Click to clear all blocked hosts added by Suricata when removing the package.  Default is checked.',
+	$pconfig['clearblocks'] == 'on' ? true:false,
 	'on'
 ));
 $form->add($section);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2021 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,38 +36,38 @@ if (!empty($_POST)) {
 	$pconfig = $_POST;
 }
 else {
-	$pconfig['enable_vrt_rules'] = $config['installedpackages']['suricata']['config'][0]['enable_vrt_rules'] == "on" ? 'on' : 'off';
-	$pconfig['oinkcode'] = htmlentities($config['installedpackages']['suricata']['config'][0]['oinkcode']);
-	$pconfig['etprocode'] = htmlentities($config['installedpackages']['suricata']['config'][0]['etprocode']);
-	$pconfig['enable_etopen_rules'] = $config['installedpackages']['suricata']['config'][0]['enable_etopen_rules'] == "on" ? 'on' : 'off';
-	$pconfig['enable_etpro_rules'] = $config['installedpackages']['suricata']['config'][0]['enable_etpro_rules'] == "on" ? 'on' : 'off';
-	$pconfig['rm_blocked'] = $config['installedpackages']['suricata']['config'][0]['rm_blocked'];
-	$pconfig['autoruleupdate'] = $config['installedpackages']['suricata']['config'][0]['autoruleupdate'];
-	$pconfig['autoruleupdatetime'] = htmlentities($config['installedpackages']['suricata']['config'][0]['autoruleupdatetime']);
-	$pconfig['live_swap_updates'] = $config['installedpackages']['suricata']['config'][0]['live_swap_updates'] == "on" ? 'on' : 'off';
-	$pconfig['log_to_systemlog'] = $config['installedpackages']['suricata']['config'][0]['log_to_systemlog'] == "on" ? 'on' : 'off';
-	$pconfig['update_notify'] = $config['installedpackages']['suricata']['config'][0]['update_notify'] == "on" ? 'on' : 'off';
-	$pconfig['rule_categories_notify'] = $config['installedpackages']['suricata']['config'][0]['rule_categories_notify'] == "on" ? 'on' : 'off';
-	$pconfig['log_to_systemlog_facility'] = $config['installedpackages']['suricata']['config'][0]['log_to_systemlog_facility'];
-	$pconfig['log_to_systemlog_priority'] = $config['installedpackages']['suricata']['config'][0]['log_to_systemlog_priority'];
-	$pconfig['forcekeepsettings'] = $config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] == "on" ? 'on' : 'off';
-	$pconfig['snortcommunityrules'] = $config['installedpackages']['suricata']['config'][0]['snortcommunityrules'] == "on" ? 'on' : 'off';
-	$pconfig['snort_rules_file'] = htmlentities($config['installedpackages']['suricata']['config'][0]['snort_rules_file']);
-	$pconfig['autogeoipupdate'] = $config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] == "on" ? 'on' : 'off';
-	$pconfig['maxmind_geoipdb_key'] = htmlentities($config['installedpackages']['suricata']['config'][0]['maxmind_geoipdb_key']);
-	$pconfig['hide_deprecated_rules'] = $config['installedpackages']['suricata']['config'][0]['hide_deprecated_rules'] == "on" ? 'on' : 'off';
-	$pconfig['enable_etopen_custom_url'] = $config['installedpackages']['suricata']['config'][0]['enable_etopen_custom_url'] == "on" ? 'on' : 'off';
-	$pconfig['enable_etpro_custom_url'] = $config['installedpackages']['suricata']['config'][0]['enable_etpro_custom_url'] == "on" ? 'on' : 'off';
-	$pconfig['enable_snort_custom_url'] = $config['installedpackages']['suricata']['config'][0]['enable_snort_custom_url'] == "on" ? 'on' : 'off';
-	$pconfig['enable_gplv2_custom_url'] = $config['installedpackages']['suricata']['config'][0]['enable_gplv2_custom_url'] == "on" ? 'on' : 'off';
-	$pconfig['etopen_custom_rule_url'] = htmlentities($config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url']);
-	$pconfig['etpro_custom_rule_url'] = htmlentities($config['installedpackages']['suricata']['config'][0]['etpro_custom_rule_url']);
-	$pconfig['snort_custom_url'] = htmlentities($config['installedpackages']['suricata']['config'][0]['snort_custom_url']);
-	$pconfig['gplv2_custom_url'] = htmlentities($config['installedpackages']['suricata']['config'][0]['gplv2_custom_url']);
-	$pconfig['enable_feodo_botnet_c2_rules'] = $config['installedpackages']['suricata']['config'][0]['enable_feodo_botnet_c2_rules'] == "on" ? 'on' : 'off';
-	$pconfig['enable_abuse_ssl_blacklist_rules'] = $config['installedpackages']['suricata']['config'][0]['enable_abuse_ssl_blacklist_rules'] == "on" ? 'on' : 'off';
-	$pconfig['enable_extra_rules'] = $config['installedpackages']['suricata']['config'][0]['enable_extra_rules'] == "on" ? 'on' : 'off';
-	$pconfig['extra_rules'] = $config['installedpackages']['suricata']['config'][0]['extra_rules'];
+	$pconfig['enable_vrt_rules'] = config_get_path('installedpackages/suricata/config/0/enable_vrt_rules') == "on" ? 'on' : 'off';
+	$pconfig['oinkcode'] = htmlentities(config_get_path('installedpackages/suricata/config/0/oinkcode'));
+	$pconfig['etprocode'] = htmlentities(config_get_path('installedpackages/suricata/config/0/etprocode'));
+	$pconfig['enable_etopen_rules'] = config_get_path('installedpackages/suricata/config/0/enable_etopen_rules') == "on" ? 'on' : 'off';
+	$pconfig['enable_etpro_rules'] = config_get_path('installedpackages/suricata/config/0/enable_etpro_rules') == "on" ? 'on' : 'off';
+	$pconfig['rm_blocked'] = config_get_path('installedpackages/suricata/config/0/rm_blocked');
+	$pconfig['autoruleupdate'] = config_get_path('installedpackages/suricata/config/0/autoruleupdate');
+	$pconfig['autoruleupdatetime'] = htmlentities(config_get_path('installedpackages/suricata/config/0/autoruleupdatetime'));
+	$pconfig['live_swap_updates'] = config_get_path('installedpackages/suricata/config/0/live_swap_updates') == "on" ? 'on' : 'off';
+	$pconfig['log_to_systemlog'] = config_get_path('installedpackages/suricata/config/0/log_to_systemlog') == "on" ? 'on' : 'off';
+	$pconfig['update_notify'] = config_get_path('installedpackages/suricata/config/0/update_notify') == "on" ? 'on' : 'off';
+	$pconfig['rule_categories_notify'] = config_get_path('installedpackages/suricata/config/0/rule_categories_notify') == "on" ? 'on' : 'off';
+	$pconfig['log_to_systemlog_facility'] = config_get_path('installedpackages/suricata/config/0/log_to_systemlog_facility');
+	$pconfig['log_to_systemlog_priority'] = config_get_path('installedpackages/suricata/config/0/log_to_systemlog_priority');
+	$pconfig['forcekeepsettings'] = config_get_path('installedpackages/suricata/config/0/forcekeepsettings') == "on" ? 'on' : 'off';
+	$pconfig['snortcommunityrules'] = config_get_path('installedpackages/suricata/config/0/snortcommunityrules') == "on" ? 'on' : 'off';
+	$pconfig['snort_rules_file'] = htmlentities(config_get_path('installedpackages/suricata/config/0/snort_rules_file'));
+	$pconfig['autogeoipupdate'] = config_get_path('installedpackages/suricata/config/0/autogeoipupdate') == "on" ? 'on' : 'off';
+	$pconfig['maxmind_geoipdb_key'] = htmlentities(config_get_path('installedpackages/suricata/config/0/maxmind_geoipdb_key'));
+	$pconfig['hide_deprecated_rules'] = config_get_path('installedpackages/suricata/config/0/hide_deprecated_rules') == "on" ? 'on' : 'off';
+	$pconfig['enable_etopen_custom_url'] = config_get_path('installedpackages/suricata/config/0/enable_etopen_custom_url') == "on" ? 'on' : 'off';
+	$pconfig['enable_etpro_custom_url'] = config_get_path('installedpackages/suricata/config/0/enable_etpro_custom_url') == "on" ? 'on' : 'off';
+	$pconfig['enable_snort_custom_url'] = config_get_path('installedpackages/suricata/config/0/enable_snort_custom_url') == "on" ? 'on' : 'off';
+	$pconfig['enable_gplv2_custom_url'] = config_get_path('installedpackages/suricata/config/0/enable_gplv2_custom_url') == "on" ? 'on' : 'off';
+	$pconfig['etopen_custom_rule_url'] = htmlentities(config_get_path('installedpackages/suricata/config/0/etopen_custom_rule_url'));
+	$pconfig['etpro_custom_rule_url'] = htmlentities(config_get_path('installedpackages/suricata/config/0/etpro_custom_rule_url'));
+	$pconfig['snort_custom_url'] = htmlentities(config_get_path('installedpackages/suricata/config/0/snort_custom_url'));
+	$pconfig['gplv2_custom_url'] = htmlentities(config_get_path('installedpackages/suricata/config/0/gplv2_custom_url'));
+	$pconfig['enable_feodo_botnet_c2_rules'] = config_get_path('installedpackages/suricata/config/0/enable_feodo_botnet_c2_rules') == "on" ? 'on' : 'off';
+	$pconfig['enable_abuse_ssl_blacklist_rules'] = config_get_path('installedpackages/suricata/config/0/enable_abuse_ssl_blacklist_rules') == "on" ? 'on' : 'off';
+	$pconfig['enable_extra_rules'] = config_get_path('installedpackages/suricata/config/0/enable_extra_rules') == "on" ? 'on' : 'off';
+	$pconfig['extra_rules'] = config_get_path('installedpackages/suricata/config/0/extra_rules', []);
 }
 
 // Do input validation on parameters
@@ -134,40 +134,40 @@ if ($_POST['enable_extra_rules']) {
 if (!$input_errors) {
 	if ($_POST["save"]) {
 
-		$config['installedpackages']['suricata']['config'][0]['enable_vrt_rules'] = $_POST['enable_vrt_rules'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['snortcommunityrules'] = $_POST['snortcommunityrules'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['enable_etopen_rules'] = $_POST['enable_etopen_rules'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['enable_etpro_rules'] = $_POST['enable_etpro_rules'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] = $_POST['autogeoipupdate'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['hide_deprecated_rules'] = $_POST['hide_deprecated_rules'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['enable_etopen_custom_url'] = $_POST['enable_etopen_custom_url'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['enable_etpro_custom_url'] = $_POST['enable_etpro_custom_url'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['enable_snort_custom_url'] = $_POST['enable_snort_custom_url'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['enable_gplv2_custom_url'] = $_POST['enable_gplv2_custom_url'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['enable_feodo_botnet_c2_rules'] = $_POST['enable_feodo_botnet_c2_rules'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['enable_abuse_ssl_blacklist_rules'] = $_POST['enable_abuse_ssl_blacklist_rules'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['enable_extra_rules'] = $_POST['enable_extra_rules'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['extra_rules'] = $extra_rules;
+		config_set_path('installedpackages/suricata/config/0/enable_vrt_rules', $_POST['enable_vrt_rules'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/snortcommunityrules', $_POST['snortcommunityrules'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/enable_etopen_rules', $_POST['enable_etopen_rules'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/enable_etpro_rules', $_POST['enable_etpro_rules'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/autogeoipupdate', $_POST['autogeoipupdate'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/hide_deprecated_rules', $_POST['hide_deprecated_rules'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/enable_etopen_custom_url', $_POST['enable_etopen_custom_url'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/enable_etpro_custom_url', $_POST['enable_etpro_custom_url'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/enable_snort_custom_url', $_POST['enable_snort_custom_url'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/enable_gplv2_custom_url', $_POST['enable_gplv2_custom_url'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/enable_feodo_botnet_c2_rules', $_POST['enable_feodo_botnet_c2_rules'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/enable_abuse_ssl_blacklist_rules', $_POST['enable_abuse_ssl_blacklist_rules'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/enable_extra_rules', $_POST['enable_extra_rules'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/extra_rules', $extra_rules);
 
 		// If any rule sets are being turned off, then remove them
 		// from the active rules section of each interface.  Start
 		// by building an arry of prefixes for the disabled rules.
 		$disabled_rules = array();
 		$disable_ips_policy = false;
-		if ($config['installedpackages']['suricata']['config'][0]['enable_vrt_rules'] == 'off') {
+		if (config_get_path('installedpackages/suricata/config/0/enable_vrt_rules') == 'off') {
 			$disabled_rules[] = VRT_FILE_PREFIX;
 			$disable_ips_policy = true;
 		}
-		if ($config['installedpackages']['suricata']['config'][0]['snortcommunityrules'] == 'off')
+		if (config_get_path('installedpackages/suricata/config/0/snortcommunityrules') == 'off')
 			$disabled_rules[] = GPL_FILE_PREFIX;
-		if ($config['installedpackages']['suricata']['config'][0]['enable_etopen_rules'] == 'off')
+		if (config_get_path('installedpackages/suricata/config/0/enable_etopen_rules') == 'off')
 			$disabled_rules[] = ET_OPEN_FILE_PREFIX;
-		if ($config['installedpackages']['suricata']['config'][0]['enable_etpro_rules'] == 'off')
+		if (config_get_path('installedpackages/suricata/config/0/enable_etpro_rules') == 'off')
 			$disabled_rules[] = ET_PRO_FILE_PREFIX;
 
-		if ($config['installedpackages']['suricata']['config'][0]['enable_feodo_botnet_c2_rules'] == 'off')
+		if (config_get_path('installedpackages/suricata/config/0/enable_feodo_botnet_c2_rules') == 'off')
 			$disabled_rules[] = "feodotracker";
-		if ($config['installedpackages']['suricata']['config'][0]['enable_abuse_ssl_blacklist_rules'] == 'off')
+		if (config_get_path('installedpackages/suricata/config/0/enable_abuse_ssl_blacklist_rules') == 'off')
 			$disabled_rules[] = "sslblacklist_tls_cert";
 
 		if (empty($enabled_extra_rules))
@@ -175,49 +175,49 @@ if (!$input_errors) {
 
 		// Now walk all the configured interface rulesets and remove
 		// any matching the disabled ruleset prefixes.
-		if (is_array($config['installedpackages']['suricata']['rule'])) {
-			foreach ($config['installedpackages']['suricata']['rule'] as &$iface) {
-				// Disable Snort IPS policy if Snort rules are disabled
-				if ($disable_ips_policy) {
-					$iface['ips_policy_enable'] = 'off';
-					unset($iface['ips_policy']);
-				}
-				$enabled_rules = explode("||", $iface['rulesets']);
-				foreach ($enabled_rules as $k => $v) {
-					foreach ($disabled_rules as $d) {
-						if (strpos(trim($v), $d) !== false) { 
-							unset($enabled_rules[$k]);
-							continue;
-						} elseif (!empty($enabled_extra_rules)) {
-							foreach ($enabled_extra_rules as $exrule) {
-								if (strpos(trim($v), EXTRARULE_FILE_PREFIX . $exrule)) {
-									unset($enabled_rules[$k]);
-									continue 2;
-								}
+		$a_ifaces = config_get_path('installedpackages/suricata/rule', []);
+		foreach ($a_ifaces as $iface) {
+			// Disable Snort IPS policy if Snort rules are disabled
+			if ($disable_ips_policy) {
+				$iface['ips_policy_enable'] = 'off';
+				unset($iface['ips_policy']);
+			}
+			$enabled_rules = explode("||", $iface['rulesets']);
+			foreach ($enabled_rules as $k => $v) {
+				foreach ($disabled_rules as $d) {
+					if (strpos(trim($v), $d) !== false) { 
+						unset($enabled_rules[$k]);
+						continue;
+					} elseif (!empty($enabled_extra_rules)) {
+						foreach ($enabled_extra_rules as $exrule) {
+							if (strpos(trim($v), EXTRARULE_FILE_PREFIX . $exrule)) {
+								unset($enabled_rules[$k]);
+								continue 2;
 							}
 						}
 					}
 				}
-				$iface['rulesets'] = implode("||", $enabled_rules);
 			}
+			$iface['rulesets'] = implode("||", $enabled_rules);
 		}
+		config_set_path('installedpackages/suricata/rule', $a_ifaces);
 
 		// If deprecated rules should be removed, then do it
-		if ($config['installedpackages']['suricata']['config'][0]['hide_deprecated_rules'] == "on") {
+		if (config_get_path('installedpackages/suricata/config/0/hide_deprecated_rules') == "on") {
 			syslog(LOG_NOTICE, gettext("[Suricata] Hide Deprecated Rules is enabled.  Removing obsoleted rules categories."));
 			suricata_remove_dead_rules();
 		}
 
-		$config['installedpackages']['suricata']['config'][0]['snort_rules_file'] = html_entity_decode($_POST['snort_rules_file']);
-		$config['installedpackages']['suricata']['config'][0]['oinkcode'] = trim(html_entity_decode($_POST['oinkcode']));
-		$config['installedpackages']['suricata']['config'][0]['etprocode'] = trim(html_entity_decode($_POST['etprocode']));
-		$config['installedpackages']['suricata']['config'][0]['rm_blocked'] = $_POST['rm_blocked'];
-		$config['installedpackages']['suricata']['config'][0]['autoruleupdate'] = $_POST['autoruleupdate'];
-		$config['installedpackages']['suricata']['config'][0]['etopen_custom_rule_url'] = trim(html_entity_decode($_POST['etopen_custom_rule_url']));
-		$config['installedpackages']['suricata']['config'][0]['etpro_custom_rule_url'] = trim(html_entity_decode($_POST['etpro_custom_rule_url']));
-		$config['installedpackages']['suricata']['config'][0]['snort_custom_url'] = trim(html_entity_decode($_POST['snort_custom_url']));
-		$config['installedpackages']['suricata']['config'][0]['gplv2_custom_url'] = trim(html_entity_decode($_POST['gplv2_custom_url']));
-		$config['installedpackages']['suricata']['config'][0]['maxmind_geoipdb_key'] = trim(html_entity_decode($_POST['maxmind_geoipdb_key']));
+		config_set_path('installedpackages/suricata/config/0/snort_rules_file', html_entity_decode($_POST['snort_rules_file']));
+		config_set_path('installedpackages/suricata/config/0/oinkcode', trim(html_entity_decode($_POST['oinkcode'])));
+		config_set_path('installedpackages/suricata/config/0/etprocode', trim(html_entity_decode($_POST['etprocode'])));
+		config_set_path('installedpackages/suricata/config/0/rm_blocked', $_POST['rm_blocked']);
+		config_set_path('installedpackages/suricata/config/0/autoruleupdate', $_POST['autoruleupdate']);
+		config_set_path('installedpackages/suricata/config/0/etopen_custom_rule_url', trim(html_entity_decode($_POST['etopen_custom_rule_url'])));
+		config_set_path('installedpackages/suricata/config/0/etpro_custom_rule_url', trim(html_entity_decode($_POST['etpro_custom_rule_url'])));
+		config_set_path('installedpackages/suricata/config/0/snort_custom_url', trim(html_entity_decode($_POST['snort_custom_url'])));
+		config_set_path('installedpackages/suricata/config/0/gplv2_custom_url', trim(html_entity_decode($_POST['gplv2_custom_url'])));
+		config_set_path('installedpackages/suricata/config/0/maxmind_geoipdb_key', trim(html_entity_decode($_POST['maxmind_geoipdb_key'])));
 
 		/* Check and adjust format of Rule Update Starttime string to add colon and leading zero if necessary */
 		if ($_POST['autoruleupdatetime']) {
@@ -226,26 +226,26 @@ if (!$input_errors) {
 				$tmp = str_pad($_POST['autoruleupdatetime'], 4, "0", STR_PAD_LEFT);
 				$_POST['autoruleupdatetime'] = substr($tmp, 0, 2) . ":" . substr($tmp, -2);
 			}
-			$config['installedpackages']['suricata']['config'][0]['autoruleupdatetime'] = str_pad(html_entity_decode($_POST['autoruleupdatetime']), 4, "0", STR_PAD_LEFT);
+			config_set_path('installedpackages/suricata/config/0/autoruleupdatetime', str_pad(html_entity_decode($_POST['autoruleupdatetime']), 4, "0", STR_PAD_LEFT));
 		}
-		$config['installedpackages']['suricata']['config'][0]['log_to_systemlog'] = $_POST['log_to_systemlog'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['update_notify'] = $_POST['update_notify'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['rule_categories_notify'] = $_POST['rule_categories_notify'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['log_to_systemlog_facility'] = $_POST['log_to_systemlog_facility'];
-		$config['installedpackages']['suricata']['config'][0]['log_to_systemlog_priority'] = $_POST['log_to_systemlog_priority'];
-		$config['installedpackages']['suricata']['config'][0]['live_swap_updates'] = $_POST['live_swap_updates'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] = $_POST['forcekeepsettings'] ? 'on' : 'off';
+		config_set_path('installedpackages/suricata/config/0/log_to_systemlog', $_POST['log_to_systemlog'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/update_notify', $_POST['update_notify'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/rule_categories_notify', $_POST['rule_categories_notify'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/log_to_systemlog_facility', $_POST['log_to_systemlog_facility']);
+		config_set_path('installedpackages/suricata/config/0/log_to_systemlog_priority', $_POST['log_to_systemlog_priority']);
+		config_set_path('installedpackages/suricata/config/0/live_swap_updates', $_POST['live_swap_updates'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/forcekeepsettings', $_POST['forcekeepsettings'] ? 'on' : 'off');
 
 		$retval = 0;
 
 		write_config("Suricata pkg: modified global settings.");
 
 		/* Toggle cron task for GeoIP database updates if setting was changed */
-		if ($config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] == 'on' && !suricata_cron_job_exists("/usr/local/pkg/suricata/suricata_geoipupdate.php")) {
+		if (config_get_path('installedpackages/suricata/config/0/autogeoipupdate') == 'on' && !suricata_cron_job_exists("/usr/local/pkg/suricata/suricata_geoipupdate.php")) {
 			include("/usr/local/pkg/suricata/suricata_geoipupdate.php");
 			install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_geoipupdate.php", TRUE, 0, 0, 8, "*", "*", "root");
 		}
-		elseif ($config['installedpackages']['suricata']['config'][0]['autogeoipupdate'] == 'off' && suricata_cron_job_exists("/usr/local/pkg/suricata/suricata_geoipupdate.php"))
+		elseif (config_get_path('installedpackages/suricata/config/0/autogeoipupdate') == 'off' && suricata_cron_job_exists("/usr/local/pkg/suricata/suricata_geoipupdate.php"))
 			install_cron_job("/usr/local/pkg/suricata/suricata_geoipupdate.php", FALSE);
 
 		/* create passlist and homenet file, then sync files */

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -177,7 +177,7 @@ if (!$input_errors) {
 		// Now walk all the configured interface rulesets and remove
 		// any matching the disabled ruleset prefixes.
 		$a_ifaces = config_get_path('installedpackages/suricata/rule', []);
-		foreach ($a_ifaces as $iface) {
+		foreach ($a_ifaces as &$iface) {
 			// Disable Snort IPS policy if Snort rules are disabled
 			if ($disable_ips_policy) {
 				$iface['ips_policy_enable'] = 'off';

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_import_aliases.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_import_aliases.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -39,7 +39,7 @@ else
 	$id = 0;
 
 $a_nat = config_get_path('installedpackages/suricata/rule', []);
-$id_gen = count(config_get_path('installedpackages/suricata/rule', []));
+$id_gen = count($a_nat);
 
 // Get list of configured firewall interfaces
 $ifaces = get_configured_interface_list();

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2021 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,12 +38,8 @@ if ($_POST['id'])
 else
 	$id = 0;
 
-if (!is_array($config['installedpackages']['suricata']['rule'])) {
-	$config['installedpackages']['suricata']['rule'] = array();
-}
-
-$a_nat = &$config['installedpackages']['suricata']['rule'];
-$id_gen = count($config['installedpackages']['suricata']['rule']);
+$a_nat = config_get_path('installedpackages/suricata/rule', []);
+$id_gen = count(config_get_path('installedpackages/suricata/rule', []));
 
 // Get list of configured firewall interfaces
 $ifaces = get_configured_interface_list();
@@ -82,6 +78,7 @@ if (isset($_POST['del_x'])) {
 		if (empty($a_nat))
 			unset($a_nat);
 
+		config_set_path('installedpackages/suricata/rule', $a_nat);
 		write_config("Suricata pkg: deleted one or more Suricata interfaces.");
 		sleep(2);
 
@@ -130,6 +127,7 @@ if (isset($_POST['del_x'])) {
 		unset($a_nat[$delbtn_list]);
 
 		// Save updated configuration
+		config_set_path('installedpackages/suricata/rule', $a_nat);
 		write_config("Suricata pkg: deleted one or more Suricata interfaces.");
 		sleep(2);
 		sync_suricata_package_config();
@@ -145,7 +143,7 @@ if (isset($_POST['del_x'])) {
 
 /* start/stop Suricata */
 if ($_POST['toggle']) {
-	$suricatacfg = $config['installedpackages']['suricata']['rule'][$_POST['id']];
+	$suricatacfg = config_get_path("installedpackages/suricata/rule/{$_POST['id']}");
 	$if_real = get_real_interface($suricatacfg['interface']);
 	$if_friendly = convert_friendly_interface_to_friendly_descr($suricatacfg['interface']);
 	$id = $_POST['id'];
@@ -165,8 +163,8 @@ if ($_POST['toggle']) {
 	<?php
 	require_once('/usr/local/pkg/suricata/suricata.inc');
 	require_once('service-utils.inc');
-	global \$g, \$rebuild_rules, \$config;
-	\$suricatacfg = \$config['installedpackages']['suricata']['rule'][{$id}];
+	global \$g, \$rebuild_rules;
+	\$suricatacfg = \config_get_path("installedpackages/suricata/rule/{$id}", []);
 	\$rebuild_rules = true;
 	touch('{$start_lck_file}');
 	sync_suricata_package_config();
@@ -372,7 +370,7 @@ include_once("head.inc"); ?>
 					</td>
 
 					<td id="frd<?=$nnats?>" ondblclick="document.location='suricata_interfaces_edit.php?id=<?=$nnats?>';">
-					<?php if ($config['installedpackages']['suricata']['rule'][$nnats]['enable'] == "on") : ?>
+					<?php if (config_get_path("installedpackages/suricata/rule/{$nnats}/enable") == "on") : ?>
 						<?php if (suricata_is_running($suricata_uuid, $if_real)) : ?>
 							<i id="suricata_<?=$if_real.$suricata_uuid;?>" class="fa fa-check-circle text-success icon-primary" title="<?=gettext('suricata is running on this interface');?>"></i>
 							&nbsp;
@@ -399,17 +397,17 @@ include_once("head.inc"); ?>
 					</td>
 
 					<td id="frd<?=$nnats?>" ondblclick="document.location='suricata_interfaces_edit.php?id=<?=$nnats?>';">
-						<?php if ($config['installedpackages']['suricata']['rule'][$nnats]['mpm_algo'] != "") : ?>
-							<?=gettext(strtoupper($config['installedpackages']['suricata']['rule'][$nnats]['mpm_algo']));?>
+						<?php if (config_get_path("installedpackages/suricata/rule/{$nnats}/mpm_algo") != "") : ?>
+							<?=gettext(strtoupper(config_get_path("installedpackages/suricata/rule/{$nnats}/mpm_algo")));?>
 						<?php else : ?>
 							<?=gettext('UNKNOWN');?>
 						<?php endif; ?>
 					</td>
 
 					<td id="frd<?=$nnats?>" ondblclick="document.location='suricata_interfaces_edit.php?id=<?=$nnats?>';">
-						<?php if ($config['installedpackages']['suricata']['rule'][$nnats]['blockoffenders'] == 'on' && $config['installedpackages']['suricata']['rule'][$nnats]['ips_mode'] == 'ips_mode_legacy') : ?>
+						<?php if (config_get_path("installedpackages/suricata/rule/{$nnats}/blockoffenders") == 'on' && config_get_path("installedpackages/suricata/rule/{$nnats}/ips_mode") == 'ips_mode_legacy') : ?>
 							<?=gettext('LEGACY MODE');?>
-						<?php elseif ($config['installedpackages']['suricata']['rule'][$nnats]['blockoffenders'] == 'on' && $config['installedpackages']['suricata']['rule'][$nnats]['ips_mode'] == 'ips_mode_inline') : ?>
+						<?php elseif (config_get_path("installedpackages/suricata/rule/{$nnats}/blockoffenders") == 'on' && config_get_path("installedpackages/suricata/rule/{$nnats}/ips_mode") == 'ips_mode_inline') : ?>
 							<?=gettext('INLINE IPS');?>
 						<?php else : ?>
 							<?=gettext('DISABLED');?>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_iprep_list_browser.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_iprep_list_browser.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2020 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_libhtp_policy_engine.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_libhtp_policy_engine.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2019 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_list_view.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_list_view.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2014 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,7 @@
 require_once("guiconfig.inc");
 require_once("/usr/local/pkg/suricata/suricata.inc");
 
-global $g, $config;
+global $g;
 
 $contents = '';
 
@@ -49,7 +49,7 @@ if ($_REQUEST['ajax'] == 'ajax') {
 $title = "List";
 
 if (isset($id) && isset($wlist)) {
-	$a_rule = $config['installedpackages']['suricata']['rule'][$id];
+	$a_rule = config_get_path("installedpackages/suricata/rule/{$id}", []);
 	if ($type == "homenet") {
 		$list = suricata_build_list($a_rule, $wlist);
 		$contents = implode("\n", $list);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_browser.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_browser.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2021 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,13 +33,9 @@ elseif (isset($_GET['instance']) && is_numericint($_GET['instance']))
 if (empty($instanceid))
 	$instanceid = 0;
 
-if (!is_array($config['installedpackages']['suricata']['rule'])) {
-	$config['installedpackages']['suricata']['rule'] = array();
-}
-
-$a_instance = $config['installedpackages']['suricata']['rule'];
-$suricata_uuid = $a_instance[$instanceid]['uuid'];
-$if_real = get_real_interface($a_instance[$instanceid]['interface']);
+$a_instance = config_get_path('installedpackages/suricata/rule', []);
+$suricata_uuid = config_get_path("installedpackages/suricata/rule/{$instanceid}/uuid", '');
+$if_real = get_real_interface(config_get_path("installedpackages/suricata/rule/{$instanceid}/interface", ''));
 
 // Construct a pointer to the instance's logging subdirectory
 $suricatalogdir = SURICATALOGDIR . "suricata_{$if_real}{$suricata_uuid}/";
@@ -80,11 +76,9 @@ if ($input_errors) {
 }
 
 function build_instance_list() {
-	global $a_instance;
-
 	$list = array();
 
-	foreach ($a_instance as $id => $instance) {
+	foreach (config_get_path('installedpackages/suricata/rule', []) as $id => $instance) {
 		$list[$id] = '(' . convert_friendly_interface_to_friendly_descr($instance['interface']) . ') ' . $instance['descr'];
 	}
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_mgmt.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2021 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,27 +33,27 @@ $suricatadir = SURICATADIR;
 $pconfig = array();
 
 // Grab saved settings from configuration
-$pconfig['enable_log_mgmt'] = $config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 'off' ? 'off' : 'on';
-$pconfig['clearlogs'] = $config['installedpackages']['suricata']['config'][0]['clearlogs'] == 'on' ? 'on' : 'off';
-$pconfig['suricataloglimit'] = $config['installedpackages']['suricata']['config'][0]['suricataloglimit'] == 'on' ? 'on' : 'off';
-$pconfig['suricataloglimitsize'] = $config['installedpackages']['suricata']['config'][0]['suricataloglimitsize'];
-$pconfig['alert_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['alert_log_limit_size'];
-$pconfig['alert_log_retention'] = $config['installedpackages']['suricata']['config'][0]['alert_log_retention'];
-$pconfig['block_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['block_log_limit_size'];
-$pconfig['block_log_retention'] = $config['installedpackages']['suricata']['config'][0]['block_log_retention'];
-$pconfig['http_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['http_log_limit_size'];
-$pconfig['http_log_retention'] = $config['installedpackages']['suricata']['config'][0]['http_log_retention'];
-$pconfig['stats_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['stats_log_limit_size'];
-$pconfig['stats_log_retention'] = $config['installedpackages']['suricata']['config'][0]['stats_log_retention'];
-$pconfig['tls_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['tls_log_limit_size'];
-$pconfig['tls_log_retention'] = $config['installedpackages']['suricata']['config'][0]['tls_log_retention'];
-$pconfig['file_store_retention'] = $config['installedpackages']['suricata']['config'][0]['file_store_retention'];
-$pconfig['file_store_limit_size'] = $config['installedpackages']['suricata']['config'][0]['file_store_limit_size'];
-$pconfig['tls_certs_store_retention'] = $config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'];
-$pconfig['eve_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['eve_log_limit_size'];
-$pconfig['eve_log_retention'] = $config['installedpackages']['suricata']['config'][0]['eve_log_retention'];
-$pconfig['sid_changes_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['sid_changes_log_limit_size'];
-$pconfig['sid_changes_log_retention'] = $config['installedpackages']['suricata']['config'][0]['sid_changes_log_retention'];
+$pconfig['enable_log_mgmt'] = config_get_path('installedpackages/suricata/config/0/enable_log_mgmt') == 'off' ? 'off' : 'on';
+$pconfig['clearlogs'] = config_get_path('installedpackages/suricata/config/0/clearlogs') == 'on' ? 'on' : 'off';
+$pconfig['suricataloglimit'] = config_get_path('installedpackages/suricata/config/0/suricataloglimit') == 'on' ? 'on' : 'off';
+$pconfig['suricataloglimitsize'] = htmlentities(config_get_path('installedpackages/suricata/config/0/suricataloglimitsize'));
+$pconfig['alert_log_limit_size'] = config_get_path('installedpackages/suricata/config/0/alert_log_limit_size', 500);
+$pconfig['alert_log_retention'] = config_get_path('installedpackages/suricata/config/0/alert_log_retention', 336);
+$pconfig['block_log_limit_size'] = config_get_path('installedpackages/suricata/config/0/block_log_limit_size', 500);
+$pconfig['block_log_retention'] = config_get_path('installedpackages/suricata/config/0/block_log_retention', 336);
+$pconfig['http_log_limit_size'] = config_get_path('installedpackages/suricata/config/0/http_log_limit_size', 1000);
+$pconfig['http_log_retention'] = config_get_path('installedpackages/suricata/config/0/http_log_retention', 168);
+$pconfig['stats_log_limit_size'] = config_get_path('installedpackages/suricata/config/0/stats_log_limit_size', 500);
+$pconfig['stats_log_retention'] = config_get_path('installedpackages/suricata/config/0/stats_log_retention', 168);
+$pconfig['tls_log_limit_size'] = config_get_path('installedpackages/suricata/config/0/tls_log_limit_size', 500);
+$pconfig['tls_log_retention'] = config_get_path('installedpackages/suricata/config/0/tls_log_retention', 336);
+$pconfig['file_store_retention'] = config_get_path('installedpackages/suricata/config/0/file_store_retention', 168);
+$pconfig['file_store_limit_size'] = config_get_path('installedpackages/suricata/config/0/file_store_limit_size');
+$pconfig['tls_certs_store_retention'] = config_get_path('installedpackages/suricata/config/0/tls_certs_store_retention', 168);
+$pconfig['eve_log_limit_size'] = config_get_path('installedpackages/suricata/config/0/eve_log_limit_size', 5000);
+$pconfig['eve_log_retention'] = config_get_path('installedpackages/suricata/config/0/eve_log_retention', 168);
+$pconfig['sid_changes_log_limit_size'] = config_get_path('installedpackages/suricata/config/0/sid_changes_log_limit_size', 250);
+$pconfig['sid_changes_log_retention'] = config_get_path('installedpackages/suricata/config/0/sid_changes_log_retention', 336);
 
 // Load up some arrays with selection values (we use these later).
 // The keys in the $retentions array are the retention period
@@ -66,51 +66,13 @@ $log_sizes = array( '0' => gettext('NO LIMIT'), '50' => gettext('50 KB'), '150' 
 			'500' => gettext('500 KB'), '750' => gettext('750 KB'), '1000' => gettext('1 MB'), '2000' => gettext('2 MB'),
 			'5000' => gettext("5 MB"), '10000' => gettext("10 MB") );
 
-// Set sensible defaults for any unset parameters
-if (empty($pconfig['enable_log_mgmt']))
-	$pconfig['enable_log_mgmt'] = 'on';
-if (empty($pconfig['suricataloglimit']))
-	$pconfig['suricataloglimit'] = 'on';
+// Set sensible default for Suricata logging directory size limit
 if (empty($pconfig['suricataloglimitsize'])) {
 	// Set limit to 20% of slice that is unused */
 	$pconfig['suricataloglimitsize'] = round(exec('df -k /var | grep -v "Filesystem" | awk \'{print $4}\'') * .20 / 1024);
 }
 
-// Set default retention periods for rotated logs
-if (!isset($pconfig['alert_log_retention']))
-	$pconfig['alert_log_retention'] = "336";
-if (!isset($pconfig['block_log_retention']))
-	$pconfig['block_log_retention'] = "336";
-if (!isset($pconfig['http_log_retention']))
-	$pconfig['http_log_retention'] = "168";
-if (!isset($pconfig['stats_log_retention']))
-	$pconfig['stats_log_retention'] = "168";
-if (!isset($pconfig['tls_log_retention']))
-	$pconfig['tls_log_retention'] = "336";
-if (!isset($pconfig['file_store_retention']))
-	$pconfig['file_store_retention'] = "168";
-if (!isset($pconfig['tls_certs_store_retention']))
-	$pconfig['tls_certs_store_retention'] = "168";
-if (!isset($pconfig['eve_log_retention']))
-	$pconfig['eve_log_retention'] = "168";
-if (!isset($pconfig['sid_changes_log_retention']))
-	$pconfig['sid_changes_log_retention'] = "336";
-
-// Set default log file size limits
-if (!isset($pconfig['alert_log_limit_size']))
-	$pconfig['alert_log_limit_size'] = "500";
-if (!isset($pconfig['block_log_limit_size']))
-	$pconfig['block_log_limit_size'] = "500";
-if (!isset($pconfig['http_log_limit_size']))
-	$pconfig['http_log_limit_size'] = "1000";
-if (!isset($pconfig['stats_log_limit_size']))
-	$pconfig['stats_log_limit_size'] = "500";
-if (!isset($pconfig['tls_log_limit_size']))
-	$pconfig['tls_log_limit_size'] = "500";
-if (!isset($pconfig['eve_log_limit_size']))
-	$pconfig['eve_log_limit_size'] = "5000";
-if (!isset($pconfig['sid_changes_log_limit_size']))
-	$pconfig['sid_changes_log_limit_size'] = "250";
+// Set a default file store size limit
 if (!isset($pconfig['file_store_limit_size']))
 	$pconfig['file_store_limit_size'] = intval($pconfig['suricataloglimitsize'] * 0.60);
 
@@ -142,7 +104,7 @@ if (isset($_POST['ResetAll'])) {
 
 if (isset($_POST['save']) || isset($_POST['apply'])) {
 	if ($_POST['enable_log_mgmt'] != 'on') {
-		$config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] = $_POST['enable_log_mgmt'] ? 'on' :'off';
+		config_set_path('installedpackages/suricata/config/0/enable_log_mgmt', $_POST['enable_log_mgmt'] ? 'on' :'off');
 		write_config("Suricata pkg: saved updated configuration for LOGS MGMT.");
 		sync_suricata_package_config();
 
@@ -162,27 +124,27 @@ if (isset($_POST['save']) || isset($_POST['apply'])) {
 	}
 
 	if (!$input_errors) {
-		$config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] = $_POST['enable_log_mgmt'] ? 'on' :'off';
-		$config['installedpackages']['suricata']['config'][0]['clearlogs'] = $_POST['clearlogs'] ? 'on' : 'off';
-		$config['installedpackages']['suricata']['config'][0]['suricataloglimit'] = $_POST['suricataloglimit'] ? 'on' :'off';
-		$config['installedpackages']['suricata']['config'][0]['suricataloglimitsize'] = $_POST['suricataloglimitsize'];
-		$config['installedpackages']['suricata']['config'][0]['alert_log_limit_size'] = $_POST['alert_log_limit_size'];
-		$config['installedpackages']['suricata']['config'][0]['alert_log_retention'] = $_POST['alert_log_retention'];
-		$config['installedpackages']['suricata']['config'][0]['block_log_limit_size'] = $_POST['block_log_limit_size'];
-		$config['installedpackages']['suricata']['config'][0]['block_log_retention'] = $_POST['block_log_retention'];
-		$config['installedpackages']['suricata']['config'][0]['http_log_limit_size'] = $_POST['http_log_limit_size'];
-		$config['installedpackages']['suricata']['config'][0]['http_log_retention'] = $_POST['http_log_retention'];
-		$config['installedpackages']['suricata']['config'][0]['stats_log_limit_size'] = $_POST['stats_log_limit_size'];
-		$config['installedpackages']['suricata']['config'][0]['stats_log_retention'] = $_POST['stats_log_retention'];
-		$config['installedpackages']['suricata']['config'][0]['tls_log_limit_size'] = $_POST['tls_log_limit_size'];
-		$config['installedpackages']['suricata']['config'][0]['tls_log_retention'] = $_POST['tls_log_retention'];
-		$config['installedpackages']['suricata']['config'][0]['file_store_retention'] = $_POST['file_store_retention'];
-		$config['installedpackages']['suricata']['config'][0]['file_store_limit_size'] = $_POST['file_store_limit_size'];
-		$config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'] = $_POST['tls_certs_store_retention'];
-		$config['installedpackages']['suricata']['config'][0]['eve_log_limit_size'] = $_POST['eve_log_limit_size'];
-		$config['installedpackages']['suricata']['config'][0]['eve_log_retention'] = $_POST['eve_log_retention'];
-		$config['installedpackages']['suricata']['config'][0]['sid_changes_log_limit_size'] = $_POST['sid_changes_log_limit_size'];
-		$config['installedpackages']['suricata']['config'][0]['sid_changes_log_retention'] = $_POST['sid_changes_log_retention'];
+		config_set_path('installedpackages/suricata/config/0/enable_log_mgmt', $_POST['enable_log_mgmt'] ? 'on' :'off');
+		config_set_path('installedpackages/suricata/config/0/clearlogs', $_POST['clearlogs'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/suricataloglimit', $_POST['suricataloglimit'] ? 'on' :'off');
+		config_set_path('installedpackages/suricata/config/0/suricataloglimitsize', html_entity_decode($_POST['suricataloglimitsize']));
+		config_set_path('installedpackages/suricata/config/0/alert_log_limit_size', $_POST['alert_log_limit_size']);
+		config_set_path('installedpackages/suricata/config/0/alert_log_retention', $_POST['alert_log_retention']);
+		config_set_path('installedpackages/suricata/config/0/block_log_limit_size', $_POST['block_log_limit_size']);
+		config_set_path('installedpackages/suricata/config/0/block_log_retention', $_POST['block_log_retention']);
+		config_set_path('installedpackages/suricata/config/0/http_log_limit_size', $_POST['http_log_limit_size']);
+		config_set_path('installedpackages/suricata/config/0/http_log_retention', $_POST['http_log_retention']);
+		config_set_path('installedpackages/suricata/config/0/stats_log_limit_size', $_POST['stats_log_limit_size']);
+		config_set_path('installedpackages/suricata/config/0/stats_log_retention', $_POST['stats_log_retention']);
+		config_set_path('installedpackages/suricata/config/0/tls_log_limit_size', $_POST['tls_log_limit_size']);
+		config_set_path('installedpackages/suricata/config/0/tls_log_retention', $_POST['tls_log_retention']);
+		config_set_path('installedpackages/suricata/config/0/file_store_retention', $_POST['file_store_retention']);
+		config_set_path('installedpackages/suricata/config/0/file_store_limit_size', $_POST['file_store_limit_size']);
+		config_set_path('installedpackages/suricata/config/0/tls_certs_store_retention', $_POST['tls_certs_store_retention']);
+		config_set_path('installedpackages/suricata/config/0/eve_log_limit_size', $_POST['eve_log_limit_size']);
+		config_set_path('installedpackages/suricata/config/0/eve_log_retention', $_POST['eve_log_retention']);
+		config_set_path('installedpackages/suricata/config/0/sid_changes_log_limit_size', $_POST['sid_changes_log_limit_size']);
+		config_set_path('installedpackages/suricata/config/0/sid_changes_log_retention', $_POST['sid_changes_log_retention']);
 
 		write_config("Suricata pkg: saved updated configuration for LOGS MGMT.");
 		sync_suricata_package_config();
@@ -231,17 +193,17 @@ $form = new Form;
 
 $section = new Form_Section('General Settings');
 $section->addInput(new Form_Checkbox(
-	'clearlogs',
-	'Remove Suricata Logs On Package Uninstall',
-	'Suricata log files will be removed when the Suricata package is uninstalled.  Default is not checked.',
-	$pconfig['clearlogs'] == 'on' ? true:false,
-	'on'
-));
-$section->addInput(new Form_Checkbox(
 	'enable_log_mgmt',
 	'Auto Log Management',
 	'Enable automatic unattended management of Suricata logs using parameters specified below.  Default is checked.',
 	$pconfig['enable_log_mgmt'] == 'on' ? true:false,
+	'on'
+));
+$section->addInput(new Form_Checkbox(
+	'clearlogs',
+	'Remove Suricata Logs On Package Uninstall',
+	'Suricata log files will be removed when the Suricata package is uninstalled.  Default is not checked.',
+	$pconfig['clearlogs'] == 'on' ? true:false,
 	'on'
 ));
 $form->add($section);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_os_policy_engine.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_os_policy_engine.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2021 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,12 +31,7 @@ $pconfig = array();
 // Arbitrary limit for IP or Alias entries per Pass List.
 $max_addresses = 1000;
 
-if (!is_array($config['installedpackages']['suricata']['passlist']))
-	$config['installedpackages']['suricata']['passlist'] = array();
-if (!is_array($config['installedpackages']['suricata']['passlist']['item']))
-	$config['installedpackages']['suricata']['passlist']['item'] = array();
-
-$a_passlist = &$config['installedpackages']['suricata']['passlist']['item'];
+$a_passlist = config_get_path('installedpackages/suricata/passlist/item', []);
 
 if (isset($_POST['id']) && is_numericint($_POST['id']))
 	$id = $_POST['id'];
@@ -155,7 +150,7 @@ if ($_POST['save']) {
 		}
 
 		$pconfig = $p_list;
-
+		config_set_path('installedpackages/suricata/passlist/item', $a_passlist);
 		write_config("Suricata pkg: modified PASS LIST {$p_list['name']}.");
 
 		/* create pass list file, then sync file with configured partners */

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2021 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,16 +26,12 @@
 require_once("guiconfig.inc");
 require_once("/usr/local/pkg/suricata/suricata.inc");
 
-global $g, $config, $rebuild_rules;
+global $g, $rebuild_rules;
 
 $suricatadir = SURICATADIR;
 $rules_map = array();
 $pconfig = array();
 $filterrules = FALSE;
-
-if (!is_array($config['installedpackages']['suricata']['rule']))
-	$config['installedpackages']['suricata']['rule'] = array();
-$a_rule = &$config['installedpackages']['suricata']['rule'];
 
 if (isset($_POST['id']) && is_numericint($_POST['id']))
 	$id = $_POST['id'];
@@ -59,10 +55,12 @@ if (is_null($id)) {
 	}
 }
 
-if (isset($id) && $a_rule[$id]) {
-	$pconfig['interface'] = $a_rule[$id]['interface'];
-	$pconfig['rulesets'] = $a_rule[$id]['rulesets'];
-	$pconfig['customrules'] = base64_decode($a_rule[$id]['customrules']);
+$a_rule = config_get_path("installedpackages/suricata/rule/{$id}", []);
+
+if (!empty($a_rule)) {
+	$pconfig['interface'] = $a_rule['interface'];
+	$pconfig['rulesets'] = $a_rule['rulesets'];
+	$pconfig['customrules'] = base64_decode($a_rule['customrules']);
 }
 
 function add_title_attribute($tag, $title) {
@@ -99,19 +97,19 @@ function add_title_attribute($tag, $title) {
 
 /* convert fake interfaces to real */
 $if_real = get_real_interface($pconfig['interface']);
-$suricata_uuid = $a_rule[$id]['uuid'];
+$suricata_uuid = $a_rule['uuid'];
 $suricatacfgdir = "{$suricatadir}suricata_{$suricata_uuid}_{$if_real}";
 $suricata_rules_dir = SURICATA_RULES_DIR;
-$snortdownload = $config['installedpackages']['suricata']['config'][0]['enable_vrt_rules'];
-$emergingdownload = $config['installedpackages']['suricata']['config'][0]['enable_etopen_rules'];
-$etpro = $config['installedpackages']['suricata']['config'][0]['enable_etpro_rules'];
+$snortdownload = config_get_path('installedpackages/suricata/config/0/enable_vrt_rules');
+$emergingdownload = config_get_path('installedpackages/suricata/config/0/enable_etopen_rules');
+$etpro = config_get_path('installedpackages/suricata/config/0/enable_etpro_rules');
 $categories = explode("||", $pconfig['rulesets']);
 
 // Get any automatic rule category enable/disable modifications
 // if auto-SID Mgmt is enabled, and adjust the available rulesets
 // in the CATEGORY drop-down box as necessary by removing disabled
 // categories and adding enabled ones.
-$cat_mods = suricata_sid_mgmt_auto_categories($a_rule[$id], FALSE);
+$cat_mods = suricata_sid_mgmt_auto_categories($a_rule, FALSE);
 foreach ($cat_mods as $k => $v) {
 	switch ($v) {
 		case 'disabled':
@@ -135,18 +133,18 @@ $categories[] = "User Forced Disabled Rules";
 
 // Only add custom ALERT or DROP Action Rules
 // option if blocking is enabled.
-if ($a_rule[$id]['blockoffenders'] == 'on') {
+if ($a_rule['blockoffenders'] == 'on') {
 	$categories[] = "User Forced ALERT Action Rules";
 
 	// Show custom DROP rules only if using Inline IPS
 	// mode or "Block Drops Only" option.
-	if ($a_rule[$id]['block_drops_only'] == 'on' || $a_rule[$id]['ips_mode'] == 'ips_mode_inline') {
+	if ($a_rule['block_drops_only'] == 'on' || $a_rule['ips_mode'] == 'ips_mode_inline') {
 		$categories[] = "User Forced DROP Action Rules";
 	}
 }
 
 // Only add custom REJECT option if using IPS Inline Mode with blocking enabled
-if ($a_rule[$id]['ips_mode'] == 'ips_mode_inline' && $a_rule[$id]['blockoffenders'] == 'on') {
+if ($a_rule['ips_mode'] == 'ips_mode_inline' && $a_rule['blockoffenders'] == 'on') {
 	$categories[] = "User Forced REJECT Action Rules";
 }
 
@@ -168,8 +166,8 @@ else
 // If we don't have any Category to display, then
 // default to showing the Custom Rules text control.
 if (empty($categories[0]) && ($currentruleset != "custom.rules") && ($currentruleset != "Auto-Flowbit Rules")) {
-	if (!empty($a_rule[$id]['ips_policy']))
-		$currentruleset = "IPS Policy - " . ucfirst($a_rule[$id]['ips_policy']);
+	if (!empty($a_rule['ips_policy']))
+		$currentruleset = "IPS Policy - " . ucfirst($a_rule['ips_policy']);
 	else
 		$currentruleset = "custom.rules";
 }
@@ -193,7 +191,7 @@ if ($currentruleset != 'custom.rules') {
 	// Test for the special case of an IPS Policy file
 	// and load the selected policy's rules.
 	elseif (substr($currentruleset, 0, 10) == "IPS Policy") {
-		$rules_map = suricata_load_vrt_policy($a_rule[$id]['ips_policy'], $a_rule[$id]['ips_policy_mode']);
+		$rules_map = suricata_load_vrt_policy($a_rule['ips_policy'], $a_rule['ips_policy_mode']);
 	}
 	// Test for the special case of "Active Rules".  This
 	// displays all currently active rules for the
@@ -214,7 +212,7 @@ if ($currentruleset != 'custom.rules') {
 		}
 		$rule_files[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
 		$rule_files[] = "{$suricatacfgdir}/rules/custom.rules";
-		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule[$id]['rule_sid_on']));
+		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule['rule_sid_on']));
 	}
 	elseif ($currentruleset == "User Forced Disabled Rules") {
 		// Search and display forced disabled rules only from
@@ -227,16 +225,16 @@ if ($currentruleset != 'custom.rules') {
 		}
 		$rule_files[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
 		$rule_files[] = "{$suricatacfgdir}/rules/custom.rules";
-		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule[$id]['rule_sid_off']));
+		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule['rule_sid_off']));
 	}
 	elseif ($currentruleset == "User Forced ALERT Action Rules") {
-		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule[$id]['rule_sid_force_alert']));
+		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule['rule_sid_force_alert']));
 	}
 	elseif ($currentruleset == "User Forced DROP Action Rules") {
-		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule[$id]['rule_sid_force_drop']));
+		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule['rule_sid_force_drop']));
 	}
 	elseif ($currentruleset == "User Forced REJECT Action Rules") {
-		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule[$id]['rule_sid_force_reject']));
+		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule['rule_sid_force_reject']));
 	}
 	// If it's not a special case, and we can't find
 	// the given rule file, then notify the user.
@@ -251,18 +249,18 @@ if ($currentruleset != 'custom.rules') {
 }
 
 /* Process the current category rules through any auto SID MGMT changes if enabled */
-suricata_auto_sid_mgmt($rules_map, $a_rule[$id], FALSE);
+suricata_auto_sid_mgmt($rules_map, $a_rule, FALSE);
 
 /* Load up our enablesid and disablesid arrays with manually enabled or disabled SIDs */
-$enablesid = suricata_load_sid_mods($a_rule[$id]['rule_sid_on']);
-$disablesid = suricata_load_sid_mods($a_rule[$id]['rule_sid_off']);
-suricata_modify_sids($rules_map, $a_rule[$id]);
+$enablesid = suricata_load_sid_mods($a_rule['rule_sid_on']);
+$disablesid = suricata_load_sid_mods($a_rule['rule_sid_off']);
+suricata_modify_sids($rules_map, $a_rule);
 
 /* Load up our rule action arrays with manually changed SID actions */
-$alertsid = suricata_load_sid_mods($a_rule[$id]['rule_sid_force_alert']);
-$dropsid = suricata_load_sid_mods($a_rule[$id]['rule_sid_force_drop']);
-$rejectsid = suricata_load_sid_mods($a_rule[$id]['rule_sid_force_reject']);
-suricata_modify_sids_action($rules_map, $a_rule[$id]);
+$alertsid = suricata_load_sid_mods($a_rule['rule_sid_force_alert']);
+$dropsid = suricata_load_sid_mods($a_rule['rule_sid_force_drop']);
+$rejectsid = suricata_load_sid_mods($a_rule['rule_sid_force_reject']);
+suricata_modify_sids_action($rules_map, $a_rule);
 
 /* Process AJAX request to view content of a specific rule */
 if ($_POST['action'] == 'loadRule') {
@@ -343,9 +341,9 @@ if (isset($_POST['rule_state_save']) && isset($_POST['ruleStateOptions']) && is_
 	$tmp = rtrim($tmp, "||");
 
 	if (!empty($tmp))
-		$a_rule[$id]['rule_sid_on'] = $tmp;
+		$a_rule['rule_sid_on'] = $tmp;
 	else
-		unset($a_rule[$id]['rule_sid_on']);
+		unset($a_rule['rule_sid_on']);
 
 	$tmp = "";
 	foreach (array_keys($disablesid) as $k1) {
@@ -355,19 +353,20 @@ if (isset($_POST['rule_state_save']) && isset($_POST['ruleStateOptions']) && is_
 	$tmp = rtrim($tmp, "||");
 
 	if (!empty($tmp))
-		$a_rule[$id]['rule_sid_off'] = $tmp;
+		$a_rule['rule_sid_off'] = $tmp;
 	else
-		unset($a_rule[$id]['rule_sid_off']);
+		unset($a_rule['rule_sid_off']);
 
 	/* Update the config.xml file. */
-	write_config("Suricata pkg: modified state for rule {$gid}:{$sid} on {$a_rule[$id]['interface']}.");
+	config_set_path("installedpackages/suricata/rule/{$id}", $a_rule);
+	write_config("Suricata pkg: modified state for rule {$gid}:{$sid} on {$a_rule['interface']}.");
 
 	// We changed a rule state, remind user to apply the changes
 	mark_subsystem_dirty('suricata_rules');
 
 	// Update our in-memory rules map with the changes just saved
 	// to the Suricata configuration file.
-	suricata_modify_sids($rules_map, $a_rule[$id]);
+	suricata_modify_sids($rules_map, $a_rule);
 
 	// Set a scroll-to anchor location
 	$anchor = "rule_{$gid}_{$sid}";
@@ -464,9 +463,9 @@ elseif (isset($_POST['rule_action_save']) && isset($_POST['ruleActionOptions']) 
 		$tmp = rtrim($tmp, "||");
 
 		if (!empty($tmp))
-			$a_rule[$id]['rule_sid_force_alert'] = $tmp;
+			$a_rule['rule_sid_force_alert'] = $tmp;
 		else
-			unset($a_rule[$id]['rule_sid_force_alert']);
+			unset($a_rule['rule_sid_force_alert']);
 
 		$tmp = "";
 		foreach (array_keys($dropsid) as $k1) {
@@ -476,9 +475,9 @@ elseif (isset($_POST['rule_action_save']) && isset($_POST['ruleActionOptions']) 
 		$tmp = rtrim($tmp, "||");
 
 		if (!empty($tmp))
-			$a_rule[$id]['rule_sid_force_drop'] = $tmp;
+			$a_rule['rule_sid_force_drop'] = $tmp;
 		else
-			unset($a_rule[$id]['rule_sid_force_drop']);
+			unset($a_rule['rule_sid_force_drop']);
 
 		$tmp = "";
 		foreach (array_keys($rejectsid) as $k1) {
@@ -488,19 +487,20 @@ elseif (isset($_POST['rule_action_save']) && isset($_POST['ruleActionOptions']) 
 		$tmp = rtrim($tmp, "||");
 
 		if (!empty($tmp))
-			$a_rule[$id]['rule_sid_force_reject'] = $tmp;
+			$a_rule['rule_sid_force_reject'] = $tmp;
 		else
-			unset($a_rule[$id]['rule_sid_force_reject']);
+			unset($a_rule['rule_sid_force_reject']);
 
 		/* Update the config.xml file. */
-		write_config("Suricata pkg: modified action for rule {$gid}:{$sid} on {$a_rule[$id]['interface']}.");
+		config_set_path("installedpackages/suricata/rule/{$id}", $a_rule);
+		write_config("Suricata pkg: modified action for rule {$gid}:{$sid} on {$a_rule['interface']}.");
 
 		// We changed a rule action, remind user to apply the changes
 		mark_subsystem_dirty('suricata_rules');
 
 		// Update our in-memory rules map with the changes just saved
 		// to the Suricata configuration file.
-		suricata_modify_sids_action($rules_map, $a_rule[$id]);
+		suricata_modify_sids_action($rules_map, $a_rule);
 
 		// Set a scroll-to anchor location
 		$anchor = "rule_{$gid}_{$sid}";
@@ -525,9 +525,9 @@ elseif (isset($_POST['disable_all']) && !empty($rules_map)) {
 	$tmp = rtrim($tmp, "||");
 
 	if (!empty($tmp))
-		$a_rule[$id]['rule_sid_on'] = $tmp;
+		$a_rule['rule_sid_on'] = $tmp;
 	else
-		unset($a_rule[$id]['rule_sid_on']);
+		unset($a_rule['rule_sid_on']);
 
 	$tmp = "";
 	foreach (array_keys($disablesid) as $k1) {
@@ -537,18 +537,18 @@ elseif (isset($_POST['disable_all']) && !empty($rules_map)) {
 	$tmp = rtrim($tmp, "||");
 
 	if (!empty($tmp))
-		$a_rule[$id]['rule_sid_off'] = $tmp;
+		$a_rule['rule_sid_off'] = $tmp;
 	else
-		unset($a_rule[$id]['rule_sid_off']);
+		unset($a_rule['rule_sid_off']);
 
 	// We changed a rule state, remind user to apply the changes
 	mark_subsystem_dirty('suricata_rules');
-
-	write_config("Suricata pkg: disabled all rules in category {$currentruleset} for {$a_rule[$id]['interface']}.");
+	config_set_path("installedpackages/suricata/rule/{$id}", $a_rule);
+	write_config("Suricata pkg: disabled all rules in category {$currentruleset} for {$a_rule['interface']}.");
 
 	// Update our in-memory rules map with the changes just saved
 	// to the Suricata configuration file.
-	suricata_modify_sids($rules_map, $a_rule[$id]);
+	suricata_modify_sids($rules_map, $a_rule);
 }
 elseif (isset($_POST['enable_all']) && !empty($rules_map)) {
 
@@ -569,9 +569,9 @@ elseif (isset($_POST['enable_all']) && !empty($rules_map)) {
 	$tmp = rtrim($tmp, "||");
 
 	if (!empty($tmp))
-		$a_rule[$id]['rule_sid_on'] = $tmp;
+		$a_rule['rule_sid_on'] = $tmp;
 	else
-		unset($a_rule[$id]['rule_sid_on']);
+		unset($a_rule['rule_sid_on']);
 
 	$tmp = "";
 	foreach (array_keys($disablesid) as $k1) {
@@ -581,18 +581,18 @@ elseif (isset($_POST['enable_all']) && !empty($rules_map)) {
 	$tmp = rtrim($tmp, "||");
 
 	if (!empty($tmp))
-		$a_rule[$id]['rule_sid_off'] = $tmp;
+		$a_rule['rule_sid_off'] = $tmp;
 	else
-		unset($a_rule[$id]['rule_sid_off']);
+		unset($a_rule['rule_sid_off']);
 
 	// We changed a rule state, remind user to apply the changes
 	mark_subsystem_dirty('suricata_rules');
-
-	write_config("Suricata pkg: enable all rules in category {$currentruleset} for {$a_rule[$id]['interface']}.");
+	config_set_path("installedpackages/suricata/rule/{$id}", $a_rule);
+	write_config("Suricata pkg: enable all rules in category {$currentruleset} for {$a_rule['interface']}.");
 
 	// Update our in-memory rules map with the changes just saved
 	// to the Suricata configuration file.
-	suricata_modify_sids($rules_map, $a_rule[$id]);
+	suricata_modify_sids($rules_map, $a_rule);
 }
 elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 
@@ -621,9 +621,9 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 	$tmp = rtrim($tmp, "||");
 
 	if (!empty($tmp))
-		$a_rule[$id]['rule_sid_on'] = $tmp;
+		$a_rule['rule_sid_on'] = $tmp;
 	else
-		unset($a_rule[$id]['rule_sid_on']);
+		unset($a_rule['rule_sid_on']);
 
 	$tmp = "";
 	foreach (array_keys($disablesid) as $k1) {
@@ -633,9 +633,9 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 	$tmp = rtrim($tmp, "||");
 
 	if (!empty($tmp))
-		$a_rule[$id]['rule_sid_off'] = $tmp;
+		$a_rule['rule_sid_off'] = $tmp;
 	else
-		unset($a_rule[$id]['rule_sid_off']);
+		unset($a_rule['rule_sid_off']);
 
 	// Write the updated alertsid, dropsid and rejectsid values to the config file.
 	$tmp = "";
@@ -646,9 +646,9 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 	$tmp = rtrim($tmp, "||");
 
 	if (!empty($tmp))
-		$a_rule[$id]['rule_sid_force_alert'] = $tmp;
+		$a_rule['rule_sid_force_alert'] = $tmp;
 	else
-		unset($a_rule[$id]['rule_sid_force_alert']);
+		unset($a_rule['rule_sid_force_alert']);
 
 	$tmp = "";
 	foreach (array_keys($dropsid) as $k1) {
@@ -658,9 +658,9 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 	$tmp = rtrim($tmp, "||");
 
 	if (!empty($tmp))
-		$a_rule[$id]['rule_sid_force_drop'] = $tmp;
+		$a_rule['rule_sid_force_drop'] = $tmp;
 	else
-		unset($a_rule[$id]['rule_sid_force_drop']);
+		unset($a_rule['rule_sid_force_drop']);
 
 	$tmp = "";
 	foreach (array_keys($rejectsid) as $k1) {
@@ -670,14 +670,14 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 	$tmp = rtrim($tmp, "||");
 
 	if (!empty($tmp))
-		$a_rule[$id]['rule_sid_force_reject'] = $tmp;
+		$a_rule['rule_sid_force_reject'] = $tmp;
 	else
-		unset($a_rule[$id]['rule_sid_force_reject']);
+		unset($a_rule['rule_sid_force_reject']);
 
 	// We changed a rule state or action, remind user to apply the changes
 	mark_subsystem_dirty('suricata_rules');
-
-	write_config("Suricata pkg: remove rule state/action changes for category {$currentruleset} on {$a_rule[$id]['interface']}.");
+	config_set_path("installedpackages/suricata/rule/{$id}", $a_rule);
+	write_config("Suricata pkg: remove rule state/action changes for category {$currentruleset} on {$a_rule['interface']}.");
 
 	// Reload the rules so we can accurately show content after
 	// resetting any user overrides.
@@ -689,7 +689,7 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 	// Test for the special case of an IPS Policy file
 	// and load the selected policy's rules.
 	elseif (substr($currentruleset, 0, 10) == "IPS Policy") {
-		$rules_map = suricata_load_vrt_policy($a_rule[$id]['ips_policy'], $a_rule[$id]['ips_policy_mode']);
+		$rules_map = suricata_load_vrt_policy($a_rule['ips_policy'], $a_rule['ips_policy_mode']);
 	}
 	// Test for the special case of "Active Rules".  This
 	// displays all currently active rules for the
@@ -710,7 +710,7 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 		}
 		$rule_files[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
 		$rule_files[] = "{$suricatacfgdir}/rules/custom.rules";
-		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule[$id]['rule_sid_on']));
+		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule['rule_sid_on']));
 	}
 	elseif ($currentruleset == "User Forced Disabled Rules") {
 		// Search and display forced disabled rules only from
@@ -723,16 +723,16 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 		}
 		$rule_files[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
 		$rule_files[] = "{$suricatacfgdir}/rules/custom.rules";
-		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule[$id]['rule_sid_off']));
+		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule['rule_sid_off']));
 	}
 	elseif ($currentruleset == "User Forced ALERT Action Rules") {
-		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule[$id]['rule_sid_force_alert']));
+		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule['rule_sid_force_alert']));
 	}
 	elseif ($currentruleset == "User Forced DROP Action Rules") {
-		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule[$id]['rule_sid_force_drop']));
+		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule['rule_sid_force_drop']));
 	}
 	elseif ($currentruleset == "User Forced REJECT Action Rules") {
-		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule[$id]['rule_sid_force_reject']));
+		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule['rule_sid_force_reject']));
 	}
 	// If it's not a special case, and we can't find
 	// the given rule file, then notify the user.
@@ -748,17 +748,19 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 elseif (isset($_POST['resetall']) && !empty($rules_map)) {
 
 	// Remove all modified SIDs from config.xml and save the changes.
-	unset($a_rule[$id]['rule_sid_on']);
-	unset($a_rule[$id]['rule_sid_off']);
-	unset($a_rule[$id]['rule_sid_force_alert']);
-	unset($a_rule[$id]['rule_sid_force_drop']);
-	unset($a_rule[$id]['rule_sid_force_reject']);
+	unset($a_rule['rule_sid_on']);
+	unset($a_rule['rule_sid_off']);
+	unset($a_rule['rule_sid_force_alert']);
+	unset($a_rule['rule_sid_force_drop']);
+	unset($a_rule['rule_sid_force_reject']);
 
 	// We changed a rule state or action, remind user to apply the changes
 	mark_subsystem_dirty('suricata_rules');
 
 	/* Update the config.xml file. */
-	write_config("Suricata pkg: remove all rule state/action changes for {$a_rule[$id]['interface']}.");
+	config_set_path("installedpackages/suricata/rule/{$id}", $a_rule);
+	config_set_path("installedpackages/suricata/rule/{$id}", $a_rule);
+	write_config("Suricata pkg: remove all rule state/action changes for {$a_rule['interface']}.");
 
 	// Reload the rules so we can accurately show content after
 	// resetting any user overrides.
@@ -769,7 +771,7 @@ elseif (isset($_POST['resetall']) && !empty($rules_map)) {
 	// Test for the special case of an IPS Policy file
 	// and load the selected policy's rules.
 	elseif (substr($currentruleset, 0, 10) == "IPS Policy") {
-		$rules_map = suricata_load_vrt_policy($a_rule[$id]['ips_policy'], $a_rule[$id]['ips_policy_mode']);
+		$rules_map = suricata_load_vrt_policy($a_rule['ips_policy'], $a_rule['ips_policy_mode']);
 	}
 	// Test for the special case of "Active Rules".  This
 	// displays all currently active rules for the
@@ -790,7 +792,7 @@ elseif (isset($_POST['resetall']) && !empty($rules_map)) {
 		}
 		$rules_file[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
 		$rules_file[] = "{$suricatacfgdir}/rules/custom.rules";
-		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule[$id]['rule_sid_on']));
+		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule['rule_sid_on']));
 	}
 	elseif ($currentruleset == "User Forced Disabled Rules") {
 		// Search and display forced disabled rules only from
@@ -803,16 +805,16 @@ elseif (isset($_POST['resetall']) && !empty($rules_map)) {
 		}
 		$rules_file[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
 		$rules_file[] = "{$suricatacfgdir}/rules/custom.rules";
-		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule[$id]['rule_sid_off']));
+		$rules_map = suricata_get_filtered_rules($rule_files, suricata_load_sid_mods($a_rule['rule_sid_off']));
 	}
 	elseif ($currentruleset == "User Forced ALERT Action Rules") {
-		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule[$id]['rule_sid_force_alert']));
+		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule['rule_sid_force_alert']));
 	}
 	elseif ($currentruleset == "User Forced DROP Action Rules") {
-		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule[$id]['rule_sid_force_drop']));
+		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule['rule_sid_force_drop']));
 	}
 	elseif ($currentruleset == "User Forced REJECT Action Rules") {
-		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule[$id]['rule_sid_force_reject']));
+		$rules_map = suricata_get_filtered_rules("{$suricatacfgdir}/rules/", suricata_load_sid_mods($a_rule['rule_sid_force_reject']));
 	}
 	// If it's not a special case, and we can't find
 	// the given rule file, then notify the user.
@@ -826,10 +828,11 @@ elseif (isset($_POST['resetall']) && !empty($rules_map)) {
 	}
 }
 elseif (isset($_POST['clear'])) {
-	unset($a_rule[$id]['customrules']);
-	write_config("Suricata pkg: clear all custom rules for {$a_rule[$id]['interface']}.");
+	unset($a_rule['customrules']);
+	config_set_path("installedpackages/suricata/rule/{$id}", $a_rule);
+	write_config("Suricata pkg: clear all custom rules for {$a_rule['interface']}.");
 	$rebuild_rules = true;
-	suricata_generate_yaml($a_rule[$id]);
+	suricata_generate_yaml($a_rule);
 	$rebuild_rules = false;
 	$pconfig['customrules'] = '';
 
@@ -837,21 +840,22 @@ elseif (isset($_POST['clear'])) {
 	suricata_sync_on_changes();
 }
 elseif (isset($_POST['cancel'])) {
-	$pconfig['customrules'] = base64_decode($a_rule[$id]['customrules']);
+	$pconfig['customrules'] = base64_decode($a_rule['customrules']);
 	clear_subsystem_dirty('suricata_rules');
 }
 elseif (isset($_POST['save'])) {
 	$pconfig['customrules'] = $_POST['customrules'];
 	if ($_POST['customrules'])
-		$a_rule[$id]['customrules'] = base64_encode(str_replace("\r\n", "\n", $_POST['customrules']));
+		$a_rule['customrules'] = base64_encode(str_replace("\r\n", "\n", $_POST['customrules']));
 	else
-		unset($a_rule[$id]['customrules']);
-	write_config("Suricata pkg: save modified custom rules for {$a_rule[$id]['interface']}.");
+		unset($a_rule['customrules']);
+	config_set_path("installedpackages/suricata/rule/{$id}", $a_rule);
+	write_config("Suricata pkg: save modified custom rules for {$a_rule['interface']}.");
 	$rebuild_rules = true;
-	suricata_generate_yaml($a_rule[$id]);
+	suricata_generate_yaml($a_rule);
 	$rebuild_rules = false;
 	/* Signal Suricata to "live reload" the rules */
-	suricata_reload_config($a_rule[$id]);
+	suricata_reload_config($a_rule);
 	clear_subsystem_dirty('suricata_rules');
 
 	// Sync to configured CARP slaves if any are enabled
@@ -863,10 +867,10 @@ elseif ($_POST['filterrules_submit']) {
 	$filterfieldsarray = array();
 	$filterfieldsarray['show_enabled'] = $_POST['filterrules_enabled'] ? $_POST['filterrules_enabled'] : null;
 	$filterfieldsarray['show_disabled'] = $_POST['filterrules_disabled'] ? $_POST['filterrules_disabled'] : null;
-	if ($a_rule[$id]['blockoffenders'] == 'on'){
+	if ($a_rule['blockoffenders'] == 'on'){
 		$filterfieldsarray['show_drop'] = $_POST['filterrules_drop'] ? $_POST['filterrules_drop'] : null;
 	}
-	if ($a_rule[$id]['ips_mode'] == 'ips_mode_inline' && $a_rule[$id]['blockoffenders'] == 'on') {
+	if ($a_rule['ips_mode'] == 'ips_mode_inline' && $a_rule['blockoffenders'] == 'on') {
 		$filterfieldsarray['show_reject'] = $_POST['filterrules_reject'] ? $_POST['filterrules_reject'] : null;
 	}
 }
@@ -877,18 +881,19 @@ elseif ($_POST['filterrules_clear']) {
 elseif (isset($_POST['apply'])) {
 
 	/* Save new configuration */
-	write_config("Suricata pkg: new rules configuration for {$a_rule[$id]['interface']}.");
+	config_set_path("installedpackages/suricata/rule/{$id}", $a_rule);
+	write_config("Suricata pkg: new rules configuration for {$a_rule['interface']}.");
 
 	/*************************************************/
 	/* Update the suricata.yaml file and rebuild the */
 	/* rules for this interface.                     */
 	/*************************************************/
 	$rebuild_rules = true;
-	suricata_generate_yaml($a_rule[$id]);
+	suricata_generate_yaml($a_rule);
 	$rebuild_rules = false;
 
 	/* Signal Suricata to "live reload" the rules */
-	suricata_reload_config($a_rule[$id]);
+	suricata_reload_config($a_rule);
 
 	// We have saved changes and done a soft restart, so clear "dirty" flag
 	clear_subsystem_dirty('suricata_rules');
@@ -898,16 +903,16 @@ elseif (isset($_POST['apply'])) {
 }
 
 function build_cat_list() {
-	global $categories, $a_rule, $id, $snortdownload, $emergingdownload, $etpro;
+	global $categories, $a_rule, $snortdownload, $emergingdownload, $etpro;
 
 	$list = array();
 
 	$files = $categories;
 
-	if ($a_rule[$id]['ips_policy_enable'] == 'on')
-		$files[] = "IPS Policy - " . ucfirst($a_rule[$id]['ips_policy']);
+	if ($a_rule['ips_policy_enable'] == 'on')
+		$files[] = "IPS Policy - " . ucfirst($a_rule['ips_policy']);
 
-	if ($a_rule[$id]['autoflowbitrules'] == 'on')
+	if ($a_rule['autoflowbitrules'] == 'on')
 		$files[] = "Auto-Flowbit Rules";
 
 	natcasesort($files);
@@ -1009,7 +1014,7 @@ if ($currentruleset == 'custom.rules') :
 		$section->addInput(new Form_Textarea(
 			'customrules',
 			'',
-			base64_decode($a_rule[$id]['customrules'])
+			base64_decode($a_rule['customrules'])
 		))->addClass('row-fluid')->setRows('18')->setAttribute('wrap', 'off')->setAttribute('style', 'max-width: 100%; width: 100%;');
 		print($section);
 ?>
@@ -1098,7 +1103,7 @@ $group->add(new Form_Checkbox(
 ));
 
 // Show DROP and REJECT filters for Inline IPS Mode operation
-if ($a_rule[$id]['blockoffenders'] == 'on') {
+if ($a_rule['blockoffenders'] == 'on') {
 	$group->add(new Form_Checkbox(
 		'filterrules_drop',
 		'Drop Rules',
@@ -1107,7 +1112,7 @@ if ($a_rule[$id]['blockoffenders'] == 'on') {
 		'on'
 	));
 }
-if ($a_rule[$id]['ips_mode'] == 'ips_mode_inline' && $a_rule[$id]['blockoffenders'] == 'on') {
+if ($a_rule['ips_mode'] == 'ips_mode_inline' && $a_rule['blockoffenders'] == 'on') {
 	$group->add(new Form_Checkbox(
 		'filterrules_reject',
 		'Reject Rules',
@@ -1162,9 +1167,9 @@ print($section);
 						<td style="padding-left: 8px;"><i class="fa fa-times-circle text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Disabled by user');?></small></td>
 						<td style="padding-left: 8px;"><i class="fa fa-adn text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Auto-disabled by SID Mgmt');?></small></td>
 						<td></td><td></td>
-				<?php if ($a_rule[$id]['blockoffenders'] == 'on') : ?>
+				<?php if ($a_rule['blockoffenders'] == 'on') : ?>
 						<td style="padding-left: 8px;"><i class="fa fa-thumbs-down text-danger"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is drop');?></small></td>
-					<?php if ($a_rule[$id]['ips_mode'] == 'ips_mode_inline') : ?>
+					<?php if ($a_rule['ips_mode'] == 'ips_mode_inline') : ?>
 						<td style="padding-left: 8px;"><i class="fa fa-hand-stop-o text-warning"></i></td><td style="padding-left: 4px;"><small><?=gettext('Rule action is reject');?></small></td>
 					<?php else : ?>
 						<td></td><td></td>
@@ -1294,15 +1299,15 @@ print($section);
 								$textss = $textse = "";
 								$iconact_class = 'class="fa fa-exclamation-triangle text-warning text-center"';
 								$title_act = gettext("Rule will alert on traffic when triggered.");
-								if ($v['action'] == 'drop' && $a_rule[$id]['blockoffenders'] == 'on') {
+								if ($v['action'] == 'drop' && $a_rule['blockoffenders'] == 'on') {
 									$iconact_class = 'class="fa fa-thumbs-down text-danger text-center"';
 									$title_act = gettext("Rule will drop traffic when triggered.");
 								}
-								elseif ($v['action'] == 'reject' && $a_rule[$id]['ips_mode'] == 'ips_mode_inline' && $a_rule[$id]['blockoffenders'] == 'on') {
+								elseif ($v['action'] == 'reject' && $a_rule['ips_mode'] == 'ips_mode_inline' && $a_rule['blockoffenders'] == 'on') {
 									$iconact_class = 'class="fa fa-hand-stop-o text-warning text-center"';
 									$title_act = gettext("Rule will reject traffic when triggered.");
 								}
-								if ($a_rule[$id]['blockoffenders'] == 'on') {
+								if ($a_rule['blockoffenders'] == 'on') {
 									$title_act .= gettext("  Click to change rule action.");
 								}
 
@@ -1349,7 +1354,7 @@ print($section);
 						<?php endif; ?>
 									</td>
 
-						<?php if ($a_rule[$id]['blockoffenders'] == 'on' && $v['noalert'] == 0) : ?>
+						<?php if ($a_rule['blockoffenders'] == 'on' && $v['noalert'] == 0) : ?>
 								       <td><?=$textss; ?><a id="rule_<?=$gid; ?>_<?=$sid; ?>_action" href="#" onClick="toggleAction('<?=$sid; ?>', '<?=$gid; ?>');" 
 										<?=$iconact_class; ?> title="<?=$title_act; ?>"></a><?=$textse; ?>
 								       </td>
@@ -1434,7 +1439,7 @@ print($section);
 					<input type="radio" name="ruleActionOptions" id="action_drop" value="action_drop"> <span class = "label label-danger">DROP</span>
 				</label>
 
-		<?php if ($a_rule[$id]['ips_mode'] == 'ips_mode_inline' && $a_rule[$id]['blockoffenders'] == 'on') : ?>
+		<?php if ($a_rule['ips_mode'] == 'ips_mode_inline' && $a_rule['blockoffenders'] == 'on') : ?>
 				<label class="radio-inline">
 					<input type="radio" name="ruleActionOptions" id="action_reject" value="action_reject"> <span class = "label label-warning">REJECT</span>
 				</label>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -299,33 +299,26 @@ if (isset($_POST['rule_state_save']) && isset($_POST['ruleStateOptions']) && is_
 		case "state_default":
 			// Return the rule to it's default state
 			// by removing all state override entries.
-			if (isset($enablesid[$gid][$sid])) {
-				unset($enablesid[$gid][$sid]);
-			}
-			if (isset($disablesid[$gid][$sid])) {
-				unset($disablesid[$gid][$sid]);
-			}
+			array_del_path($enablesid, "{$gid}/{$sid}");
+			array_del_path($disablesid, "{$gid}/{$sid}");
+
 			// Restore the default state flag so we
 			// can display state properly on RULES
 			// page without needing to reload the
 			// entire set of rules.
-			if (isset($rules_map[$gid][$sid])) {
+			if (array_get_path($rules_map, "{$gid}/{$sid}")) {
 				$rules_map[$gid][$sid]['disabled'] = !$rules_map[$gid][$sid]['default_state'];
 			}
 			break;
 
 		case "state_enabled":
-			if (isset($disablesid[$gid][$sid])) {
-				unset($disablesid[$gid][$sid]);
-			}
-			$enablesid[$gid][$sid] = "enablesid";
+			array_del_path($disablesid, "{$gid}/{$sid}");
+			array_set_path($enablesid, "{$gid}/{$sid}", 'enablesid');
 			break;
 
 		case "state_disabled":
-			if (isset($enablesid[$gid][$sid])) {
-				unset($enablesid[$gid][$sid]);
-			}
-			$disablesid[$gid][$sid] = "disablesid";
+			array_del_path($enablesid, "{$gid}/{$sid}");
+			array_set_path($disablesid, "{$gid}/{$sid}", 'disablesid');
 			break;
 
 		default:
@@ -387,66 +380,30 @@ elseif (isset($_POST['rule_action_save']) && isset($_POST['ruleActionOptions']) 
 	switch ($action) {
 		case "action_default":
 			$rules_map[$gid][$sid]['action'] = $rules_map[$gid][$sid]['default_action'];
-			if (isset($alertsid[$gid][$sid])) {
-				unset($alertsid[$gid][$sid]);
-			}
-			if (isset($dropsid[$gid][$sid])) {
-				unset($dropsid[$gid][$sid]);
-			}
-			if (isset($rejectsid[$gid][$sid])) {
-				unset($rejectsid[$gid][$sid]);
-			}
+			array_del_path($alertsid, "{$gid}/{$sid}");
+			array_del_path($dropsid, "{$gid}/{$sid}");
+			array_del_path($rejectsid, "{$gid}/{$sid}");
 			break;
 
 		case "action_alert":
 			$rules_map[$gid][$sid]['action'] = $rules_map[$gid][$sid]['alert'];
-			if (!is_array($alertsid[$gid])) {
-				$alertsid[$gid] = array();
-			}
-			if (!is_array($alertsid[$gid][$sid])) {
-				$alertsid[$gid][$sid] = array();
-			}
-			$alertsid[$gid][$sid] = "alertsid";
-			if (isset($dropsid[$gid][$sid])) {
-				unset($dropsid[$gid][$sid]);
-			}
-			if (isset($rejectsid[$gid][$sid])) {
-				unset($rejectsid[$gid][$sid]);
-			}
+			array_set_path($alertsid, "{$gid}/{$sid}", "alertsid");
+			array_del_path($dropsid, "{$gid}/{$sid}");
+			array_del_path($rejectsid, "{$gid}/{$sid}");
 			break;
 
 		case "action_drop":
 			$rules_map[$gid][$sid]['action'] = $rules_map[$gid][$sid]['drop'];
-			if (!is_array($dropsid[$gid])) {
-				$dropsid[$gid] = array();
-			}
-			if (!is_array($dropsid[$gid][$sid])) {
-				$dropsid[$gid][$sid] = array();
-			}
-			$dropsid[$gid][$sid] = "dropsid";
-			if (isset($alertsid[$gid][$sid])) {
-				unset($alertsid[$gid][$sid]);
-			}
-			if (isset($rejectsid[$gid][$sid])) {
-				unset($rejectsid[$gid][$sid]);
-			}
+			array_set_path($dropsid, "{$gid}/{$sid}", "dropsid");
+			array_del_path($alertsid, "{$gid}/{$sid}");
+			array_del_path($rejectsid, "{$gid}/{$sid}");
 			break;
 
 		case "action_reject":
 			$rules_map[$gid][$sid]['action'] = $rules_map[$gid][$sid]['reject'];
-			if (!is_array($rejectsid[$gid])) {
-				$rejectsid[$gid] = array();
-			}
-			if (!is_array($rejectsid[$gid][$sid])) {
-				$rejectsid[$gid][$sid] = array();
-			}
-			$rejectsid[$gid][$sid] = "rejectsid";
-			if (isset($alertsid[$gid][$sid])) {
-				unset($alertsid[$gid][$sid]);
-			}
-			if (isset($dropsid[$gid][$sid])) {
-				unset($dropsid[$gid][$sid]);
-			}
+			array_set_path($rejectsid, "{$gid}/{$sid}", "rejectsid");
+			array_del_path($alertsid, "{$gid}/{$sid}");
+			array_del_path($dropsid, "{$gid}/{$sid}");
 			break;
 
 		default:
@@ -510,9 +467,8 @@ elseif (isset($_POST['disable_all']) && !empty($rules_map)) {
 	// Mark all rules in the currently selected category "disabled".
 	foreach (array_keys($rules_map) as $k1) {
 		foreach (array_keys($rules_map[$k1]) as $k2) {
-			if (isset($enablesid[$k1][$k2]))
-				unset($enablesid[$k1][$k2]);
-			$disablesid[$k1][$k2] = "disablesid";
+			array_del_path($enablesid, "{$k1}/{$k2}");
+			array_set_path($disablesid, "{$k1}/{$k2}", 'disablesid');
 		}
 	}
 
@@ -555,9 +511,8 @@ elseif (isset($_POST['enable_all']) && !empty($rules_map)) {
 	// Mark all rules in the currently selected category "enabled".
 	foreach (array_keys($rules_map) as $k1) {
 		foreach (array_keys($rules_map[$k1]) as $k2) {
-			if (isset($disablesid[$k1][$k2]))
-				unset($disablesid[$k1][$k2]);
-			$enablesid[$k1][$k2] = "enablesid";
+			array_del_path($disablesid, "{$k1}/{$k2}");
+			array_set_path($enablesid, "{$k1}/{$k2}", 'enablesid');
 		}
 	}
 	// Write the updated enablesid and disablesid values to the config file.
@@ -599,16 +554,11 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 	// Reset any modified SIDs in the current rule category to their defaults.
 	foreach (array_keys($rules_map) as $k1) {
 		foreach (array_keys($rules_map[$k1]) as $k2) {
-			if (isset($enablesid[$k1][$k2]))
-				unset($enablesid[$k1][$k2]);
-			if (isset($disablesid[$k1][$k2]))
-				unset($disablesid[$k1][$k2]);
-			if (isset($alertsid[$k1][$k2]))
-				unset($alertsid[$k1][$k2]);
-			if (isset($dropsid[$k1][$k2]))
-				unset($dropsid[$k1][$k2]);
-			if (isset($rejectsid[$k1][$k2]))
-				unset($rejectsid[$k1][$k2]);
+			array_del_path($enablesid, "{$k1}/{$k2}");
+			array_del_path($disablesid, "{$k1}/{$k2}");
+			array_del_path($alertsid, "{$k1}/{$k2}");
+			array_del_path($dropsid, "{$k1}/{$k2}");
+			array_del_path($rejectsid, "{$k1}/{$k2}");
 		}
 	}
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2019 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,14 +41,10 @@ if (is_null($id)) {
 	exit;
 }
 
-if (!is_array($config['installedpackages']['suricata']['rule'])) {
-	$config['installedpackages']['suricata']['rule'] = array();
-}
+$a_rule = config_get_path("installedpackages/suricata/rule/"{$id}", []);
 
-$a_rule = &$config['installedpackages']['suricata']['rule'];
-
-$if_real = get_real_interface($a_rule[$id]['interface']);
-$suricata_uuid = $a_rule[$id]['uuid'];
+$if_real = get_real_interface($a_rule['interface']);
+$suricata_uuid = $a_rule['uuid'];
 $suricatacfgdir = "{$suricatadir}suricata_{$suricata_uuid}_{$if_real}/";
 
 $file = htmlspecialchars($_GET['openruleset'], ENT_QUOTES | ENT_HTML401);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules_edit.php
@@ -41,7 +41,7 @@ if (is_null($id)) {
 	exit;
 }
 
-$a_rule = config_get_path("installedpackages/suricata/rule/"{$id}", []);
+$a_rule = config_get_path("installedpackages/suricata/rule/{$id}", []);
 
 $if_real = get_real_interface($a_rule['interface']);
 $suricata_uuid = $a_rule['uuid'];

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_select_alias.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_select_alias.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2018 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,10 +74,7 @@ if (is_null($type) || is_null($varname)) {
 // Used to track if any selectable Aliases are found
 $selectablealias = false;
 
-// Initialize required array variables as necessary
-if (!is_array($config['aliases']['alias']))
-	$config['aliases']['alias'] = array();
-$a_aliases = $config['aliases']['alias'];
+$a_aliases = config_get_path('aliases/alias', []);
 
 // Create an array consisting of the Alias types the
 // caller wants to select from.

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2021 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,14 +26,8 @@
 require_once("guiconfig.inc");
 require_once("/usr/local/pkg/suricata/suricata.inc");
 
-if (!is_array($config['installedpackages']['suricata']['rule']))
-	$config['installedpackages']['suricata']['rule'] = array();
-if (!is_array($config['installedpackages']['suricata']['suppress']))
-	$config['installedpackages']['suricata']['suppress'] = array();
-if (!is_array($config['installedpackages']['suricata']['suppress']['item']))
-	$config['installedpackages']['suricata']['suppress']['item'] = array();
-$a_suppress = &$config['installedpackages']['suricata']['suppress']['item'];
-$id_gen = count($config['installedpackages']['suricata']['suppress']['item']);
+$a_suppress = config_get_path('installedpackages/suricata/suppress/item', []);
+$id_gen = count($a_suppress);
 
 function suricata_suppresslist_used($supplist) {
 
@@ -45,12 +39,7 @@ function suricata_suppresslist_used($supplist) {
 	/* Returns:  TRUE if list is in use, else FALSE			*/
 	/****************************************************************/
 
-	global $config;
-
-	$suricataconf = $config['installedpackages']['suricata']['rule'];
-	if (empty($suricataconf))
-		return false;
-	foreach ($suricataconf as $value) {
+	foreach (config_get_path('installedpackages/suricata/rule', []) as $value) {
 		if ($value['suppresslistname'] == $supplist)
 			return true;
 	}
@@ -68,11 +57,7 @@ function suricata_find_suppresslist_interface($supplist) {
 	/*		  FALSE if no interface found.			*/
 	/****************************************************************/
 
-	global $config;
-	$suricataconf = $config['installedpackages']['suricata']['rule'];
-	if (empty($suricataconf))
-		return false;
-	foreach ($suricataconf as $rule => $value) {
+	foreach (config_get_path('installedpackages/suricata/rule', []) as $rule => $value) {
 		if ($value['suppresslistname'] == $supplist)
 			return $rule;
 	}
@@ -92,6 +77,7 @@ if (isset($_POST['del_btn'])) {
 			}
 		}
 		if ($need_save) {
+			config_set_path('installedpackages/suricata/suppress/item', $a_suppress);
 			write_config("Suricata pkg: deleted SUPPRESSION LIST.");
 			sync_suricata_package_config();
 			header("Location: /suricata/suricata_suppress.php");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2021 Bill Meeks
+ * Copyright (c) 2022 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,21 +26,12 @@
 require_once("guiconfig.inc");
 require_once("/usr/local/pkg/suricata/suricata.inc");
 
-
-if (!is_array($config['installedpackages']['suricata']))
-	$config['installedpackages']['suricata'] = array();
-$suricataglob = $config['installedpackages']['suricata'];
-
-if (!is_array($config['installedpackages']['suricata']['suppress']))
-	$config['installedpackages']['suricata']['suppress'] = array();
-if (!is_array($config['installedpackages']['suricata']['suppress']['item']))
-	$config['installedpackages']['suricata']['suppress']['item'] = array();
-$a_suppress = &$config['installedpackages']['suricata']['suppress']['item'];
-
 if (isset($_POST['id']) && is_numericint($_POST['id']))
 	$id = $_POST['id'];
 elseif (isset($_GET['id']) && is_numericint($_GET['id']))
 	$id = htmlspecialchars($_GET['id']);
+
+$a_suppress = config_get_path('installedpackages/suricata/suppress/item', []);
 
 /* returns true if $name is a valid name for a whitelist file name or ip */
 function is_validwhitelistname($name) {
@@ -112,6 +103,7 @@ if ($_POST['save']) {
 		else
 			$a_suppress[] = $s_list;
 
+		config_set_path('installedpackages/suricata/suppress/item', $a_suppress);
 		write_config("Suricata pkg: saved changes to Suppress List {$s_list['name']}.");
 		sync_suricata_package_config();
 


### PR DESCRIPTION
pfSense-pkg-suricata-6.0.6_1
This update fixes a number of PHP8 compatibility issues and introduces the new _config_path()_ and _array_path()_ functions.

**New Features:**
1. Introduce use of pfSense config_path() and array_path() functions family for safe access of array data.

**Bug Fixes:**
1. Fixes [Redmine Issue #13531](https://redmine.pfsense.org/issues/13531) - PHP8 errors thrown during package installation and operation.
