### PR TITLE
pfSense-pkg-snort-4.1.6_8 -- Fix Redmine Issues 14469 and 14496.

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.1.6
-PORTREVISION=	7
+PORTREVISION=	8
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort_generate_conf.php
@@ -1008,16 +1008,22 @@ preprocessor appid: \
 EOD;
 
 /* def ARP Spoof preprocessor */
-$arpspoof_preproc = "# ARP Spoof preprocessor #\n";
+$arpspoof_preproc = "";
 if ($snortcfg['arp_unicast_detection'] == 'on') {
+	$arpspoof_preproc = "# ARP Spoof preprocessor (detect unicast ARP requests) #\n";
 	$arpspoof_preproc .= "preprocessor arpspoof: -unicast\n";
+	foreach (array_get_path($snortcfg, 'arp_spoof_engine/item', []) as $f => $v) {
+		$arpspoof_preproc .= "preprocessor arpspoof_detect_host: ";
+		$arpspoof_preproc .= $v['ip_addr'] . " " . str_replace('-', ':', $v['mac_addr']) . "\n";
+	}
 }
-else {
+elseif ($snortcfg['arpspoof_preproc'] == 'on') {
+	$arpspoof_preproc = "# ARP Spoof preprocessor #\n";
 	$arpspoof_preproc .= "preprocessor arpspoof\n";
-}
-foreach (array_get_path($snortcfg, 'arp_spoof_engine/item', []) as $f => $v) {
-	$arpspoof_preproc .= "preprocessor arpspoof_detect_host: ";
-	$arpspoof_preproc .= $v['ip_addr'] . " " . str_replace('-', ':', $v['mac_addr']) . "\n";
+	foreach (array_get_path($snortcfg, 'arp_spoof_engine/item', []) as $f => $v) {
+		$arpspoof_preproc .= "preprocessor arpspoof_detect_host: ";
+		$arpspoof_preproc .= $v['ip_addr'] . " " . str_replace('-', ':', $v['mac_addr']) . "\n";
+	}
 }
 
 /***************************************/

--- a/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
+++ b/security/pfSense-pkg-snort/files/usr/local/www/snort/snort_interfaces_edit.php
@@ -134,8 +134,6 @@ if (isset($id) && $a_rule[$id]) {
 	/* old options */
 	$if_friendly = convert_friendly_interface_to_friendly_descr($a_rule[$id]['interface']);
 	$pconfig = $a_rule[$id];
-	if (!empty($pconfig['configpassthru']))
-		$pconfig['configpassthru'] = base64_decode($pconfig['configpassthru']);
 	if (empty($pconfig['uuid']))
 		$pconfig['uuid'] = $snort_uuid;
 	if (get_real_interface($pconfig['interface']) == "") {
@@ -922,7 +920,7 @@ $section = new Form_Section('Custom Configuration Options');
 $section->addInput(new Form_Textarea (
 	'configpassthru',
 	'Advanced Configuration Pass-Through',
-	$pconfig['configpassthru']
+	base64_decode($pconfig['configpassthru'])
 ))->setHelp('Enter any additional configuration parameters to add to the Snort configuration here, separated by a newline');
 
 $form->add($section);


### PR DESCRIPTION
### pfSense-pkg-snort-4.1.6_8
This update for the Snort GUI package corrects two reported bugs. No new features are added.

**New Features:**
None

**Bug Fixes:**
1. Fix [Redmine Issue #14469](https://redmine.pfsense.org/issues/14469) - Config pass-through parameter is not properly base64 encoded/decoded after saving a page change. This can result in an invalid value being written to the _snort.conf_ file for the interface.
2. Fix [Redmine Issue #14496](https://redmine.pfsense.org/issues/14496) - When IP and MAC address host pairings are present in the config, but ARP Spoof detection is not currently enabled, an invalid configuration is created in the _snort.conf_ file for the interface resulting in Snort startup failure.