### PR TITLE
pfBlockerNG-devel v3.1.0 9

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG-devel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-pfBlockerNG-devel
 PORTVERSION=	3.1.0
-PORTREVISION=	7
+PORTREVISION=	9
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1155,10 +1155,6 @@ def operate(id, event, qstate, qdata):
                     qstate.ext_state[id] = MODULE_ERROR
                     return True
 
-                if qstate.return_msg.qinfo:
-                    invalidateQueryInCache(qstate, qstate.return_msg.qinfo)
-                    storeQueryInCache(qstate, qstate.return_msg.qinfo, qstate.return_msg.rep, 0)
-
                 qstate.return_rcode = RCODE_NOERROR
                 qstate.return_msg.rep.security = 2
                 qstate.ext_state[id] = MODULE_FINISHED
@@ -1212,10 +1208,6 @@ def operate(id, event, qstate, qdata):
                                     qstate.ext_state[id] = MODULE_ERROR
                                     return True
 
-                                if qstate.return_msg.qinfo:
-                                    invalidateQueryInCache(qstate, qstate.return_msg.qinfo)
-                                    storeQueryInCache(qstate, qstate.return_msg.qinfo, qstate.return_msg.rep, 0)
-
                                 MODULE_RESTART_NEXT = 3
                                 qstate.no_cache_store = 1
                                 qstate.ext_state[id] = MODULE_RESTART_NEXT
@@ -1236,10 +1228,6 @@ def operate(id, event, qstate, qdata):
                             qstate.ext_state[id] = MODULE_ERROR
                             return True
 
-                        if qstate.return_msg.qinfo:
-                            invalidateQueryInCache(qstate, qstate.return_msg.qinfo)
-                            storeQueryInCache(qstate, qstate.return_msg.qinfo, qstate.return_msg.rep, 0)
- 
                         qstate.return_rcode = RCODE_NOERROR
                         qstate.return_msg.rep.security = 2
                         qstate.ext_state[id] = MODULE_FINISHED

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4233,10 +4233,11 @@ function pfb_download_failure($alias, $header, $pfbfolder, $list_url, $format, $
 	$pfbfound = FALSE;
 
 	// Re-evaluate URL
-	if ($format == 'whois' || $format == 'asn') {
-		if (empty(pfb_filter($list_url, PFB_FILTER_ALNUM, 'pfb_download_failure'))) {
-			pfb_logger("\n Invalid ASN. Terminating Download! [ {$list_url} ]\n", 1);
-		}
+	if ($format == 'whois' && empty(pfb_filter($list_url, PFB_FILTER_DOMAIN, 'pfb_download_failure'))) {
+		pfb_logger("\n Invalid WHOIS. Terminating Download! [ {$list_url} ]\n", 1);
+	} 
+	elseif ($format == 'asn' && empty(pfb_filter($list_url, PFB_FILTER_ALNUM, 'pfb_download_failure'))) {
+		pfb_logger("\n Invalid ASN. Terminating Download! [ {$list_url} ]\n", 1);
 	}
 	elseif (!pfb_filter($list_url, PFB_FILTER_URL, 'pfb_download_failure')) {
 		pfb_logger("\n Invalid URL. Terminating Download! [ {$list_url} ]\n", 1);
@@ -7835,7 +7836,7 @@ function sync_package_pfblockerng($cron='') {
 								} elseif (strpos($line, ' AAAA ') !== FALSE) {
 									$safesearch_hosts[$domain]['AAAA'] = $host_ip;
 
-								# CNAME SafeSearch is not compatable in Python Mode, use Unbound mode for now
+								# CNAME SafeSearch is not compatible in Python Mode, use Unbound mode for now
 								} elseif (strpos($line, ' CNAME ') !== FALSE) {
 									$ss_cname = TRUE;
 									if (!$DDG && strpos($line, 'duckduckgo.com') !== FALSE) {

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng.php
@@ -265,8 +265,16 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 		if (strpos($list_url, ' ') !== FALSE) {
 			$list_url = strstr($list_url, ' ', TRUE);
 		}
-		if (empty(pfb_filter($list_url, PFB_FILTER_ALNUM, 'php'))) {
-                        pfb_logger("\n Invalid ASN. Terminating Download! [ {$list_url} ]\n", 1);
+
+		$pfb_filter_type = PFB_FILTER_ALNUM;
+		$pfb_filter_text = 'ASN';
+		if ($format == 'whois') {
+			$pfb_filter_type = PFB_FILTER_DOMAIN;
+			$pfb_filter_text = 'WHOIS';
+		}
+
+		if (empty(pfb_filter($list_url, $pfb_filter_type, 'php'))) {
+                        pfb_logger("\n Invalid {$pfb_filter_text}. Terminating Download! [ {$list_url} ]\n", 1);
 			return;
 		}
 

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -518,7 +518,7 @@ if ($_POST && isset($_POST['save'])) {
 			}
 
 			if ($value != 'Disabled' && $_POST["format-{$key_1}"] == 'whois') {
-				if (empty(pfb_filter($_POST["format-{$key_1}"], PFB_FILTER_DOMAIN, 'Category_edit'))) {
+				if (empty(pfb_filter($_POST["url-{$key_1}"], PFB_FILTER_DOMAIN, 'Category_edit'))) {
 					$input_errors[] = "{$type} Source Definitions, Line {$line}: "
 							. "Invalid Domain Name (Whois format)";
 				}
@@ -746,7 +746,7 @@ if ($_POST && isset($_POST['save'])) {
 				// Collect all rowhelper keys
 				$rowhelper_exist[$k_field[1]] = '';
 
-				if (!empty($value)) {
+				if (!empty($value) && $k_field[0] != 'url') {
 					$value = pfb_filter($value, PFB_FILTER_HTML, 'Category_edit save');
 				}
 				init_config_arr(array('installedpackages', $conf_type, 'config', $rowid, 'row', $k_field[1]));


### PR DESCRIPTION
Changelog:

* Fix issue causing Resolver issues in certain cases
* Fix issue with Header Field Auto-Sort
* Fix issue with 'Whois' Format

* Fix issue saving URLs in the IPv4/v6/DNSBL Tab. 
Each save would repeat the htmlspecialchars() encoding resulting in duplicate ";amp" tags being added. 
Please review any IP Aliaes/ DNSBL Groups that have been saved since the last update and manually remove any of these erroneous tags. 
I assume that these will still download ok, so its more cosmetic, and these Feeds will show in the Feeds Tab - Unknown User defined feeds at the bottom of the page.