### PR TITLE
Snort-2.9.20_2 - Fix Redmine Issue #13623 - luajit-openresty conflict with luajit-devel.

### DIFF
--- a/security/snort/Makefile
+++ b/security/snort/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	snort
 PORTVERSION=	2.9.20
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	https://snort.org/downloads/snort/ \
 		https://snort.org/downloads/archive/snort/
@@ -78,7 +78,7 @@ FILEINSPECT_CONFIGURE_ENABLE=	file-inspect
 
 BARNYARD_RUN_DEPENDS=	barnyard2:security/barnyard2
 PULLEDPORK_RUN_DEPENDS=	pulledpork.pl:security/pulledpork
-APPID_USES=		luajit
+APPID_USES=		luajit:luajit-openresty
 APPID_CONFIGURE_ENV+=	luajit_CFLAGS="-I${LUAJIT_INCDIR}" \
 			luajit_LIBS="-L${LOCALBASE}/lib -lluajit-5.1"
 


### PR DESCRIPTION
### Snort-2.9.20_2
This update for the Snort binary package addresses an issue caused by changes in FreeBSD-ports upstream to the version  of the _luajit_ library. The fix is to explicitly specify the current version of _luajit-openresty_ as the required _luajit_ library to be used with the OpenAppID option in Snort.

**New Features:**
None

**Bug Fixes:**
1. [Redmine Issue #13623](https://redmine.pfsense.org/issues/13623) - Snort binary fails to install in the latest pfSense 2.7.0-DEVEL snapshots due to _luajit-openresty_ and _luajit-devel_ conflicts.