### PR TITLE
Feature #13821 (Redmine); Added pfSense-pkg-DNSleaktest source to sysutils;

### DIFF
--- a/sysutils/pfSense-pkg-DNSleaktest/LICENSE
+++ b/sysutils/pfSense-pkg-DNSleaktest/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sysutils/pfSense-pkg-DNSleaktest/Makefile
+++ b/sysutils/pfSense-pkg-DNSleaktest/Makefile
@@ -1,0 +1,48 @@
+PORTNAME=		pfSense-pkg-DNSleaktest
+PORTVERSION=		0.1.0
+CATEGORIES=		sysutils
+MASTER_SITES=		# empty
+DISTFILES=		# empty
+EXTRACT_ONLY=		# empty
+
+MAINTAINER=		luis@moraguez.com
+COMMENT=		DNSleaktest package for pfSense
+
+LICENSE=		APACHE20
+
+USE_GITHUB=		yes
+GH_ACCOUNT=		z3d6380
+
+NO_BUILD=		yes
+NO_MTREE=		yes
+
+SUB_FILES=		pkg-install pkg-deinstall
+SUB_LIST=		PORTNAME=${PORTNAME}
+
+do-extract:
+	${MKDIR} ${WRKSRC}
+
+do-install:
+	${MKDIR} ${STAGEDIR}${PREFIX}/pkg
+	${MKDIR} ${STAGEDIR}/etc/inc/priv
+	${MKDIR} ${STAGEDIR}${PREFIX}/www/packages/dnsleaktest
+	${MKDIR} ${STAGEDIR}${DATADIR}
+	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/dnsleaktest.xml \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/dnsleaktest.inc \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} -m 0755 ${FILESDIR}${PREFIX}/pkg/dnsleaktest.sh \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/dnsleaktest.priv.inc \
+		${STAGEDIR}/etc/inc/priv
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/packages/dnsleaktest/dnsleaktest.php \
+		${STAGEDIR}${PREFIX}/www/packages/dnsleaktest
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/packages/dnsleaktest/index.php \
+		${STAGEDIR}${PREFIX}/www/packages/dnsleaktest
+	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \
+		${STAGEDIR}${DATADIR}
+	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
+		${STAGEDIR}${PREFIX}/pkg/dnsleaktest.xml \
+		${STAGEDIR}${DATADIR}/info.xml
+
+.include <bsd.port.mk>

--- a/sysutils/pfSense-pkg-DNSleaktest/README.md
+++ b/sysutils/pfSense-pkg-DNSleaktest/README.md
@@ -1,0 +1,34 @@
+# pfSense-pkg-DNSleaktest
+A DNS Leaktest package I made for pfSense Project.
+
+## Installation
+Currently I'm working on the processes of getting this package prepped to be submitted to and reviewed by the maintainers of the pfSense Project, so that it will be included in future releases. If it does get approved, you will be able to install this package through the pfSense Package Manager.
+
+## Interface and Usage
+
+### GUI (Initial):
+![image](https://user-images.githubusercontent.com/73666574/209186555-3fcbfb3a-f0d8-4e64-8ace-dd8716ce9b15.png)
+ - GUI can be opened through the "Diagnostics" dropdown in the pfSense Menubar
+
+### GUI (Selected Network Interface and API):
+![image](https://user-images.githubusercontent.com/73666574/209186971-adc8d089-f7e8-49bd-929f-c96fd01ed766.png)
+ - **Source Interface**: Select an egress network interface (such as WAN or VPN Tunnel) to perform the test on
+ - **API Domain**: Select the dns leak test API of your choice (currently only bash.ws is supported)
+
+### GUI (Output after clicking "Scan" button):
+![image](https://user-images.githubusercontent.com/73666574/209187303-ea3d4585-f8a5-4ba2-829f-640305c6d6fe.png)
+- The results will be displayed to you. If more than one DNS server is detected, it will tell you that DNS may be leaking, so it will be up to you to determine if the DNS servers shown are the ones you intended on using, and if they are trustworthy.
+- Based on the results and your assesment of them, take the appropriate steps to remediate if necessary.
+
+
+## Action Items:
+- [x] Interface and support for bash.ws dns leak testing
+- [ ] Add support for other DNS Leak Testing APIs (dnsleaktest.com, etc)
+
+## Contributions:
+Contributions are welcome. Fork the repo, make your changes, create a diff file, and email the diff file and your GitHub username to luis@moraguez.com. If the changes are approved, you will be added as a contributor to the repo.
+
+## Donations:
+If this utility helped you with a project you're working on and you wish to make a donation, you can do so by clicking the donate button that follows. Thank you for your generosity and support!
+
+<noscript><a href="https://liberapay.com/z3d6380/donate"><img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg"></a></noscript>

--- a/sysutils/pfSense-pkg-DNSleaktest/distinfo
+++ b/sysutils/pfSense-pkg-DNSleaktest/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1672653998
+SHA256 (z3d6380-pfSense-pkg-DNSleaktest-0.1.0_GH0.tar.gz) = 004518feb986cd22fee76c7c7d3518c0c7717f5a228a3d06f4c2be81dccde038
+SIZE (z3d6380-pfSense-pkg-DNSleaktest-0.1.0_GH0.tar.gz) = 9684

--- a/sysutils/pfSense-pkg-DNSleaktest/files/etc/inc/priv/dnsleaktest.priv.inc
+++ b/sysutils/pfSense-pkg-DNSleaktest/files/etc/inc/priv/dnsleaktest.priv.inc
@@ -1,0 +1,33 @@
+<?php
+/*
+ * dnsleaktest.priv.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2015-2022 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2022 Luis Moraguez (Package Author)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+global $priv_list;
+
+$priv_list['page-diagnostics-dnsleaktest'] = array();
+$priv_list['page-diagnostics-dnsleaktest']['name'] = "WebCfg - Diagnostics: DNSleaktest package";
+$priv_list['page-diagnostics-dnsleaktest']['descr'] = "Allow access to DNSleaktest package GUI";
+
+$priv_list['page-diagnostics-dnsleaktest']['match'] = array();
+$priv_list['page-diagnostics-dnsleaktest']['match'][] = "packages/dnsleaktest/dnsleaktest.php*";
+$priv_list['page-diagnostics-dnsleaktest']['match'][] = "packages/dnsleaktest/index.php*";
+
+?>

--- a/sysutils/pfSense-pkg-DNSleaktest/files/pkg-deinstall.in
+++ b/sysutils/pfSense-pkg-DNSleaktest/files/pkg-deinstall.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/local/bin/php -f /etc/rc.packages %%PORTNAME%% ${2}

--- a/sysutils/pfSense-pkg-DNSleaktest/files/pkg-install.in
+++ b/sysutils/pfSense-pkg-DNSleaktest/files/pkg-install.in
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "${2}" != "POST-INSTALL" ]; then
+    exit 0
+fi
+
+${PKG_ROOTDIR}/usr/local/bin/php -f ${PKG_ROOTDIR}/etc/rc.packages %%PORTNAME%% ${2}

--- a/sysutils/pfSense-pkg-DNSleaktest/files/usr/local/pkg/dnsleaktest.inc
+++ b/sysutils/pfSense-pkg-DNSleaktest/files/usr/local/pkg/dnsleaktest.inc
@@ -1,0 +1,26 @@
+<?php
+/*
+ * dnsleaktest.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2015-2022 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2022 Luis Moraguez (Package Author)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once('pfsense-utils.inc');
+require_once('interfaces.inc');
+
+?>

--- a/sysutils/pfSense-pkg-DNSleaktest/files/usr/local/pkg/dnsleaktest.sh
+++ b/sysutils/pfSense-pkg-DNSleaktest/files/usr/local/pkg/dnsleaktest.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+# MIT License
+
+# Copyright (c) 2018 macvk - (This version is derived from https://github.com/macvk/dnsleaktest)
+# Copyright (c) 2022 Luis Moraguez (For modifications to pass api domain and interface parameters to shell script)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+api_domain=$1
+source_interface=$2
+error_code=1
+
+function increment_error_code {
+    error_code=$((error_code + 1))
+}
+
+function program_exit {
+    command -v $1 > /dev/null
+    if [ $? -ne 0 ]; then
+        echo "Please, install \"$1\""
+        exit $error_code
+    fi
+    increment_error_code
+}
+
+function check_internet_connection {
+    curl --interface $source_interface --silent --head  --request GET "https://${api_domain}" | grep "200 OK" > /dev/null
+    if [ $? -ne 0 ]; then
+        echo "No internet connection."
+        exit $error_code
+    fi
+    increment_error_code
+}
+
+program_exit curl --interface $source_interface
+program_exit ping
+check_internet_connection
+
+if command -v jq &> /dev/null; then
+    jq_exists=1
+else
+    jq_exists=0
+fi
+
+if hash shuf 2>/dev/null; then
+    id=$(shuf -i 1000000-9999999 -n 1)
+else
+    id=$(jot -w %i -r 1 1000000 9999999)
+fi
+
+for i in $(seq 1 10); do
+    ping -c 1 "${i}.${id}.${api_domain}" > /dev/null 2>&1
+done
+
+function print_servers {
+
+    if (( "$jq_exists" )); then
+
+        echo "${result_json}" | \
+            jq  --monochrome-output \
+            --raw-output \
+            ".[] | select(.type == \"${1}\") | \"\(.ip)\(if .country_name != \"\" and  .country_name != false then \" [\(.country_name)\(if .asn != \"\" and .asn != false then \" \(.asn)\" else \"\" end)]\" else \"\" end)\""
+
+    else
+
+        while IFS= read -r line; do
+            if [[ "$line" != *${1} ]]; then
+                continue
+            fi
+
+            ip=$(echo "$line" | cut -d'|' -f 1)
+            code=$(echo "$line" | cut -d'|' -f 2)
+            country=$(echo "$line" | cut -d'|' -f 3)
+            asn=$(echo "$line" | cut -d'|' -f 4)
+
+            if [ -z "${ip// }" ]; then
+                 continue
+            fi
+
+            if [ -z "${country// }" ]; then
+                 echo "$ip"
+            else
+                 if [ -z "${asn// }" ]; then
+                     echo "$ip [$country]"
+                 else
+                     echo "$ip [$country, $asn]"
+                 fi
+            fi
+        done <<< "$result_txt"
+
+    fi
+}
+
+
+if (( "$jq_exists" )); then
+    result_json=$(curl --interface $source_interface --silent "https://${api_domain}/dnsleak/test/${id}?json")
+else
+    result_txt=$(curl --interface $source_interface --silent "https://${api_domain}/dnsleak/test/${id}?txt")
+fi
+
+dns_count=$(print_servers "dns" | wc -l)
+
+echo "Your IP:"
+print_servers "ip"
+
+echo ""
+if [ "${dns_count}" -eq "0" ];then
+    echo "No DNS servers found"
+else
+    if [ "${dns_count}" -eq "1" ];then
+        echo "You use ${dns_count} DNS server:"
+    else
+        echo "You use ${dns_count} DNS servers:"
+    fi
+    print_servers "dns"
+fi
+
+echo ""
+echo "Conclusion:"
+print_servers "conclusion"
+
+exit 0

--- a/sysutils/pfSense-pkg-DNSleaktest/files/usr/local/pkg/dnsleaktest.xml
+++ b/sysutils/pfSense-pkg-DNSleaktest/files/usr/local/pkg/dnsleaktest.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
+<packagegui>
+    <copyright>
+    <![CDATA[
+        /*
+        * dnsleaktest.xml
+        *
+        * part of pfSense (https://www.pfsense.org)
+        * Copyright (c) 2015-2022 Rubicon Communications, LLC (Netgate)
+        * Copyright (c) 2022 Luis Moraguez (Package Author)
+        * All rights reserved.
+        *
+        * Licensed under the Apache License, Version 2.0 (the "License");
+        * you may not use this file except in compliance with the License.
+        * You may obtain a copy of the License at
+        *
+        * http://www.apache.org/licenses/LICENSE-2.0
+        *
+        * Unless required by applicable law or agreed to in writing, software
+        * distributed under the License is distributed on an "AS IS" BASIS,
+        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        * See the License for the specific language governing permissions and
+        * limitations under the License.
+        */
+	]]>
+    </copyright>
+    <name>dnsleaktest</name>
+    <version>%%PKGVERSION%%</version>
+    <title>DNSleaktest Settings</title>
+    <include_file>/usr/local/pkg/dnsleaktest.inc</include_file>
+    <menu>
+        <name>DNSleaktest</name>
+        <section>Diagnostics</section>
+        <configfile>dnsleaktest.xml</configfile>
+        <url>/packages/dnsleaktest/dnsleaktest.php</url>
+    </menu>
+</packagegui>

--- a/sysutils/pfSense-pkg-DNSleaktest/files/usr/local/share/pfSense-pkg-DNSleaktest/info.xml
+++ b/sysutils/pfSense-pkg-DNSleaktest/files/usr/local/share/pfSense-pkg-DNSleaktest/info.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<pfsensepkgs>
+    <package>
+        <name>DNSleaktest</name>
+        <descr><![CDATA[The DNSleaktest utility is used to test whether or not there is a dns leak on any outgoing interface.]]></descr>
+        <version>%%PKGVERSION%%</version>
+        <configurationfile>dnsleaktest.xml</configurationfile>
+        <category>Diagnostics</category>
+    </package>
+</pfsensepkgs>

--- a/sysutils/pfSense-pkg-DNSleaktest/files/usr/local/www/packages/dnsleaktest/dnsleaktest.php
+++ b/sysutils/pfSense-pkg-DNSleaktest/files/usr/local/www/packages/dnsleaktest/dnsleaktest.php
@@ -1,0 +1,129 @@
+<?php
+/*
+ * dnsleaktest.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2015-2022 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2022 Luis Moraguez (Package Author)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+##|+PRIV
+##|*IDENT=page-diagnostics-dnsleaktest
+##|*NAME=Diagnostics: DNSleaktest
+##|*DESCR=Allow access to the 'Diagnostics: DNSleaktest' page.
+##|*MATCH=dnsleaktest.php*
+##|-PRIV
+
+$allowautocomplete = true;
+$pgtitle = array(gettext("Diagnostics"), gettext("DNSleaktest"));
+require_once("guiconfig.inc");
+require_once("/usr/local/pkg/dnsleaktest.inc");
+
+$do_dnsleaktest = false;
+$api_domain = '';
+$sourceif = '';
+
+# Function to get real interfaces and convert to array
+$real_interfaces = shell_exec("/sbin/ifconfig -a | /usr/bin/sed 's/[ :\t].*//;/^$/d'");
+$real_interfaces_array = explode("\n", $real_interfaces);
+# Remove last element of array (blank space)
+array_pop($real_interfaces_array);
+
+# if submit button is clicked
+if ($_POST['submit']) {
+    unset($input_errors);
+    unset($do_dnsleaktest);
+
+    # Check if source interface is selected
+    if (empty($_POST['srcinterface'])) {
+        $input_errors[] = gettext("You must select a source interface.");
+    }
+
+    # Check if API domain is empty
+    if (empty($_POST['api_domain'])) {
+        $input_errors[] = gettext("You must enter an API domain.");
+    }
+
+    # If no errors, run the test
+    if (!$input_errors) {
+        if ($_POST) {
+            $do_dnsleaktest = true;
+        }
+        if (isset($_REQUEST['srcinterface'])) {
+            $sourceif = $_REQUEST['srcinterface'];
+        }
+        if (isset($_REQUEST['api_domain'])) {
+            $api_domain = $_REQUEST['api_domain'];
+        }
+    }
+}
+
+if ($do_dnsleaktest) {
+    $command = "/usr/local/pkg/dnsleaktest.sh";
+    $cmd = "{$command} {$api_domain} {$sourceif}";
+    $result = shell_exec($cmd);
+}
+
+include("head.inc");
+
+?>
+
+<?php
+    $form = new Form(false);
+    $section = new Form_Section('DNSleaktest');
+
+    $section->addInput(new Form_Select(
+        'srcinterface',
+        '*Source Interface',
+        $sourceif,
+        ['' => ''] + array_combine($real_interfaces_array, $real_interfaces_array)
+    ))->setHelp('Select the source interface for the DNSleaktest query.');
+
+    $section->addInput(new Form_Select(
+        'api_domain',
+        '*API Domain',
+        $api_domain,
+        ['' => '', 'bash.ws' => 'bash.ws']
+    ))->setHelp('Select the API Domain for the DNSleaktest query.');
+
+    $form->add($section);
+
+    $form->addGlobal(new Form_Button(
+        'submit',
+        'Scan',
+        null,
+        'fa-rss'        
+    ))->addClass('btn-primary');
+
+    print $form;
+
+    if ($do_dnsleaktest && !empty($result)) {
+?>
+
+    <div class="panel panel-default">
+		<div class="panel-heading">
+			<h2 class="panel-title"><?=gettext('Results')?></h2>
+		</div>
+
+		<div class="panel-body">
+			<pre><?= htmlspecialchars($result) ?></pre>
+		</div>
+	</div>
+
+<?php 
+}
+
+include("foot.inc"); ?>

--- a/sysutils/pfSense-pkg-DNSleaktest/files/usr/local/www/packages/dnsleaktest/index.php
+++ b/sysutils/pfSense-pkg-DNSleaktest/files/usr/local/www/packages/dnsleaktest/index.php
@@ -1,0 +1,6 @@
+<?php
+
+Header("Location: /");
+exit;
+
+?>

--- a/sysutils/pfSense-pkg-DNSleaktest/pkg-descr
+++ b/sysutils/pfSense-pkg-DNSleaktest/pkg-descr
@@ -1,0 +1,3 @@
+The DNSleaktest utility is used to test whether or
+not there is a dns leak on any outgoing interface.
+From the GUI you would select the outgoing interfaces.

--- a/sysutils/pfSense-pkg-DNSleaktest/pkg-plist
+++ b/sysutils/pfSense-pkg-DNSleaktest/pkg-plist
@@ -1,0 +1,8 @@
+/etc/inc/priv/dnsleaktest.priv.inc
+pkg/dnsleaktest.inc
+pkg/dnsleaktest.sh
+pkg/dnsleaktest.xml
+%%DATADIR%%/info.xml
+www/packages/dnsleaktest/dnsleaktest.php
+www/packages/dnsleaktest/index.php
+@dir /etc/inc/priv


### PR DESCRIPTION
Added pfSense-pkg-DNSleaktest source to sysutils; portlint passing;

'make install' is also working and allowing me to see the package added to the pfSense GUI, under the "Diagnostics" category. The package itself is working once accessed through GUI, and DNS leak test on outgoing interfaces works.

Redmine issue submitted: https://redmine.pfsense.org/issues/13821

