### PR TITLE
pfSense-pkg-suricata-6.0.10_3_PHP-8.1 - Add support for URL Table alias usage in custom Pass List

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.10
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -338,9 +338,13 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 					$home_net[] = $addr;
 				}
 			} elseif ($passlist) {
-				if (is_alias($addr) && (alias_get_type($addr) == "host" || alias_get_type($addr) == "network")) {
+				// Only accept "host", "network", or "urltable" aliases, otherwise treat as direct IP
+				if (is_alias($addr) &&
+					(alias_get_type($addr) == "host" ||
+					 alias_get_type($addr) == "network" ||
+					 alias_get_type($addr) == "urltable")) {
 					$tmp = trim(filter_expand_alias($addr));
-					if (strlen($tmp) > 0) {
+					if (strlen($tmp) > 0 && alias_get_type($addr) !== "urltable") {
 						$home_net = array_merge($home_net, explode(" ", $tmp));
 					} elseif (!in_array($addr, $home_net)) {
 						$home_net[] = $addr;

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -33,7 +33,7 @@ $suricatalogdir = SURICATALOGDIR;
 $rcdir = RCFILEPREFIX;
 $suri_starting = array();
 
-if ($_POST['id'])
+if (is_numeric($_POST['id']))
 	$id = $_POST['id'];
 else
 	$id = 0;
@@ -143,6 +143,16 @@ if (isset($_POST['del_x'])) {
 
 /* start/stop Suricata */
 if ($_POST['toggle']) {
+	// Ensure the interface index is legit, else bail and redisplay this page
+	if (!is_numeric($_POST['id']) || intval($_POST['id']) >= $id_gen) {
+		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
+		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
+		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+		header( 'Cache-Control: post-check=0, pre-check=0', false );
+		header( 'Pragma: no-cache' );
+		header("Location: /suricata/suricata_interfaces.php");
+		exit;
+	}
 	$suricatacfg = config_get_path("installedpackages/suricata/rule/{$_POST['id']}");
 	$if_real = get_real_interface($suricatacfg['interface']);
 	$if_friendly = convert_friendly_interface_to_friendly_descr($suricatacfg['interface']);
@@ -161,16 +171,16 @@ if ($_POST['toggle']) {
 	$start_lck_file = "{$g['varrun_path']}/suricata_{$if_real}{$suricatacfg['uuid']}_starting.lck";
 	$suricata_start_cmd = <<<EOD
 	<?php
-	require_once('/usr/local/pkg/suricata/suricata.inc');
-	require_once('service-utils.inc');
+	require_once("/usr/local/pkg/suricata/suricata.inc");
+	require_once("service-utils.inc");
 	global \$g, \$rebuild_rules;
-	\$suricatacfg = \config_get_path("installedpackages/suricata/rule/{$id}", []);
+	\$suricatacfg = config_get_path("installedpackages/suricata/rule/{$id}", []);
 	\$rebuild_rules = true;
-	touch('{$start_lck_file}');
+	touch("{$start_lck_file}");
 	sync_suricata_package_config();
 	\$rebuild_rules = false;
-	suricata_start(\$suricatacfg, '{$if_real}');
-	unlink_if_exists('{$start_lck_file}');
+	suricata_start(\$suricatacfg, "{$if_real}");
+	unlink_if_exists("{$start_lck_file}");
 	unlink(__FILE__);
 	?>
 EOD;

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
@@ -119,8 +119,8 @@ if ($_POST['save']) {
 			if (is_ipaddroralias($_POST["address{$x}"]) || is_subnet($_POST["address{$x}"])) {
 				$addrs[] = $_POST["address{$x}"];
 				if (is_alias($_POST["address{$x}"])) {
-					if (alias_get_type($_POST["address{$x}"]) != "host" && alias_get_type($_POST["address{$x}"]) != "network") {
-						$input_errors[] = gettext("Custom Address entry '" . $_POST["address{$x}"] . "' is not a Host or Network Alias!");
+					if (alias_get_type($_POST["address{$x}"]) != "host" && alias_get_type($_POST["address{$x}"]) != "network" && alias_get_type($_POST["address{$x}"]) != "urltable") {
+						$input_errors[] = gettext("Custom Address entry '" . $_POST["address{$x}"] . "' is not a Host, Network, or URL Table Alias!");
 					}
 				}
 			} else {
@@ -333,7 +333,7 @@ print($form);
 <script type="text/javascript">
 //<![CDATA[
 // ---------- Autocomplete --------------------------------------------------------------------
-var addressarray = <?= json_encode(get_alias_list(array("host", "network"))) ?>;
+var addressarray = <?= json_encode(get_alias_list(array("host", "network", "urltable"))) ?>;
 
 events.push(function() {
 


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.10_3
This update to the Suricata GUI package adds support for URL Table Aliases in a custom Pass List when using Legacy Blocking Mode.

**New Features:**
1. Add support for URL Table Aliases in a custom Pass List

**Bug Fixes:**
1. Modify the heredoc coding in the snort_interfaces.php per email comments from Jim Pingle to double-quote the variable strings and validate the $id interface index value prior to use.