### PR TITLE
pfSense-pkg-snort-4.1.6_2 - Fix Redmine Issue #13612 - Multilingual issue with lists named 'default'.

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.1.6
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
@@ -574,7 +574,7 @@ function snort_get_config_lists($lists) {
 	// stored in the config file if one exists.  Always
 	// return at least the single entry, "default".
 	$result = array();
-	$result['default'] = 'default';
+	$result['default'] = gettext("default");
 	foreach (config_get_path("installedpackages/snortglobal/{$lists}/item", []) as $v) {
 		$result[$v['name']] = gettext($v['name']);
 	}


### PR DESCRIPTION
### pfSense-pkg-snort-4.1.6_2
This update corrects a bug reported in [Redmine Issue #13612](https://redmine.pfsense.org/issues/13612) where a missing _gettext()_ translation of list names equal to 'default' causes the creation of an empty list in non-English multilingual installs.

**New Features:**
None

**Bug Fixes:**
1. Correct the issue identified in [Redmine Issue #13612](https://redmine.pfsense.org/issues/13612) - Snort building of lists in multilingual non-English systems is broken when the list name is 'default'.