### PR TITLE
pfSense-pkg-suricata-6.0.10_2 - Fix Redmine Issue 14029, dangling config array references

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.10
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -56,7 +56,7 @@ if (config_get_path('installedpackages/suricata/config/0/suricata_config_ver') <
 /**********************************************************/
 /* Create new Auto SID Mgmt settings if not set           */
 /**********************************************************/
-if (empty(config_get_path('installedpackages/suricata/config/0/auto_manage_sids'))) {
+if (config_get_path('installedpackages/suricata/config/0/auto_manage_sids') === null) {
 	config_set_path('installedpackages/suricata/config/0/auto_manage_sids', "off");
 	config_set_path('installedpackages/suricata/config/0/sid_changes_log_limit_size', "250");
 	config_set_path('installedpackages/suricata/config/0/sid_changes_log_retention', "336");
@@ -68,7 +68,7 @@ if (empty(config_get_path('installedpackages/suricata/config/0/auto_manage_sids'
 /* /var/db/suricata/sidmods directory to Base64 encoded   */
 /* strings in SID_MGMT_LIST array in config.xml.          */
 /**********************************************************/
-if (empty(config_get_path('installedpackages/suricata/config/0/sid_list_migration')) && count(config_get_path('installedpackages/suricata/sid_mgmt_lists', [])) < 1) {
+if (config_get_path('installedpackages/suricata/config/0/sid_list_migration') === null && count(config_get_path('installedpackages/suricata/sid_mgmt_lists', [])) < 1) {
 	$a_list = config_get_path('installedpackages/suricata/sid_mgmt_lists/item', []);
 	$sidmodfiles = return_dir_as_array("/var/db/suricata/sidmods/");
 	foreach ($sidmodfiles as $sidfile) {
@@ -87,11 +87,12 @@ if (empty(config_get_path('installedpackages/suricata/config/0/sid_list_migratio
 }
 
 /**********************************************************/
-/* Default Auto GeoLite2 DB update setting to "off" due   */
-/* to recent MaxMind changes to the GeoLite2 database     */
-/* download permissions.                                  */
+/* Default Auto GeoLite2 DB update setting to "off" when  */
+/* no GeoLite2 DB password is configured due to recent    */
+/* MaxMind changes to the GeoLite2 database download      */
+/* permissions.                                           */
 /**********************************************************/
-if (empty(config_get_path('installedpackages/suricata/config/0/autogeoipupdate')) || empty(config_get_path('installedpackages/suricata/config/0/maxmind_geoipdb_key'))) {
+if (config_get_path('installedpackages/suricata/config/0/autogeoipupdate') === "on" && config_get_path('installedpackages/suricata/config/0/maxmind_geoipdb_key') === null) {
 	config_set_path('installedpackages/suricata/config/0/autogeoipupdate', "off");
 	$updated_cfg = true;
 }
@@ -99,7 +100,7 @@ if (empty(config_get_path('installedpackages/suricata/config/0/autogeoipupdate')
 /**********************************************************/
 /* Create new ET IQRisk IP Reputation setting if not set  */
 /**********************************************************/
-if (empty(config_get_path('installedpackages/suricata/config/0/et_iqrisk_enable'))) {
+if (config_get_path('installedpackages/suricata/config/0/et_iqrisk_enable') === null) {
 	config_set_path('installedpackages/suricata/config/0/et_iqrisk_enable', "off");
 	$updated_cfg = true;
 }
@@ -107,7 +108,7 @@ if (empty(config_get_path('installedpackages/suricata/config/0/et_iqrisk_enable'
 /**********************************************************/
 /* Create new HIDE_DEPRECATED_RULES setting if not set    */
 /**********************************************************/
-if (empty(config_get_path('installedpackages/suricata/config/0/hide_deprecated_rules'))) {
+if (config_get_path('installedpackages/suricata/config/0/hide_deprecated_rules') === null) {
 	config_set_path('installedpackages/suricata/config/0/hide_deprecated_rules', "off");
 	$updated_cfg = true;
 }
@@ -132,7 +133,7 @@ if (config_path_enabled('installedpackages/suricata/config/0', 'last_rule_upd_ti
 /* large numbers of pfSense users hitting Snort.org at    */
 /* the same minute past the hour for rules updates.       */
 /**********************************************************/
-if (empty(config_get_path('installedpackages/suricata/config/0/autoruleupdatetime')) ||
+if (config_get_path('installedpackages/suricata/config/0/autoruleupdatetime') === null ||
 	config_get_path('installedpackages/suricata/config/0/autoruleupdatetime') == '00:05' ||
 	strlen(config_get_path('installedpackages/suricata/config/0/autoruleupdatetime')) < 5) {
 	config_set_path('installedpackages/suricata/config/0/autoruleupdatetime', "00:" . str_pad(strval(random_int(0,59)), 2, "00", STR_PAD_LEFT));
@@ -142,66 +143,66 @@ if (empty(config_get_path('installedpackages/suricata/config/0/autoruleupdatetim
 /**********************************************************/
 /* Set default log size and retention limits if not set   */
 /**********************************************************/
-if (!config_path_enabled('installedpackages/suricata/config/0', 'alert_log_retention')) {
+if (config_get_path('installedpackages/suricata/config/0/alert_log_retention') === null) {
 	config_set_path('installedpackages/suricata/config/0/alert_log_retention', "336");
 	$updated_cfg = true;
 }
-if (!config_path_enabled('installedpackages/suricata/config/0', 'alert_log_limit_size')) {
+if (config_get_path('installedpackages/suricata/config/0/alert_log_limit_size') === null) {
 	config_set_path('installedpackages/suricata/config/0/alert_log_limit_size', "500");
 	$updated_cfg = true;
 }
 
-if (!config_path_enabled('installedpackages/suricata/config/0', 'block_log_retention')) {
+if (config_get_path('installedpackages/suricata/config/0/block_log_retention') === null) {
 	config_set_path('installedpackages/suricata/config/0/block_log_retention', "336");
 	$updated_cfg = true;
 }
-if (!config_path_enabled('installedpackages/suricata/config/0', 'block_log_limit_size')) {
+if (config_get_path('installedpackages/suricata/config/0/block_log_limit_size') === null) {
 	config_set_path('installedpackages/suricata/config/0/block_log_limit_size', "500");
 	$updated_cfg = true;
 }
 
-if (!config_path_enabled('installedpackages/suricata/config/0', 'eve_log_retention')) {
+if (config_get_path('installedpackages/suricata/config/0/eve_log_retention') === null) {
 	config_set_path('installedpackages/suricata/config/0/eve_log_retention', "168");
 	$updated_cfg = true;
 }
-if (!config_path_enabled('installedpackages/suricata/config/0', 'eve_log_limit_size')) {
+if (config_get_path('installedpackages/suricata/config/0/eve_log_limit_size') === null) {
 	config_set_path('installedpackages/suricata/config/0/eve_log_limit_size', "5000");
 	$updated_cfg = true;
 }
 
-if (!config_path_enabled('installedpackages/suricata/config/0', 'http_log_retention')) {
+if (config_get_path('installedpackages/suricata/config/0/http_log_retention') === null) {
 	config_set_path('installedpackages/suricata/config/0/http_log_retention', "168");
 	$updated_cfg = true;
 }
-if (!config_path_enabled('installedpackages/suricata/config/0', 'http_log_limit_size')) {
+if (config_get_path('installedpackages/suricata/config/0/http_log_limit_size') === null) {
 	config_set_path('installedpackages/suricata/config/0/http_log_limit_size', "1000");
 	$updated_cfg = true;
 }
 
-if (!config_path_enabled('installedpackages/suricata/config/0', 'stats_log_retention')) {
+if (config_get_path('installedpackages/suricata/config/0/stats_log_retention') === null) {
 	config_set_path('installedpackages/suricata/config/0/stats_log_retention', "168");
 	$updated_cfg = true;
 }
-if (!config_path_enabled('installedpackages/suricata/config/0', 'stats_log_limit_size')) {
+if (config_get_path('installedpackages/suricata/config/0/stats_log_limit_size') === null) {
 	config_set_path('installedpackages/suricata/config/0/stats_log_limit_size', "500");
 	$updated_cfg = true;
 }
 
-if (!config_path_enabled('installedpackages/suricata/config/0', 'tls_log_retention')) {
+if (config_get_path('installedpackages/suricata/config/0/tls_log_retention') === null) {
 	config_set_path('installedpackages/suricata/config/0/tls_log_retention', "336");
 	$updated_cfg = true;
 }
-if (!config_path_enabled('installedpackages/suricata/config/0', 'tls_log_limit_size')) {
+if (config_get_path('installedpackages/suricata/config/0/tls_log_limit_size') === null) {
 	config_set_path('installedpackages/suricata/config/0/tls_log_limit_size', "500");
 	$updated_cfg = true;
 }
 
-if (!config_path_enabled('installedpackages/suricata/config/0', 'file_store_retention')) {
+if (config_get_path('installedpackages/suricata/config/0/file_store_retention') === null) {
 	config_set_path('installedpackages/suricata/config/0/file_store_retention', "168");
 	$updated_cfg = true;
 }
 
-if (!config_path_enabled('installedpackages/suricata/config/0', 'tls_certs_store_retention')) {
+if (config_get_path('installedpackages/suricata/config/0/tls_certs_store_retention') === null) {
 	config_set_path('installedpackages/suricata/config/0/tls_certs_store_retention', "168");
 	$updated_cfg = true;
 }
@@ -209,11 +210,11 @@ if (!config_path_enabled('installedpackages/suricata/config/0', 'tls_certs_store
 /**********************************************************/
 /* Remove deprecated file-log settings from LOGS MGMT     */
 /**********************************************************/
-if (config_path_enabled('installedpackages/suricata/config/0', 'files_json_log_retention')) {
+if (config_get_path('installedpackages/suricata/config/0/files_json_log_retention') !== null) {
 	config_del_path('installedpackages/suricata/config/0/files_json_log_retention');
 	$updated_cfg = true;
 }
-if (config_path_enabled('installedpackages/suricata/config/0', 'files_json_log_limit_size')) {
+if (config_get_path('installedpackages/suricata/config/0/files_json_log_limit_size') !== null) {
 	config_del_path('installedpackages/suricata/config/0/files_json_log_limit_size');
 	$updated_cfg = true;
 }
@@ -224,12 +225,13 @@ if (config_path_enabled('installedpackages/suricata/config/0', 'files_json_log_l
 /* element for existing entries into an array. Migrate    */
 /* any existing <address> to the new array structure.     */
 /**********************************************************/
-foreach (config_get_path('installedpackages/suricata/passlist/item', []) as &$wlisti) {
+foreach (config_get_path('installedpackages/suricata/passlist/item', []) as $idx => $wlisti) {
 	if (!is_array($wlisti['address']) && !empty($wlisti['address']) && !is_array($wlisti['address']['item'])) {
 		$tmp = $wlisti['address'];
 		$wlisti['address'] = array();
 		$wlisti['address']['item'] = array();
 		$wlisti['address']['item'][] = $tmp;
+		config_set_path("installedpackages/suricata/passlist/item/{$idx}", $wlisti);
 		$updated_cfg = true;
 	}
 }
@@ -239,19 +241,23 @@ foreach (config_get_path('installedpackages/suricata/passlist/item', []) as &$wl
 /* from the snort2c pf table that were added by the Legacy */
 /* Blocking custom plugin. Default empty value to 'yes'.   */
 /***********************************************************/
-if (!config_path_enabled('installedpackages/suricata/config/0/clearblocks')) {
+if (config_get_path('installedpackages/suricata/config/0/clearblocks') === null) {
 	config_set_path('installedpackages/suricata/config/0/clearblocks', 'on');
+	$updated_cfg = true;
 }
 
-// Now process the interface-specific migration settings
-$a_rules = config_get_path('installedpackages/suricata/rule', []);
-foreach ($a_rules as &$pconfig) {
+/***********************************************************/
+/* Process the interface-specific settings migration.      */
+/***********************************************************/
+foreach (config_get_path('installedpackages/suricata/rule', []) as $idx => &$pconfig) {
+	$updated_intf_cfg = false;
 
 	/***********************************************************/
 	/* Add the new 'dns-events.rules' file to the rulesets.    */
 	/***********************************************************/
 	if (strpos(array_get_path($pconfig, 'rulesets', ''), "dns-events.rules") === FALSE) {
 		$pconfig['rulesets'] = rtrim(array_get_path($pconfig, 'rulesets', ''), "||") . "||dns-events.rules";	
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -260,6 +266,7 @@ foreach ($a_rules as &$pconfig) {
 	/***********************************************************/
 	if (strpos(array_get_path($pconfig, 'rulesets', ''), "dhcp-events.rules") === FALSE) {
 		$pconfig['rulesets'] = rtrim(array_get_path($pconfig, 'rulesets', ''), "||") . "||dhcp-events.rules";	
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -268,6 +275,7 @@ foreach ($a_rules as &$pconfig) {
 	/***********************************************************/
 	if (strpos(array_get_path($pconfig, 'rulesets', ''), "http2-events.rules") === FALSE) {
 		$pconfig['rulesets'] = rtrim(array_get_path($pconfig, 'rulesets', ''), "||") . "||http2-events.rules";	
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -276,6 +284,7 @@ foreach ($a_rules as &$pconfig) {
 	/***********************************************************/
 	if (strpos(array_get_path($pconfig, 'rulesets', ''), "mqtt-events.rules") === FALSE) {
 		$pconfig['rulesets'] = rtrim(array_get_path($pconfig, 'rulesets', ''), "||") . "||mqtt-events.rules";	
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -284,6 +293,7 @@ foreach ($a_rules as &$pconfig) {
 	/***********************************************************/
 	if (strpos(array_get_path($pconfig, 'rulesets', ''), "ssh-events.rules") === FALSE) {
 		$pconfig['rulesets'] = rtrim(array_get_path($pconfig, 'rulesets', ''), "||") . "||ssh-events.rules";	
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -292,6 +302,7 @@ foreach ($a_rules as &$pconfig) {
 	/***********************************************************/
 	if (empty($pconfig['runmode'])) {
 		$pconfig['runmode'] = "autofp";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -300,6 +311,7 @@ foreach ($a_rules as &$pconfig) {
 	/***********************************************************/
 	if (empty($pconfig['intf_promisc_mode'])) {
 		$pconfig['intf_promisc_mode'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -308,6 +320,7 @@ foreach ($a_rules as &$pconfig) {
 	/***********************************************************/
 	if (!isset($pconfig['http_log_extended'])) {
 		$pconfig['http_log_extended'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -316,110 +329,137 @@ foreach ($a_rules as &$pconfig) {
 	/***********************************************************/
 	if (!isset($pconfig['eve_output_type'])) {
 		$pconfig['eve_output_type'] = "regular";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_alerts_xff'])) {
 		$pconfig['eve_log_alerts_xff'] = "off";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_alerts_xff_mode'])) {
 		$pconfig['eve_log_alerts_xff_mode'] = "extra-data";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_alerts_xff_deployment'])) {
 		$pconfig['eve_log_alerts_xff_deployment'] = "reverse";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_alerts_xff_header'])) {
 		$pconfig['eve_log_alerts_xff_header'] = "X-Forwarded-For";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['eve_systemlog_facility'])) {
 		$pconfig['eve_systemlog_facility'] = "local1";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['eve_systemlog_priority'])) {
 		$pconfig['eve_systemlog_priority'] = "info";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_alerts'])) {
 		$pconfig['eve_log_alerts'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_alerts_metadata'])) {
 		$pconfig['eve_log_alerts_metadata'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_http'])) {
 		$pconfig['eve_log_http'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_nfs'])) {
 		$pconfig['eve_log_nfs'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_smb'])) {
 		$pconfig['eve_log_smb'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_krb5'])) {
 		$pconfig['eve_log_krb5'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_ikev2'])) {
 		$pconfig['eve_log_ikev2'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_tftp'])) {
 		$pconfig['eve_log_tftp'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_dns'])) {
 		$pconfig['eve_log_dns'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_tls'])) {
 		$pconfig['eve_log_tls'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_ftp'])) {
 		$pconfig['eve_log_ftp'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_http2'])) {
 		$pconfig['eve_log_http2'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_rfb'])) {
 		$pconfig['eve_log_rfb'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_dhcp'])) {
 		$pconfig['eve_log_dhcp'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_dhcp_extended'])) {
 		$pconfig['eve_log_dhcp_extended'] = "off";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_files'])) {
 		$pconfig['eve_log_files'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_ssh'])) {
 		$pconfig['eve_log_ssh'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_smtp'])) {
 		$pconfig['eve_log_smtp'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['eve_log_flow'])) {
 		$pconfig['eve_log_flow'] = "off";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}    
 	if (!isset($pconfig['eve_log_drop'])) {
 		$pconfig['eve_log_drop'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -429,11 +469,13 @@ foreach ($a_rules as &$pconfig) {
 		$pconfig['eve_log_http_extended_headers'] .= "date, dnt, etags, from, last-modified, link, location, max-forwards, origin, pragma, proxy-authenticate, proxy-authorization, range, ";
 		$pconfig['eve_log_http_extended_headers'] .= "referrer, refresh, retry-after, server, set-cookie, te, trailer, transfer-encoding, upgrade, vary, via, warning, www-authenticate, ";
 		$pconfig['eve_log_http_extended_headers'] .= "x-authenticated-user, x-flash-version, x-forwarded-proto, x-requested-with";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
 	if (!isset($pconfig['eve_log_smtp_extended_fields'])) {
 		$pconfig['eve_log_smtp_extended_fields'] = "received, x-mailer, x-originating-ip, relays, reply-to, bcc";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -442,30 +484,37 @@ foreach ($a_rules as &$pconfig) {
 	/************************************************************/
 	if (empty($pconfig['dns_global_memcap'])) {
 		$pconfig['dns_global_memcap'] = "16777216";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['dns_state_memcap'])) {
 		$pconfig['dns_state_memcap'] = "524288";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['dns_request_flood_limit'])) {
 		$pconfig['dns_request_flood_limit'] = "500";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['dns_parser_udp'])) {
 		$pconfig['dns_parser_udp'] = "yes";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['dns_parser_tcp'])) {
 		$pconfig['dns_parser_tcp'] = "yes";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['dns_parser_udp_ports'])) {
 		$pconfig['dns_parser_udp_ports'] = "53";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['dns_parser_tcp_ports'])) {
 		$pconfig['dns_parser_tcp_ports'] = "53";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -474,10 +523,12 @@ foreach ($a_rules as &$pconfig) {
 	/***********************************************************/
 	if (empty($pconfig['http_parser'])) {
 		$pconfig['http_parser'] = "yes";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['http_parser_memcap'])) {
 		$pconfig['http_parser_memcap'] = "67108864";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -486,22 +537,27 @@ foreach ($a_rules as &$pconfig) {
 	/***********************************************************/
 	if (empty($pconfig['smtp_parser_decode_mime'])) {
 		$pconfig['smtp_parser_decode_mime'] = "off";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['smtp_parser_decode_base64'])) {
 		$pconfig['smtp_parser_decode_base64'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['smtp_parser_decode_quoted_printable'])) {
 		$pconfig['smtp_parser_decode_quoted_printable'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['smtp_parser_extract_urls'])) {
 		$pconfig['smtp_parser_extract_urls'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['smtp_parser_compute_body_md5'])) {
 		$pconfig['smtp_parser_compute_body_md5'] = "on";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -510,14 +566,17 @@ foreach ($a_rules as &$pconfig) {
 	/***********************************************************/
 	if (empty($pconfig['tls_detect_ports'])) {
 		$pconfig['tls_detect_ports'] = "443";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['tls_encrypt_handling'])) {
 		$pconfig['tls_encrypt_handling'] = "default";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['tls_ja3_fingerprint'])) {
 		$pconfig['tls_ja3_fingerprint'] = "auto";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -526,62 +585,77 @@ foreach ($a_rules as &$pconfig) {
 	/**********************************************************/
 	if (empty($pconfig['tls_parser'])) {
 		$pconfig['tls_parser'] = "yes";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['smtp_parser'])) {
 		$pconfig['smtp_parser'] = "yes";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['imap_parser'])) {
 		$pconfig['imap_parser'] = "detection-only";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['ssh_parser'])) {
 		$pconfig['ssh_parser'] = "yes";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['ftp_parser'])) {
 		$pconfig['ftp_parser'] = "yes";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['dcerpc_parser'])) {
 		$pconfig['dcerpc_parser'] = "yes";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['smb_parser'])) {
 		$pconfig['smb_parser'] = "yes";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['msn_parser'])) {
 		$pconfig['msn_parser'] = "detection-only";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['snmp_parser'])) {
 		$pconfig['snmp_parser'] = "yes";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['rdp_parser'])) {
 		$pconfig['rdp_parser'] = "yes";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['sip_parser'])) {
 		$pconfig['sip_parser'] = "yes";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['http2_parser'])) {
 		$pconfig['http2_parser'] = "yes";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['rfb_parser'])) {
 		$pconfig['rfb_parser'] = "yes";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['enip_parser'])) {
 		$pconfig['enip_parser'] = "yes";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['mqtt_parser'])) {
 		$pconfig['mqtt_parser'] = "yes";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -590,18 +664,22 @@ foreach ($a_rules as &$pconfig) {
 	/**********************************************************/
 	if (empty($pconfig['enable_iprep'])) {
 		$pconfig['enable_iprep'] = "off";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['host_memcap'])) {
 		$pconfig['host_memcap'] = "16777216";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['host_hash_size'])) {
 		$pconfig['host_hash_size'] = "4096";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (empty($pconfig['host_prealloc'])) {
 		$pconfig['host_prealloc'] = "1000";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -610,14 +688,17 @@ foreach ($a_rules as &$pconfig) {
 	/**********************************************************/
 	if (empty($pconfig['max_synack_queued'])) {
 		$pconfig['max_synack_queued'] = "5";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['stream_bypass'])) {
 		$pconfig['stream_bypass'] = "no";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['stream_drop_invalid'])) {
 		$pconfig['stream_drop_invalid'] = "no";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -626,6 +707,7 @@ foreach ($a_rules as &$pconfig) {
 	/**********************************************************/
 	if (empty($pconfig['ips_mode'])) {
 		$pconfig['ips_mode'] = "ips_mode_legacy";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -635,6 +717,7 @@ foreach ($a_rules as &$pconfig) {
 	/**********************************************************/
 	if (empty($pconfig['block_drops_only'])) {
 		$pconfig['block_drops_only'] = "no";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -644,6 +727,7 @@ foreach ($a_rules as &$pconfig) {
 	/**********************************************************/
 	if (empty($pconfig['intf_snaplen'])) {
 		$pconfig['intf_snaplen'] = "1518";
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -652,6 +736,7 @@ foreach ($a_rules as &$pconfig) {
 	/* control parameter.                                     */
 	/**********************************************************/
 	if (!isset($pconfig['enable_stats_collection'])) {
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 		if ($pconfig['enable_stats_log'] == "on") {
 			$pconfig['enable_stats_collection'] = "on";
@@ -667,18 +752,22 @@ foreach ($a_rules as &$pconfig) {
 	/**********************************************************/
 	if (isset($pconfig['enable_json_file_log'])) {
 		unset($pconfig['enable_json_file_log']);
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (isset($pconfig['append_json_file_log'])) {
 		unset($pconfig['append_json_file_log']);
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (isset($pconfig['enable_tracked_files_magic'])) {
 		unset($pconfig['enable_tracked_files_magic']);
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 	if (isset($pconfig['tracked_files_hash'])) {
 		unset($pconfig['tracked_files_hash']);
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 
@@ -686,139 +775,30 @@ foreach ($a_rules as &$pconfig) {
 	/* Remove deprecated Barnyard2 configuration parameters   */
 	/* from this interface if any are present.                */
 	/**********************************************************/
-	if (isset($pconfig['barnyard_enable'])) {
-		unset($pconfig['barnyard_enable']);
-		$updated_cfg = true;
+	$barnyard_params = array( 'barnyard_enable', 'barnyard_dump_payload', 'barnyard_mysql_enable',
+							  'barnyard_syslog_enable', 'barnyard_syslog_local', 'barnyard_syslog_rhost',
+							  'barnyard_syslog_dport', 'barnyard_syslog_proto', 'barnyard_syslog_opmode',
+							  'barnyard_syslog_facility', 'barnyard_syslog_priority', 'barnyard_disable_sig_ref_tbl',
+							  'barnyard_sensor_id', 'barnyard_sensor_name', 'barnyard_dbhost', 'barnyard_dbname',
+							  'barnyard_dbuser', 'barnyard_bro_ids_enable', 'barnyard_bro_ids_rhost',
+							  'barnyard_bro_ids_dport', 'barnconfigpassthru', 'barnyard_dbpwd', 'barnyard_show_year',
+							  'barnyard_archive_enable', 'barnyard_archive_enable', 'barnyard_obfuscate_ip',
+							  'barnyard_xff_logging', 'barnyard_xff_mode', 'barnyard_xff_deployment',
+							  'barnyard_xff_header', 'unified2_log_limit', 'u2_archive_log_retention' );
+	foreach ($barnyard_params as $param) {
+		if (isset($pconfig[$param])) {
+			unset($pconfig[$param]);
+			$updated_intf_cfg = true;
+			$updated_cfg = true;
+		}
 	}
-	if (isset($pconfig['barnyard_dump_payload'])) {
-		unset($pconfig['barnyard_dump_payload']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_mysql_enable'])) {
-		unset($pconfig['barnyard_mysql_enable']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_syslog_enable'])) {
-		unset($pconfig['barnyard_syslog_enable']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_syslog_local'])) {
-		unset($pconfig['barnyard_syslog_local']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_syslog_rhost'])) {
-		unset($pconfig['barnyard_syslog_rhost']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_syslog_dport'])) {
-		unset($pconfig['barnyard_syslog_dport']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_syslog_proto'])) {
-		unset($pconfig['barnyard_syslog_proto']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_syslog_opmode'])) {
-		unset($pconfig['barnyard_syslog_opmode']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_syslog_facility'])) {
-		unset($pconfig['barnyard_syslog_facility']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_syslog_priority'])) {
-		unset($pconfig['barnyard_syslog_priority']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_disable_sig_ref_tbl'])) {
-		unset($pconfig['barnyard_disable_sig_ref_tbl']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_sensor_id'])) {
-		unset($pconfig['barnyard_sensor_id']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_sensor_name'])) {
-		unset($pconfig['barnyard_sensor_name']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_dbhost'])) {
-		unset($pconfig['barnyard_dbhost']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_dbname'])) {
-		unset($pconfig['barnyard_dbname']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_dbuser'])) {
-		unset($pconfig['barnyard_dbuser']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_bro_ids_enable'])) {
-		unset($pconfig['barnyard_bro_ids_enable']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_bro_ids_rhost'])) {
-		unset($pconfig['barnyard_bro_ids_rhost']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_bro_ids_dport'])) {
-		unset($pconfig['barnyard_bro_ids_dport']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnconfigpassthru'])) {
-		unset($pconfig['barnconfigpassthru']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_dbpwd'])) {
-		unset($pconfig['barnyard_dbpwd']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_show_year'])) {
-		unset($pconfig['barnyard_show_year']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_archive_enable'])) {
-		unset($pconfig['barnyard_archive_enable']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_obfuscate_ip'])) {
-		unset($pconfig['barnyard_obfuscate_ip']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_xff_logging'])) {
-		unset($pconfig['barnyard_xff_logging']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_xff_mode'])) {
-		unset($pconfig['barnyard_xff_mode']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_xff_deployment'])) {
-		unset($pconfig['barnyard_xff_deployment']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['barnyard_xff_header'])) {
-		unset($pconfig['barnyard_xff_header']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['unified2_log_limit'])) {
-		unset($pconfig['unified2_log_limit']);
-		$updated_cfg = true;
-	}
-	if (isset($pconfig['u2_archive_log_retention'])) {
-		unset($pconfig['u2_archive_log_retention']);
-		$updated_cfg = true;
-	}
-	/**********************************************************/
-	/* End Barnyard2 parameter removal                        */
-	/**********************************************************/
 
 	/**********************************************************/
 	/* Add new 'netmap_threads' parameter for the interface   */
 	/* when using Inline IPS Mode. Default is 'auto'.         */
 	/**********************************************************/
 	if (!isset($pconfig['ips_netmap_threads'])) {
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 		$pconfig['ips_netmap_threads'] = 'auto';
 	}
@@ -828,20 +808,29 @@ foreach ($a_rules as &$pconfig) {
 	/* when using 'autofp" runmode.                           */
 	/**********************************************************/
 	if (!isset($pconfig['autofp_scheduler'])) {
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 		$pconfig['autofp_scheduler'] = 'hash';
 	}
+
+	/**********************************************************/
+	/* If we updated this interface, write it to config array */
+	/**********************************************************/
+	if ($updated_intf_cfg === true) {
+		config_set_path("installedpackages/suricata/rule/{$idx}", $pconfig);
+	}
 }
-// Save the updated interfaces configuration
-config_set_path('installedpackages/suricata/rule', $a_rules);
+
+// Release prior config array reference as we are done with it
+unset($pconfig);
 
 // Log a message indicating what we did
-if ($updated_cfg) {
+if ($updated_cfg === true) {
 	write_config("Updated Suricata package settings to new configuration format.");
-	syslog(LOG_NOTICE, "[Suricata] Settings successfully migrated to new configuration format.");
+	syslog(LOG_NOTICE, "[Suricata] Package settings successfully migrated to new configuration format.");
 }
 else {
-	syslog(LOG_NOTICE, "[Suricata] Configuration version is current.");
+	syslog(LOG_NOTICE, "[Suricata] Package settings configuration format is current.");
 }
 return true;
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
@@ -292,6 +292,9 @@ print($form);
 				$ip = inet_pton($ip);
 			}
 
+			// Unset $blocked_ips_array reference as we are done with it
+			unset($ip);
+
 			$tmpblocked = array_flip($blocked_ips_array);
 			$src_ip_list = array();
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -176,8 +176,7 @@ if (!$input_errors) {
 
 		// Now walk all the configured interface rulesets and remove
 		// any matching the disabled ruleset prefixes.
-		$a_ifaces = config_get_path('installedpackages/suricata/rule', []);
-		foreach ($a_ifaces as &$iface) {
+		foreach (config_get_path('installedpackages/suricata/rule', []) as $idx => &$iface) {
 			// Disable Snort IPS policy if Snort rules are disabled
 			if ($disable_ips_policy) {
 				$iface['ips_policy_enable'] = 'off';
@@ -200,8 +199,10 @@ if (!$input_errors) {
 				}
 			}
 			$iface['rulesets'] = implode("||", $enabled_rules);
+			config_set_path("installedpackages/suricata/rule/{$idx}", $iface);
 		}
-		config_set_path('installedpackages/suricata/rule', $a_ifaces);
+		// Release the config array reference we used
+		unset($iface);
 
 		// If deprecated rules should be removed, then do it
 		if (config_get_path('installedpackages/suricata/config/0/hide_deprecated_rules') == "on") {


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.10_2
This package update corrects the issue identified in [Redmine Issue #14029](https://redmine.pfsense.org/issues/14029). Safe practice is to unset array reference variables when no longer needed to prevent unintended consequences if the same variable happens to be set to a value elsewhere in the code module.

**New Features:**
none

**Bug Fixes:**
1. Fix Redmine #14029 - Release dangling array reference variables used in post-install migration.
2. While here, fix two additional instances of dangling array reference variables. 
3. Modify checks for config array values in the package migration of settings code per earlier recommendations of Reid Linnemann. Some areas of this code were actually not working as intended.
4. Simplify and shorten the code section used to remove deprecated Barnyard2 parameters.