### PR TITLE
pfSense-pkg-snort-4.1.6_PHP-8.1 - Fix Redmine Issue #13910, invalid Perf Stats Log Size limit created

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.1.6
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
@@ -250,7 +250,7 @@ $stream5_ports_both .= "\t           55555 56712";
 
 /* def perform_stat */
 
-if (config_get_path('installedpackages/snortglobal/stats_log_limit_size'. '0') != '0')
+if (config_get_path('installedpackages/snortglobal/stats_log_limit_size', '0') != '0')
 	$stats_log_limit = "max_file_size " . config_get_path('installedpackages/snortglobal/stats_log_limit_size') * 1000;
 else
 	$stats_log_limit = "";


### PR DESCRIPTION
### pfSense-pkg-snort-4.1.6_5
This update to the Snort GUI package corrects the problem identified in [Redmine Issue #13910](https://redmine.pfsense.org/issues/13910).

**New Features:**
none

**Bug Fixes:**
1. Fix [Redmine Issue #13910](https://redmine.pfsense.org/issues/13910) - invalid snort.conf parameter for Perf Stats Log Size Limit is created when Performance Stats logging is enabled.