### PR TITLE
pfSense-pkg-suricata-6.0.13 -- Fix Redmine Issue 14475 and add support for 6.0.13 binary.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	6.0.12
+PORTVERSION=	6.0.13
 PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=6.0.12:security/suricata
+RUN_DEPENDS=	suricata>=6.0.13:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -672,7 +672,11 @@ if (($enable_extra_rules == 'on') && !empty($extra_rules)) {
 						$existing_rules = unserialize(file_get_contents("{$suricatadir}{$rulesfilename}.ruleslist"));
 						$newrules = array_diff($downloaded_rules, $existing_rules);
 						if (!empty($newrules)) {
-							$notify_new_message .= gettext("- Extra {$exrule['name']} rules: " . implode(', ', $newrules) . "\n");
+							$tmpstring = implode(', ', $newrules);
+							// There is a 4096 character limit enforced for strings sent to gettext() !!
+							// Make sure we don't exceed that if there are lots of new rule categories.
+							$tmpstring = (strlen($tmpstring) > 4096) ? substr($tmpstring,0,4000).'... msg truncated - too long to translate' : $tmpstring;
+							$notify_new_message .= gettext("- Extra {$exrule['name']} rules: " . $tmpstring . "\n");
 							@file_put_contents("{$suricatadir}{$rulesfilename}.ruleslist", serialize($downloaded_rules));
 						}
 					} else {
@@ -763,7 +767,9 @@ if ($emergingthreats == 'on') {
 			$existing_rules = unserialize(file_get_contents("{$suricatadir}{$emergingthreats_filename}.ruleslist"));
 			$newrules = array_diff($downloaded_rules, $existing_rules);
 			if (!empty($newrules)) {
-				$notify_new_message .= gettext("- {$et_name} rules: " . implode(', ', $newrules) . "\n");
+				$tmpstring = implode(', ', $newrules);
+				$tmpstring = (strlen($tmpstring) > 4096) ? substr($tmpstring,0,4000).'... msg truncated - too long to translate' : $tmpstring;
+				$notify_new_message .= gettext("- {$et_name} rules: " . $tmpstring . "\n");
 				@file_put_contents("{$suricatadir}{$emergingthreats_filename}.ruleslist", serialize($downloaded_rules));
 			}
 		} else {
@@ -817,7 +823,9 @@ if ($snortdownload == 'on') {
 			$existing_rules = unserialize(file_get_contents("{$suricatadir}{$snort_filename}.ruleslist"));
 			$newrules = array_diff($downloaded_rules, $existing_rules);
 			if (!empty($newrules)) {
-				$notify_new_message .= gettext("- Snort rules: " . implode(', ', $newrules) . "\n");
+				$tmpstring = implode(', ', $newrules);
+				$tmpstring = (strlen($tmpstring) > 4096) ? substr($tmpstring,0,4000).'... msg truncated - too long to translate' : $tmpstring;
+				$notify_new_message .= gettext("- Snort rules: " . $tmpstring . "\n");
 				@file_put_contents("{$suricatadir}{$snort_filename}.ruleslist", serialize($downloaded_rules));
 			}
 		} else {
@@ -856,7 +864,9 @@ if ($snortcommunityrules == 'on') {
 			$existing_rules = unserialize(file_get_contents("{$suricatadir}{$snort_community_rules_filename}.ruleslist"));
 			$newrules = array_diff($downloaded_rules, $existing_rules);
 			if (!empty($newrules)) {
-				$notify_new_message .= gettext("- Snort GPLv2 Community Rules: " . implode(', ', $newrules) . "\n");
+				$tmpstring = implode(', ', $newrules);
+				$tmpstring = (strlen($tmpstring) > 4096) ? substr($tmpstring,0,4000).'... msg truncated - too long to translate' : $tmpstring;
+				$notify_new_message .= gettext("- Snort GPLv2 Community Rules: " . $tmpstring . "\n");
 				@file_put_contents("{$suricatadir}{$snort_community_rules_filename}.ruleslist", serialize($downloaded_rules));
 			}
 		} else {


### PR DESCRIPTION
**pfSense-pkg-suricata-6.0.13**
This package update provides support for the latest 6.0.13 binary version from upstream and fixes [Redmine Issue #14475](https://redmine.pfsense.org/issues/14475).

**New Features:**
None

**Bug Fixes:**
1. Fix [Redmine Issue #14475](https://redmine.pfsense.org/issues/14475) - PHP crash error for some users when updating rules due to calling _gettext()_ with a string argument longer than 4096 characters.