### PR TITLE
pfSense-pkg-suricata-6.0.8_1 - Fix Redmine Issue #13714 - fatal error when adding new interface.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.8
-PORTREVISION=	0
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.8_1
This update addresses [Redmine Issue #13714](https://redmine.pfsense.org/issues/13714), "PHP 8.1 error when adding a new interface".

**New Features:**
None

**Bug Fixes:**
1. PHP 8.1 fatal error when adding a new interface. [Redmine Issue #13714](https://redmine.pfsense.org/issues/13714).