### PR TITLE
pfSense-pkg-suricata-6.0.8_5 - Improve uninstall code based on Redmine 13827 and add one new feature

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.8
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
@@ -32,8 +32,6 @@ $suricatalogdir = SURICATALOGDIR;
 $sidmodspath = SURICATA_SID_MODS_PATH;
 $iprep_path = SURICATA_IPREP_PATH;
 $rcdir = RCFILEPREFIX;
-$suricata_rules_upd_log = SURICATA_RULES_UPD_LOGFILE;
-$suri_pf_table = SURICATA_PF_TABLE;
 
 syslog(LOG_NOTICE, gettext("[Suricata] Suricata package uninstall in progress..."));
 
@@ -61,16 +59,16 @@ sleep(1);
 unlink_if_exists("{$g['varrun_path']}/barnyard2_*.pid");
 
 /* Remove the Suricata cron jobs. */
-install_cron_job("suricata_check_for_rule_updates.php", false);
-install_cron_job("suricata_check_cron_misc.inc", false);
-install_cron_job("{$suri_pf_table}" , false);
-install_cron_job("suricata_geoipupdate.php" , false);
-install_cron_job("suricata_etiqrisk_update.php", false);
+install_cron_job("/usr/local/pkg/suricata/suricata_check_for_rule_updates.php", false);
+install_cron_job("/usr/local/pkg/suricata/suricata_check_cron_misc.inc", false);
+install_cron_job(SURICATA_PF_TABLE, false);
+install_cron_job("/usr/local/pkg/suricata/suricata_geoipupdate.php" , false);
+install_cron_job("/usr/local/pkg/suricata/suricata_etiqrisk_update.php", false);
 
 /* See if we are to keep Suricata log files on uninstall */
 if (config_get_path('installedpackages/suricata/config/0/clearlogs') == 'on') {
 	syslog(LOG_NOTICE, gettext("[Suricata] Clearing all Suricata-related log files..."));
-	unlink_if_exists("{$suricata_rules_upd_log}");
+	unlink_if_exists(SURICATA_RULES_UPD_LOGFILE);
 	rmdir_recursive("{$suricatalogdir}");
 }
 
@@ -124,15 +122,18 @@ if (config_get_path('installedpackages/suricata/config/0/clearblocks') == 'on') 
 	mwexec("/sbin/pfctl -t snort2c -T flush");
 }
 
-/* Keep this as a last step */
+/* Keep this as the last step of the uninstall procedure */
 if (config_get_path('installedpackages/suricata/config/0/forcekeepsettings') != 'on') {
-	syslog(LOG_NOTICE, gettext("Not saving settings... all Suricata configuration info and logs deleted..."));
+	syslog(LOG_NOTICE, gettext("Not saving Suricata settings... all Suricata configuration info and logs deleted..."));
 	config_del_path('installedpackages/suricata');
 	config_del_path('installedpackages/suricatasync');
-	unlink_if_exists("{$suricata_rules_upd_log}");
+	unlink_if_exists(SURICATA_RULES_UPD_LOGFILE);
 	rmdir_recursive("{$suricatalogdir}");
-	write_config("Removing Suricata configuration");
-	syslog(LOG_NOTICE, gettext("[Suricata] The package has been removed from this system..."));
+	write_config("Deleted the Suricata package and its configuration settings.");
+	syslog(LOG_NOTICE, gettext("[Suricata] The package and its configuration settings have been deleted from this system..."));
+} else {
+	write_config("Removed the Suricata package.");
+	syslog(LOG_NOTICE, gettext("[Suricata] The package has been removed from this system, but the configuration settings were retained..."));
 }
 
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -65,6 +65,7 @@ $extra_rules = config_get_path('installedpackages/suricata/config/0/extra_rules/
 $no_emerging_files = false;
 $no_snort_files = false;
 $inline_ips_mode = $a_nat['ips_mode'] == 'ips_mode_inline' ? true:false;
+$ips_policy_mode_enable = $a_nat['block_drops_only'] == 'on' ? true:false;
 
 $enabled_rulesets_array = explode("||", $a_nat['rulesets']);
 
@@ -981,7 +982,7 @@ events.push(function() {
 		var endis = !($('#ips_policy_enable').prop('checked'));
 
 		hideInput('ips_policy', endis);
-	<?php if ($inline_ips_mode): ?>
+	<?php if ($inline_ips_mode || $ips_policy_mode_enable): ?>
 			hideInput('ips_policy_mode', endis);
 	<?php else: ?>
 			hideInput('ips_policy_mode', true);


### PR DESCRIPTION
### pfSense-pkg-6.0.8_5
This update improves the code flow during package uninstallation based on items discussed in [Redmine Issue #13827](https://redmine.pfsense.org/issues/13827). One new feature is also added allowing use of IPS Policy Mode to automatically set rule actions when using either Inline IPS Mode or Block On DROPs Only Mode.

**New Features:**
1. Added the ability to utilize the built-in IPS Policy "action" metadata to automatically set IPS Policy rule actions to the value specified in the policy metadata (alert or drop) when using Legacy Blocking Mode with the "Block on DROPs Only" option enabled. Formerly IPS Policy "action" metadata was only available for use when using Inline IPS Mode, but that option can also be effective in Legacy Mode Blocking when "Block on DROPs Only" is enabled.

**Bug Fixes:**
1. Improved the code flow in the package uninstall function based on information gleaned from [Redmine Issue #13827](https://redmine.pfsense.org/issues/13827).