### PR TITLE
pfSense-pkg-snort-4.1.6_3 - Fix Redmine #13858

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.1.6
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_rules.php
@@ -127,7 +127,7 @@ $cat_mods = snort_sid_mgmt_auto_categories($a_rule[$id], FALSE);
 foreach ($cat_mods as $k => $v) {
 	switch ($v) {
 		case 'disabled':
-			if (($key = array_search($k, $categories)) !== FALSE)
+			if (($key = array_search($k, $categories, true)) !== FALSE)
 				unset($categories[$key]);
 			break;
 
@@ -173,7 +173,7 @@ if (isset($_POST['openruleset']))
 elseif (isset($_GET['openruleset']))
 	$currentruleset = htmlspecialchars($_GET['openruleset']);
 else
-	$currentruleset = $categories[key($categories)];
+	$currentruleset = $categories[array_key_first($categories)];
 
 // One last sanity check -- if the rules directory is empty, default to loading custom rules
 $tmp = glob("{$snortdir}/rules/*.rules");

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_sid_mgmt.php
@@ -185,7 +185,7 @@ if (isset($_POST['save_auto_sid_conf'])) {
 	}
 	if (is_array($_POST['enable_sid_file'])) {
 		foreach ($_POST['enable_sid_file'] as $k => $v) {
-			if ($v == "None") {
+			if (strcasecmp($v, "None") == 0) {
 				unset($a_nat[$k]['enable_sid_file']);
 				continue;
 			}
@@ -194,7 +194,7 @@ if (isset($_POST['save_auto_sid_conf'])) {
 	}
 	if (is_array($_POST['disable_sid_file'])) {
 		foreach ($_POST['disable_sid_file'] as $k => $v) {
-			if ($v == "None") {
+			if (strcasecmp($v, "None") == 0) {
 				unset($a_nat[$k]['disable_sid_file']);
 				continue;
 			}
@@ -203,7 +203,7 @@ if (isset($_POST['save_auto_sid_conf'])) {
 	}
 	if (is_array($_POST['modify_sid_file'])) {
 		foreach ($_POST['modify_sid_file'] as $k => $v) {
-			if ($v == "None") {
+			if (strcasecmp($v, "None") == 0) {
 				unset($a_nat[$k]['modify_sid_file']);
 				continue;
 			}
@@ -213,7 +213,7 @@ if (isset($_POST['save_auto_sid_conf'])) {
 
 	if (is_array($_POST['drop_sid_file'])) {
 		foreach ($_POST['drop_sid_file'] as $k => $v) {
-			if ($v == "None") {
+			if (strcasecmp($v, "None") == 0) {
 				unset($a_nat[$k]['drop_sid_file']);
 				continue;
 			}
@@ -223,7 +223,7 @@ if (isset($_POST['save_auto_sid_conf'])) {
 
 	if (is_array($_POST['reject_sid_file'])) {
 		foreach ($_POST['reject_sid_file'] as $k => $v) {
-			if ($v == "None") {
+			if (strcasecmp($v, "None") == 0) {
 				unset($a_nat[$k]['reject_sid_file']);
 				continue;
 			}
@@ -629,7 +629,7 @@ print($section);
 								?>
 							</select>
 						<?php else : ?>
-							<input type="hidden" name="drop_sid_file[<?=$k?>]" id="drop_sid_file[<?=$k?>]" value="<?=isset($natent['drop_sid_file']) ? $natent['drop_sid_file'] : 'none';?>">
+							<input type="hidden" name="drop_sid_file[<?=$k?>]" id="drop_sid_file[<?=$k?>]" value="<?=isset($natent['drop_sid_file']) ? $natent['drop_sid_file'] : 'None';?>">
 							<span class="text-center"><?=gettext("N/A")?></span>
 						<?php endif; ?>
 					</td>
@@ -648,7 +648,7 @@ print($section);
 								?>
 							</select>
 						<?php else : ?>
-							<input type="hidden" name="reject_sid_file[<?=$k?>]" id="reject_sid_file[<?=$k?>]" value="<?=isset($natent['reject_sid_file']) ? $natent['reject_sid_file'] : 'none';?>">
+							<input type="hidden" name="reject_sid_file[<?=$k?>]" id="reject_sid_file[<?=$k?>]" value="<?=isset($natent['reject_sid_file']) ? $natent['reject_sid_file'] : 'None';?>">
 							<span class="text-center"><?=gettext("N/A")?></span>
 						<?php endif; ?>
 					</td>


### PR DESCRIPTION
### pfSense-pkg-snort-4.1.6_3

This update corrects three GUI issues originally identified in Suricata that were also present in Snort due to the shared PHP code between the two packages.

**New Features:**
None

**Bug Fixes:**
1. Fix [Redmine Issue #13858](https://redmine.pfsense.org/issues/13858).