### PR TITLE
pfSense-pkg-suricata-6.0.12 -- Update Suricata GUI package to support latest 6.0.12 binary

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	6.0.11
+PORTVERSION=	6.0.12
 PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=6.0.11:security/suricata
+RUN_DEPENDS=	suricata>=6.0.12:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes


### PR DESCRIPTION
### pfSense-pkg-suricata-6.0.12
This request updates the pfSense Suricata GUI package to support the latest 6.0.12 upstream binary release.

**New Features:**
None

**Bug Fixes:**
None
