### PR TITLE
pfSense-pkg-suricata-6.0.8_7-PHP-8.1 - Fix Redmine Issue #13919, typo in function removing dashboard widget

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.8
-PORTREVISION=	6
+PORTREVISION=	7
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
@@ -105,7 +105,7 @@ if (!empty($widgets)) {
 			if (config_get_path('installedpackages/suricata/config/0/forcekeepsettings') == 'on') {
 				config_set_path('installedpackages/suricata/config/0/dashboard_widget', $widget);
 				if (config_get_path('widgets/widget_suricata_display_lines')) {
-					cpnfig_set_path('installedpackages/suricata/config/0/dashboard_widget_rows', config_get_path('widgets/widget_suricata_display_lines'));
+					config_set_path('installedpackages/suricata/config/0/dashboard_widget_rows', config_get_path('widgets/widget_suricata_display_lines'));
 					config_del_path('widgets/widget_suricata_display_lines');
 				}
 			}


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.8_7
This update corrects a function name typo identified in [Redmine Issue #13919](https://redmine.pfsense.org/issues/13919).

**New Features:**
none

**Bug Fixes:**
1. Fix [Redmine Issue #13919](https://redmine.pfsense.org/issues/13919), typo in function name within the dashboard widget removal code.