### PR TITLE
suricata-6.0.8_2 - Address Redmine #13623 in Suricata -- luajit-openresty conflict.

### DIFF
--- a/security/suricata/Makefile
+++ b/security/suricata/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	suricata
 DISTVERSION=	6.0.8
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	https://www.openinfosecfoundation.org/download/
 
@@ -73,7 +73,7 @@ HYPERSCAN_LIB_DEPENDS=	libhs.so:devel/hyperscan
 
 IPFW_CONFIGURE_ON=	--enable-ipfw
 
-LUAJIT_USES=		luajit
+LUAJIT_USES=		luajit:luajit-openresty
 LUAJIT_CONFIGURE_ON=	--enable-luajit
 
 LUA_USES=		lua:51


### PR DESCRIPTION
### Suricata-6.0.8_2
This update corrects a conflict between the luajit-devel and luajit-openresty libraries in pfSense. This modifies the Suricata binary to explicitly use luajit-openresty. This is the same issue previously corrected in the Snort binary package as reported in [Redmine Issue #13623](https://redmine.pfsense.org/issues/13623) (already closed against Snort).

**New Features:**
None

**Bug Fixes:**
1. Resolve conflict between the luajit-devel and luajit-openresty shared libraries when installing the Suricata binary package.
