### PR TITLE
Redmine #14299: pfBlockerNG: cURL srcint parameter missing from a few critical locations.

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8194,6 +8194,9 @@ function sync_package_pfblockerng($cron='') {
 				$pfb['domain_clear']	= FALSE;		// Flag to signal no Aliases defined or all Aliases disabled.
 				$alias_cnt		= 0;
 
+				// cURL Source Interface (sets CURLOPT_INTERFACE)
+				$srcint = $list['srcint'] ?: FALSE;
+
 				if ($list['action'] != 'Disabled' && isset($list['row'])) {
 					$alias				= "DNSBL_{$list['aliasname']}";
 					if (empty(pfb_filter($alias, PFB_FILTER_WORD, 'DNSBL - Processes'))) {

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng.php
@@ -247,7 +247,7 @@ if (in_array($argv[1], array('update', 'updateip', 'updatednsbl', 'dc', 'dcc', '
 
 
 // Determine if source list file has an updated timestamp
-function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $format, $vtype) {
+function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $format, $vtype, $srcint=FALSE) {
 	global $config, $pfb;
 
 	$log = "[ {$header} ] [ NOW ]\n";
@@ -371,6 +371,12 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 					curl_setopt($ch, CURLOPT_SSL_CIPHER_LIST, 'TLSv1.2, TLSv1, SSLv3');
 				}
 
+				// If source interface is specified (not 'default') set CURLOPT_INTERFACE
+				if ($srcint) {
+					curl_setopt($ch, CURLOPT_INTERFACE, $srcint);
+					pfb_logger("\nList: {$header} will be downloaded via interface: {$srcint}\n", 1);
+				}
+
 				// Try up to 3 times to download the file before giving up
 				for ($retries = 1; $retries <= 3; $retries++) {
 					$remote_stamp_raw = -1;
@@ -400,7 +406,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 		if ($remote_stamp_raw == -1) {
 
 			// Download Feed to compare md5's. If update required, downloaded md5 file will be used instead of downloading twice
-			if (pfb_download("{$list_download}", "{$pfborig}/{$header}.md5", $pflex, $header, '', 1, '', 300, 'md5', '', '')) {
+			if (pfb_download("{$list_download}", "{$pfborig}/{$header}.md5", $pflex, $header, '', 1, '', 300, 'md5', '', '', $srcint)) {
 
 				// Collect md5 checksums
 				$remote_md5	= @md5_file("{$pfborig}/{$header}.md5.raw");
@@ -561,6 +567,9 @@ function pfblockerng_sync_cron() {
 								continue;
 							}
 
+							// Determine cURL source interface (sets CURLOPT_INTERFACE; applies to entire alias)
+							$srcint = $list['srcint'] ?: FALSE;
+
 							// Determine folder location for alias (return array $pfbarr)
 							pfb_determine_list_detail($list['action'], '', '', '');
 							$pfbfolder	= $pfbarr['folder'];
@@ -573,7 +582,7 @@ function pfblockerng_sync_cron() {
 
 							// Attempt download, when a previous 'fail' file marker is found.
 							if (file_exists("{$pfbfolder}/{$header}.fail")) {
-								pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format'], $vtype);
+								pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format'], $vtype, $srcint);
 								continue;
 							}
 
@@ -586,18 +595,18 @@ function pfblockerng_sync_cron() {
 							switch ($list['cron']) {
 								case 'EveryDay':
 									if ($hour == $pfb['24hour']) {
-										pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format'], $vtype);
+										pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format'], $vtype, $srcint);
 									}
 									break;
 								case 'Weekly':
 									if ($hour == $pfb['24hour'] && $dow == $list['dow']) {
-										pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format'], $vtype);
+										pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format'], $vtype, $srcint);
 									}
 									break;
 								default:
 									$pfb_sch = pfb_cron_base_hour($list['cron']);
 									if (in_array($hour, $pfb_sch)) {
-										pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format'], $vtype);
+										pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format'], $vtype, $srcint);
 									}
 									break;
 							}


### PR DESCRIPTION
[Redmine #14299](https://redmine.pfsense.org/issues/14299)