### PR TITLE
pfSense-pkg-suricata-6.0.8_6_PHP-8.1 - Fix Redmine Issue #13870, PHP error when building VPNs List

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.8
-PORTREVISION=	5
+PORTREVISION=	6
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -4258,7 +4258,7 @@ function suricata_get_vpns_list() {
 	}
 	// OpenVPN CSO
 	foreach (config_get_path('openvpn/openvpn-csc', []) as $ovpnent) {
-		if (is_array($ovpnent) && !config_path_enabled($ovpnent, 'disable')) {
+		if (is_array($ovpnent) && !array_path_enabled($ovpnent, 'disable')) {
 			if (!empty($ovpnent['tunnel_network'])) {
 				if (function_exists('openvpn_gen_tunnel_network')) {
 					$vpns_arr[] = implode('/', openvpn_gen_tunnel_network($ovpnent['tunnel_network']));


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.8_6
This update corrects the problem identified in [Redmine Issue #13870](https://redmine.pfsense.org/issues/13870).

**New Features:**
None

**Bug Fixes:**
1. Fix [Redmine Issue #13870](https://redmine.pfsense.org/issues/13870) - PHP error thrown when building VPNs list for use in a Pass List.