### PR TITLE
pfSense-pkg-suricata-6.0.10_4_PHP-8.1 - Fix Redmine Issues 14041 and 14042.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	6.0.10
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -962,12 +962,6 @@ function suricata_load_suppress_sigs($suricatacfg, $track_by=false) {
 						$genid = $matches[1];
 						$sigid = $matches[2];
 						if (!empty($genid) && !empty($sigid)) {
-							if (!is_array($suppress[$genid])) {
-								$suppress[$genid] = array();
-							}
-							if (!is_array($suppress[$genid][$sigid])) {
-								$suppress[$genid][$sigid] = array();
-							}
 							array_set_path($suppress, "{$genid}/{$sigid}", "suppress");
 						}
 					}
@@ -1377,12 +1371,7 @@ function suricata_load_rules_map($rules_path) {
 			}
 
 			$gid = suricata_get_gid($rule);
-			if (!is_array($map_ref[$gid])) {
-				$map_ref[$gid] = array();
-			}
-			if (!is_array($map_ref[$gid][$sid])) {
-				$map_ref[$gid][$sid] = array();
-			}			
+			array_init_path($map_ref, "{$gid}/{$sid}");
 			$map_ref[$gid][$sid]['rule'] = $rule;
 			$map_ref[$gid][$sid]['category'] = basename($file, ".rules");
 			$map_ref[$gid][$sid]['state_toggled'] = 0;
@@ -1543,9 +1532,7 @@ function suricata_get_checked_flowbits($rules_map) {
 					$target = preg_split('/[&|]/', substr($flowbit, $pos + 1));
 					foreach ($target as $t) {
 						if (!empty($t) && !isset($checked_flowbits[$t])) {
-							if (!is_array($checked_flowbits[$t])) {
-								$checked_flowbits[$t] = array();
-							}
+							array_init_path($checked_flowbits, $t);
 							$checked_flowbits[$t] = $action;
 						}
 					}
@@ -1594,9 +1581,7 @@ function suricata_get_set_flowbits($rules_map) {
 					$target = preg_split('/[&|]/', substr($flowbit, $pos + 1));
 					foreach ($target as $t) {
 						if (!empty($t) && !isset($set_flowbits[$t])) {
-							if (!is_array($set_flowbits[$t])) {
-								$set_flowbits[$t] = array();
-							}
+							array_init_path($set_flowbits, $t);
 							$set_flowbits[$t] = $action;
 						}
 					}
@@ -1648,13 +1633,7 @@ function suricata_find_flowbit_required_rules($rules, $active_rules, $unchecked_
 				if (!strcasecmp(substr($action, 0, 3), "set")) {
 					$tmp = substr($flowbit, strpos($flowbit, ",") +1 );
 					if (!empty($tmp) && isset($unchecked_flowbits[$tmp])) {
-						if (!is_array($required_flowbits_rules[$k1])) {
-							$required_flowbits_rules[$k1] = array();
-						}
-						if (!is_array($required_flowbits_rules[$k1][$k2])) {
-							$required_flowbits_rules[$k1][$k2] = array();
-						}
-
+						array_init_path($required_flowbits_rules, "{$k1}/{$k2}");
 						$required_flowbits_rules[$k1][$k2]['noalert'] = $rule2['noalert'];
 						if ($rule2['disabled'] == 0) {
 							// If not disabled, just return the rule text "as is"
@@ -1837,12 +1816,7 @@ function suricata_load_vrt_policy($policy, $mode='alert', $all_rules=null) {
 		foreach ($arulem as $k2 => $arulem2) {
 			if (strripos($arulem2['rule'], "policy {$policy}-ips") !== false) {
 				if (!preg_match('/flowbits\s*:\s*noalert/i', $arulem2['rule'])) {
-					if (!is_array($vrt_policy_rules[$k1])) {
-						$vrt_policy_rules[$k1] = array();
-					}
-					if (!is_array($vrt_policy_rules[$k1][$k2])) {
-						$vrt_policy_rules[$k1][$k2] = array();
-					}
+					array_init_path($vrt_policy_rules, "{$k1}/{$k2}");
 					$vrt_policy_rules[$k1][$k2] = $arulem2;
 
 					// Enable the policy rule if disabled
@@ -3006,9 +2980,7 @@ function suricata_load_sid_mods($sids) {
 	$tmp = explode("||", $sids);
 	foreach ($tmp as $v) {
 		if (preg_match('/(\d+)\s*:\s*(\d+)/', $v, $match)) {
-			if (!is_array($result[$match[1]])) {
-				$result[$match[1]] = array();
-			}
+			array_init_path($result, "{$match[1]}/{$match[2]}");
 			$result[$match[1]][$match[2]] = "{$match[1]}:{$match[2]}";
 		}
 	}
@@ -3201,13 +3173,8 @@ function suricata_get_filtered_rules($rules, $filter) {
 	// over to the filtered array.
 	foreach ($filter as $k1 => $rulem) {
 		foreach($rulem as $k2 => $v) {
-			if (isset($tmp_map[$k1][$k2])) {
-				if (!is_array($filtered_map[$k1])) {
-					$filtered_map[$k1] = array();
-				}
-				if (!is_array($filtered_map[$k1][$k2])) {
-					$filtered_map[$k1][$k2] = array();
-				}
+			if (array_get_path($tmp_map, "{$k1}/{$k2}") !== null) {
+				array_init_path($filtered_map, "{$k1}/{$k2}");
 				$filtered_map[$k1][$k2]['rule'] = $tmp_map[$k1][$k2]['rule'];
 				$filtered_map[$k1][$k2]['category'] = $tmp_map[$k1][$k2]['category'];
 				$filtered_map[$k1][$k2]['action'] = $tmp_map[$k1][$k2]['action'];
@@ -3278,9 +3245,7 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 			if (!empty($suricatacfg['rulesets'])) {
 				foreach (explode("||", $suricatacfg['rulesets']) as $file){
 						$category = basename($file, ".rules");
-						if (!is_array($enabled_files[$category])) {
-							$enabled_files[$category] = array();
-						}
+						array_init_path($enabled_files, $category);
 						$enabled_files[$category] = $file;
 				}
 			}
@@ -3317,12 +3282,7 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 			foreach ($all_rules as $k1 => $rulem) {
 				foreach ($rulem as $k2 => $v) {
 					if (isset($enabled_files[$v['category']])) {
-						if (!is_array($enabled_rules[$k1])) {
-							$enabled_rules[$k1] = array();
-						}
-						if (!is_array($enabled_rules[$k1][$k2])) {
-							$enabled_rules[$k1][$k2] = array();
-						}
+						array_init_path($enabled_rules, "{$k1}/{$k2}");
 						$enabled_rules[$k1][$k2]['rule'] = $v['rule'];
 						$enabled_rules[$k1][$k2]['category'] = $v['category'];
 						$enabled_rules[$k1][$k2]['disabled'] = $v['disabled'];
@@ -3354,12 +3314,7 @@ function suricata_prepare_rule_files($suricatacfg, $suricatacfgdir) {
 			$policy_rules = suricata_load_vrt_policy($suricatacfg['ips_policy'], $policy_mode, $all_rules);
 			foreach ($policy_rules as $k1 => $policy) {
 				foreach ($policy as $k2 => $p) {
-					if (!is_array($enabled_rules[$k1])) {
-						$enabled_rules[$k1] = array();
-					}
-					if (!is_array($enabled_rules[$k1][$k2])) {
-						$enabled_rules[$k1][$k2] = array();
-					}
+					array_init_path($enabled_rules, "{$k1}/{$k2}");
 					$enabled_rules[$k1][$k2]['rule'] = $p['rule'];
 					$enabled_rules[$k1][$k2]['category'] = $p['category'];
 					$enabled_rules[$k1][$k2]['disabled'] = $p['disabled'];

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -226,7 +226,7 @@ if (config_get_path('installedpackages/suricata/config/0/files_json_log_limit_si
 /* any existing <address> to the new array structure.     */
 /**********************************************************/
 foreach (config_get_path('installedpackages/suricata/passlist/item', []) as $idx => $wlisti) {
-	if (!is_array($wlisti['address']) && !empty($wlisti['address']) && !is_array($wlisti['address']['item'])) {
+	if (!is_array($wlisti['address']) && !empty($wlisti['address'])) {
 		$tmp = $wlisti['address'];
 		$wlisti['address'] = array();
 		$wlisti['address']['item'] = array();

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -40,15 +40,15 @@ function suricata_is_alert_globally_suppressed($list, $gid, $sid) {
 	/* global suppression of the $gid:$sid.         */
 	/************************************************/
 
-	/* If entry has a child array, then it's by src or dst ip. */
-	/* So if there is a child array or the keys are not set,   */
-	/* then this gid:sid is not globally suppressed.           */
-	if (is_array($list[$gid][$sid]))
-		return false;
-	elseif (!isset($list[$gid][$sid]))
-		return false;
-	else
+	/* If entry at array key [GID][SID] is set to the
+	 * string "suppress", then the rule is globally
+	 * suppressed, otherwise it will  have a child
+	 * array for track "by_src" or "by_dst".
+     */
+	if (array_get_path($list, "{$gid}/{$sid}", "") == "suppress")
 		return true;
+	else
+		return false;
 }
 
 function suricata_add_supplist_entry($suppress) {

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
@@ -66,10 +66,9 @@ if (isset($id) && !empty($a_nat)) {
 				  "request-body-limit" => 4096, "response-body-limit" => 4096,
 				  "double-decode-path" => "no", "double-decode-query" => "no",
 				  "uri-include-all" => "no", "meta-field-limit" => 18432 );
-		$pconfig['libhtp_policy']['item'] = array();
+		array_init_path($pconfig, 'libhtp_policy/item');
 		$pconfig['libhtp_policy']['item'][] = $default;
-		if (!is_array($a_nat['libhtp_policy']['item']))
-			$a_nat['libhtp_policy']['item'] = array();
+		array_init_path($a_nat, 'libhtp_policy/item');
 		$a_nat['libhtp_policy']['item'][] = $default;
 		config_set_path("installedpackages/suricata/rule/{$id}", $a_nat);
 		write_config("Suricata pkg: created a new default HTTP server configuration for " . convert_friendly_interface_to_friendly_descr($a_nat['interface']));

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
@@ -56,8 +56,7 @@ if (isset($id) && !empty($a_nat)) {
 		$default = array( "name" => "default", "bind_to" => "all", "policy" => "bsd" );
 		$pconfig['host_os_policy']['item'] = array();
 		$pconfig['host_os_policy']['item'][] = $default;
-		if (!is_array($a_nat['host_os_policy']['item']))
-			$a_nat['host_os_policy']['item'] = array();
+		array_init_path($a_nat, 'host_os_policy/item');
 		$a_nat['host_os_policy']['item'][] = $default;
 		config_set_path("installedpackages/suricata/rule/{$id}", $a_nat);
 		write_config("Suricata pkg: saved new default Host_OS_Policy engine.");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -680,20 +680,14 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$natent['host_prealloc'] = "1000";
 
 			$default = array( "name" => "default", "bind_to" => "all", "policy" => "bsd" );
-			if (!is_array($natent['host_os_policy']))
-				$natent['host_os_policy'] = array();
-			if (!is_array($natent['host_os_policy']['item']))
-				$natent['host_os_policy']['item'] = array();
+			array_init_path($natent, 'host_os_policy/item');
 			$natent['host_os_policy']['item'][] = $default;
 
 			$default = array( "name" => "default", "bind_to" => "all", "personality" => "IDS",
 					  "request-body-limit" => 4096, "response-body-limit" => 4096,
 					  "double-decode-path" => "no", "double-decode-query" => "no",
 					  "uri-include-all" => "no", "meta-field-limit" => 18432 );
-			if (!is_array($natent['libhtp_policy']))
-				$natent['libhtp_policy'] = array();
-			if (!is_array($natent['libhtp_policy']['item']))
-				$natent['libhtp_policy']['item'] = array();
+			array_init_path($natent, 'libhtp_policy/item');
 			$natent['libhtp_policy']['item'][] = $default;
 
 			// Enable the basic default rules for the interface

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist.php
@@ -47,6 +47,10 @@ function suricata_is_passlist_used($list) {
 	foreach(config_get_path('installedpackages/suricata/rule', []) as $v) {
 		if (isset($v['passlistname']) && $v['passlistname'] == $list)
 			return TRUE;
+		if (isset($v['homelistname']) && $v['homelistname'] == $list)
+			return TRUE;
+		if (isset($v['externallistname']) && $v['externallistname'] == $list)
+			return TRUE;
 	}
 	return FALSE;
 }

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_passlist_edit.php
@@ -65,10 +65,7 @@ if (!isset($pconfig['vips'])) {
 if (!isset($pconfig['vpnips'])) {
 	$pconfig['vpnips'] = "yes";
 }
-if (!is_array($pconfig['address'])) {
-	$pconfig['address'] = array();
-	$pconfig['address']['item'] = array();
-}
+array_init_path($pconfig, 'address/item');
 
 /* If no entry for this passlist, then create a UUID and treat it like a new list */
 if (!isset($a_passlist[$id]['uuid']) && empty($pconfig['uuid'])) {


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.10_4
This GUI package update for Suricata addresses two bug fixes for [Redmine Issue #14041](https://redmine.pfsense.org/issues/14041) and [Redmine Issue #14042](https://redmine.pfsense.org/issues/14042).

**New Features:**
none

**Bug Fixes:**
1. Fix [Redmine Issue #14041](https://redmine.pfsense.org/issues/14041) - post-install migration of existing settings throws a PHP error when the configuration contains the legacy layout of a single alias in a Pass List.
2. Fix [Redmine Issue #14042](https://redmine.pfsense.org/issues/14042) - an assigned Pass List is not shown as "Assigned" on the PASS LISTS tab when the list is used in the HOME_NET or EXTERNAL_NET setting on a Suricata interface.