### PR TITLE
Fix WWW for pfSense-pkg-lldpd

### DIFF
--- a/net-mgmt/pfSense-pkg-lldpd/pkg-descr
+++ b/net-mgmt/pfSense-pkg-lldpd/pkg-descr
@@ -3,4 +3,4 @@ as well as support for several proprietary discovery protocols including
 Cisco Discovery Protocol (CDP), Extreme Discovery Protocol (EDP), Foundry
 Discovery Protocol (FDP), and Nortel Discovery Protocol (NDP / SONMP).
 
-WWW: https://docs.netgate.com/pfsense/en/latest/packages/nut.html
+WWW: https://docs.netgate.com/pfsense/en/latest/packages/lldp.html


### PR DESCRIPTION
Though it's unclear if this is the correct page to link to. As that [page](https://docs.netgate.com/pfsense/en/latest/packages/lldp.html) references `lldpd`, but on [the package list](https://docs.netgate.com/pfsense/en/latest/packages/list.html) `LADVD` links to `https://docs.netgate.com/pfsense/en/latest/packages/lldp.html`.