### PR TITLE
security/pfSense-pkg-acme: add dns_googledomains

### DIFF
--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
@@ -759,6 +759,15 @@ $acme_domain_validation_method['dns_gd'] = array('name' => "DNS-GoDaddy",
 			'description' => "GoDaddy API Secret"
 		)
 	));
+$acme_domain_validation_method['dns_googledomains'] = array('name' => "DNS-Google Domains",
+	'fields' => array(
+		'GOOGLEDOMAINS_ACCESS_TOKEN' => array('name' => "googledomains_access_token", 'columnheader' => "Key", 'type' => "textbox",
+			'description' => "Google Domain API Key"
+		),
+		'GOOGLEDOMAINS_ZONE' => array('name' => "googledomains_zone", 'columnheader' => "Zone", 'type' => "textbox",
+			'description' => "Google Domain Zone"
+		)
+	));
 $acme_domain_validation_method['dns_hetzner'] = array('name' => "DNS-Hetzner",
 	'fields' => array(
 		'HETZNER_Token' => array('name' => "hetzner_token", 'columnheader' => "API Token", 'type' => "password",


### PR DESCRIPTION
Add support for Google Domains DNS API

ref: https://domains.google/learn/gts-acme/

This is an ACME API for Google Domains customers, which is different from the Google Cloud Domains API for Google Cloud customers.

There are 2 competing upstream PRs for this support, once available in upstream (and the ENV variable ratified) this can be pulled in.

The PRs are:
- https://github.com/acmesh-official/acme.sh/pull/4542
  - using GOOGLEDOMAINS_ACCESS_TOKEN
- https://github.com/acmesh-official/acme.sh/pull/4546
  - using GOOGLEDOMAINS_TOKEN