### PR TITLE
pfSense-pkg-suricata-6.0.89_2 - Fix Redmine Issue #13730 - failure to download Emerging Threats rules

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.8
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
@@ -53,11 +53,15 @@ if (!defined('SURICATA_PBI_BINDIR'))
 if (!defined("SURICATA_BIN_VERSION")) {
 	// Grab the Suricata binary version programmatically
 	$suricatabindir = SURICATA_PBI_BINDIR;
-	$suricataver = exec_command("{$suricatabindir}suricata -V 2>&1 |/usr/bin/cut -c26-");
+
+	// Since upstream now includes extra text after the version number, we cut by fields instead
+	// of grabbing up to the EOL. Field 5 currently has the version string we need.
+	$suricataver = exec_command("{$suricatabindir}suricata -V 2>&1 |/usr/bin/cut -d \" \" -f5");
 	if (!empty($suricataver))
 		define("SURICATA_BIN_VERSION", $suricataver);
 	else
-		define("SURICATA_BIN_VERSION", "");
+		// If we could not find a version, set a safe default
+		define("SURICATA_BIN_VERSION", "5.0.0");
 }
 
 // Define the name of the pf table used for IP blocks


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.8_2
This update corrects the issue identified in [Redmine Issue #13730](https://redmine.pfsense.org/issues/13730). A change in output behavior of the _filter_var()_ function in PHP 8.1 caused the generation of an incorrect URL for downloading Emerging Threats rules archives.

**New Features:**
None

**Bug Fixes:**
1. Suricata fails to download Emerging Threats rule archive due to a behavior change in a native PHP function in PHP 8.1. [Redmine Issue #13730](https://redmine.pfsense.org/issues/13730).