### PR TITLE
pfBlockerNG-devel v3.1.0_10

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG-devel/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-pfBlockerNG-devel
 PORTVERSION=	3.1.0
-PORTREVISION=	9
+PORTREVISION=	10
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -254,6 +254,7 @@ $pfb['mime_types'] = array_flip(array(	'inode/x-empty',
 					'text/xml',
 					'text/csv',
 					'application/csv',
+					'application/json',
 					'application/x-tar',
 					'application/gzip',
 					'application/x-gzip',
@@ -343,11 +344,11 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 				}
 
 				$validate_list = '';
-				if (!$data || !is_array($data) || !isset($data['path']) || empty($data['path'])) {
+				if (!$data || !is_array($data)) {
 					pfb_logger("{$header} Invalid URL (missing data) [ " . htmlspecialchars($input) . " ]", 6);
 					return FALSE;
 				} elseif (!isset($data['host']) || empty($data['host'])) {
-					pfb_logger("{$header} Invalid URL (missing data2) [ " . htmlspecialchars($input) . " ]", 6);
+					pfb_logger("{$header} Invalid URL (missing hostname) [ " . htmlspecialchars($input) . " ]", 6);
 					return FALSE;
 				} elseif (is_ipaddr($data['host'])) {
 					$validate_list = array(array('type' => 'IP', 'data' => $data['host']));
@@ -517,7 +518,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			break;
 		case PFB_FILTER_CSV_WHOIS:
 			// Validate Whoisconvert string
-			if (preg_match("/^[a-zA-Z0-9,\._]+$/", $input)) {
+			if (preg_match("/^[a-zA-Z0-9,\._\-]+$/", $input)) {
 				$result = htmlspecialchars($input);
 			}
 			break;
@@ -565,9 +566,9 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			if ($retval != 0 || empty($output[0]) || !isset($pfb['mime_types'][$output[0]])) {
 
 				// Exceptions
+				$hostname = parse_url($input[2], PHP_URL_HOST);
 				if ($output[0] == 'text/x-asm' &&
-				    ($input[2] == 'https://easylist-downloads.adblockplus.org/easylist_noelemhide.txt' ||
-				    $input[2] == 'https://easylist.to/easylist/easyprivacy.txt')) {
+				    ($hostname == 'easylist-downloads.adblockplus.org' || $hostname == 'easylist.to' )) {
 					$output[0] = 'text/plain';
 				}
 				else {
@@ -593,17 +594,9 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			}
 			exec("/usr/bin/file -bZ --mime-type {$input[0]} 2>&1", $output, $retval);
 			if ($retval != 0 || empty($output[0]) || !isset($pfb['mime_types'][$output[0]])) {
-
-				// Exception for Stop Forum Spam
-				if ($output[0] == 'application/x-decompression-error-gzip-Unknown-compression-format' &&
-				    parse_url($input[2], PHP_URL_HOST) == 'www.stopforumspam.com') {
-					$output[0] = 'text/plain';
-				}
-				else {
-					pfb_logger("{$header} Failed or invalid Mime Type Compressed: [" .  htmlspecialchars($output[0]) . "|" . htmlspecialchars($retval) . "]", 2);
-					unlink_if_exists($input[1]);
-					return FALSE;
-				}
+				pfb_logger("{$header} Failed or invalid Mime Type Compressed: [" .  htmlspecialchars($output[0]) . "|" . htmlspecialchars($retval) . "]", 2);
+				unlink_if_exists($input[1]);
+				return FALSE;
 			}
 			$result = htmlspecialchars($output[0]);
 			break;
@@ -3897,12 +3890,15 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 	$list_url = trim($list_url);
 
 	// Re-evaluate URL
-	if ($format == 'whois' || $format == 'asn') {
-		if (empty(pfb_filter($list_url, PFB_FILTER_ALNUM, 'pfb_download'))) {
-			pfb_logger("\n Failed", 2);
-			return FALSE;
-		}
-	} elseif (!pfb_filter($list_url, PFB_FILTER_URL, 'pfb_download')) {
+	if ($format == 'whois' && empty(pfb_filter($list_url, PFB_FILTER_DOMAIN, 'pfb_download'))) {
+		pfb_logger("\n Failed", 2);
+		return FALSE;
+	}
+	elseif ($format == 'asn' && empty(pfb_filter($list_url, PFB_FILTER_ALNUM, 'pfb_download'))) {
+		pfb_logger("\n Failed", 2);
+		return FALSE;
+	}
+	elseif (!pfb_filter($list_url, PFB_FILTER_URL, 'pfb_download_failure')) {
 		pfb_logger("\n Failed", 2);
 		return FALSE;
 	}
@@ -4101,7 +4097,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			if ($type == 'geoip') {
 				// Extras - MaxMind downloads
 				@rename("{$file_download}", strstr("{$file_download}", '.raw', TRUE));
-				exec("/usr/bin/tar -xzf {$file_dwn_esc} --strip=1 -C {$pfb['geoipshare']} >/dev/null 2>&1");
+				exec("/usr/bin/tar -xzf {$file_download} --strip=1 -C {$pfb['geoipshare']} >/dev/null 2>&1");
 				return TRUE;
 			}
 			elseif ($type == 'blacklist') {
@@ -4161,9 +4157,11 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 
 			pfb_logger('.', 1);
 
+			/* TODO: FIX - Bypass ZIP Compression file mime type validation due to incompatability with ZIP files
 			if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download')) {
 				return FALSE;
 			}
+			*/
 
 			// Check if ZIP archive contains xlsx files
 			$xlsxtest = exec("/usr/bin/tar -tf {$file_dwn_esc}");
@@ -4177,6 +4175,12 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				pfb_logger('.', 1);
 				// Process ZIP file (SFS and hpHosts workaround)
 				exec("/usr/bin/tar -xOf {$file_dwn_esc} | /usr/bin/sed 's/,[[:space:]]/; /g' | /usr/bin/tr ',' '\n' > {$file_org_esc}", $output, $retval);
+			}
+
+			// TODO: Validate file contents after extraction (to be removed once ZIP compression file mime type is fixed above)
+			if (!pfb_filter(array("{$file_org_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME, 'pfb_download')) {
+				unlink_if_exists("{$file_org_esc}");
+				return FALSE;
 			}
 		}
 		elseif ($file_type == 'application/x-7z-compressed') {
@@ -4235,7 +4239,7 @@ function pfb_download_failure($alias, $header, $pfbfolder, $list_url, $format, $
 	// Re-evaluate URL
 	if ($format == 'whois' && empty(pfb_filter($list_url, PFB_FILTER_DOMAIN, 'pfb_download_failure'))) {
 		pfb_logger("\n Invalid WHOIS. Terminating Download! [ {$list_url} ]\n", 1);
-	} 
+	}
 	elseif ($format == 'asn' && empty(pfb_filter($list_url, PFB_FILTER_ALNUM, 'pfb_download_failure'))) {
 		pfb_logger("\n Invalid ASN. Terminating Download! [ {$list_url} ]\n", 1);
 	}
@@ -7319,11 +7323,11 @@ function sync_package_pfblockerng($cron='') {
 	if (!$pfb['dnsbl_py_blacklist']) {
 		$pfb['pfs_mem'] = array(   '0' => '100000', '1500' =>  '150000', '2000' =>  '200000', '2500' =>  '250000', '3000' =>  '400000',
 					'4000' => '600000', '5000' => '1000000', '6000' => '1500000', '7000' => '2000000', '8000' => '2500000',
-					'12000' => '3000000', '16000' => '4000000');
+					'12000' => '3000000', '16000' => '4000000', '32000' => '8000000');
 	} else {
 		$pfb['pfs_mem'] = array(   '0' => '200000', '1500' =>  '300000', '2000' =>  '400000', '2500' =>  '500000', '3000' =>  '800000',
 					'4000' => '1200000', '5000' => '2000000', '6000' => '3000000', '7000' => '4000000', '8000' => '5000000',
-					'12000' => '6000000', '16000' => '8000000');
+					'12000' => '6000000', '16000' => '8000000', '32000' => '16000000');
 	}
 
 	foreach ($pfb['pfs_mem'] as $pfb_mem => $domain_max) {
@@ -8277,7 +8281,7 @@ function sync_package_pfblockerng($cron='') {
 								pfb_logger("{$log}", 2);
 								continue;
 							}
-							$header_esc = escapeshellarg($header);
+							$header_esc	= escapeshellarg($header);
 
 							$liteparser	= FALSE;	// Minimal DNSBL Parser
 							$rev_format	= FALSE;	// Host style format is reversed
@@ -10816,6 +10820,12 @@ function pfblockerng_php_pre_deinstall_command() {
 		unlink_if_exists("{$pfb['dnsbl_conf']}");
 		unlink_if_exists("{$pfb['dnsbl_cert']}");
 		unlink_if_exists("{$pfb['aliasarchive']}");
+		unlink_if_exists("{$pfb['dnsbl_info']}");
+		unlink_if_exists("{$pfb['dnsbl_resolver']}");
+
+		unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound.py");
+		unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound_include.inc");
+		unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_hsts.txt");
 	}
 	else {
 		update_status(" All customizations/data will be retained...");
@@ -10828,15 +10838,9 @@ function pfblockerng_php_pre_deinstall_command() {
 	unlink_if_exists('/usr/local/etc/rc.d/pfb_filter.sh');
 	unlink_if_exists('/usr/local/etc/rc.d/pfb_dnsbl.sh');
 
-	unlink_if_exists("{$pfb['dnsbl_info']}");
-	unlink_if_exists("{$pfb['dnsbl_resolver']}");
 	unlink_if_exists("{$pfb['dnsbl_cache']}");
 	unlink_if_exists("/var/tmp/unbound_cache_*");
 	unlink_if_exists("{$pfb['ip_cache']}");
-
-	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound.py");
-	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound_include.inc");
-	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_hsts.txt");
 
 	// Remove incorrect xml setting
 	if (isset($config['installedpackages']['pfblockerngantartica'])) {

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -22,6 +22,7 @@
 
 require_once('pfsense-utils.inc');
 require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
+require_once('/usr/local/www/pfblockerng/pfblockerng.php');
 
 global $config, $g, $pfb;
 pfb_global();
@@ -31,16 +32,22 @@ $g['pfblockerng_install'] = TRUE;
 
 // MaxMind Database is no longer pre-installed during package installation
 if (empty($pfb['maxmind_key'])) {
- update_status("\nMaxMind GeoIP databases are not pre-installed during installation.\nTo utilize the MaxMind GeoIP functionalities, you will be required to register for a free MaxMind user account and access key. Review the IP tab: MaxMind Settings for more details.\n\n");
+	update_status("\nMaxMind GeoIP databases are not pre-installed during installation.\nTo utilize the MaxMind GeoIP functionalities, you will be required to register for a free MaxMind user account and access key. Review the IP tab: MaxMind Settings for more details.\n\n");
+}
+else {
+	// Update any PHP changes to GeoIP Tabs
+	update_status("\nRebuilding GeoIP tabs...");
+	pfblockerng_get_countries();
+	update_status(" done.");
 }
 
 // Create Reputation tab
 if (!file_exists('/usr/local/www/pfblockerng/pfblockerng_reputation.php') || empty($pfb['maxmind_key'])) {
-	require_once('/usr/local/www/pfblockerng/pfblockerng.php');
+	update_status("\nRebuild Reputation tab...");
 	pfb_build_reputation_tab();
+	update_status(" done.");
 }
 
-$pfb['widgets'] = $config['widgets']['sequence'];
 if ($pfb['keep'] == 'on' && isset($pfb['widgets']) && strpos($pfb['widgets'], 'pfblockerng') !== FALSE) {
 	update_status("\nRestoring previous pfBlockerNG Widget settings...");
 
@@ -52,21 +59,23 @@ if ($pfb['keep'] == 'on' && isset($pfb['widgets']) && strpos($pfb['widgets'], 'p
 
 	$config['widgets']['sequence'] = $pfb['widgets'];
 	write_config('pfBlockerNG: Save widget');
+	update_status(" done.");
 } else {
-	update_status("\nAdding pfBlockerNG Widget to the Dashboard...");
 	$widgets = $config['widgets']['sequence'];
 	if (strpos($widgets, 'pfblockerng') === FALSE) {
+		update_status("\nAdding pfBlockerNG Widget to the Dashboard...");
 		if (empty($widgets)) {
 			$config['widgets']['sequence'] = 'pfblockerng:col2:open:0';
 		} else {
 			$config['widgets']['sequence'] .= ',pfblockerng:col2:open:0';
 		}
 		write_config('pfBlockerNG: Save widget');
+		update_status(" done.");
 	}
 }
 
 // Create Firewall filter service and link required executables
-update_status(" done.\n\nCreating Firewall filter service...");
+update_status("\nCreating Firewall filter service...");
 pfb_filter_service();
 stop_service('pfb_filter');
 update_status(" done.\nRenew Firewall filter executables...");
@@ -561,6 +570,47 @@ if (is_array($config['installedpackages']['pfblockerng']['config'][0]) &&
 			$ufound = TRUE;
 			$config['installedpackages']['pfblockerngipsettings']['config'][0][$m_setting] = $maxmind_config[$m_setting];
 			unset($maxmind_config[$m_setting]);
+		}
+	}
+}
+
+if ($ufound) {
+	update_status(" saving new changes ... done.\n");
+} else {
+	update_status(" no changes required ... done.\n");
+}
+
+// Validate widget pfBlockerNG clear [ dnsbl/IP ] counter CRON jobs
+update_status(" Validating Widget cron settings...");
+$ufound = FALSE;
+
+foreach (array('clearip', 'cleardnsbl') as $type) {
+	if (isset($config['installedpackages']['pfblockerngglobal']['widget-' . $type])) {
+
+		// Remove incorrect cron entries
+		$pfb_cmd_esc = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php '{$type}' >/dev/null 2>&1";
+		if (pfblockerng_cron_exists($pfb_cmd_esc, '0', '0', '*', '*')) {
+			$ufound = TRUE;
+			install_cron_job("pfblockerng.php '{$type}'", false);
+		}
+		if (pfblockerng_cron_exists($pfb_cmd_esc, '0', '0', '*', '7')) {
+			$ufound = TRUE;
+			install_cron_job("pfblockerng.php '{$type}'", false);
+		}
+
+		// Add correct cron entry, if enabled
+		if ($config['installedpackages']['pfblockerngglobal']['widget-' . $type] != 'never') {
+
+			$pfb_day = '*';
+			if ($config['installedpackages']['pfblockerngglobal']['widget-' . $type] == 'weekly') {
+				$pfb_day = '7';
+			}
+
+			$pfb_cmd = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php {$type} >/dev/null 2>&1";
+			if (!pfblockerng_cron_exists($pfb_cmd, '0', '0', '*', $pfb_day)) {
+				$ufound = TRUE;
+				install_cron_job($pfb_cmd, true, '0', '0', '*', '*', $pfb_day, 'root');
+			}
 		}
 	}
 }

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng.php
@@ -707,8 +707,12 @@ function pfblockerng_uc_countries() {
 			}
 		}
 
-		unset($cc);
-		@fclose($handle);
+		if ($cc) {
+			unset($cc);
+		}
+		if ($handle) {
+			@fclose($handle);
+		}
 	}
 
 	// Add 'Proxy and Satellite' geoname_ids
@@ -1229,8 +1233,12 @@ function pfblockerng_uc_countries() {
 					}
 				}
 			}
-			unset($cc);
-			@fclose($handle);
+			if ($cc) {
+				unset($cc);
+			}
+			if ($handle) {
+				@fclose($handle);
+			}
 		}
 		else {
 			$log = "\n Failed to load file: {$maxmind_cc}\n";
@@ -1261,6 +1269,8 @@ function pfblockerng_get_countries() {
 	// Collect data to generate new continent PHP files.
 	$log = " Creating pfBlockerNG Continent PHP files\n";
 	pfb_logger("{$log}", 4);
+
+	$continent = $continent_en = '';
 
 	foreach ($geoip_files as $cont => $file) {
 
@@ -1372,7 +1382,15 @@ function pfblockerng_get_countries() {
 					$linenum++;
 				}
 			}
-			@fclose($handle);
+
+			if ($handle) {
+				@fclose($handle);
+			}
+
+			if (empty($continent)) {
+				pfb_logger("Continent data [ {$cont} ] not found\n", 4);
+				continue;
+			}
 
 			// Sort IP Countries alphabetically and build PHP drop-down lists for Continent tabs
 			if (!empty(${'coptions' . $type})) {
@@ -1454,19 +1472,24 @@ $options_aliaslog		= [	'enabled' => 'Enabled', 'disabled' => 'Disabled' ];
 
 // Collect all pfSense 'Port' Aliases
 $portslist = $networkslist = '';
+$options_aliasports_in = $options_aliasports_out = array();
+
 if (!empty($config['aliases']['alias'])) {
 	foreach ($config['aliases']['alias'] as $alias) {
 		if ($alias['type'] == 'port') {
 			$portslist .= "{$alias['name']},";
-		} elseif ($alias['type'] == 'network') {
+			$options_aliasports_in[$alias['name']] = $alias['name'];
+			$options_aliasports_out[$alias['name']] = $alias['name'];
+		}
+		elseif ($alias['type'] == 'network') {
 			$networkslist .= "{$alias['name']},";
+			$options_aliasaddr_in[$alias['name']] = $alias['name'];
+			$options_aliasaddr_out[$alias['name']] = $alias['name'];
 		}
 	}
 }
 $ports_list			= trim($portslist, ',');
 $networks_list			= trim($networkslist, ',');
-$options_aliasports_in		= $options_aliasports_out	= explode(',', $ports_list);
-$options_aliasaddr_in		= $options_aliasaddr_out	= explode(',', $networks_list);
 
 $options_autoproto_in		= $options_autoproto_out	= [ '' => 'any', 'tcp' => 'TCP', 'udp' => 'UDP', 'tcp/udp' => 'TCP/UDP' ];
 $options_agateway_in		= $options_agateway_out		= pfb_get_gateways();

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -39,7 +39,7 @@ $aglobal_array = array(	'pfbunicnt' => 200, 'pfbdenycnt' => 25, 'pfbpermitcnt' =
 init_config_arr(array('installedpackages', 'pfblockerngglobal'));
 $pfb['aglobal'] = &$config['installedpackages']['pfblockerngglobal'];
 
-$alertrefresh	= $pfb['aglobal']['alertrefresh']	!= ''	? $pfb['aglobal']['alertrefresh']	: 'on';
+$alertrefresh	= isset($pfb['aglobal']['alertrefresh'])	? $pfb['aglobal']['alertrefresh']	: 'on';
 $pfbpageload	= $pfb['aglobal']['pfbpageload']	!= ''	? $pfb['aglobal']['pfbpageload']	: 'unified';
 $pfbmaxtable	= $pfb['aglobal']['pfbmaxtable']	!= ''	? $pfb['aglobal']['pfbmaxtable']	: '1000';
 $pfbreplytypes	= explode(',', $pfb['aglobal']['pfbreplytypes'])?: array();
@@ -3476,33 +3476,35 @@ if ($pfb['dnsbl'] == 'on') {
 	))->setHelp('DNS Reply Event color')
 	  ->setAttribute('style', "background: {$pfb['unireply2']}; color: white;")
 	  ->setWidth(2);
-
-	if ($pfb['dnsbl_mode'] == 'dnsbl_python') {
-		$group = new Form_Group('DNS Reply Log Options');
-		$group->add(new Form_Select(
-			'pfbreplytypes',
-			'',
-			$pfbreplytypes,
-			$options_pfbreplytypes,
-			TRUE
-		))->setHelp('DNS Reply Type Suppress')
-		  ->setAttribute('title', 'Select the DNS Types to suppress from the DNS Reply Log')
-		  ->setWidth(2)
-		  ->setAttribute('size', 6);
-
-		$group->add(new Form_Select(
-			'pfbreplyrec',
-			'',
-			$pfbreplyrec,
-			$options_pfbreplyrec,
-			TRUE
-		))->setHelp('DNS Reply Record Suppress')
-		  ->setWidth(2)
-		  ->setAttribute('title', 'Select the DNS Record Types to suppress from the DNS Reply Log')
-		  ->setAttribute('size', 16);
-	}
 }
 $section->add($group);
+
+if ($pfb['dnsbl'] == 'on' && $pfb['dnsbl_mode'] == 'dnsbl_python') {
+	$group = new Form_Group('DNS Reply Log Options');
+	$group->add(new Form_Select(
+		'pfbreplytypes',
+		'',
+		$pfbreplytypes,
+		$options_pfbreplytypes,
+		TRUE
+	))->setHelp('DNS Reply Type Suppress')
+	  ->setAttribute('title', 'Select the DNS Types to suppress from the DNS Reply Log')
+	  ->setWidth(2)
+	  ->setAttribute('size', 6);
+
+	$group->add(new Form_Select(
+		'pfbreplyrec',
+		'',
+		$pfbreplyrec,
+		$options_pfbreplyrec,
+		TRUE
+	))->setHelp('DNS Reply Record Suppress')
+	  ->setWidth(2)
+	  ->setAttribute('title', 'Select the DNS Record Types to suppress from the DNS Reply Log')
+	  ->setAttribute('size', 16);
+
+	$section->add($group);
+}
 
 $group = new Form_Group('Event Timeline Options');
 $group->add(new Form_Select(

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -356,19 +356,24 @@ $options_stateremoval		= [	'enabled' => 'Enabled', 'disabled' => 'Disabled' ];
 
 // Collect all pfSense 'Port' Aliases
 $portslist = $networkslist = '';
+$options_aliasports_in = $options_aliasports_out = array();
+
 if (!empty($config['aliases']['alias'])) {
 	foreach ($config['aliases']['alias'] as $alias) {
 		if ($alias['type'] == 'port') {
 			$portslist .= "{$alias['name']},";
-		} elseif ($alias['type'] == 'network') {
+			$options_aliasports_in[$alias['name']] = $alias['name'];
+			$options_aliasports_out[$alias['name']] = $alias['name'];
+		}
+		elseif ($alias['type'] == 'network') {
 			$networkslist .= "{$alias['name']},";
+			$options_aliasaddr_in[$alias['name']] = $alias['name'];
+			$options_aliasaddr_out[$alias['name']] = $alias['name'];
 		}
 	}
 }
 $ports_list			= trim($portslist, ',');
 $networks_list			= trim($networkslist, ',');
-$options_aliasports_in		= $options_aliasports_out	= explode(',', $ports_list);
-$options_aliasaddr_in		= $options_aliasaddr_out	= explode(',', $networks_list);
 
 $options_autoproto_in		= $options_autoproto_out	= [ '' => 'any', 'tcp' => 'TCP', 'udp' => 'UDP', 'tcp/udp' => 'TCP/UDP' ];
 $options_agateway_in		= $options_agateway_out		= pfb_get_gateways();

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -458,7 +458,7 @@ if ($_POST) {
 				'pfb_noaaaa_list'	=> 'domain',
 				'pfb_gp_bypass_list'	=> 'ip',
 				'suppression'		=> 'domain',
-				'tldexclusion'		=> 'domain',
+				'tldexclusion'		=> 'hostname',
 				'tldblacklist'		=> 'tld',
 				'tldwhitelist'		=> 'tldwhite' ) as $custom_type => $custom_format) {
 
@@ -475,6 +475,12 @@ if ($_POST) {
 							switch ($custom_format) {
 								case 'regex':
 									// TODO (See non-ascii validation above)
+									break;
+								case 'hostname':
+									$value[0] = trim($value[0], '.');
+									if (empty(pfb_filter($value[0], PFB_FILTER_HOSTNAME, 'dnsbl'))) {
+										$input_errors[] = "Customlist {$custom_type}: Invalid  Hostname entry: [ " . htmlspecialchars($line) . " ]";
+									}
 									break;
 								case 'domain':
 									$value[0] = trim($value[0], '.');

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -199,7 +199,7 @@ function url_compare($ftype, $key, $rowid, $aliasname, $row_aliasname, $row_url,
 		}
 		else {
 			if (!isset($alt_feeds[$ftype][$aliasname][$alt_header])) {
-				$slt_feeds[$ftype][$aliasname][$feed_header][$a_key] = array(	'icon' => $x_icon, 'url' => $feed_url, 'header' => $alt_header,
+				$alt_feeds[$ftype][$aliasname][$feed_header][$a_key] = array(	'icon' => $x_icon, 'url' => $feed_url, 'header' => $alt_header,
 												'info' => $alt_info, 'register' => !empty($alt_register) ? TRUE : FALSE);
 				$alt_feeds[$ftype][$aliasname][$alt_header] = TRUE;
 			} else {

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -105,24 +105,42 @@ if ($_POST) {
 
 		// Define pfBlockerNG clear [ dnsbl and/or IP ] counter CRON job
 		foreach (array( 'clearip', 'cleardnsbl') as $type) {
-			if (isset($pfb['wglobal']['widget-' . $type]) &&
-			    $pfb['wglobal']['widget-' . $type] != 'never') {
+			if (isset($pfb['wglobal']['widget-' . $type])) {
+				if ($pfb['wglobal']['widget-' . $type] != 'never') {
 
-				$type_esc = escapeshellarg($type);
-				$pfb_cmd = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php {$type_esc} >/dev/null 2>&1";
+					$pfb_day = '*';
+					if ($pfb['wglobal']['widget-' . $type] == 'weekly') {
+						$pfb_day = '7';
+					}
 
-				$pfb_day = '*';
-				if ($pfb['wglobal']['widget-' . $type] == 'weekly') {
-					$pfb_day = '7';
+					$pfb_cmd = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php {$type} >/dev/null 2>&1";
+
+					// Remove unreferenced 'daily' or 'weekly' cron job
+					$pfb_other = ($pfb_day == '*') ? '7' : '*';
+					if (pfblockerng_cron_exists($pfb_cmd, '0', '0', '*', $pfb_other)) {
+						install_cron_job("pfblockerng.php {$type}", false);
+					}
+
+					if (!pfblockerng_cron_exists($pfb_cmd, '0', '0', '*', $pfb_day)) {
+						install_cron_job($pfb_cmd, true, '0', '0', '*', '*', $pfb_day, 'root');
+					}
 				}
-
-				if (!pfblockerng_cron_exists($pfb_cmd, '0', '0', '*', $pfb_day)) {
-					install_cron_job("pfblockerng.php {$type}", false);
-					install_cron_job($pfb_cmd, true, '0', '0', '*', '*', $pfb_day, 'root');
+				else {
+					if (pfblockerng_cron_exists($pfb_cmd, '0', '0', '*', '*')) {
+						install_cron_job("pfblockerng.php {$type}", false);
+					}
+					if (pfblockerng_cron_exists($pfb_cmd, '0', '0', '*', '7')) {
+						install_cron_job("pfblockerng.php {$type}", false);
+					}
 				}
 			}
 			else {
-				install_cron_job("pfblockerng.php {$type}", false);
+				if (pfblockerng_cron_exists($pfb_cmd, '0', '0', '*', '*')) {
+					install_cron_job("pfblockerng.php {$type}", false);
+				}
+				if (pfblockerng_cron_exists($pfb_cmd, '0', '0', '*', '7')) {
+					install_cron_job("pfblockerng.php {$type}", false);
+				}
 			}
 		}
 


### PR DESCRIPTION
- Add "application/json" to list of allowed file download mime-types
- Remove validation for paths in URL validations.
- Add dash as an allowed character in Whois/TLD customlist settings
- Add workaround for .ZIP compressed files. Will now validate ZIP files contents after extraction as opposed to beforehand.
- Fix regression with ASN/Whois File downloads
- Fix regression for the extraction of MaxMind MMDB database file
- Increase DNSBL max domain count for 32GB Ram installs.
- Fix Advanced Inbound/Outbound Port definition regression not saving properly
- Fix DNSBL and IP Counter clearing for the Widget
- Fix Alerts Tab - Dark mode colour options missing in some cases
- Fix Alerts Tab - Page Refresh on/off not saving correctly