### PR TITLE
security/pfSense-pkg-acme: allow creating account keys with EAB

### DIFF
--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
@@ -1647,8 +1647,8 @@ function & get_certificate($name) {
 		return $acmesh->generateDomainKey($domain, $keylength);
 	}
 	
-	function registerAcmeAccountKey($name, $ca, $key, $email = "") {
-		$acmesh = new acme_sh($name, $ca, $email);
+	function registerAcmeAccountKey($name, $ca, $key, $email = "", $eabkid = "", $eabhmackey = "") {
+		$acmesh = new acme_sh($name, $ca, $email, $eabkid, $eabhmackey);
 		return $acmesh->registeraccount($key);
 	}
 

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_sh.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_sh.inc
@@ -110,12 +110,12 @@ class acme_sh {
 		return $return_value;
 	}
 	
-	function __construct($name, $ca, $email) {
+	function __construct($name, $ca, $email, $eabkid = "", $eabhmackey = "") {
 		$this->name = $name;
-		$this->init($ca, $name, $email);
+		$this->init($ca, $name, $email, $eabkid, $eabhmackey);
 	}
 	
-	function init($ca, $name, $email) {
+	function init($ca, $name, $email, $eabkid, $eabhmackey) {
 		$conf = "ACME_DIRECTORY='{$ca}'\nACCOUNT_EMAIL='{$email}'\n";
 		$cadir = parse_url($ca, PHP_URL_HOST) . parse_url($ca, PHP_URL_PATH);
 		$acmeconf = "/tmp/acme/{$name}/";
@@ -124,6 +124,8 @@ class acme_sh {
 		safe_mkdir($this->path_account);
 		$this->accountconfig = "{$this->acmeconf}accountconf.conf";
 		file_put_contents("{$this->accountconfig}", $conf);
+		$this->eabkid = $eabkid;
+		$this->eabhmackey = $eabhmackey;
 	}
 	
 	function generateAccountKey() {
@@ -142,12 +144,18 @@ class acme_sh {
 	function registeraccount($key) {
 		file_put_contents("{$this->path_account}/account.key", $key);
 		$this->debug = false;
+		$cmdadd = "";
+		if ($this->eabkid) {
+			$cmdadd = " --eab-kid " . escapeshellarg($this->eabkid)
+				. " --eab-hmac-key " . escapeshellarg($this->eabhmackey);
+		}
 		$result = $this->execacmesh(""
 				. " --home " . escapeshellarg($this->acmeconf)
 				. " --registeraccount"
 				. " --accountconf " . escapeshellarg($this->accountconfig)
 				. " --log-level 3"
-				. " --log " . escapeshellarg($this->acmeconf."acme_issuecert.log"));
+				. " --log " . escapeshellarg($this->acmeconf."acme_issuecert.log")
+				. $cmdadd);
 		return $result == 0;
 	}
 	

--- a/security/pfSense-pkg-acme/files/usr/local/www/acme/acme_accountkeys_edit.php
+++ b/security/pfSense-pkg-acme/files/usr/local/www/acme/acme_accountkeys_edit.php
@@ -38,9 +38,11 @@ if ($_POST['action'] == "registerkey") {
 	$caname = $_POST['caname'];
 	$key = $_POST['key'];
 	$email = $_POST['email'];
+	$eabkid = $_POST['eabkid'];
+	$eabhmackey = $_POST['eabhmackey'];
 	$ca = $a_acmeserver[$caname]['url'];
 	echo "Register key at ca: {$ca}\n";
-	echo (registerAcmeAccountKey("_registerkey", $ca, $key, $email)) ? "reg-ok" : "reg-fail" ;
+	echo (registerAcmeAccountKey("_registerkey", $ca, $key, $email, $eabkid, $eabhmackey)) ? "reg-ok" : "reg-fail" ;
 	exit;
 }
 
@@ -66,8 +68,9 @@ if (!is_numeric($id))
 
 global $simplefields;
 $simplefields = array(
-	"name","descr", "email",
-	"acmeserver","renewafter"
+	"name","descr","email",
+	"acmeserver","renewafter",
+	"eabkid","eabhmackey"
 );
 
 function customdrawcell_actions($object, $item, $itemvalue, $editable, $itemname, $counter) {
@@ -208,6 +211,20 @@ $section->addInput(new \Form_Select(
 	'Let\'s Encrypt ACMEv1 servers no longer allow new registrations, and in June 2021 they will be completely disabled.%1$s%1$s', '<br/>');
 
 $section->addInput(new \Form_Input(
+	'eabkid',
+	'EAB kid',
+	'text',
+        $pconfig['eabkid']
+))->setHelp('Enter the EAB kid for the ACME Server new account request here. (Required for Google)');
+
+$section->addInput(new \Form_Input(
+	'eabhmackey',
+	'EAB hmac-key',
+	'text',
+        $pconfig['eabhmackey']
+))->setHelp('Enter the EAB hmac-key for the ACME Server new account request here. (Required for Google)');
+
+$section->addInput(new \Form_Input(
 	'email',
 	'E-Mail Address',
 	'text',
@@ -302,9 +319,11 @@ events.push(function() {
 		var key = $("#accountkey").val();
 		var caname = $("#acmeserver").val();
 		var email = $("#email").val();
+		var eabkid = $("#eabkid").val();
+		var eabhmackey = $("#eabhmackey").val();
 		ajaxRequest = $.ajax({
 			type: "post",
-			data: { action: "registerkey", caname: caname, key: key, email: email },
+			data: { action: "registerkey", caname: caname, key: key, email: email, eabkid: eabkid, eabhmackey: eabhmackey },
 			success: function(data) {
 				if (data.toLowerCase().indexOf("reg-ok") > -1 ) {
 					$("#btnregisterkeyicon").removeClass("fa-cog fa-spin").addClass("fa-check");


### PR DESCRIPTION
Enhance the registerAcmeAccountKey function to use the EAB kid and hmac-key generated by gcloud:
  `gcloud alpha publicca external-account-keys create`

References:
- https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.4
- https://cloud.google.com/blog/products/identity-security/automate-public-certificate-lifecycle-management-via--acme-client-api
- https://github.com/acmesh-official/acme.sh/wiki/Google-public-CA