### PR TITLE
pfSense-pkg-suricata-6.0.8_4 - Fix Suricata Redmine Issues #13806, #13808, and 13812

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.8
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -119,9 +119,7 @@ if (config_get_path('installedpackages/suricata/config/0/forcekeepsettings') == 
 		// Array of default events rules for Suricata. This array
 		// must be kept in sync with the content of the "/rules"
 		// directory in the Suricata binary source tarball.
-		$builtin_rules = array( "app-layer-events.rules", "decoder-events.rules", "dhcp-events.rules", "dnp3-events.rules", "dns-events.rules", "files.rules", "http-events.rules", "http2-events.rules", "ipsec-events.rules", 
-					"kerberos-events.rules", "modbus-events.rules", "mqtt-events.rules", "nfs-events.rules", "ntp-events.rules", "ssh-events.rules", "smb-events.rules", "smtp-events.rules", "stream-events.rules", 
-					"tls-events.rules" );
+		$builtin_rules = SURICATA_DEFAULT_RULES;
 
 		$a_ifaces = config_get_path('installedpackages/suricata/rule', []);
 		foreach ($a_ifaces as &$suricatacfg) {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -718,8 +718,25 @@ if (isset($_POST["save"]) && !$input_errors) {
 		// Refresh page fields with just-saved values
 		$pconfig = $natent;
 		$new_interface = false;
-	} else
+	} else {
+		// Restore the existing parameters so the user can fix the detected error
 		$pconfig = $_POST;
+		if ($_POST['eve_log_http_extended_headers']) {
+			$pconfig['eve_log_http_extended_headers'] = implode(", ",$_POST['eve_log_http_extended_headers']);
+		} else {
+			$pconfig['eve_log_http_extended_headers'] = "";
+		}
+		if ($_POST['eve_log_smtp_extended_fields']) {
+			$pconfig['eve_log_smtp_extended_fields'] = implode(", ",$_POST['eve_log_smtp_extended_fields']);
+		} else {
+			$pconfig['eve_log_smtp_extended_fields'] = "";
+		}
+		if ($_POST['eve_log_tls_extended_fields']) {
+			$pconfig['eve_log_tls_extended_fields'] = implode(", ",$_POST['eve_log_tls_extended_fields']);
+		} else {
+			$pconfig['eve_log_tls_extended_fields'] = "";
+		}
+	}
 }
 
 /**************************************************************/

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -113,7 +113,7 @@ $cat_mods = suricata_sid_mgmt_auto_categories($a_rule, FALSE);
 foreach ($cat_mods as $k => $v) {
 	switch ($v) {
 		case 'disabled':
-			if (($key = array_search($k, $categories)) !== FALSE)
+			if (($key = array_search($k, $categories, true)) !== FALSE)
 				unset($categories[$key]);
 			break;
 
@@ -161,11 +161,11 @@ elseif ($_POST['selectbox'])
 elseif ($_POST['openruleset'])
 	$currentruleset = $_POST['openruleset'];
 else
-	$currentruleset = $categories[0];
+	$currentruleset = $categories[array_key_first($categories)];
 
 // If we don't have any Category to display, then
 // default to showing the Custom Rules text control.
-if (empty($categories[0]) && ($currentruleset != "custom.rules") && ($currentruleset != "Auto-Flowbit Rules")) {
+if (empty($categories) && ($currentruleset != "custom.rules") && ($currentruleset != "Auto-Flowbit Rules")) {
 	if (!empty($a_rule['ips_policy']))
 		$currentruleset = "IPS Policy - " . ucfirst($a_rule['ips_policy']);
 	else
@@ -178,7 +178,8 @@ if (empty($tmp))
 	$currentruleset = "custom.rules";
 
 $ruledir = SURICATA_RULES_DIR;
-$rulefile = "{$ruledir}/{$currentruleset}";
+$rulefile = "{$ruledir}{$currentruleset}";
+
 if ($currentruleset != 'custom.rules') {
 	// Read the currently selected rules file into our rules map array.
 	// There are a few special cases possible, so test and adjust as
@@ -208,7 +209,7 @@ if ($currentruleset != 'custom.rules') {
 
 		// Prepend the Suricata rules path to each entry.
 		foreach ($rule_files as $k => $v) {
-			$rule_files[$k] = $ruledir . "/" . $v;
+			$rule_files[$k] = $ruledir . $v;
 		}
 		$rule_files[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
 		$rule_files[] = "{$suricatacfgdir}/rules/custom.rules";
@@ -221,7 +222,7 @@ if ($currentruleset != 'custom.rules') {
 
 		// Prepend the Suricata rules path to each entry.
 		foreach ($rule_files as $k => $v) {
-			$rule_files[$k] = $ruledir . "/" . $v;
+			$rule_files[$k] = $ruledir . $v;
 		}
 		$rule_files[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
 		$rule_files[] = "{$suricatacfgdir}/rules/custom.rules";
@@ -656,7 +657,7 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 
 		// Prepend the Suricata rules path to each entry.
 		foreach ($rule_files as $k => $v) {
-			$rule_files[$k] = $ruledir . "/" . $v;
+			$rule_files[$k] = $ruledir . $v;
 		}
 		$rule_files[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
 		$rule_files[] = "{$suricatacfgdir}/rules/custom.rules";
@@ -669,7 +670,7 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 
 		// Prepend the Suricata rules path to each entry.
 		foreach ($rule_files as $k => $v) {
-			$rule_files[$k] = $ruledir . "/" . $v;
+			$rule_files[$k] = $ruledir . $v;
 		}
 		$rule_files[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
 		$rule_files[] = "{$suricatacfgdir}/rules/custom.rules";
@@ -738,7 +739,7 @@ elseif (isset($_POST['resetall']) && !empty($rules_map)) {
 
 		// Prepend the Suricata rules path to each entry.
 		foreach ($rule_files as $k => $v) {
-			$rule_files[$k] = $ruledir . "/" . $v;
+			$rule_files[$k] = $ruledir . $v;
 		}
 		$rules_file[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
 		$rules_file[] = "{$suricatacfgdir}/rules/custom.rules";
@@ -751,7 +752,7 @@ elseif (isset($_POST['resetall']) && !empty($rules_map)) {
 
 		// Prepend the Suricata rules path to each entry.
 		foreach ($rule_files as $k => $v) {
-			$rule_files[$k] = $ruledir . "/" . $v;
+			$rule_files[$k] = $ruledir . $v;
 		}
 		$rules_file[] = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
 		$rules_file[] = "{$suricatacfgdir}/rules/custom.rules";

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -125,12 +125,10 @@ if (isset($_POST["save"])) {
 		unset($a_nat['ips_policy_mode']);
 	}
 
-	// Always start with the default events and files rules
-	$enabled_items = implode("||", $default_rules);
 	if (is_array($_POST['toenable']))
-		$enabled_items .= "||" . implode("||", $_POST['toenable']);
+		$enabled_items = implode("||", $_POST['toenable']);
 	else
-		$enabled_items .=  "||{$_POST['toenable']}";
+		$enabled_items =  "{$_POST['toenable']}";
 
 	$a_nat['rulesets'] = $enabled_items;
 
@@ -182,11 +180,10 @@ if (isset($_POST["save"])) {
 	$pconfig['ips_policy'] = $_POST['ips_policy'];
 	$pconfig['ips_policy_mode'] = $_POST['ips_policy_mode'];
 
-	// Remove all but the default events and files rules
+	// Remove all the rules
 	$enabled_rulesets_array = array();
-	$enabled_rulesets_array = $default_rules;
 
-	$savemsg = gettext("All rule categories have been de-selected.  ");
+	$savemsg = gettext("All rule categories, including default events rules, have been de-selected.  ");
 	if ($_POST['ips_policy_enable'] == "on")
 		$savemsg .= gettext("Only the rules included in the selected IPS Policy will be used.");
 	else


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.8_4
This update corrects Redmine Issues [#13806](https://redmine.pfsense.org/issues/13806), [#13808](https://redmine.pfsense.org/issues/13808), and [#13812](https://redmine.pfsense.org/issues/13812) reported for the Suricata package.

**New Features:**
None

**Bug Fixes:**
1. Fix [Redmine Issue #13806](https://redmine.pfsense.org/issues/13806), Suricata interface rules cannot be viewed.
2. Fix [Redmine Issue #13808](https://redmine.pfsense.org/issues/13808), Suricata saves duplicate entries for the default built-in rules when saving changes on the CATEGORIES tab.
3. Fix [Redmine Issue #13812](https://redmine.pfsense.org/issues/13812), attempting to change suricata blocking mode on LAN interface from legacy to inline throws a PHP error .