### PR TITLE
Fixes in Squid Proxy's Youtube SafeSearch - Redmine issue #13811

### DIFF
--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid_nac.xml
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid_nac.xml
@@ -251,7 +251,7 @@
 			<fieldname>youtube_restrict</fieldname>
 			<type>select</type>
 			<options>
-				<option><name>None</name><value>none</value></option>
+				<option><name>None</name><value></value></option>
 				<option><name>Moderate</name><value>moderate</value></option>
 				<option><name>Strict</name><value>strict</value></option>
 			</options>


### PR DESCRIPTION
Even though there was None selected. Youtube content was getting filtered as `squid.conf` generated by `squid.inc` was adding headers with none value.

A simple fix by setting the value of None drop down item with empty string as `squid.inc` will check for a empty string before adding it to `squid.conf`. As it will receive empty value so it will not add it to `squid.conf` file. As a result youtube will not get filtered on None Selection.