### PR TITLE
Add ignoreDisk for /var/unbound/dev

### DIFF
--- a/net-mgmt/pfSense-pkg-net-snmp/Makefile
+++ b/net-mgmt/pfSense-pkg-net-snmp/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-net-snmp
 PORTVERSION=	0.1.5
-PORTREVISION=	10
+PORTREVISION=	11
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-net-snmp/files/usr/local/pkg/net-snmp.inc
+++ b/net-mgmt/pfSense-pkg-net-snmp/files/usr/local/pkg/net-snmp.inc
@@ -333,6 +333,7 @@ function netsnmp_resync() {
 	/* Ignore /dev and its copies as they are not filesystems that need monitored */
 	$snmpd_config .= "ignoreDisk /dev\n";
 	$snmpd_config .= "ignoreDisk /var/dhcpd/dev\n";
+	$snmpd_config .= "ignoreDisk /var/unbound/dev\n";
 	/* Monitor all disks that snmpd can find */
 	$snmpd_config .= "includeAllDisks {$nhisettings['disk_usage_percent']}%\n";
 


### PR DESCRIPTION
This adds an ignoreDIsk directive for /var/unbound/dev for net-smp. Addresses issue [14670](https://redmine.pfsense.org/issues/14670).