### PR TITLE
pfSense-pkg-snort-4.1.6_6-PHP-8.1 - Fix Redmine Issues #13922 and #13923.

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.1.6
-PORTREVISION=	5
+PORTREVISION=	6
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
@@ -52,7 +52,6 @@ $snort_config_pass_thru = rtrim($snort_config_pass_thru);
 /* create a few directories and ensure the sample files are in place */
 $snort_dirs = array( $snortdir, $snortcfgdir, "{$snortcfgdir}/rules",
 	"{$snortlogdir}/snort_{$if_real}{$snort_uuid}",
-	"{$snortlogdir}/snort_{$if_real}{$snort_uuid}/barnyard2", 
 	"{$snortcfgdir}/preproc_rules", 
 	"dynamicrules" => "{$snortlibdir}/snort_dynamicrules",
 	"dynamicengine" => "{$snortlibdir}/snort_dynamicengine",

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_download_updates.php
@@ -155,12 +155,12 @@ if ($_REQUEST['ajax'] == 'status') {
 		// Check for the PID launched as the rules update task
 		$rc = shell_exec("/bin/ps -o pid= -p {$_REQUEST['pid']}");
 		if (!empty($rc)) {
-			print("RUNNING");
+			print "RUNNING";
 		} else {
-			print("DONE");
+			print "DONE";
 		}
 	} else {
-		print("DONE");
+		print "DONE";
 	}
 	exit;
 }
@@ -173,7 +173,7 @@ if ($_REQUEST['ajax'] == 'getlog') {
 	else {
 		$contents = gettext("*** Rules Update logfile is empty! ***");
 	}
-	print($contents);
+	print $contents;
 	exit;
 }
 
@@ -195,8 +195,8 @@ if (isset($_POST['mode'])) {
 	
 	// Launch a background process to download the updates
 	$upd_pid = 0;
-	$upd_pid = mwexec_bg("/usr/local/bin/php-cgi -f /usr/local/pkg/snort/snort_check_for_rule_updates.php");
-	print($upd_pid);
+	$upd_pid = mwexec_bg("/usr/local/bin/php -f /usr/local/pkg/snort/snort_check_for_rule_updates.php");
+	print $upd_pid;
 
 	// If we failed to launch our background process, throw up an error for the user.
 	if ($upd_pid == 0) {
@@ -370,7 +370,7 @@ $modal->addInput(new Form_StaticText (
 ));
 $form->add($modal);
 
-print($form);
+print $form;
 ?>
 
 <script type="text/javascript">


### PR DESCRIPTION
### pfSense-pkg-snort-4.1.6_6
This update fixes Redmine Issues [#13922](https://redmine.pfsense.org/issues/13922) and [#13923](https://redmine.pfsense.org/issues/13923). While here some unneeded parentheses were removed from print statements.

**New Features:**
none

**Bug Fixes:**
1. Fix [Redmine Issue #13922](https://redmine.pfsense.org/issues/13922), Snort rules package downloads may hang for an extended period if remote site offers an HTTP/2 connection.
2. Fix [Redmine Issue #13923](https://redmine.pfsense.org/issues/13923), Snort fails to clean-up all files when uninstalling and also creates an unnecessary barnyard2 logging subdirectory.