### PR TITLE
pfSense-pkg-suricata-6.0.10_1+PHP-8.1 - Fix Redmine Issue #13995 and update copyright year in missed files

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.10
-PORTREVISION=	0
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -67,25 +67,25 @@ function suricata_add_supplist_entry($suppress) {
 	/*   TRUE if successful or FALSE on failure     */
 	/************************************************/
 
-	global $a_instance, $instanceid;
+	global $instanceid;
 
 	$a_suppress = config_get_path('installedpackages/suricata/suppress/item', []);
 	$found_list = false;
 
 	/* If no Suppress List is set for the interface, then create one with the interface name */
-	if (empty($a_instance['suppresslistname']) || $a_instance['suppresslistname'] == 'default') {
+	if (empty(config_get_path("installedpackages/suricata/rule/{$instanceid}/suppresslistname", '')) || config_get_path("installedpackages/suricata/rule/{$instanceid}/suppresslistname", '') == 'default') {
 		$s_list = array();
 		$s_list['uuid'] = uniqid();
-		$s_list['name'] = $a_instance['interface'] . "suppress" . "_" . $s_list['uuid'];
+		$s_list['name'] = config_get_path("installedpackages/suricata/rule/{$instanceid}/interface") . "suppress" . "_" . $s_list['uuid'];
 		$s_list['descr']  =  "Auto-generated list for Alert suppression";
 		$s_list['suppresspassthru'] = base64_encode($suppress);
 		$a_suppress[] = $s_list;
-		$a_instance['suppresslistname'] = $s_list['name'];
+		config_set_path("installedpackages/suricata/rule/{$instanceid}/suppresslistname", $s_list['name']);
 		$found_list = true;
 	} else {
 		/* If we get here, a Suppress List is defined for the interface so see if we can find it */
 		foreach ($a_suppress as $a_id => $alist) {
-			if ($alist['name'] == $a_instance['suppresslistname']) {
+			if ($alist['name'] == config_get_path("installedpackages/suricata/rule/{$instanceid}/suppresslistname", '')) {
 				$found_list = true;
 				if (!empty($alist['suppresspassthru'])) {
 					$tmplist = base64_decode($alist['suppresspassthru']);
@@ -104,7 +104,6 @@ function suricata_add_supplist_entry($suppress) {
 	/* If we created a new list or updated an existing one, save the change */
 	/* and return true; otherwise return false.                             */
 	if ($found_list) {
-		config_set_path("installedpackages/suricata/rule/{$instanceid}", $a_instance);
 		config_set_path('installedpackages/suricata/suppress/item', $a_suppress);
 		write_config("Suricata pkg: saved change to Suppress List " . $s_list['name'] . " from ALERTS tab.");
 		sync_suricata_package_config();

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_define_vars.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_define_vars.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_files.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_files.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2022 Bill Meeks
+ * Copyright (c) 2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.10_1
This update to the Suricata GUI package corrects [Redmine Issue #13995](https://redmine.pfsense.org/issues/13995), Suricata fails to save the interface assignment for an automatically generated Suppress List.

**New Features:**
None

**Bug Fixes:**
1. Fix [Redmine Issue #13995](https://redmine.pfsense.org/issues/13995) - Suricata not saving automatic assignment of a new pass list for an interface - PHP 8.1 regression.