### PR TITLE
pfSense-pkg-suricata-6.0.8_8_PHP-8.1 - Fix Redmine Issue #13839 and a few other clean-ups.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.8
-PORTREVISION=	7
+PORTREVISION=	8
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -448,5 +448,5 @@ if (config_get_path('installedpackages/suricata/config/0/enable_log_mgmt') == 'o
 if (config_get_path('installedpackages/suricata/config/0/suricataloglimit') == 'on') {
 	suricata_check_dir_size_limit(config_get_path('installedpackages/suricata/config/0/suricataloglimitsize'));
 }
-
+return true;
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -163,7 +163,7 @@ function suricata_download_file_url($url, $file_out) {
 	/* It provides logging of returned CURL errors. */
 	/************************************************/
 
-	global $g, $last_curl_error, $fout, $ch;
+	global $g, $last_curl_error;
 
 	$rfc2616 = array(
 			100 => "100 Continue",
@@ -211,16 +211,18 @@ function suricata_download_file_url($url, $file_out) {
 
 	$last_curl_error = "";
 
-	$fout = fopen($file_out, "wb");
+	$fout = fopen($file_out, 'wb');
 	if ($fout) {
 		$ch = curl_init($url);
 		if (!$ch)
 			return false;
 		curl_setopt($ch, CURLOPT_FILE, $fout);
-		curl_setopt($ch, CURLOPT_HEADER, false);
-		curl_setopt($ch, CURLOPT_NOPROGRESS, '1');
 		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-		curl_setopt($ch, CURLOPT_SSL_CIPHER_LIST, "TLSv1.2, TLSv1");
+		curl_setopt($ch, CURLOPT_AUTOREFERER, true);
+		curl_setopt($ch, CURLOPT_MAXREDIRS, 10);
+		curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_NONE);
+		curl_setopt($ch, CURLOPT_SSL_ENABLE_ALPN, true);
+		curl_setopt($ch, CURLOPT_SSL_ENABLE_NPN, true);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
@@ -1017,4 +1019,6 @@ if ((config_get_path('installedpackages/suricata/config/0/rule_categories_notify
 	notify_all_remote("Suricata new rule categories are available:\n" . $notify_new_message);
 }
 
+// Returns true when no errors occurred
+return !$update_errors;
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -221,6 +221,7 @@ function suricata_download_file_url($url, $file_out) {
 		curl_setopt($ch, CURLOPT_AUTOREFERER, true);
 		curl_setopt($ch, CURLOPT_MAXREDIRS, 10);
 		curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_NONE);
+		curl_setopt($ch, CURLOPT_FORBID_REUSE, true);
 		curl_setopt($ch, CURLOPT_SSL_ENABLE_ALPN, true);
 		curl_setopt($ch, CURLOPT_SSL_ENABLE_NPN, true);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
@@ -268,7 +269,6 @@ function suricata_download_file_url($url, $file_out) {
 		$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 		if (isset($rfc2616[$http_code]))
 			$last_curl_error = $rfc2616[$http_code];
-		curl_close($ch);
 		fclose($fout);
 
 		// If we had to try more than once, log it

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_etiqrisk_update.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_etiqrisk_update.php
@@ -169,5 +169,5 @@ if ($success == TRUE && is_process_running("suricata")) {
 if (config_get_path('installedpackages/suricata/config/0/update_notify') == 'on') {
 	notify_all_remote($notify_message);
 }
-
+return true;
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -1196,5 +1196,5 @@ EOD;
 }
 
 $suricata_config_pass_thru = base64_decode($suricatacfg['configpassthru']);
-
+return true;
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
@@ -53,9 +53,13 @@ function suricata_download_geoip_file($url, $tmpfile, &$result = NULL) {
 	curl_setopt($ch, CURLOPT_FILE, $fout);
 	curl_setopt($ch, CURLOPT_ENCODING, 'gzip');
 	curl_setopt($ch, CURLOPT_HEADER, false);
-	curl_setopt($ch, CURLOPT_NOPROGRESS, '1');
 	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-	curl_setopt($ch, CURLOPT_SSL_CIPHER_LIST, "TLSv1.3, TLSv1.2, TLSv1.1, TLSv1, SSLv3");
+	curl_setopt($ch, CURLOPT_AUTOREFERER, true);
+	curl_setopt($ch, CURLOPT_MAXREDIRS, 10);
+	curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_NONE);
+	curl_setopt($ch, CURLOPT_FORBID_REUSE, true);
+	curl_setopt($ch, CURLOPT_SSL_ENABLE_ALPN, true);
+	curl_setopt($ch, CURLOPT_SSL_ENABLE_NPN, true);
 	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 	curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
 	curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
@@ -102,7 +106,6 @@ function suricata_download_geoip_file($url, $tmpfile, &$result = NULL) {
 		syslog(LOG_ERR, "[Suricata] ERROR: GeoLite2-Country IP database download failed.  The HTTP Response Code was " . $response . ".");
 	}
 	fclose($fout);
-	curl_close($ch);
 	if (isset($result) && $rc === TRUE) {
 		$result = $response;
 	}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
@@ -201,5 +201,5 @@ $notify_message .= gettext("Suricata MaxMind GeoLite2 IP database update finishe
 if (config_get_path('installedpackages/suricata/config/0/update_notify') == 'on') {
 	notify_all_remote($notify_message);
 }
-
+return true;
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -843,5 +843,5 @@ if ($updated_cfg) {
 else {
 	syslog(LOG_NOTICE, "[Suricata] Configuration version is current.");
 }
-
+return true;
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
@@ -77,7 +77,9 @@ if (config_get_path('installedpackages/suricata/config/0/clearlogs') == 'on') {
 /* pkg will clean up the base install files.             */
 /*********************************************************/
 unlink_if_exists("{$suricatadir}*.gz.md5");
+unlink_if_exists("{$suricatadir}*.ruleslist");
 unlink_if_exists("{$suricatadir}gen-msg.map");
+unlink_if_exists("{$suricatadir}unicode.map");
 unlink_if_exists("{$suricatadir}classification.config");
 unlink_if_exists("{$suricatadir}reference.config");
 unlink_if_exists("{$suricatadir}rulesupd_status");
@@ -135,5 +137,5 @@ if (config_get_path('installedpackages/suricata/config/0/forcekeepsettings') != 
 	write_config("Removed the Suricata package.");
 	syslog(LOG_NOTICE, gettext("[Suricata] The package has been removed from this system, but the configuration settings were retained..."));
 }
-
+return true;
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
@@ -173,8 +173,8 @@ if ($_REQUEST['updatemode']) {
 
 	// Launch a background process to download the updates
 	$upd_pid = 0;
-	$upd_pid = mwexec_bg("/usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_check_for_rule_updates.php");
-	print($upd_pid);
+	$upd_pid = mwexec_bg("/usr/local/bin/php -f /usr/local/pkg/suricata/suricata_check_for_rule_updates.php");
+	print $upd_pid;
 
 	// If we failed to launch our background process, throw up an error for the user.
 	if ($upd_pid == 0) {
@@ -188,13 +188,14 @@ if ($_REQUEST['ajax'] == 'status') {
 	if (is_numeric($_REQUEST['pid'])) {
 		// Check for the PID launched as the rules update task
 		$rc = shell_exec("/bin/ps -o pid= -p {$_REQUEST['pid']}");
+
 		if (!empty($rc)) {
-			print("RUNNING");
+			print "RUNNING";
 		} else {
-			print("DONE");
+			print "DONE";
 		}
 	} else {
-		print("DONE");
+		print "DONE";
 	}
 	exit;
 }
@@ -437,7 +438,7 @@ $modal->addInput(new Form_StaticText (
 	'<i class="content fa fa-spinner fa-pulse fa-lg text-center text-info"></i>'
 ));
 $form->add($modal);
-print($form);
+print $form;
 ?>
 
 <div class="infoblock">


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.8_8
This update to the Suricata GUI package addresses [Redmine Issue #13839](https://redmine.pfsense.org/issues/13839) (Suricata version updates take a long time). While here, a few other code clean-ups were added.

**New Features:**
none

**Bug Fixes:**
1. Fix [Redmine Issue #13839](https://redmine.pfsense.org/issues/13839), Suricata version updates take a long time. This bug only surfaced when certain rules download URLs were used. The cause was traced to a failure to properly negotiate an HTTP/2 session when one was offered by the remote site during the download of new rules packages.
2. While here, make sure all our locally created files are removed when uninstalling Suricata.
3. Add return as the last command in files that are called via include statements (to be a good PHP citizen).