### PR TITLE
LCDproc - Add NUT UPS Information. Feature: #14321

### DIFF
--- a/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc_client.php
+++ b/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc_client.php
@@ -1277,25 +1277,25 @@ function lcdproc_loop_status($lcd) {
 									break;
 							}
 						} else {
-							$runtime = ($ups_status['_hms'] == null) ? "VOLTS: {$ups_status['battery.voltage']}/{$ups_status['battery.voltage.low']}" : "{$ups_status['_hms']}";
+							$runtime = ($ups_status['_hms'] == null) ? "VOLTS: {$ups_status['battery.voltage']}/{$ups_status['battery.voltage.low']}" : "HMS: {$ups_status['_hms']}";
 							switch($lcdpanel_height) {
 								case 1:
-									$lcd_cmds[] = "widget_set $name summary_wdgt 1 1 $lcdpanel_width 2 h 2 \"{$ups_status['_summary']} HMS:{$runtime} BATT:{$ups_status['battery.charge']}% LOAD:{$ups_status['ups.load']}%\"";
+									$lcd_cmds[] = "widget_set $name summary_wdgt 1 1 $lcdpanel_width 2 h 2 \"{$ups_status['_summary']} {$runtime} BATT:{$ups_status['battery.charge']}% LOAD:{$ups_status['ups.load']}%\"";
 									break;
 								case 2:
 									$lcd_cmds[] = "widget_set $name summary_wdgt 1 1 $lcdpanel_width 2 h 3 \"{$ups_status['_summary']}\"";
-									$lcd_cmds[] = "widget_set $name runtime_wdgt 1 2 $lcdpanel_width 2 h 3 \"HMS:{$runtime} BATT:{$ups_status['battery.charge']}% LOAD:{$ups_status['ups.load']}%\"";
+									$lcd_cmds[] = "widget_set $name runtime_wdgt 1 2 $lcdpanel_width 2 h 3 \"{$runtime} BATT:{$ups_status['battery.charge']}% LOAD:{$ups_status['ups.load']}%\"";
 									break;
 								case 4:
 									$lcd_cmds[] = "widget_set $name summary_wdgt 1 1 $lcdpanel_width 2 h 3 \"{$ups_status['_summary']}\"";
-									$lcd_cmds[] = "widget_set $name runtime_wdgt 1 2 $lcdpanel_width 2 h 3 \"" . (($lcdpanel_width <= 12) ? "HMS: {$runtime}" : "HMS:  {$runtime}") . "\"";
+									$lcd_cmds[] = "widget_set $name runtime_wdgt 1 2 $lcdpanel_width 2 h 3 \"{$runtime}\"";
 									$lcd_cmds[] = "widget_set $name batt_wdgt 1 3 \"BATT: {$ups_status['battery.charge']}%\"";
 									$lcd_cmds[] = "widget_set $name load_wdgt 1 4 \"LOAD: {$ups_status['ups.load']}%\"";
 									break;
 								default:
 									// Handle a future LCD height by playing it safe with 2 rows and scrolling
 									$lcd_cmds[] = "widget_set $name summary_wdgt 1 1 $lcdpanel_width 2 h 3 \"{$ups_status['_summary']}\"";
-									$lcd_cmds[] = "widget_set $name runtime_wdgt 1 2 $lcdpanel_width 2 h 3 \"HMS:{$runtime} BATT:{$ups_status['battery.charge']}% LOAD:{$ups_status['ups.load']}%\"";
+									$lcd_cmds[] = "widget_set $name runtime_wdgt 1 2 $lcdpanel_width 2 h 3 \"{$runtime} BATT:{$ups_status['battery.charge']}% LOAD:{$ups_status['ups.load']}%\"";
 									break;
 							}
 						}

--- a/sysutils/pfSense-pkg-LCDproc/files/usr/local/www/packages/lcdproc/lcdproc_screens.php
+++ b/sysutils/pfSense-pkg-LCDproc/files/usr/local/www/packages/lcdproc/lcdproc_screens.php
@@ -44,6 +44,9 @@ if (!isset($pconfig['scr_ipsec']))                           $pconfig['scr_ipsec
 if (!isset($pconfig['scr_interfaces']))                      $pconfig['scr_interfaces']                      = false;
 if (!isset($pconfig['scr_mbuf']))                            $pconfig['scr_mbuf']                            = false;
 if (!isset($pconfig['scr_cpufrequency']))                    $pconfig['scr_cpufrequency']                    = false;
+if (!isset($pconfig['scr_cputemperature']))                  $pconfig['scr_cputemperature']                  = false;
+if (!isset($pconfig['scr_cputemperature_unit']))             $pconfig['scr_cputemperature_unit']             = 'c';
+if (!isset($pconfig['scr_nut_ups']))                         $pconfig['scr_nut_ups']                         = false;
 if (!isset($pconfig['scr_traffic']))                         $pconfig['scr_traffic']                         = false;
 if (!isset($pconfig['scr_traffic_interface']))               $pconfig['scr_traffic_interface']               = '';
 if (!isset($pconfig['scr_top_interfaces_by_bps']))           $pconfig['scr_top_interfaces_by_bps']           = false;
@@ -79,6 +82,9 @@ if ($_POST) {
 		$lcdproc_screens_config['scr_interfaces']                      = $pconfig['scr_interfaces'];
 		$lcdproc_screens_config['scr_mbuf']                            = $pconfig['scr_mbuf'];
 		$lcdproc_screens_config['scr_cpufrequency']                    = $pconfig['scr_cpufrequency'];
+		$lcdproc_screens_config['scr_cputemperature']                  = $pconfig['scr_cputemperature'];
+		$lcdproc_screens_config['scr_cputemperature_unit']             = $pconfig['scr_cputemperature_unit'];
+		$lcdproc_screens_config['scr_nut_ups']                         = $pconfig['scr_nut_ups'];
 		$lcdproc_screens_config['scr_traffic']                         = $pconfig['scr_traffic'];
 		$lcdproc_screens_config['scr_traffic_interface']               = $pconfig['scr_traffic_interface'];
 		$lcdproc_screens_config['scr_top_interfaces_by_bps']           = $pconfig['scr_top_interfaces_by_bps'];
@@ -220,6 +226,36 @@ $section->addInput(
 		$pconfig['scr_cpufrequency'] // checkbox initial value
 	)
 );
+$section->addInput(
+	new Form_Checkbox(
+		'scr_nut_ups', // checkbox name (id)
+		'NUT UPS Status', // checkbox label
+		'Display UPS status', // checkbox text
+		$pconfig['scr_nut_ups'] // checkbox initial value
+	)
+)->setHelp('Display current UPS Status, Runtime, Battery Level and Load. Battery voltage displayed if runtime is not available. Restart LCDproc service if changing values of NUT remote UPS monitoring. NOTE: NUT packaged required');
+
+$group = new Form_Group('CPU Temperature');
+
+$group->add(
+	new Form_Checkbox(
+		'scr_cputemperature', // checkbox name (id)
+		'CPU Temperature', // checkbox label
+		'Display CPU temperature', // checkbox text
+		$pconfig['scr_cputemperature'] // checkbox initial value
+	)
+);
+$group->add(
+	new Form_Select(
+		'scr_cputemperature_unit',
+		'',
+		$pconfig['scr_cputemperature_unit'],
+		array (
+			'c'	=> gettext('Celsius'),
+			'f'	=> gettext('Fahrenheit')
+	)
+))->setHelp('Unit of temperature');
+$section->add($group);
 
 $group = new Form_Group('Traffic of interface');
 


### PR DESCRIPTION
Hi,

As requested in redmine. I'd like to please get this reviewed. It's branched off my PR #1125 - it looks busy until that is merged. Jim indicated that it looks good to merge. Hopefully this is an ok path to take - branching from code that isn't merged yet(please let me know if there's a more suited path).

Functions mainly for review are L100 and L1258 if that helps.

So far under testing(months) it works well locally. I need to triple check again the remote NUT monitoring part and different size LCD screens - for intended behaviours.

I've got some questions if I could please get advice on:

- L30, is that a sane way to determine if the NUT package is installed?
- L1280, are inline if conditions ok to use?

Thank you.

Example how it should look:
![LCDproc_NUT_UPS](https://user-images.githubusercontent.com/19909711/237060169-bc90f688-e667-4fc0-8edd-961a50397f1d.jpg)

