### PR TITLE
pfSense-pkg-suricata-6.0.10_PHP-8.1 -- Fix Redmine #13925, add support for Suricata 6.0.10, and other fixes

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,8 +1,8 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	6.0.8
-PORTREVISION=	8
+PORTVERSION=	6.0.10
+PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=6.0.8:security/suricata
+RUN_DEPENDS=	suricata>=6.0.10:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-suricata/files/etc/inc/priv/suricata.priv.inc
+++ b/security/pfSense-pkg-suricata/files/etc/inc/priv/suricata.priv.inc
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2018-2023 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2020 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -4,10 +4,10 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2023 Rubicon Communications, LLC (Netgate)
- * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
- * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
- * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2022 Bill Meeks
+ * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (c) 2009 Robert Zelaya Sr. Developer
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -352,8 +352,8 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 		}
 	}
 
-	// Always add loopback to HOME_NET and passlist
-	if (!$externallist) {
+	// Always add loopback addresses to HOME_NET
+	if (!$externallist && !$passlist) {
 		if (!in_array("127.0.0.1/32", $home_net)) {
 			$home_net[] = "127.0.0.1/32";
 		}
@@ -363,15 +363,16 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 	}
 
 	/********************************************************************/
-	/* Always put the interface running Suricata in HOME_NET and        */
-	/* pass list unless it's the WAN.  WAN options are handled further  */
-	/* down.  If the user specifically chose not to include LOCAL_NETS  */
-	/* in the PASS LIST, then do not include the Suricata interface     */
-	/* subnet in the PASS LIST. We do include the actual LAN interface  */
-	/* IP for Suricata, though, to prevent locking out the firewall.    */
+	/* Always put the interface running Suricata in HOME_NET unless     */
+	/* it's the WAN.  WAN options are handled further down. If the      */
+	/* user specifically chose not to include LOCAL_NETS in the         */
+	/* PASS LIST, then do not include the Suricata interface subnet     */
+	/* in the PASS LIST. The specific interface IP for the Suricata     */
+	/* instance is automatically added by the underlying binary to      */
+	/* a built-in list to prevent locking out the firewall interface.   */
 	/********************************************************************/
 	$suricataip = get_interface_ip($suricatacfg['interface']);
-	if (($externallist && $localnet == 'yes') || (!$externallist && $passlist && ($localnet == 'yes' || empty($localnet)))) {
+	if (($externallist && $localnet == 'yes') || (!$externallist && !$passlist && ($localnet == 'yes' || empty($localnet)))) {
 		if (is_ipaddrv4($suricataip)) {
 			if ($suricatacfg['interface'] <> "wan") {
 				if ($sn = get_interface_subnet($suricatacfg['interface'])) {
@@ -383,7 +384,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 			}
 		}
 	}
-	elseif (!$externallist && $localnet != 'yes') {
+	elseif (!$externallist && !$passlist && $localnet != 'yes') {
 		if (is_ipaddrv4($suricataip) && $suricatacfg['interface'] <> "wan") {
 			if (!in_array($suricataip . "/32", $home_net)) {
 				$home_net[] = $suricataip . "/32";
@@ -397,7 +398,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 	if (strpos($suricataip, "%") !== FALSE) {
 		$suricataip = substr($suricataip, 0, strpos($suricataip, "%"));
 	}
-	if (($externallist && $localnet == 'yes') || ($passlist && ($localnet == 'yes' || empty($localnet))) || (!$externallist && !$passlist && ($localnet == 'yes' || empty($localnet)))) {
+	if (($externallist && $localnet == 'yes') || (!$externallist && !$passlist && ($localnet == 'yes' || empty($localnet)))) {
 		if (is_ipaddrv6($suricataip)) {
 			if ($suricatacfg['interface'] <> "wan") {
 				if ($sn = get_interface_subnetv6($suricatacfg['interface'])) {
@@ -409,7 +410,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 			}
 		}
 	}
-	elseif (!$externallist && $localnet != 'yes') {
+	elseif (!$externallist && !$passlist && $localnet != 'yes') {
 		if (is_ipaddrv6($suricataip) && $suricatacfg['interface'] <> "wan") {
 			if (!in_array($suricataip . "/128", $home_net)) {
 				$home_net[] = $suricataip . "/128";
@@ -417,9 +418,9 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 		}
 	}
 
-	// Add link-local address if user included locally-attached networks
+	// Add link-local IPv6 addresses if user included locally-attached networks
 	$suricataip = get_interface_linklocal($suricatacfg['interface']);
-	if (!empty($suricataip) && $localnet == 'yes') {
+	if (!empty($suricataip) && !$passlist && $localnet == 'yes') {
 		// Trim off the interface designation (e.g., %em1) if present
 		if (strpos($suricataip, "%") !== FALSE) {
 			$suricataip = substr($suricataip, 0, strpos($suricataip, "%"));
@@ -467,9 +468,9 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 				}
 			}
 
-			// Add link-local address
+			// Add link-local IPv6 addresses
 			$suricataip = get_interface_linklocal($int);
-			if (!empty($suricataip)) {
+			if (!empty($suricataip) && !$passlist) {
 				// Trim off the interface designation (e.g., %em1) if present
 				if (strpos($suricataip, "%") !== FALSE) {
 					$suricataip = substr($suricataip, 0, strpos($suricataip, "%"));
@@ -482,7 +483,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 	}
 
 	// If user chose to include the WAN IP, then do so.
-	if ($wanip == 'yes') {
+	if ($wanip == 'yes' && !$passlist) {
 		$ip = get_interface_ip("wan");
 		if (is_ipaddrv4($ip)) {
 			if (!in_array($ip . "/32", $home_net)) {
@@ -499,7 +500,7 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 				$home_net[] = $ip . "/128";
 			}
 		}
-		// Explicitly grab the WAN Link-Local address
+		// Explicitly grab the WAN Link-Local IPv6 address
 		$ip = get_interface_linklocal("wan");
 		if (!empty($ip)) {
 			// Trim off the interface designation (e.g., %em1) if present

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -4,10 +4,10 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2023 Rubicon Communications, LLC (Netgate)
- * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
- * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
- * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2022 Bill Meeks
+ * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (c) 2009 Robert Zelaya Sr. Developer
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -4,10 +4,10 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2023 Rubicon Communications, LLC (Netgate)
- * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
- * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
- * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2022 Bill Meeks
+ * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (c) 2009 Robert Zelaya Sr. Developer
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
@@ -4,10 +4,10 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2023 Rubicon Communications, LLC (Netgate)
- * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
- * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
- * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2022 Bill Meeks
+ * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (c) 2009 Robert Zelaya Sr. Developer
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_etiqrisk_update.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_etiqrisk_update.php
@@ -4,10 +4,10 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2023 Rubicon Communications, LLC (Netgate)
- * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
- * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
- * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2022 Bill Meeks
+ * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (c) 2009 Robert Zelaya Sr. Developer
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -4,10 +4,10 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2023 Rubicon Communications, LLC (Netgate)
- * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
- * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
- * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2022 Bill Meeks
+ * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (c) 2009 Robert Zelaya Sr. Developer
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
@@ -4,10 +4,10 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2023 Rubicon Communications, LLC (Netgate)
- * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
- * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
- * Copyright (C) 2009 Robert Zelaya Sr. Developer
- * Copyright (C) 2022 Bill Meeks
+ * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (c) 2009 Robert Zelaya Sr. Developer
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2019-2023 Rubicon Communications, LLC (Netgate)
- * Copyright (C) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_sync.xml
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_sync.xml
@@ -10,7 +10,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2015-2023 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2013 Marcello Coutinho
- * Copyright (c) 2014-2017 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_import_aliases.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_import_aliases.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -555,7 +555,9 @@ if (isset($_POST["save"]) && !$input_errors) {
 		// Check if Inline IPS mode is enabled. Auto-enable 'Live Rule Swap' and display a message
 		// about potential incompatibilities with Netmap and some NIC hardware drivers.
 		if ($natent['ips_mode'] == "ips_mode_inline") {
-			$savemsg2 = gettext("Inline IPS Mode is selected. Live Rule Swap will be automatically enabled to prevent netmap interfaces from cycling offline/online during future rules updates.  Please note that not all hardware NIC drivers support Netmap operation which is required for Inline IPS Mode.  If problems are experienced, switch to Legacy Mode instead.");
+			$savemsg2 = gettext("Inline IPS Mode is selected. Live Rule Swap will be automatically enabled to prevent netmap interfaces from cycling offline/online during future rules updates. " .
+								"For better performance with Inline IPS Mode operation, consider changing the runmode setting to workers. " .
+								"Please note that not all hardware NIC drivers support Netmap operation- which is required for Inline IPS Mode. If problems are experienced, switch to Legacy Mode instead.");
 			config_set_path('installedpackages/suricata/config/0/live_swap_updates', "on");
 		}
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1534,11 +1534,11 @@ $group->add(new Form_Select(
 	array( "ips_mode_legacy" => "Legacy Mode", "ips_mode_inline" => "Inline Mode" )
 ))->setHelp('Select blocking mode operation.  Legacy Mode inspects copies of packets while Inline Mode inserts the Suricata inspection engine ' . 
 		'into the network stack between the NIC and the OS. Default is Legacy Mode.');
-$group->setHelp('Legacy Mode uses the PCAP engine to generate copies of packets for inspection as they traverse the interface.  Some "leakage" of packets will occur before ' . 
-		'Suricata can determine if the traffic matches a rule and should be blocked.  Inline mode instead intercepts and inspects packets before they are handed ' . 
-		'off to the host network stack for further processing.  Packets matching DROP rules are simply discarded (dropped) and not passed to the host ' . 
+$group->setHelp('Legacy Mode uses the PCAP engine to generate copies of packets for inspection as they traverse the interface.  Some "leakage" of packets will occur before ' .
+		'Suricata can determine if the traffic matches a rule and should be blocked.  Inline mode instead intercepts and inspects packets before they are handed ' .
+		'off to the host network stack for further processing.  Packets matching DROP rules are simply discarded (dropped) and not passed to the host ' .
 		'network stack.  No leakage of packets occurs with Inline Mode.  WARNING:  Inline Mode only works with NIC drivers which properly support Netmap! ' .
-		'Supported drivers: ' . implode(', ', $netmapifs) . '. If problems are experienced with Inline Mode, switch to Legacy Mode instead.');
+		'Supported drivers include: ' . implode(', ', $netmapifs) . '. If problems are experienced with Inline Mode, switch to Legacy Mode instead.');
 $section->add($group);
 
 $section->addInput(new Form_Input(
@@ -1602,8 +1602,10 @@ $section->addInput(new Form_Select(
 	'Run Mode',
 	$pconfig['runmode'],
 	array('autofp' => 'AutoFP', 'workers' => 'Workers', 'single' => 'Single')
-))->setHelp('Choose a Suricata run mode setting. Default is "AutoFP" and is the recommended setting for most cases.  "Workers" uses multiple worker threads, each of which single-handedly processes the packets it acquires (i.e., each thread runs all thread modules). ' . 
-	    '"Single" uses only a single thread for all operations on a packet and is intended for use only in testing or development instances.');
+))->setHelp('Choose a Suricata run mode setting. Default is "AutoFP" and is the recommended setting for IDS-only and Legacy Blocking Mode. ' .
+		'"Workers" uses multiple worker threads, each of which processes the packets it acquires through all the decode and detect modules. ' .
+		'"Workers" runmode is preferred for Inline IPS Mode blocking because it offers superior performance in that configuration. ' .
+	    '"Single" uses only a single thread for all operations, and is intended for use only in testing or development instances.');
 $section->addInput(new Form_Select(
 	'autofp_scheduler',
 	'AutoFP Scheduler Type',
@@ -1616,7 +1618,7 @@ $section->addInput(new Form_Input(
 	'Max Pending Packets',
 	'text',
 	$pconfig['max_pending_packets']
-))->setHelp('Enter number of simultaneous packets to process. Default is 1024.<br/>This controls the number simultaneous packets the engine can handle. ' .
+))->setHelp('Enter number of simultaneous packets to process. Default is 1024.<br/>This controls the number of simultaneous packets the engine can handle. ' .
 			'Setting this higher generally keeps the threads more busy. The minimum value is 1 and the maximum value is 65,000.<br />' .
 			'Warning: Setting this too high can lead to degradation and a possible system crash by exhausting available memory.');
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_list_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_list_mgmt.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_ip_reputation.php
@@ -81,6 +81,10 @@ if ($_POST['mode'] == 'iplist_add' && isset($_POST['iplist'])) {
 			}
 		}
 		if (!$input_errors) {
+			if (!is_array($a_nat['iplist_files'])){
+				$a_nat['iplist_files'] = array( "item" => array() );
+			}
+
 			$a_nat['iplist_files']['item'][] = basename($_POST['iplist']);
 			config_set_path("installedpackages/suricata/rule/{$id}", $a_nat);
 			write_config("Suricata pkg: added new whitelist file for IP REPUTATION preprocessor.");
@@ -240,7 +244,7 @@ $form->addGlobal(new Form_Input('mode', null, 'hidden'));
 $form->addGlobal(new Form_Input('iplist', null, 'hidden'));
 $form->addGlobal(new Form_Input('list_id', null, 'hidden'));
 
-print($form);
+print $form;
 ?>
 
 <div class="panel panel-default">
@@ -300,14 +304,13 @@ print($form);
 				</thead>
 				<tbody>
 <?php
-				if (is_array($pconfig['iplist_files']['item'])) :
-					foreach($pconfig['iplist_files']['item'] as $k => $f) :
-						if (!file_exists("{$iprep_path}{$f}")) {
-							$filedate = gettext("Unknown -- file missing");
-						}
-						else
-							$filedate = date('M-d Y   g:i a', filemtime("{$iprep_path}{$f}"));
-				 ?>
+				foreach(array_get_path($pconfig, 'iplist_files/item', []) as $k => $f) :
+					if (!file_exists("{$iprep_path}{$f}")) {
+						$filedate = gettext("Unknown -- file missing");
+					} else {
+						$filedate = date('M-d Y   g:i a', filemtime("{$iprep_path}{$f}"));
+					}
+?>
 					<tr>
 						<td><?=htmlspecialchars($f);?></td>
 						<td><?=$filedate;?></td>
@@ -316,8 +319,7 @@ print($form);
 							<i class="fa fa-times icon-embed-btn"></i><?=gettext("Delete")?></button>
 						</td>
 					</tr>
-<?php 					endforeach;
-				endif;
+<?php 			endforeach;
 ?>
 				</tbody>
 		</table>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_iprep_list_browser.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_iprep_list_browser.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_libhtp_policy_engine.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_libhtp_policy_engine.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_list_view.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_list_view.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_browser.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_browser.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_mgmt.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_os_policy_engine.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_os_policy_engine.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules_flowbits.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules_flowbits.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_select_alias.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_select_alias.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_suppress_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/widgets/include/widget-suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/widgets/include/widget-suricata.inc
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2023 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2014 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/widgets/javascript/suricata_alerts.js
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/widgets/javascript/suricata_alerts.js
@@ -3,7 +3,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2023 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2014 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/widgets/widgets/suricata_alerts.widget.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/widgets/widgets/suricata_alerts.widget.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2016 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/widgets/widgets/suricata_alerts.widget.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/widgets/widgets/suricata_alerts.widget.php
@@ -28,13 +28,7 @@ $nocsrf = true;
 require_once("guiconfig.inc");
 require_once("/usr/local/www/widgets/include/widget-suricata.inc");
 
-global $config, $g;
-
-/* Retrieve Suricata configuration */
-if (!is_array($config['installedpackages']['suricata']['rule']))
-	$config['installedpackages']['suricata']['rule'] = array();
-
-$a_instance = &$config['installedpackages']['suricata']['rule'];
+global $g;
 
 /* array sorting */
 function suricata_sksort(&$array, $subkey="id", $sort_ascending=false) {
@@ -73,7 +67,7 @@ function suricata_sksort(&$array, $subkey="id", $sort_ascending=false) {
 }
 
 /* check if suricata widget variable is set */
-$suri_nentries = $config['widgets']['widget_suricata_display_lines'];
+$suri_nentries = config_get_path('widgets/widget_suricata_display_lines', '5');
 if (empty($suri_nentries) || $suri_nentries < 0) {
 	$suri_nentries = 5;
 }
@@ -97,7 +91,7 @@ if (isset($_GET['getNewAlerts'])) {
 }
 
 if(isset($_POST['widget_suricata_display_lines'])) {
-	$config['widgets']['widget_suricata_display_lines'] = $_POST['widget_suricata_display_lines'];
+	config_set_path('widgets/widget_suricata_display_lines', $_POST['widget_suricata_display_lines']);
 	write_config("Saved Suricata Alerts Widget Displayed Lines Parameter via Dashboard");
 	header("Location: ../../index.php");
 }
@@ -105,15 +99,15 @@ if(isset($_POST['widget_suricata_display_lines'])) {
 // Read "$suri_nentries" worth of alerts from the top of the alerts.log file
 function suricata_widget_get_alerts() {
 
-	global $g, $config, $a_instance, $suri_nentries;
+	global $g, $suri_nentries;
 	$suricata_alerts = array();
 
 	/* read log file(s) */
 	$counter=0;
 
-	foreach ($a_instance as $instanceid => $instance) {
-		$suricata_uuid = $a_instance[$instanceid]['uuid'];
-		$if_real = get_real_interface($a_instance[$instanceid]['interface']);
+	foreach (config_get_path('installedpackages/suricata/rule', []) as $instanceid => $instance) {
+		$suricata_uuid = $instance['uuid'];
+		$if_real = get_real_interface($instance['interface']);
 
 		// make sure alert file exists, then grab the most recent {$suri_nentries} from it
 		// and write them to a temp file.
@@ -205,7 +199,7 @@ function suricata_widget_get_alerts() {
 						$fields['class'] = "No classtype assigned";
 					}
 
-					$suricata_alerts[$counter]['instanceid'] = strtoupper(convert_friendly_interface_to_friendly_descr($a_instance[$instanceid]['interface']));
+					$suricata_alerts[$counter]['instanceid'] = strtoupper(convert_friendly_interface_to_friendly_descr($instance['interface']));
 					$suricata_alerts[$counter]['msg'] = $fields['msg'];
 
 					// Add square brackets around any IPv6 address
@@ -301,7 +295,7 @@ function suricata_widget_get_alerts() {
 				<label for="widget_suricata_display_lines" class="col-sm-4 control-label"><?=gettext('Alerts to Display:')?></label>
 				<div class="col-sm-3">
 					<input type="number" name="widget_suricata_display_lines" class="form-control" id="widget_suricata_display_lines" 
-					value="<?= $config['widgets']['widget_suricata_display_lines'] ?>" placeholder="5" min="1" max="20" />
+					value="<?= config_get_path('widgets/widget_suricata_display_lines') ?>" placeholder="5" min="1" max="20" />
 				</div>
 				<div class="col-sm-3">
 					<button id="submitd" name="submitd" type="submit" class="btn btn-sm btn-primary"><?=gettext('Save')?></button>


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.10
This GUI package update adds support for the latest 6.0.10 version of the Suricata binary from upstream. It also addresses [Redmine Issue #13925](https://redmine.pfsense.org/issues/13925), removes the inclusion of firewall interface IPs in GUI generated Pass Lists as these are added automatically by code within the custom blocking plugin, and corrects some typos in Help Text on the INTERFACE SETTINGS tab.

**New Features:**
1. When generating the text-based Pass List file for an interface, the GUI code no longer pulls in the firewall interface assigned IP addresses. It still pulls in the network subnet assigned on firewall interfaces (excluding the WAN, as always), but it does not pull in the interface IP itself. This is because firewall interface IP addresses are automatically added to an internal interface pass list maintained by the custom blocking module binary. Thus there presence in the text-based Pass List file is redundant.
2. Add support for the Suricata 6.0.10 binary.

**Bug Fixes:**
1. Fix [Redmine Issue #13925](https://redmine.pfsense.org/issues/13925), PHP fatal error on the IP REPUTATION tab due to the change to PHP 8.1.
2. Correct previously overlooked direct $config array access in the Suricata Dashboard Widget code.
3. Correct some typos in Help Text on the INTERFACE SETTINGS tab.
4. Update copyright year to 2023 in all GUI source files.