### PR TITLE
pfSense-pkg-suricata-6.0.8 - Fix Redmine Issue 13709 and match up GUI and binary version numbers

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,8 +1,8 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	6.0.6
-PORTREVISION=	1
+PORTVERSION=	6.0.8
+PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=6.0.6:security/suricata
+RUN_DEPENDS=	suricata>=6.0.8:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -542,7 +542,7 @@ if ($_POST['mode'] == 'togglesid' && is_numeric($_POST['sidid']) && is_numeric($
 	// See if the target SID is in our list of modified SIDs,
 	// and toggle it if present.
 	array_del_path($enablesid, "{$gid}/{$sid}");
-	if (array_get_path($disablesid, "{$gid}/{$sid}") {
+	if (array_get_path($disablesid, "{$gid}/{$sid}")) {
 		array_del_path($disablesid, "{$gid}/{$sid}");
 	} else {
 		array_set_path($disablesid, "{$gid}/{$sid}", 'disablesid');


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.8
This update corrects one syntax error bug on the ALERTS tab and matches up the GUI package version number with that of the underlying Suricata binary (which was recently updated to 6.0.8 via resync with FreeBSD ports upstream).

**New Features:**
None

**Bug Fixes:**
1. [Redmine Issue #13709](https://redmine.pfsense.org/issues/13709), syntax error when loading ALERTS tab page due to a missing parenthesis.