### PR TITLE
Mk/bsd.port.mk: Include bsd.tex.mk again

### DIFF
--- a/Mk/bsd.port.mk
+++ b/Mk/bsd.port.mk
@@ -1401,6 +1401,10 @@ USE_APACHE:=	${USE_APACHE:S/common/server,/}
 USES+=	apache:${USE_APACHE:C/2([0-9])/2.\1/g}
 .    endif
 
+.    if defined(USE_TEX)
+.include "${PORTSDIR}/Mk/bsd.tex.mk"
+.    endif
+
 .    if defined(USE_GECKO)
 .include "${PORTSDIR}/Mk/bsd.gecko.mk"
 .    endif


### PR DESCRIPTION
Added the 3 lines where Mk/bsd.tex.mk was included, after they've been removed in the last commit of this file. Apparently these lines were needed to build the package print/texinfo from scratch. Since this package is needed as a dependency for many packages (~120) the build ultimately fails. Probably some changes were mixed up from the original FreeBSD-ports tree. There are two solutions to this problem, I provided the easier one by only adding the 3 lines to Mk/bsd.port.mk. For the second Solution use the changes made in [this commit](https://github.com/freebsd/freebsd-ports/commit/721e5776c957ada07a0d148f5fc3e782a251e6dc) on the original ports-tree. They also removed the lines, that were needed to include bsd.tex.mk, but they also added a file (Mk/Uses/tex.mk), that allowed using "tex" in the "USES" variable but made it not possible to use the "USE_TEX" variable anymore, to indicate that the package needs the mk file for tex