### PR TITLE
pfSense-pkg-snort-4.1.6_7-PHP-8.1 - Fix Redmine Issues #13991 and #13994

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.1.6
-PORTREVISION=	6
+PORTREVISION=	7
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -808,7 +808,7 @@ $tab_array = array();
 	$tab_array[10] = array(gettext("Sync"), false, "/pkg_edit.php?xml=snort/snort_sync.xml");
 display_top_tabs($tab_array, true);
 
-print ($form);
+print $form;
 
 ?>
 
@@ -819,7 +819,7 @@ print ($form);
 				if (!$filterfieldsarray)
 					printf(gettext("Last %s Alert Log Entries"), $pconfig['alertnumber']);
 				else
-					print($anentries. ' ' . gettext('Matched Log Entries') . ' ');
+					print $anentries. ' ' . gettext('Matched Log Entries') . ' ';
 			?>
 		</h2>
 	</div>

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -70,27 +70,27 @@ function snort_add_supplist_entry($suppress) {
 	/*   TRUE if successful or FALSE on failure     */
 	/************************************************/
 
-	global $a_instance, $instanceid;
+	global $instanceid;
 
 	$a_suppress = config_get_path('installedpackages/snortglobal/suppress/item', []);
 
 	$found_list = false;
 
 	/* If no Suppress List is set for the interface, then create one with the interface name */
-	if (empty(array_get_path($a_instance, "{$instanceid}/suppresslistname", '')) || array_get_path($a_instance, "{$instanceid}/suppresslistname", '') == 'default') {
+	if (empty(config_get_path("installedpackages/snortglobal/rule/{$instanceid}/suppresslistname", '')) || config_get_path("installedpackages/snortglobal/rule/{$instanceid}/suppresslistname", '') == 'default') {
 		$s_list = array();
 		$s_list['uuid'] = uniqid();
-		$s_list['name'] = $a_instance[$instanceid]['interface'] . "suppress" . "_" . $s_list['uuid'];
+		$s_list['name'] = config_get_path("installedpackages/snortglobal/rule/{$instanceid}/interface") . "suppress" . "_" . $s_list['uuid'];
 		$s_list['descr']  =  "Auto-generated list for Alert suppression";
 		$s_list['suppresspassthru'] = base64_encode($suppress);
 		$a_suppress[] = $s_list;
-		$a_instance[$instanceid]['suppresslistname'] = $s_list['name'];
+		config_set_path("installedpackages/snortglobal/rule/{$instanceid}/suppresslistname", $s_list['name']);
 		$found_list = true;
 		$list_name = $s_list['name'];
 	} else {
 		/* If we get here, a Suppress List is defined for the interface so see if we can find it */
 		foreach ($a_suppress as $a_id => $alist) {
-			if ($alist['name'] == $a_instance[$instanceid]['suppresslistname']) {
+			if ($alist['name'] == config_get_path("installedpackages/snortglobal/rule/{$instanceid}/suppresslistname", '')) {
 				$found_list = true;
 				$list_name = $alist['name'];
 				if (!empty($alist['suppresspassthru'])) {
@@ -113,7 +113,7 @@ function snort_add_supplist_entry($suppress) {
 		config_set_path('installedpackages/snortglobal/suppress/item', $a_suppress);
 		write_config("Snort pkg: modified Suppress List {$list_name}.");
 		sync_snort_package_config();
-		snort_reload_config($a_instance[$instanceid]);
+		snort_reload_config(config_get_path("installedpackages/snortglobal/rule/{$instanceid}", ''));
 		return true;
 	}
 	else

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_alerts.php
@@ -46,7 +46,9 @@ function snort_is_alert_globally_suppressed($list, $gid, $sid) {
 	/* If entry has a child array, then it's by src or dst ip. */
 	/* So if there is a child array or the keys are not set,   */
 	/* then this gid:sid is not globally suppressed.           */
-	if (array_get_path($list, "{$gid}/{$sid}"))
+	if (is_array($list[$gid][$sid]))
+		return false;
+	elseif (!isset($list[$gid][$sid]))
 		return false;
 	else
 		return true;

--- a/security/pfSense-pkg-snort/files/usr/local/www/widgets/include/widget-snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/www/widgets/include/widget-snort.inc
@@ -28,17 +28,15 @@ $snort_alerts_title_link = "snort/snort_alerts.php";
 
 function widget_snort_uninstall() {
 
-	global $config;
-
 	/* Remove the Snort widget from the Dashboard display list */
-	$widgets = $config['widgets']['sequence'];
+	$widgets = config_get_path('widgets/sequence', '');
 	if (!empty($widgets)) {
 		$widgetlist = explode(",", $widgets);
 		foreach ($widgetlist as $key => $widget) {
 			if (strstr($widget, "snort_alerts"))
 				unset($widgetlist[$key]);
 		}
-		$config['widgets']['sequence'] = implode(",", $widgetlist);
+		config_set_path('widgets/sequence', implode(",", $widgetlist));
 		write_config("Snort widget removed");
 	}
 }

--- a/security/pfSense-pkg-snort/files/usr/local/www/widgets/widgets/snort_alerts.widget.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/widgets/widgets/snort_alerts.widget.php
@@ -25,15 +25,10 @@ $nocsrf = true;
 require_once("guiconfig.inc");
 require_once("/usr/local/www/widgets/include/widget-snort.inc");
 
-global $config, $g;
+global $g;
 
 /* retrieve snort variables */
-if (!is_array($config['installedpackages']['snortglobal']['rule'])) {
-	$config['installedpackages'] = array();
-	$config['installedpackages']['snortglobal'] = array();
-	$config['installedpackages']['snortglobal']['rule'] = array();
-}
-$a_instance = &$config['installedpackages']['snortglobal']['rule'];
+$a_instance = config_get_path('installedpackages/snortglobal/rule', []);
 
 // Set some CSS class variables
 $alertRowEvenClass = "listMReven";
@@ -41,8 +36,8 @@ $alertRowOddClass = "listMRodd";
 $alertColClass = "listMRr";
 
 /* check if Snort widget alert display lines value is set */
-$snort_nentries = $config['widgets']['widget_snort_display_lines'];
-if (!isset($snort_nentries) || $snort_nentries <= 0)
+$snort_nentries = intval(config_get_path('widgets/widget_snort_display_lines', '5'));
+if ($snort_nentries <= 0)
 	$snort_nentries = 5;
 
 /* array sorting of the alerts */
@@ -92,9 +87,9 @@ if (isset($_GET['getNewAlerts'])) {
 // See if saving new display line count value
 if(isset($_POST['widget_snort_display_lines'])) {
 	if($_POST['widget_snort_display_lines'] == "") {
-		unset($config['widgets']['widget_snort_display_lines']);
+		config_set_path('widgets/widget_snort_display_lines', '5');
 	} else {
-		$config['widgets']['widget_snort_display_lines'] = max(intval($_POST['widget_snort_display_lines']), 1);
+		config_set_path('widgets/widget_snort_display_lines', max(intval($_POST['widget_snort_display_lines']), 1));
 	}
 	write_config("Saved Snort Alerts Widget Displayed Lines Parameter via Dashboard");
 	header("Location: ../../index.php");
@@ -105,7 +100,7 @@ if(isset($_POST['widget_snort_display_lines'])) {
 // alerts in a sorted array (most recent alert first).
 function snort_widget_get_alerts() {
 
-	global $config, $a_instance, $snort_nentries;
+	global $a_instance, $snort_nentries;
 	$snort_alerts = array();
 	/* read log file(s) */
 	$counter=0;
@@ -227,7 +222,7 @@ function snort_widget_get_alerts() {
 				<label for="widget_snort_display_lines" class="col-sm-4 control-label"><?=gettext('Alerts to Display:')?></label>
 				<div class="col-sm-3">
 					<input type="number" name="widget_snort_display_lines" class="form-control" id="widget_snort_display_lines" 
-					value="<?= $config['widgets']['widget_snort_display_lines'] ?>" placeholder="5" min="1" max="20" />
+					value="<?= config_get_path('widgets/widget_snort_display_lines') ?>" placeholder="5" min="1" max="20" />
 				</div>
 				<div class="col-sm-3">
 					<button id="submitd" name="submitd" type="submit" class="btn btn-sm btn-primary"><?=gettext('Save')?></button>


### PR DESCRIPTION
### pfSense-pkg-snort-4.1.6_7
This GUI package update corrects two bugs and cleans up direct _$config_ array access in the Snort Dashboard Widget.

**New Features:**
None

**Bug Fixes:**
1. Fix [Redmine Issue #13991](https://redmine.pfsense.org/issues/13991) - Suppress icon on ALERTS tab always shows "globally suppressed" for all entries under GID:SID column on ALERTS tab.
2. Fix [Redmine Issue $13994](https://redmine.pfsense.org/issues/13994) - Snort not saving automatically created and assigned Suppress List on an interface when performing actions on the ALERTS tab.
3. Remove previously overlooked direct $config array access in the Snort Dashboard Widget and replace with appropriate config_get_path() or config_set_path() functions.