### PR TITLE
pfSense-pkg-suricata-6.0.11 - Update Suricata GUI package to support version 6.0.11 of the binary.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,8 +1,8 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	6.0.10
-PORTREVISION=	4
+PORTVERSION=	6.0.11
+PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=6.0.10:security/suricata
+RUN_DEPENDS=	suricata>=6.0.11:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.11
This update adds support for the latest 6.0.11 version of the Suricata binary from upstream.

**New Features:**
None

**Bug Fixes:**
None
