### PR TITLE
pfSense-pkg-suricata-6.0.8_3 - Fix Redmine Issues #13771 and #13794.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.8
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -640,6 +640,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$natent['dns_parser_tcp'] = "yes";
 			$natent['dns_parser_udp_ports'] = "53";
 			$natent['dns_parser_tcp_ports'] = "53";
+			$natent['enip_parser'] = "yes";
 			$natent['http_parser'] = "yes";
 			$natent['tls_parser'] = "yes";
 			$natent['tls_detect_ports'] = "443";
@@ -654,6 +655,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$natent['imap_parser'] = "detection-only";
 			$natent['ssh_parser'] = "yes";
 			$natent['ftp_parser'] = "yes";
+			$natent['ftp_data_parser'] = "on";
 			$natent['dcerpc_parser'] = "yes";
 			$natent['smb_parser'] = "yes";
 			$natent['msn_parser'] = "detection-only";
@@ -663,6 +665,12 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$natent['tftp_parser'] = "yes";
 			$natent['ntp_parser'] = "yes";
 			$natent['dhcp_parser'] = "yes";
+			$natent['rdp_parser'] = "yes";
+			$natent['sip_parser'] = "yes";
+			$natent['snmp_parser'] = "yes";
+			$natent['http2_parser'] = "yes";
+			$natent['rfb_parser'] = "yes";
+			$natent['mqtt_parser'] = "yes";
 
 			$natent['enable_iprep'] = "off";
 			$natent['host_memcap'] = "33554432";

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
@@ -183,21 +183,21 @@ if (isset($_POST['save_auto_sid_conf'])) {
 		$a_nat[$k]['sid_state_order'] = $v;
 	}
 	foreach ($_POST['enable_sid_file'] as $k => $v) {
-		if ($v == "None") {
+		if (strcasecmp($v, "None") == 0) {
 			unset($a_nat[$k]['enable_sid_file']);
 			continue;
 		}
 		$a_nat[$k]['enable_sid_file'] = $v;
 	}
 	foreach ($_POST['disable_sid_file'] as $k => $v) {
-		if ($v == "None") {
+		if (strcasecmp($v, "None") == 0) {
 			unset($a_nat[$k]['disable_sid_file']);
 			continue;
 		}
 		$a_nat[$k]['disable_sid_file'] = $v;
 	}
 	foreach ($_POST['modify_sid_file'] as $k => $v) {
-		if ($v == "None") {
+		if (strcasecmp($v, "None") == 0) {
 			unset($a_nat[$k]['modify_sid_file']);
 			continue;
 		}
@@ -205,7 +205,7 @@ if (isset($_POST['save_auto_sid_conf'])) {
 	}
 
 	foreach ($_POST['drop_sid_file'] as $k => $v) {
-		if ($v == "None") {
+		if (strcasecmp($v, "None") == 0) {
 			unset($a_nat[$k]['drop_sid_file']);
 			continue;
 		}
@@ -213,7 +213,7 @@ if (isset($_POST['save_auto_sid_conf'])) {
 	}
 
 	foreach ($_POST['reject_sid_file'] as $k => $v) {
-		if ($v == "None") {
+		if (strcasecmp($v, "None") == 0) {
 			unset($a_nat[$k]['reject_sid_file']);
 			continue;
 		}
@@ -628,7 +628,7 @@ if ($savemsg) {
 								?>
 							</select>
 						<?php else : ?>
-							<input type="hidden" name="drop_sid_file[<?=$k?>]" id="drop_sid_file[<?=$k?>]" value="<?=isset($natent['drop_sid_file']) ? $natent['drop_sid_file'] : 'none';?>">
+							<input type="hidden" name="drop_sid_file[<?=$k?>]" id="drop_sid_file[<?=$k?>]" value="<?=isset($natent['drop_sid_file']) ? $natent['drop_sid_file'] : 'None';?>">
 							<span class="text-center"><?=gettext("N/A")?></span>
 						<?php endif; ?>
 					</td>
@@ -647,7 +647,7 @@ if ($savemsg) {
 								?>
 							</select>
 						<?php else : ?>
-							<input type="hidden" name="reject_sid_file[<?=$k?>]" id="reject_sid_file[<?=$k?>]" value="<?=isset($natent['reject_sid_file']) ? $natent['reject_sid_file'] : 'none';?>">
+							<input type="hidden" name="reject_sid_file[<?=$k?>]" id="reject_sid_file[<?=$k?>]" value="<?=isset($natent['reject_sid_file']) ? $natent['reject_sid_file'] : 'None';?>">
 							<span class="text-center"><?=gettext("N/A")?></span>
 						<?php endif; ?>
 					</td>


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.8_3
This update addresses Redmine Issues [13771](https://redmine.pfsense.org/issues/13771) and [13794](https://redmine.pfsense.org/issues/13794).

**New Features:**
None

**Bug Fixes:**
1. Fix [Redmine Issue #13771](https://redmine.pfsense.org/issues/13771) - Suricata tries to load invalid SID file.
2. Fix [Redmine Issue #13794](https://redmine.pfsense.org/issues/13794) - when adding a new interface the latest app-layer protocol decoders are not default enabled on the new interface.