### PR TITLE
pf-Sense-pkg-suricata-7.0.0 -- Add support for Suricata 7.0.0 binary from upstream

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	6.0.13
+PORTVERSION=	7.0.0
 PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=6.0.13:security/suricata
+RUN_DEPENDS=	suricata>=7.0.0:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -82,7 +82,7 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 			syslog(LOG_NOTICE, gettext("[Suricata] Cleaning logs for {$value['descr']} ({$if_real})..."));
 
 			// Clean-up packet capture files if any exist
-			$filelist = glob("{$suricata_log_dir}/log.pcap.*");
+			$filelist = glob("{$suricata_log_dir}/pcaps/log.pcap.*");
 
 			// Keep most recent file
 			unset($filelist[count($filelist) - 1]);
@@ -423,8 +423,25 @@ if (config_get_path('installedpackages/suricata/config/0/enable_log_mgmt') == 'o
 			unset($files);
 		}
 
+		// Prune aged-out PCAP log files if any exist
+		if (is_dir("{$suricata_log_dir}/pcaps") &&
+		    config_get_path('installedpackages/suricata/config/0/pkt_capture_file_retention') > 0) {
+			$now = time();
+			$files = glob("{$suricata_log_dir}/pcaps/*.*");
+			$prune_count = 0;
+			foreach ($files as $f) {
+				if (($now - filemtime($f)) > (int)(config_get_path('installedpackages/suricata/config/0/pkt_capture_file_retention') * 3600)) {
+					$prune_count++;
+					unlink_if_exists($f);
+				}
+			}
+			if ($prune_count > 0)
+				syslog(LOG_NOTICE, gettext("[Suricata] PCAP files retention cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/pcaps/ whose creation date exceeded the retention limit."));
+			unset($files);
+		}
+
 		// Prune any pcap log files over configured limit
-		$files = glob("{$suricata_log_dir}/log.pcap.*");
+		$files = glob("{$suricata_log_dir}/pcaps/log.pcap.*");
 		if (count($files) > $value['max_pcap_log_files']) {
 			$over = count($files) - $value['max_pcap_log_files'];
 			$remove_files = array();
@@ -438,7 +455,7 @@ if (config_get_path('installedpackages/suricata/config/0/enable_log_mgmt') == 'o
 				unlink_if_exists($f);
 			}
 			if ($prune_count > 0)
-				syslog(LOG_NOTICE, gettext("[Suricata] Packet Capture log cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/..."));
+				syslog(LOG_NOTICE, gettext("[Suricata] Packet Capture log cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/pcaps/ to stay below the configured max files limit."));
 			unset($files, $remove_files);
 		}
 	}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
@@ -84,9 +84,11 @@ if (!defined('SURICATA_IPREP_PATH'))
 
 // Define an array consisting of Suricata default events rules
 if (!defined("SURICATA_DEFAULT_RULES"))
-	define("SURICATA_DEFAULT_RULES", array( "app-layer-events.rules", "decoder-events.rules", "dhcp-events.rules", "dnp3-events.rules", "dns-events.rules", "files.rules", "http-events.rules", "http2-events.rules", "ipsec-events.rules",
-						"kerberos-events.rules", "modbus-events.rules", "mqtt-events.rules", "nfs-events.rules", "ntp-events.rules", "smb-events.rules", "smtp-events.rules", "ssh-events.rules", "stream-events.rules",
-						"tls-events.rules" ));
+	define("SURICATA_DEFAULT_RULES", array( "app-layer-events.rules", "decoder-events.rules", "dhcp-events.rules", "dnp3-events.rules",
+						"dns-events.rules", "files.rules", "ftp-events.rules", "http-events.rules", "http2-events.rules", "ipsec-events.rules",
+						"kerberos-events.rules", "modbus-events.rules", "mqtt-events.rules", "nfs-events.rules", "ntp-events.rules",
+						"quic-events.rules", "rfb-events.rules", "smb-events.rules", "smtp-events.rules", "ssh-events.rules",
+						"stream-events.rules", "tls-events.rules" ));
 
 // Rule set download URLs, filenames and prefixes
 if (!defined("VRT_DNLD_URL"))

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -252,6 +252,7 @@ else {
 /* End stats collection configuration   */
 /****************************************/
 
+// HTTP log configuration
 if ($suricatacfg['enable_http_log'] == 'on')
 	$http_log_enabled = "yes";
 else
@@ -262,26 +263,57 @@ if ($suricatacfg['append_http_log'] == 'on')
 else
 	$http_log_append = "no";
 
+if ($suricatacfg['http_log_filetype'] == 'unix_dgram' || $suricatacfg['http_log_filetype'] == 'unix_stream') {
+	$http_log_filetype = $suricatacfg['http_log_filetype'];
+	$http_log_filename = base64_decode($suricatacfg['http_log_socket']);
+} else {
+	$http_log_filetype = "regular";
+	$http_log_filename = "http.log";
+}
+
 if ($suricatacfg['http_log_extended'] == 'on')
 	$http_log_extended = "yes";
 else
 	$http_log_extended = "no";
 
+// TLS log configuration
 if ($suricatacfg['enable_tls_log'] == 'on')
 	$tls_log_enabled = "yes";
 else
 	$tls_log_enabled = "no";
 
-if ($suricatacfg['enable_tls_store'] == 'on')
-	$tls_store_enabled = "yes";
+if ($suricatacfg['append_tls_log'] == 'on')
+	$tls_log_append = "yes";
 else
-	$tls_store_enabled = "no";
+	$tls_log_append = "no";
+
+if ($suricatacfg['tls_log_filetype'] == 'unix_dgram' || $suricatacfg['tls_log_filetype'] == 'unix_stream') {
+	$tls_log_filetype = $suricatacfg['tls_log_filetype'];
+	$tls_log_filename = base64_decode($suricatacfg['tls_log_socket']);
+} else {
+	$tls_log_filetype = "regular";
+	$tls_log_filename = "tls.log";
+}
 
 if ($suricatacfg['tls_log_extended'] == 'on')
 	$tls_log_extended = "yes";
 else
 	$tls_log_extended = "no";
 
+if ($suricatacfg['tls_session_resumption'] == 'on')
+	$tls_session_resumption = "yes";
+else
+	$tls_session_resumption = "no";
+
+// TLS certificate store configuration
+if ($suricatacfg['enable_tls_store'] == 'on') {
+	$tls_store_enabled = "yes";
+	$tls_certs_dir = "{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/certs";
+	safe_mkdir($tls_certs_dir);
+} else
+	$tls_store_enabled = "no";
+
+// File store configuration
 if ($suricatacfg['enable_file_store'] == 'on') {
 	$file_store_enabled = "yes";
 	if (!empty($suricatacfg['file_store_logdir'])) {
@@ -296,9 +328,12 @@ else {
 	$file_store_logdir = "filestore";
 }
 
-if ($suricatacfg['enable_pcap_log'] == 'on')
+// PCAP logging and capture options
+if ($suricatacfg['enable_pcap_log'] == 'on') {
 	$pcap_log_enabled = "yes";
-else
+	$pcap_log_dir = "{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/pcaps";
+	safe_mkdir($pcap_log_dir);
+} else
 	$pcap_log_enabled = "no";
 
 if (!empty($suricatacfg['max_pcap_log_size']))
@@ -310,6 +345,21 @@ if (!empty($suricatacfg['max_pcap_log_files']))
 	$pcap_log_max_files = $suricatacfg['max_pcap_log_files'];
 else
 	$pcap_log_max_files = "1000";
+
+if ($suricatacfg['pcap_use_stream_depth'] == "on")
+	$pcap_use_stream_depth = "yes";
+else
+	$pcap_use_stream_depth = "no";
+	
+if ($suricatacfg['pcap_honor_pass_rules'] == "on")
+	$pcap_honor_pass_rules = "yes";
+else
+	$pcap_honor_pass_rules = "no";
+
+if (!empty($suricatacfg['pcap_log_conditional']))
+	$pcap_log_conditional = $suricatacfg['pcap_log_conditional'];
+else
+	$pcap_log_conditional = "alerts";
 
 // Unified2 X-Forwarded-For logging options
 if ($suricatacfg['barnyard_xff_logging'] == 'on') {
@@ -339,10 +389,18 @@ if ($suricatacfg['enable_eve_log'] == 'on')
 else
 	$enable_eve_log = "no";
 
-if (!empty($suricatacfg['eve_output_type']))
-	$eve_output_type = $suricatacfg['eve_output_type'];
-else
+if (!empty($suricatacfg['eve_output_type'])) {
+	if ($suricatacfg['eve_output_type'] == 'unix_dgram' || $suricatacfg['eve_output_type'] == 'unix_stream') {
+		$eve_output_type = $suricatacfg['eve_output_type'];
+		$eve_output_filename = base64_decode($suricatacfg['eve_output_socket']);
+	} else {
+		$eve_output_type = $suricatacfg['eve_output_type'];
+		$eve_output_filename = "eve.json";
+	}
+} else {
 	$eve_output_type = "regular";
+	$eve_output_filename = "eve.json";
+}
 
 // EVE SYSLOG output settings
 if (!empty($suricatacfg['eve_systemlog_facility']))
@@ -396,7 +454,15 @@ if ($suricatacfg['eve_log_alerts'] == 'on') {
 	$eve_out_types .= "\n            http-body: " . (($suricatacfg['eve_log_alerts_payload'] == 'on'|| $suricatacfg['eve_log_alerts_payload'] == 'only-base64') ?'yes':'no ') . "            # enable dumping of http body in Base64";
 	$eve_out_types .= "\n            http-body-printable: " . (($suricatacfg['eve_log_alerts_payload'] == 'on' || $suricatacfg['eve_log_alerts_payload'] == 'only-printable') ? 'yes':'no ') . "  # enable dumping of http body in printable format";
 	$eve_out_types .= "\n            metadata: " . ($suricatacfg['eve_log_alerts_metadata'] == 'on' ? 'yes':'no ') . "             # enable inclusion of app layer metadata with alert";
-	$eve_out_types .= "\n            tagged-packets: yes       # enable logging of tagged packets for rules using the 'tag' keyword";
+	$eve_out_types .= "\n            tagged-packets: " . ($suricatacfg['eve_log_alerts_tagged'] == 'on' ? 'yes':'no ') . "       # enable logging of tagged packets for rules using the 'tag' keyword";
+	$eve_out_types .= "\n            verdict: " . ($suricatacfg['eve_log_alerts_verdict'] == 'on' ? 'yes':'no ') . "              # enable logging the final action taken on a packet by the engine";
+}
+
+if ($suricatacfg['eve_log_drops'] == 'on' ) {
+	$eve_out_types .= "\n        - drop:";
+	$eve_out_types .= "\n            alerts: " . ($suricatacfg['eve_log_alert_drops'] == 'on' ? 'yes':'no');
+	$eve_out_types .= "\n            verdict: " . ($suricatacfg['eve_log_drops_verdict'] == 'on' ? 'yes':'no');
+	$eve_out_types .= "\n            flows: " . ($suricatacfg['eve_log_drops_flows'] == 'start' ? 'start':'all');
 }
 
 if (($suricatacfg['eve_log_anomaly'] == 'on')) {
@@ -443,8 +509,8 @@ if ($suricatacfg['eve_log_http'] == 'on') {
 if ($suricatacfg['eve_log_dns'] == 'on') {
 	$eve_out_types .= "\n        - dns:";
 	$eve_out_types .= "\n            version: 2";
-	$eve_out_types .= "\n            query: yes";
-	$eve_out_types .= "\n            answer: yes";
+	$eve_out_types .= "\n            requests: yes";
+	$eve_out_types .= "\n            responses: yes";
 }
 
 if ($suricatacfg['eve_log_tls'] == 'on') {
@@ -455,14 +521,6 @@ if ($suricatacfg['eve_log_tls'] == 'on') {
 		$eve_out_types .= "\n            extended: no";
 	if($suricatacfg['eve_log_tls_extended_fields'] != "")
 		$eve_out_types .= "\n            custom: [".$suricatacfg['eve_log_tls_extended_fields']."]";
-}
-
-if ($suricatacfg['eve_log_dhcp'] == 'on') {
-	$eve_out_types .= "\n        - dhcp:";
-	if ($suricatacfg['eve_log_dhcp_extended'] == 'on')
-		$eve_out_types .= "\n            extended: yes";
-	else
-		$eve_out_types .= "\n            extended: no";
 }
 
 if ($suricatacfg['eve_log_files'] == 'on') {
@@ -476,40 +534,20 @@ if ($suricatacfg['eve_log_files'] == 'on') {
 	}
 }
 
-if ($suricatacfg['eve_log_ssh'] == 'on') {
-	$eve_out_types .= "\n        - ssh";
+if ($suricatacfg['eve_log_bittorrent'] == 'on') {
+	$eve_out_types .= "\n        - bittorrent-dht";
 }
 
-if ($suricatacfg['eve_log_nfs'] == 'on') {
-	$eve_out_types .= "\n        - nfs";
-}
-
-if ($suricatacfg['eve_log_smb'] == 'on') {
-	$eve_out_types .= "\n        - smb";
-}
-
-if ($suricatacfg['eve_log_krb5'] == 'on') {
-	$eve_out_types .= "\n        - krb5";
-}
-
-if ($suricatacfg['eve_log_ikev2'] == 'on') {
-	$eve_out_types .= "\n        - ikev2";
-}
-
-if ($suricatacfg['eve_log_tftp'] == 'on') {
-	$eve_out_types .= "\n        - tftp";
-}
-
-if ($suricatacfg['eve_log_rdp'] == 'on') {
-	$eve_out_types .= "\n        - rdp";
-}
-
-if ($suricatacfg['eve_log_sip'] == 'on') {
-	$eve_out_types .= "\n        - sip";
-}
-
-if ($suricatacfg['eve_log_snmp'] == 'on') {
-	$eve_out_types .= "\n        - snmp";
+if ($suricatacfg['eve_log_dhcp'] == 'on') {
+	$eve_out_types .= "\n        - dhcp:";
+	$eve_out_types .= "\n            enabled: yes";
+	if ($suricatacfg['eve_log_dhcp_extended'] == 'on')
+		$eve_out_types .= "\n            extended: yes";
+	else
+		$eve_out_types .= "\n            extended: no";
+} else {
+	$eve_out_types .= "\n        - dhcp:";
+	$eve_out_types .= "\n            enabled: no";
 }
 
 if ($suricatacfg['eve_log_ftp'] == 'on') {
@@ -520,12 +558,44 @@ if ($suricatacfg['eve_log_http2'] == 'on') {
 	$eve_out_types .= "\n        - http2";
 }
 
-if ($suricatacfg['eve_log_rfb'] == 'on') {
-	$eve_out_types .= "\n        - rfb";
+if ($suricatacfg['eve_log_ikev2'] == 'on') {
+	$eve_out_types .= "\n        - ike";
+}
+
+if ($suricatacfg['eve_log_krb5'] == 'on') {
+	$eve_out_types .= "\n        - krb5";
 }
 
 if ($suricatacfg['eve_log_mqtt'] == 'on') {
 	$eve_out_types .= "\n        - mqtt";
+}
+
+if ($suricatacfg['eve_log_nfs'] == 'on') {
+	$eve_out_types .= "\n        - nfs";
+}
+
+if ($suricatacfg['eve_log_pgsql'] == 'on' && $suricatacfg['pgsql_parser'] == 'yes') {
+	$eve_out_types .= "\n        - pgsql";
+}
+
+if ($suricatacfg['eve_log_quic'] == 'on') {
+	$eve_out_types .= "\n        - quic";
+}
+
+if ($suricatacfg['eve_log_rdp'] == 'on') {
+	$eve_out_types .= "\n        - rdp";
+}
+
+if ($suricatacfg['eve_log_rfb'] == 'on') {
+	$eve_out_types .= "\n        - rfb";
+}
+
+if ($suricatacfg['eve_log_sip'] == 'on') {
+	$eve_out_types .= "\n        - sip";
+}
+
+if ($suricatacfg['eve_log_smb'] == 'on') {
+	$eve_out_types .= "\n        - smb";
 }
 
 if ($suricatacfg['eve_log_smtp'] == 'on') {
@@ -540,10 +610,16 @@ if ($suricatacfg['eve_log_smtp'] == 'on') {
 	$eve_out_types .= "\n            md5: [subject]";
 }
 
-if ($suricatacfg['eve_log_drop'] == 'on' && $suricatacfg['ips_mode'] == "ips_mode_inline") {
-	$eve_out_types .= "\n        - drop:";
-	$eve_out_types .= "\n            alerts: yes";
-	$eve_out_types .= "\n            flows: all";
+if ($suricatacfg['eve_log_snmp'] == 'on') {
+	$eve_out_types .= "\n        - snmp";
+}
+
+if ($suricatacfg['eve_log_ssh'] == 'on') {
+	$eve_out_types .= "\n        - ssh";
+}
+
+if ($suricatacfg['eve_log_tftp'] == 'on') {
+	$eve_out_types .= "\n        - tftp";
 }
 
 if ($suricatacfg['eve_log_stats'] == 'on'){
@@ -566,6 +642,11 @@ if (!empty($suricatacfg['frag_memcap']))
 	$frag_memcap = $suricatacfg['frag_memcap'];
 else
 	$frag_memcap = "33554432";
+
+if (!empty($suricatacfg['defrag_memcap_policy']))
+	$defrag_memcap_policy = $suricatacfg['defrag_memcap_policy'];
+else
+	$defrag_memcap_policy = "ignore";
 
 if (!empty($suricatacfg['ip_max_trackers']))
 	$ip_max_trackers = $suricatacfg['ip_max_trackers'];
@@ -591,7 +672,12 @@ else
 if (!empty($suricatacfg['flow_memcap']))
 	$flow_memcap = $suricatacfg['flow_memcap'];
 else
-	$flow_memcap = "33554432";
+	$flow_memcap = "134217728";
+
+if (!empty($suricatacfg['flow_memcap_policy']))
+	$flow_memcap_policy = $suricatacfg['flow_memcap_policy'];
+else
+	$flow_memcap_policy = "ignore";
 
 if (!empty($suricatacfg['flow_hash_size']))
 	$flow_hash_size = $suricatacfg['flow_hash_size'];
@@ -688,7 +774,12 @@ else
 if (!empty($suricatacfg['stream_memcap']))
 	$stream_memcap = $suricatacfg['stream_memcap'];
 else
-	$stream_memcap = "131217728";
+	$stream_memcap = "268435456";
+
+if (!empty($suricatacfg['stream_memcap_policy']))
+	$stream_memcap_policy = $suricatacfg['stream_memcap_policy'];
+else
+	$stream_memcap_policy = "ignore";
 
 if (!empty($suricatacfg['stream_prealloc_sessions']))
 	$stream_prealloc_sessions = $suricatacfg['stream_prealloc_sessions'];
@@ -699,6 +790,11 @@ if (!empty($suricatacfg['reassembly_memcap']))
 	$reassembly_memcap = $suricatacfg['reassembly_memcap'];
 else
 	$reassembly_memcap = "131217728";
+
+if (!empty($suricatacfg['reassembly_memcap_policy']))
+	$reassembly_memcap_policy = $suricatacfg['reassembly_memcap_policy'];
+else
+	$reassembly_memcap_policy = "ignore";
 
 if (!empty($suricatacfg['reassembly_depth']) || $suricatacfg['reassembly_depth'] == '0')
 	$reassembly_depth = $suricatacfg['reassembly_depth'];
@@ -724,6 +820,16 @@ if ($suricatacfg['enable_midstream_sessions'] == 'on')
 	$stream_enable_midstream = "true";
 else
 	$stream_enable_midstream = "false";
+
+if (!empty($suricatacfg['midstream_policy']))
+	$midstream_policy = $suricatacfg['midstream_policy'];
+else
+	$midstream_policy = "ignore";
+
+if ($suricatacfg['stream_checksum_validation'] == 'on')
+	$stream_checksum_validation = "yes";
+else
+	$stream_checksum_validation = "no";
 
 if ($suricatacfg['enable_async_sessions'] == 'on')
 	$stream_enable_async = "true";
@@ -850,77 +956,37 @@ else
 	$asn1_max_frames = "256";
 
 // Configure App-Layer Parsers/Detection
+if (!empty($suricatacfg['app_layer_error_policy']))
+	$app_layer_error_policy = $suricatacfg['app_layer_error_policy'];
+else
+	$app_layer_error_policy = "ignore";
+
+if (!empty($suricatacfg['bittorrent_parser']))
+	$bittorrent_parser = $suricatacfg['bittorrent_parser'];
+else
+	$bittorrent_parser = "no";
+
 if (!empty($suricatacfg['dcerpc_parser']))
 	$dcerpc_parser = $suricatacfg['dcerpc_parser'];
 else
 	$dcerpc_parser = "yes";
-if (!empty($suricatacfg['ftp_parser']))
-	$ftp_parser = $suricatacfg['ftp_parser'];
-else
-	$ftp_parser = "yes";
-if ($suricatacfg['ftp_data_parser'] == 'on')
-	$ftp_data_parser = "yes";
-else
-	$ftp_data_parser = "no";
-if (!empty($suricatacfg['ssh_parser']))
-	$ssh_parser = $suricatacfg['ssh_parser'];
-else
-	$ssh_parser = "yes";
-if (!empty($suricatacfg['imap_parser']))
-	$imap_parser = $suricatacfg['imap_parser'];
-else
-	$imap_parser = "detection-only";
-if (!empty($suricatacfg['msn_parser']))
-	$msn_parser = $suricatacfg['msn_parser'];
-else
-	$msn_parser = "detection-only";
-if (!empty($suricatacfg['smb_parser']))
-	$smb_parser = $suricatacfg['smb_parser'];
-else
-	$smb_parser = "yes";
-if (!empty($suricatacfg['krb5_parser']))
-	$krb5_parser = $suricatacfg['krb5_parser'];
-else
-	$krb5_parser = "yes";
-if (!empty($suricatacfg['ikev2_parser']))
-	$ikev2_parser = $suricatacfg['ikev2_parser'];
-else
-	$ikev2_parser = "yes";
-if (!empty($suricatacfg['nfs_parser']))
-	$nfs_parser = $suricatacfg['nfs_parser'];
-else
-	$nfs_parser = "yes";
-if (!empty($suricatacfg['tftp_parser']))
-	$tftp_parser = $suricatacfg['tftp_parser'];
-else
-	$tftp_parser = "yes";
-if (!empty($suricatacfg['ntp_parser']))
-	$ntp_parser = $suricatacfg['ntp_parser'];
-else
-	$ntp_parser = "yes";
+
 if (!empty($suricatacfg['dhcp_parser']))
 	$dhcp_parser = $suricatacfg['dhcp_parser'];
 else
 	$dhcp_parser = "yes";
-
-if (!empty($suricatacfg['http2_parser']))
-	$http2_parser = $suricatacfg['http2_parser'];
-else
-	$http2_parser = "no";
-if (!empty($suricatacfg['rfb_parser']))
-	$rfb_parser = $suricatacfg['rfb_parser'];
-else
-	$rfb_parser = "yes";
 
 /* DNS Parser */
 if (!empty($suricatacfg['dns_parser_tcp']))
 	$dns_parser_tcp = $suricatacfg['dns_parser_tcp'];
 else
 	$dns_parser_tcp = "yes";
+
 if (!empty($suricatacfg['dns_parser_udp']))
 	$dns_parser_udp = $suricatacfg['dns_parser_udp'];
 else
 	$dns_parser_udp = "yes";
+
 if (!empty($suricatacfg['dns_parser_udp_ports'])) {
 	if (is_alias($suricatacfg['dns_parser_udp_ports'])) {
 		$dns_parser_udp_port = trim(filter_expand_alias($suricatacfg['dns_parser_udp_ports']));
@@ -933,6 +999,7 @@ if (!empty($suricatacfg['dns_parser_udp_ports'])) {
 else {
 	$dns_parser_udp_port = "443";
 }
+
 if (!empty($suricatacfg['dns_parser_tcp_ports'])) {
 	if (is_alias($suricatacfg['dns_parser_tcp_ports'])) {
 		$dns_parser_tcp_port = trim(filter_expand_alias($suricatacfg['dns_parser_tcp_ports']));
@@ -945,14 +1012,17 @@ if (!empty($suricatacfg['dns_parser_tcp_ports'])) {
 else {
 	$dns_parser_tcp_port = "443";
 }
+
 if (!empty($suricatacfg['dns_global_memcap']))
 	$dns_global_memcap = $suricatacfg['dns_global_memcap'];
 else
 	$dns_global_memcap = "16777216";
+
 if (!empty($suricatacfg['dns_state_memcap']))
 	$dns_state_memcap = $suricatacfg['dns_state_memcap'];
 else
 	$dns_state_memcap = "524288";
+
 if (!empty($suricatacfg['dns_request_flood_limit']))
 	$dns_request_flood_limit = $suricatacfg['dns_request_flood_limit'];
 else
@@ -964,21 +1034,106 @@ if (!empty($suricatacfg['enip_parser']))
 else
 	$enip_parser = "yes";
 
+/* FTP Parser */
+if (!empty($suricatacfg['ftp_parser']))
+	$ftp_parser = $suricatacfg['ftp_parser'];
+else
+	$ftp_parser = "yes";
+
+if ($suricatacfg['ftp_data_parser'] == 'on')
+	$ftp_data_parser = "yes";
+else
+	$ftp_data_parser = "no";
+
 /* HTTP Parser */
 if (!empty($suricatacfg['http_parser']))
 	$http_parser = $suricatacfg['http_parser'];
 else
 	$http_parser = "yes";
+
 if (!empty($suricatacfg['http_parser_memcap']))
 	$http_parser_memcap = $suricatacfg['http_parser_memcap'];
 else
 	$http_parser_memcap = "67108864";
+
+if (!empty($suricatacfg['http2_parser']))
+	$http2_parser = $suricatacfg['http2_parser'];
+else
+	$http2_parser = "no";
+
+if (!empty($suricatacfg['ikev2_parser']))
+	$ikev2_parser = $suricatacfg['ikev2_parser'];
+else
+	$ikev2_parser = "yes";
+
+if (!empty($suricatacfg['imap_parser']))
+	$imap_parser = $suricatacfg['imap_parser'];
+else
+	$imap_parser = "detection-only";
+
+if (!empty($suricatacfg['krb5_parser']))
+	$krb5_parser = $suricatacfg['krb5_parser'];
+else
+	$krb5_parser = "yes";
 
 /* MQTT Parser */
 if (!empty($suricatacfg['mqtt_parser']))
 	$mqtt_parser = $suricatacfg['mqtt_parser'];
 else
 	$mqtt_parser = "yes";
+
+if (!empty($suricatacfg['msn_parser']))
+	$msn_parser = $suricatacfg['msn_parser'];
+else
+	$msn_parser = "detection-only";
+
+if (!empty($suricatacfg['nfs_parser']))
+	$nfs_parser = $suricatacfg['nfs_parser'];
+else
+	$nfs_parser = "yes";
+
+if (!empty($suricatacfg['ntp_parser']))
+	$ntp_parser = $suricatacfg['ntp_parser'];
+else
+	$ntp_parser = "yes";
+
+/* PostgreSQL Parser */
+if (!empty($suricatacfg['pgsql_parser']))
+	$pgsql_parser = $suricatacfg['pgsql_parser'];
+else
+	$pgsql_parser = "no";
+
+/* QUICv1 Parser */
+if (!empty($suricatacfg['quic_parser']))
+	$quic_parser = $suricatacfg['quic_parser'];
+else
+	$quic_parser = "yes";
+
+ /* RDP Parser */
+if (!empty($suricatacfg['rdp_parser'])) {
+	$rdp_parser = $suricatacfg['rdp_parser'];
+}
+else {
+	$rdp_parser = "yes";
+}
+
+if (!empty($suricatacfg['rfb_parser']))
+	$rfb_parser = $suricatacfg['rfb_parser'];
+else
+	$rfb_parser = "yes";
+
+/* SIP Parser */
+if (!empty($suricatacfg['sip_parser'])) {
+	$sip_parser = $suricatacfg['sip_parser'];
+}
+else {
+	$sip_parser = "yes";
+}
+
+if (!empty($suricatacfg['smb_parser']))
+	$smb_parser = $suricatacfg['smb_parser'];
+else
+	$smb_parser = "yes";
 
 /* SMTP Parser */
 if (!empty($suricatacfg['smtp_parser'])) {
@@ -1018,6 +1173,29 @@ else {
 	$smtp_body_md5 = "no";
 }
 
+/* SNMP Parser */
+if (!empty($suricatacfg['snmp_parser'])) {
+	$snmp_parser = $suricatacfg['snmp_parser'];
+}
+else {
+	$snmp_parser = "yes";
+}
+
+if (!empty($suricatacfg['ssh_parser']))
+	$ssh_parser = $suricatacfg['ssh_parser'];
+else
+	$ssh_parser = "yes";
+
+if (!empty($suricatacfg['telnet_parser']))
+	$telnet_parser = $suricatacfg['telnet_parser'];
+else
+	$telnet_parser = "yes";
+
+if (!empty($suricatacfg['tftp_parser']))
+	$tftp_parser = $suricatacfg['tftp_parser'];
+else
+	$tftp_parser = "yes";
+
 /* TLS Parser */
 if (!empty($suricatacfg['tls_parser'])) {
 	$tls_parser = $suricatacfg['tls_parser'];
@@ -1054,30 +1232,6 @@ if (!empty($suricatacfg['tls_encrypt_handling'])) {
 }
 else {
 	$tls_encrypt_handling = "default";
-}
-
- /* RDP Parser */
-if (!empty($suricatacfg['rdp_parser'])) {
-	$rdp_parser = $suricatacfg['rdp_parser'];
-}
-else {
-	$rdp_parser = "yes";
-}
-
-/* SIP Parser */
-if (!empty($suricatacfg['sip_parser'])) {
-	$sip_parser = $suricatacfg['sip_parser'];
-}
-else {
-	$sip_parser = "yes";
-}
-
-/* SNMP Parser */
-if (!empty($suricatacfg['snmp_parser'])) {
-	$snmp_parser = $suricatacfg['snmp_parser'];
-}
-else {
-	$snmp_parser = "yes";
 }
 
 /* Configure the IP REP section */

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -836,12 +836,12 @@ if ($suricatacfg['enable_async_sessions'] == 'on')
 else
 	$stream_enable_async = "false";
 
-if ($suricatacfg['stream_bypass'] == 'yes' || $suricatacfg['tls_encrypt_handling'] == 'bypass')
+if ($suricatacfg['stream_bypass'] == 'on' || $suricatacfg['tls_encrypt_handling'] == 'bypass')
 	$stream_bypass_enable = "yes";
 else
 	$stream_bypass_enable = "no";
 
-if ($suricatacfg['stream_drop_invalid'] == 'yes')
+if ($suricatacfg['stream_drop_invalid'] == 'on')
 	$stream_drop_invalid_enable = "yes";
 else
 	$stream_drop_invalid_enable = "no";

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -344,7 +344,7 @@ else
 if (!empty($suricatacfg['max_pcap_log_files']))
 	$pcap_log_max_files = $suricatacfg['max_pcap_log_files'];
 else
-	$pcap_log_max_files = "1000";
+	$pcap_log_max_files = "100";
 
 if ($suricatacfg['pcap_use_stream_depth'] == "on")
 	$pcap_use_stream_depth = "yes";

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -196,14 +196,18 @@ if (config_get_path('installedpackages/suricata/config/0/tls_log_limit_size') ==
 	config_set_path('installedpackages/suricata/config/0/tls_log_limit_size', "500");
 	$updated_cfg = true;
 }
+if (config_get_path('installedpackages/suricata/config/0/tls_certs_store_retention') === null) {
+	config_set_path('installedpackages/suricata/config/0/tls_certs_store_retention', "168");
+	$updated_cfg = true;
+}
 
 if (config_get_path('installedpackages/suricata/config/0/file_store_retention') === null) {
 	config_set_path('installedpackages/suricata/config/0/file_store_retention', "168");
 	$updated_cfg = true;
 }
 
-if (config_get_path('installedpackages/suricata/config/0/tls_certs_store_retention') === null) {
-	config_set_path('installedpackages/suricata/config/0/tls_certs_store_retention', "168");
+if (config_get_path('installedpackages/suricata/config/0/pkt_capture_file_retention') === null) {
+	config_set_path('installedpackages/suricata/config/0/pkt_capture_file_retention', "168");
 	$updated_cfg = true;
 }
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -863,8 +863,8 @@ foreach (config_get_path('installedpackages/suricata/rule', []) as $idx => &$pco
 	/* existing value to at least 128 MB, but leave larger    */
 	/* values untouched.                                      */
 	/**********************************************************/
-	if ((int)$pconfig['stream_memcap'] < 134217728) {
-		$pconfig['stream_memcap'] = '134217728';
+	if ((int)$pconfig['flow_memcap'] < 134217728) {
+		$pconfig['flow_memcap'] = '134217728';
 		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -814,6 +814,16 @@ foreach (config_get_path('installedpackages/suricata/rule', []) as $idx => &$pco
 	}
 
 	/**********************************************************/
+	/* Set new minimum TCP Stream_Memcap value to 256 MB.     */
+	/* Increase existing value to at least 256 MB, but leave  */
+	/* large values untouched.                                */
+	/**********************************************************/
+	if ((int)$pconfig['stream_memcap'] < 268435456) {
+		$pconfig['stream_memcap'] = '268435456';
+		$updated_cfg = true;
+	}
+
+	/**********************************************************/
 	/* If we updated this interface, write it to config array */
 	/**********************************************************/
 	if ($updated_intf_cfg === true) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_migrate_config.php
@@ -253,51 +253,6 @@ foreach (config_get_path('installedpackages/suricata/rule', []) as $idx => &$pco
 	$updated_intf_cfg = false;
 
 	/***********************************************************/
-	/* Add the new 'dns-events.rules' file to the rulesets.    */
-	/***********************************************************/
-	if (strpos(array_get_path($pconfig, 'rulesets', ''), "dns-events.rules") === FALSE) {
-		$pconfig['rulesets'] = rtrim(array_get_path($pconfig, 'rulesets', ''), "||") . "||dns-events.rules";	
-		$updated_intf_cfg = true;
-		$updated_cfg = true;
-	}
-
-	/***********************************************************/
-	/* Add the new 'dhcp-events.rules' file to the rulesets.   */
-	/***********************************************************/
-	if (strpos(array_get_path($pconfig, 'rulesets', ''), "dhcp-events.rules") === FALSE) {
-		$pconfig['rulesets'] = rtrim(array_get_path($pconfig, 'rulesets', ''), "||") . "||dhcp-events.rules";	
-		$updated_intf_cfg = true;
-		$updated_cfg = true;
-	}
-
-	/***********************************************************/
-	/* Add the new 'http2-events.rules' file to the rulesets.  */
-	/***********************************************************/
-	if (strpos(array_get_path($pconfig, 'rulesets', ''), "http2-events.rules") === FALSE) {
-		$pconfig['rulesets'] = rtrim(array_get_path($pconfig, 'rulesets', ''), "||") . "||http2-events.rules";	
-		$updated_intf_cfg = true;
-		$updated_cfg = true;
-	}
-
-	/***********************************************************/
-	/* Add the new 'mqtt-events.rules' file to the rulesets.   */
-	/***********************************************************/
-	if (strpos(array_get_path($pconfig, 'rulesets', ''), "mqtt-events.rules") === FALSE) {
-		$pconfig['rulesets'] = rtrim(array_get_path($pconfig, 'rulesets', ''), "||") . "||mqtt-events.rules";	
-		$updated_intf_cfg = true;
-		$updated_cfg = true;
-	}
-
-	/***********************************************************/
-	/* Add the new 'ssh-events.rules' file to the rulesets.    */
-	/***********************************************************/
-	if (strpos(array_get_path($pconfig, 'rulesets', ''), "ssh-events.rules") === FALSE) {
-		$pconfig['rulesets'] = rtrim(array_get_path($pconfig, 'rulesets', ''), "||") . "||ssh-events.rules";	
-		$updated_intf_cfg = true;
-		$updated_cfg = true;
-	}
-
-	/***********************************************************/
 	/* Add new run mode value and default it to 'autofp'.      */
 	/***********************************************************/
 	if (empty($pconfig['runmode'])) {
@@ -480,6 +435,15 @@ foreach (config_get_path('installedpackages/suricata/rule', []) as $idx => &$pco
 	}
 
 	/************************************************************/
+	/* Add new App-Layer parser exception policy if not set     */
+	/************************************************************/
+	if (empty($pconfig['app_layer_error_policy'])) {
+		$pconfig['app_layer_error_policy'] = "ignore";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+
+	/************************************************************/
 	/* Create new DNS App-Layer parser settings if not set      */
 	/************************************************************/
 	if (empty($pconfig['dns_global_memcap'])) {
@@ -564,6 +528,11 @@ foreach (config_get_path('installedpackages/suricata/rule', []) as $idx => &$pco
 	/***********************************************************/
 	/* Create new TLS App-Layer parser settings if not set    */
 	/***********************************************************/
+	if (empty($pconfig['tls_parser'])) {
+		$pconfig['tls_parser'] = "yes";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
 	if (empty($pconfig['tls_detect_ports'])) {
 		$pconfig['tls_detect_ports'] = "443";
 		$updated_intf_cfg = true;
@@ -583,28 +552,8 @@ foreach (config_get_path('installedpackages/suricata/rule', []) as $idx => &$pco
 	/**********************************************************/
 	/* Create other App-Layer parser settings if not set      */
 	/**********************************************************/
-	if (empty($pconfig['tls_parser'])) {
-		$pconfig['tls_parser'] = "yes";
-		$updated_intf_cfg = true;
-		$updated_cfg = true;
-	}
-	if (empty($pconfig['smtp_parser'])) {
-		$pconfig['smtp_parser'] = "yes";
-		$updated_intf_cfg = true;
-		$updated_cfg = true;
-	}
-	if (empty($pconfig['imap_parser'])) {
-		$pconfig['imap_parser'] = "detection-only";
-		$updated_intf_cfg = true;
-		$updated_cfg = true;
-	}
-	if (empty($pconfig['ssh_parser'])) {
-		$pconfig['ssh_parser'] = "yes";
-		$updated_intf_cfg = true;
-		$updated_cfg = true;
-	}
-	if (empty($pconfig['ftp_parser'])) {
-		$pconfig['ftp_parser'] = "yes";
+	if (empty($pconfig['bittorrent_parser'])) {
+		$pconfig['bittorrent_parser'] = "yes";
 		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
@@ -613,38 +562,8 @@ foreach (config_get_path('installedpackages/suricata/rule', []) as $idx => &$pco
 		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
-	if (empty($pconfig['smb_parser'])) {
-		$pconfig['smb_parser'] = "yes";
-		$updated_intf_cfg = true;
-		$updated_cfg = true;
-	}
-	if (empty($pconfig['msn_parser'])) {
-		$pconfig['msn_parser'] = "detection-only";
-		$updated_intf_cfg = true;
-		$updated_cfg = true;
-	}
-	if (empty($pconfig['snmp_parser'])) {
-		$pconfig['snmp_parser'] = "yes";
-		$updated_intf_cfg = true;
-		$updated_cfg = true;
-	}
-	if (empty($pconfig['rdp_parser'])) {
-		$pconfig['rdp_parser'] = "yes";
-		$updated_intf_cfg = true;
-		$updated_cfg = true;
-	}
-	if (empty($pconfig['sip_parser'])) {
-		$pconfig['sip_parser'] = "yes";
-		$updated_intf_cfg = true;
-		$updated_cfg = true;
-	}
-	if (empty($pconfig['http2_parser'])) {
-		$pconfig['http2_parser'] = "yes";
-		$updated_intf_cfg = true;
-		$updated_cfg = true;
-	}
-	if (empty($pconfig['rfb_parser'])) {
-		$pconfig['rfb_parser'] = "yes";
+	if (empty($pconfig['dhcp_parser'])) {
+		$pconfig['dhcp_parser'] = "yes";
 		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
@@ -653,8 +572,93 @@ foreach (config_get_path('installedpackages/suricata/rule', []) as $idx => &$pco
 		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
+	if (empty($pconfig['ftp_parser'])) {
+		$pconfig['ftp_parser'] = "yes";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['http2_parser'])) {
+		$pconfig['http2_parser'] = "yes";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['ikev2_parser'])) {
+		$pconfig['ikev2_parser'] = "yes";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['imap_parser'])) {
+		$pconfig['imap_parser'] = "detection-only";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
 	if (empty($pconfig['mqtt_parser'])) {
 		$pconfig['mqtt_parser'] = "yes";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['msn_parser'])) {
+		$pconfig['msn_parser'] = "detection-only";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['nfs_parser'])) {
+		$pconfig['nfs_parser'] = "yes";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['ntp_parser'])) {
+		$pconfig['ntp_parser'] = "yes";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['pgsql_parser'])) {
+		$pconfig['pgsql_parser'] = "no";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['quic_parser'])) {
+		$pconfig['quic_parser'] = "yes";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['rdp_parser'])) {
+		$pconfig['rdp_parser'] = "yes";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['rfb_parser'])) {
+		$pconfig['rfb_parser'] = "yes";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['sip_parser'])) {
+		$pconfig['sip_parser'] = "yes";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['smb_parser'])) {
+		$pconfig['smb_parser'] = "yes";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['smtp_parser'])) {
+		$pconfig['smtp_parser'] = "yes";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['snmp_parser'])) {
+		$pconfig['snmp_parser'] = "yes";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['ssh_parser'])) {
+		$pconfig['ssh_parser'] = "yes";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['telnet_parser'])) {
+		$pconfig['telnet_parser'] = "yes";
 		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
@@ -684,8 +688,18 @@ foreach (config_get_path('installedpackages/suricata/rule', []) as $idx => &$pco
 	}
 
 	/**********************************************************/
-	/* Create new interface stream setting if not set         */
+	/* Create new interface flow/stream settings if not set   */
 	/**********************************************************/
+	if (!isset($pconfig['defrag_memcap_policy'])) {
+		$pconfig['defrag_memcap_policy'] = "ignore";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['flow_memcap_policy'])) {
+		$pconfig['flow_memcap_policy'] = "ignore";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
 	if (empty($pconfig['max_synack_queued'])) {
 		$pconfig['max_synack_queued'] = "5";
 		$updated_intf_cfg = true;
@@ -698,6 +712,26 @@ foreach (config_get_path('installedpackages/suricata/rule', []) as $idx => &$pco
 	}
 	if (!isset($pconfig['stream_drop_invalid'])) {
 		$pconfig['stream_drop_invalid'] = "no";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['stream_memcap_policy'])) {
+		$pconfig['stream_memcap_policy'] = "ignore";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['reassembly_memcap_policy'])) {
+		$pconfig['reassembly_memcap_policy'] = "ignore";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['midstream_policy'])) {
+		$pconfig['midstream_policy'] = "ignore";
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['stream_checksum_validation'])) {
+		$pconfig['stream_checksum_validation'] = "on";
 		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
@@ -816,10 +850,22 @@ foreach (config_get_path('installedpackages/suricata/rule', []) as $idx => &$pco
 	/**********************************************************/
 	/* Set new minimum TCP Stream_Memcap value to 256 MB.     */
 	/* Increase existing value to at least 256 MB, but leave  */
-	/* large values untouched.                                */
+	/* larger values untouched.                               */
 	/**********************************************************/
 	if ((int)$pconfig['stream_memcap'] < 268435456) {
 		$pconfig['stream_memcap'] = '268435456';
+		$updated_intf_cfg = true;
+		$updated_cfg = true;
+	}
+
+	/**********************************************************/
+	/* Set new minimum Flow_Memcap value to 128 MB. Increase  */
+	/* existing value to at least 128 MB, but leave larger    */
+	/* values untouched.                                      */
+	/**********************************************************/
+	if ((int)$pconfig['stream_memcap'] < 134217728) {
+		$pconfig['stream_memcap'] = '134217728';
+		$updated_intf_cfg = true;
 		$updated_cfg = true;
 	}
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_post_install.php
@@ -111,7 +111,7 @@ if (config_get_path('installedpackages/suricata/config/0/forcekeepsettings') == 
 	update_status(gettext("Saved settings detected...") . "\n");
 
 	/****************************************************************/
-	/* Add all the new built-in events rules to each configured     */
+	/* Add any new built-in events rules to each configured         */
 	/* interface.                                                   */
 	/****************************************************************/
 	if (count(config_get_path('installedpackages/suricata/rule', [])) > 0) {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -41,7 +41,7 @@ stats:
 # Configure the type of alert (and other) logging.
 outputs:
 
-  # alert-pf blocking plugin
+  # alert-pf custom blocking plugin for pfSense only
   - alert-pf:
       enabled: {$suri_blockoffenders}
       kill-state: {$suri_killstates}
@@ -49,6 +49,7 @@ outputs:
       pass-list: {$suri_passlist}
       block-ip: {$suri_blockip}
       pf-table: {$suri_pf_table}
+      passlist-debugging: no   # Do not enable debugging on production systems!
 
   # a line based alerts log similar to Snort's fast.log
   - fast:
@@ -65,6 +66,7 @@ outputs:
       extended: {$http_log_extended}
       filetype: regular
 
+  # a PCAP format packet capture facility
   - pcap-log:
       enabled: {$pcap_log_enabled}
       filename: log.pcap

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -59,7 +59,8 @@ outputs:
 
   - http-log:
       enabled: {$http_log_enabled}
-      filename: http.log
+      filename: {$http_log_filename}
+      filetype: {$http_log_filetype}
       append: {$http_log_append}
       extended: {$http_log_extended}
       filetype: regular
@@ -67,18 +68,27 @@ outputs:
   - pcap-log:
       enabled: {$pcap_log_enabled}
       filename: log.pcap
+      dir: {$pcap_log_dir}/
       limit: {$pcap_log_limit_size}mb
       max-files: {$pcap_log_max_files}
       mode: normal
+      compression: none
+      ts-format: sec
+      use-stream-depth: {$pcap_use_stream_depth}
+      honor-pass-rules: {$pcap_honor_pass_rules}
+      conditional: {$pcap_log_conditional}
 
   - tls-log:
       enabled: {$tls_log_enabled}
-      filename: tls.log
+      filename: {$tls_log_filename}
+      filetype: {$tls_log_filetype}
+      append: {$tls_log_append}
       extended: {$tls_log_extended}
+      session-resumption: {$tls_session_resumption}
 
   - tls-store:
       enabled: {$tls_store_enabled}
-      certs-log-dir: certs
+      certs-log-dir: {$tls_certs_dir}
 
   - stats:
       enabled: {$stats_log_enabled}
@@ -94,12 +104,6 @@ outputs:
       facility: {$alert_syslog_facility}
       level: {$alert_syslog_priority}
 
-  - drop:
-      enabled: no
-      filename: drop.log
-      append: yes
-      filetype: regular
-
   - file-store:
       version: 2
       enabled: {$file_store_enabled}
@@ -109,7 +113,7 @@ outputs:
   - eve-log:
       enabled: {$enable_eve_log}
       filetype: {$eve_output_type}
-      filename: eve.json
+      filename: {$eve_output_filename}
       redis: {$eve_redis_output}
       identity: "suricata"
       facility: {$eve_systemlog_facility}
@@ -170,6 +174,7 @@ spm-algo: auto
 # Defrag settings:
 defrag:
   memcap: {$frag_memcap}
+  memcap-policy: {$defrag_memcap_policy}
   hash-size: {$frag_hash_size}
   trackers: {$ip_max_trackers}
   max-frags: {$ip_max_frags}
@@ -179,6 +184,7 @@ defrag:
 # Flow settings:
 flow:
   memcap: {$flow_memcap}
+  memcap-policy: {$flow_memcap_policy}
   hash-size: {$flow_hash_size}
   prealloc: {$flow_prealloc}
   emergency-recovery: {$flow_emerg_recovery}
@@ -218,16 +224,19 @@ flow-timeouts:
 
 stream:
   memcap: {$stream_memcap}
-  checksum-validation: no
+  memcap-policy: {$stream_memcap_policy}
+  checksum-validation: {$stream_checksum_validation}
   inline: auto
   prealloc-sessions: {$stream_prealloc_sessions}
   midstream: {$stream_enable_midstream}
+  midstream-policy: {$midstream_policy}
   async-oneside: {$stream_enable_async}
   max-synack-queued: {$max_synack_queued}
   bypass: {$stream_bypass_enable}
   drop-invalid: {$stream_drop_invalid_enable}
   reassembly:
     memcap: {$reassembly_memcap}
+    memcap-policy: {$reassembly_memcap_policy}
     depth: {$reassembly_depth}
     toserver-chunk-size: {$reassembly_to_server_chunk}
     toclient-chunk-size: {$reassembly_to_client_chunk}
@@ -312,7 +321,10 @@ pcre:
 
 # Holds details on the app-layer. The protocols section details each protocol.
 app-layer:
+  error-policy: {$app_layer_error_policy}
   protocols:
+    bittorrent-dht:
+      enabled: {$bittorrent_parser}
     dcerpc:
       enabled: {$dcerpc_parser}
     dhcp:
@@ -342,7 +354,9 @@ app-layer:
     http:
       enabled: {$http_parser}
       memcap: {$http_parser_memcap}
-    ikev2:
+    http2:
+      enabled: {$http2_parser}
+    ike:
       enabled: {$ikev2_parser}
     imap:
       enabled: {$imap_parser}
@@ -362,12 +376,18 @@ app-layer:
       enabled: {$nfs_parser}
     ntp:
       enabled: {$ntp_parser}
-    tls:
-      enabled: {$tls_parser}
+    pgsql:
+      enabled: {$pgsql_parser}
+    quic:
+      enabled: {$quic_parser}
+    rdp:
+      enabled: {$rdp_parser}
+    rfb:
+      enabled: {$rfb_parser}
       detection-ports:
-        dp: {$tls_detect_port}
-      ja3-fingerprints: {$tls_ja3}
-      encrypt-handling: {$tls_encrypt_handling}
+        dp: 5900, 5901, 5902, 5903, 5904, 5905, 5906, 5907, 5908, 5909
+    sip:
+      enabled: {$sip_parser}
     smb:
       enabled: {$smb_parser}
       detection-ports:
@@ -387,20 +407,16 @@ app-layer:
         content-inspect-window: 4096
     ssh:
       enabled: {$ssh_parser}
+    telnet:
+      enabled: {$telnet_parser}
     tftp:
       enabled: {$tftp_parser}
-    rdp:
-      enabled: {$rdp_parser}
-    sip:
-      enabled: {$sip_parser}
-    snmp:
-      enabled: {$snmp_parser}
-    http2:
-      enabled: {$http2_parser}
-    rfb:
-      enabled: {$rfb_parser}
+    tls:
+      enabled: {$tls_parser}
       detection-ports:
-        dp: 5900, 5901, 5902, 5903, 5904, 5905, 5906, 5907, 5908, 5909
+        dp: {$tls_detect_port}
+      ja3-fingerprints: {$tls_ja3}
+      encrypt-handling: {$tls_encrypt_handling}
 
 ###########################################################################
 # Configure libhtp.

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
@@ -58,6 +58,8 @@ $pconfig = array();
 if (isset($id) && !empty($a_nat)) {
 	/* Get current values from config for page form fields */
 	$pconfig = $a_nat;
+	if (empty($pconfig['app_layer_error_policy']))
+		$pconfig['app_layer_error_policy'] = "ignore";
 
 	// See if Host-OS policy engine array is configured and use
 	// it; otherwise create a default engine configuration.
@@ -244,46 +246,51 @@ elseif ($_POST['cancel_libhtp_policy']) {
 elseif ($_POST['ResetAll']) {
 
 	/* Reset all the settings to defaults */
+	$pconfig['app_layer_error_policy'] = "ignore";
 	$pconfig['asn1_max_frames'] = "256";
+	$pconfig['bittorrent_parser'] = "yes";
+	$pconfig['dcerpc_parser'] = "yes";
+	$pconfig['dhcp_parser'] = "yes";
 	$pconfig['dns_global_memcap'] = "16777216";
 	$pconfig['dns_state_memcap'] = "524288";
 	$pconfig['dns_request_flood_limit'] = "500";
-	$pconfig['http_parser_memcap'] = "67108864";
 	$pconfig['dns_parser_udp'] = "yes";
 	$pconfig['dns_parser_udp_ports'] = "53";
 	$pconfig['dns_parser_tcp'] = "yes";
 	$pconfig['dns_parser_tcp_ports'] = "53";
 	$pconfig['enip_parser'] = "yes";
+	$pconfig['ftp_parser'] = "yes";
+	$pconfig['ftp_data_parser'] = "on";
 	$pconfig['http_parser'] = "yes";
-	$pconfig['tls_parser'] = "yes";
-	$pconfig['tls_detect_ports'] = "443";
-	$pconfig['tls_encrypt_handling'] = "default";
-	$pconfig['tls_ja3_fingerprint'] = "auto";
+	$pconfig['http_parser_memcap'] = "67108864";
+	$pconfig['http2_parser'] = "yes";
+	$pconfig['ikev2_parser'] = "yes";
+	$pconfig['imap_parser'] = "detection-only";
+	$pconfig['krb5_parser'] = "yes";
+	$pconfig['mqtt_parser'] = "yes";
+	$pconfig['msn_parser'] = "detection-only";
+	$pconfig['nfs_parser'] = "yes";
+	$pconfig['ntp_parser'] = "yes";
+	$pconfig['pgsql_parser'] = "no";
+	$pconfig['quic_parser'] = "yes";
+	$pconfig['rfb_parser'] = "yes";
+	$pconfig['rdp_parser'] = "yes";
+	$pconfig['sip_parser'] = "yes";
+	$pconfig['smb_parser'] = "yes";
 	$pconfig['smtp_parser'] = "yes";
 	$pconfig['smtp_parser_decode_mime'] = "off";
 	$pconfig['smtp_parser_decode_base64'] = "on";
 	$pconfig['smtp_parser_decode_quoted_printable'] = "on";
 	$pconfig['smtp_parser_extract_urls'] = "on";
 	$pconfig['smtp_parser_compute_body_md5'] = "off";
-	$pconfig['imap_parser'] = "detection-only";
-	$pconfig['ssh_parser'] = "yes";
-	$pconfig['ftp_parser'] = "yes";
-	$pconfig['ftp_data_parser'] = "on";
-	$pconfig['dcerpc_parser'] = "yes";
-	$pconfig['smb_parser'] = "yes";
-	$pconfig['msn_parser'] = "detection-only";
-	$pconfig['krb5_parser'] = "yes";
-	$pconfig['ikev2_parser'] = "yes";
-	$pconfig['nfs_parser'] = "yes";
-	$pconfig['tftp_parser'] = "yes";
-	$pconfig['ntp_parser'] = "yes";
-	$pconfig['dhcp_parser'] = "yes";
-	$pconfig['rdp_parser'] = "yes";
-	$pconfig['sip_parser'] = "yes";
 	$pconfig['snmp_parser'] = "yes";
-	$pconfig['http2_parser'] = "yes";
-	$pconfig['rfb_parser'] = "yes";
-	$pconfig['mqtt_parser'] = "yes";
+	$pconfig['ssh_parser'] = "yes";
+	$pconfig['tftp_parser'] = "yes";
+	$pconfig['tls_parser'] = "yes";
+	$pconfig['tls_detect_ports'] = "443";
+	$pconfig['tls_encrypt_handling'] = "default";
+	$pconfig['tls_ja3_fingerprint'] = "auto";
+	$pconfig['telnet_parser'] = "yes";
 
 	/* Log a message at the top of the page to inform the user */
 	$savemsg = gettext("All flow and stream settings on this page have been reset to their defaults.  Click APPLY if you wish to keep these new settings.");
@@ -440,6 +447,7 @@ elseif ($_POST['save'] || $_POST['apply']) {
 
 	/* if no errors write to conf */
 	if (!$input_errors) {
+		if ($_POST['app_layer_error_policy'] != "") { $natent['app_layer_error_policy'] = $_POST['app_layer_error_policy']; }
 		if ($_POST['asn1_max_frames'] != "") { $natent['asn1_max_frames'] = $_POST['asn1_max_frames']; }else{ $natent['asn1_max_frames'] = "256"; }
 		if ($_POST['dns_global_memcap'] != ""){ $natent['dns_global_memcap'] = $_POST['dns_global_memcap']; }else{ $natent['dns_global_memcap'] = "16777216"; }
 		if ($_POST['dns_state_memcap'] != ""){ $natent['dns_state_memcap'] = $_POST['dns_state_memcap']; }else{ $natent['dns_state_memcap'] = "524288"; }
@@ -481,6 +489,9 @@ elseif ($_POST['save'] || $_POST['apply']) {
 		$natent['rfb_parser'] = $_POST['rfb_parser'];
 		$natent['enip_parser'] = $_POST['enip_parser'];
 		$natent['mqtt_parser'] = $_POST['mqtt_parser'];
+		$natent['bittorrent_parser'] = $_POST['bittorrent_parser'];
+		$natent['pgsql_parser'] = $_POST['pgsql_parser'];
+		$natent['quic_parser'] = $_POST['quic_parser'];
 
 		/**************************************************/
 		/* If we have a valid rule ID, save configuration */
@@ -584,7 +595,23 @@ if ($importalias) {
 	print('<input name="id" type="hidden" value="' . $id . '"/>');
 	print('<input type="hidden" name="eng_id" id="eng_id" value=""/>');
 
-	$section = new Form_Section('Abstract Syntax One Settings');
+	$section= new Form_Section('App-Layer Error Policy Settings');
+	$section->addInput(new Form_Select(
+		'app_layer_error_policy',
+		'Application Layer Parser Exception Policy',
+		$pconfig['app_layer_error_policy'],
+		array( "drop-flow" => "Drop Flow", "pass-flow" => "Pass Flow", "bypass" => "Bypass", "drop-packet" => "Drop Packet",
+			   "pass-packet" => "Pass Packet", "reject" => "Reject", "ignore" => "Ignore" )
+	))->setHelp('Apply selected policy if an application layer parser reaches an error state. Default is "Ignore". ' .
+				'"Drop Flow" will disable inspection for the whole flow (packets, payload, and application layer protocol), drop ' .
+				'the packet and all future packets in the flow. "Drop Packet" drops the current packet. "Reject" is the same as "Drop Flow" ' .
+				'but rejects the current packet as well. "Bypass" will bypass the flow, and no further inspection is done. ' .
+				'"Pass Flow" will disable payload and packet detection, but stream reassembly, app-layer parsing and logging still happen. ' .
+				'"Pass Packet" will disable detection, but still does stream updates and app-layer parsing (depending on which policy triggered it). ' .
+				'"Ignore" does not apply exception policies.');
+	print($section);
+
+	$section = new Form_Section('Abstract Syntax One App-Layer Parser Settings');
 	$section->addInput(new Form_Input(
 		'asn1_max_frames',
 		'Asn1 Max Frames',
@@ -729,6 +756,12 @@ if ($importalias) {
 
 	$section = new Form_Section('Other App-Layer Parser Settings');
 	$section->addInput(new Form_Select(
+		'bittorrent_parser',
+		'BitTorrent-DHT Parser',
+		$pconfig['bittorrent_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for BitTorrent-DHT. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
 		'dcerpc_parser',
 		'DCERPC Parser',
 		$pconfig['dcerpc_parser'],
@@ -754,10 +787,10 @@ if ($importalias) {
 	))->setHelp('Choose the parser/detection setting for HTTP2. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
 	$section->addInput(new Form_Select(
 		'ikev2_parser',
-		'IKEv2 Parser',
+		'IKE Parser',
 		$pconfig['ikev2_parser'],
 		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
-	))->setHelp('Choose the parser/detection setting for IKEv2. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	))->setHelp('Choose the parser/detection setting for IKE. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
 	$section->addInput(new Form_Select(
 		'imap_parser',
 		'IMAP Parser',
@@ -795,6 +828,18 @@ if ($importalias) {
 		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
 	))->setHelp('Choose the parser/detection setting for NTP. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
 	$section->addInput(new Form_Select(
+		'pgsql_parser',
+		'PostgreSQL Parser',
+		$pconfig['pgsql_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for PostgreSQL. Default is "no". Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
+		'quic_parser',
+		'QUICv1 Parser',
+		$pconfig['quic_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for QUICv1. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
 		'rdp_parser',
 		'RDP Parser',
 		$pconfig['rdp_parser'],
@@ -807,23 +852,11 @@ if ($importalias) {
 		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
 	))->setHelp('Choose the parser/detection setting for RFB. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
 	$section->addInput(new Form_Select(
-		'smb_parser',
-		'SMB Parser',
-		$pconfig['smb_parser'],
-		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
-	))->setHelp('Choose the parser/detection setting for SMB. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
-	$section->addInput(new Form_Select(
 		'ssh_parser',
 		'SSH Parser',
 		$pconfig['ssh_parser'],
 		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
 	))->setHelp('Choose the parser/detection setting for SSH. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
-	$section->addInput(new Form_Select(
-		'tftp_parser',
-		'TFTP Parser',
-		$pconfig['tftp_parser'],
-		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
-	))->setHelp('Choose the parser/detection setting for TFTP. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
 	$section->addInput(new Form_Select(
 		'sip_parser',
 		'SIP Parser',
@@ -831,11 +864,29 @@ if ($importalias) {
 		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
 	))->setHelp('Choose the parser/detection setting for SIP. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
 	$section->addInput(new Form_Select(
+		'smb_parser',
+		'SMB Parser',
+		$pconfig['smb_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for SMB. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
 		'snmp_parser',
 		'SNMP Parser',
 		$pconfig['snmp_parser'],
 		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
 	))->setHelp('Choose the parser/detection setting for SNMP. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
+		'telnet_parser',
+		'Telnet Parser',
+		$pconfig['telnet_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for Telnet. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
+	$section->addInput(new Form_Select(
+		'tftp_parser',
+		'TFTP Parser',
+		$pconfig['tftp_parser'],
+		array(  "yes" => "yes", "no" => "no", "detection-only" => "detection-only" )
+	))->setHelp('Choose the parser/detection setting for TFTP. Default is yes. Selecting "yes" enables detection and parser, "no" disables both and "detection-only" disables parser.');
 
 	print($section);
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
@@ -60,7 +60,7 @@ if (isset($id) && !empty($a_nat)) {
 	if (empty($pconfig['flow_memcap_policy']))
 		$pconfig['flow_memcap_policy'] = "ignore";
 	if (empty($pconfig['stream_checksum_validation']))
-		$pconfig['stream_checksum_validation'] = "yes";
+		$pconfig['stream_checksum_validation'] = "on";
 
 	// See if Host-OS policy engine array is configured and use
 	// it; otherwise create a default engine configuration.
@@ -316,8 +316,8 @@ elseif ($_POST['save'] || $_POST['apply']) {
 		if ($_POST['stream_checksum_validation'] == "on") { $natent['stream_checksum_validation'] = 'on'; }else{ $natent['stream_checksum_validation'] = 'off'; }
 		if ($_POST['midstream_policy']) { $natent['midstream_policy'] = $_POST['midstream_policy']; }
 		if ($_POST['enable_async_sessions'] == "on") { $natent['enable_async_sessions'] = 'on'; }else{ $natent['enable_async_sessions'] = 'off'; }
-		if ($_POST['stream_bypass'] == "yes") { $natent['stream_bypass'] = 'yes'; }else{ $natent['stream_bypass'] = 'no'; }
-		if ($_POST['stream_drop_invalid'] == "yes") { $natent['stream_drop_invalid'] = 'yes'; }else{ $natent['stream_drop_invalid'] = 'no'; }
+		if ($_POST['stream_bypass'] == "on") { $natent['stream_bypass'] = 'on'; }else{ $natent['stream_bypass'] = 'no'; }
+		if ($_POST['stream_drop_invalid'] == "on") { $natent['stream_drop_invalid'] = 'on'; }else{ $natent['stream_drop_invalid'] = 'no'; }
 		if ($_POST['reassembly_memcap'] != "") { $natent['reassembly_memcap'] = $_POST['reassembly_memcap']; }else{ $natent['reassembly_memcap'] = "134217728"; }
 		if ($_POST['reassembly_memcap_policy']) { $natent['reassembly_memcap_policy'] = $_POST['reassembly_memcap_policy']; }
 		if ($_POST['reassembly_depth'] != "") { $natent['reassembly_depth'] = $_POST['reassembly_depth']; }else{ $natent['reassembly_depth'] = "1048576"; }
@@ -842,22 +842,22 @@ $section->addInput(new Form_Checkbox(
 	'Checksum Validation',
 	'Suricata will validate the checksum of received packets. When enabled, packets with invalid checksum values will not be ' . 
 	'processed by the engine stream/app layer. Default is Checked.',
-	$pconfig['stream_checksum_validation'] == 'yes' ? true:false,
-	'yes'
+	$pconfig['stream_checksum_validation'] == 'on' ? true:false,
+	'on'
 ));
 $section->addInput(new Form_Checkbox(
 	'stream_bypass',
 	'Bypass Packets',
 	'Suricata will bypass packets when stream reassembly depth (configured below) is reached. Default is Not Checked.',
-	$pconfig['stream_bypass'] == 'yes' ? true:false,
-	'yes'
+	$pconfig['stream_bypass'] == 'on' ? true:false,
+	'on'
 ));
 $section->addInput(new Form_Checkbox(
 	'stream_drop_invalid',
 	'Drop Invalid Packets',
 	'When using Inline mode, Suricata will drop packets that are invalid with regards to streaming engine. Default is Not Checked.',
-	$pconfig['stream_drop_invalid'] == 'yes' ? true:false,
-	'yes'
+	$pconfig['stream_drop_invalid'] == 'on' ? true:false,
+	'on'
 ));
 $section->addInput(new Form_Input(
 	'reassembly_memcap',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
@@ -49,6 +49,18 @@ $pconfig = array();
 if (isset($id) && !empty($a_nat)) {
 	/* Get current values from config for page form fields */
 	$pconfig = $a_nat;
+	if (empty($pconfig['stream_memcap_policy']))
+		$pconfig['stream_memcap_policy'] = "ignore";
+	if (empty($pconfig['midstream_policy']))
+		$pconfig['midstream_policy'] = "ignore";
+	if (empty($pconfig['defrag_memcap_policy']))
+		$pconfig['defrag_memcap_policy'] = "ignore";
+	if (empty($pconfig['reassembly_memcap_policy']))
+		$pconfig['reassembly_memcap_policy'] = "ignore";
+	if (empty($pconfig['flow_memcap_policy']))
+		$pconfig['flow_memcap_policy'] = "ignore";
+	if (empty($pconfig['stream_checksum_validation']))
+		$pconfig['stream_checksum_validation'] = "yes";
 
 	// See if Host-OS policy engine array is configured and use
 	// it; otherwise create a default engine configuration.
@@ -207,13 +219,15 @@ elseif ($_POST['cancel_os_policy']) {
 elseif ($_POST['ResetAll']) {
 
 	/* Reset all the settings to defaults */
+	$pconfig['defrag_memcap_policy'] = "ignore";
 	$pconfig['ip_max_frags'] = "65535";
 	$pconfig['ip_frag_timeout'] = "60";
 	$pconfig['frag_memcap'] = '33554432';
 	$pconfig['ip_max_trackers'] = '65535';
 	$pconfig['frag_hash_size'] = '65536';
 
-	$pconfig['flow_memcap'] = '33554432';
+	$pconfig['flow_memcap'] = '134217728';
+	$pconfig['flow_memcap_policy'] = 'ignore';
 	$pconfig['flow_prealloc'] = '10000';
 	$pconfig['flow_hash_size'] = '65536';
 	$pconfig['flow_emerg_recovery'] = '30';
@@ -246,6 +260,9 @@ elseif ($_POST['ResetAll']) {
 	$pconfig['reassembly_to_server_chunk'] = '2560';
 	$pconfig['reassembly_to_client_chunk'] = '2560';
 	$pconfig['enable_midstream_sessions'] = 'off';
+	$pconfig['stream_memcap_policy'] = 'ignore';
+	$pconfig['midstream_policy'] = 'ignore';
+	$pconfig['reassembly_memcap_policy'] = 'ignore';
 	$pconfig['enable_async_sessions'] = 'off';
 	$pconfig['max_synack_queued'] = '5';
 	$pconfig['stream_bypass'] = "no";
@@ -265,9 +282,11 @@ elseif ($_POST['save'] || $_POST['apply']) {
 		if ($_POST['ip_max_frags'] != "") { $natent['ip_max_frags'] = $_POST['ip_max_frags']; }else{ $natent['ip_max_frags'] = "65535"; }
 		if ($_POST['ip_frag_timeout'] != "") { $natent['ip_frag_timeout'] = $_POST['ip_frag_timeout']; }else{ $natent['ip_frag_timeout'] = "60"; }
 		if ($_POST['frag_memcap'] != "") { $natent['frag_memcap'] = $_POST['frag_memcap']; }else{ $natent['frag_memcap'] = "33554432"; }
+		if ($_POST['defrag_memcap_policy']) { $natent['defrag_memcap_policy'] = $_POST['defrag_memcap_policy']; }
 		if ($_POST['ip_max_trackers'] != "") { $natent['ip_max_trackers'] = $_POST['ip_max_trackers']; }else{ $natent['ip_max_trackers'] = "65535"; }
 		if ($_POST['frag_hash_size'] != "") { $natent['frag_hash_size'] = $_POST['frag_hash_size']; }else{ $natent['frag_hash_size'] = "65536"; }
-		if ($_POST['flow_memcap'] != "") { $natent['flow_memcap'] = $_POST['flow_memcap']; }else{ $natent['flow_memcap'] = "33554432"; }
+		if ($_POST['flow_memcap'] != "") { $natent['flow_memcap'] = $_POST['flow_memcap']; }else{ $natent['flow_memcap'] = "134217728"; }
+		if ($_POST['flow_memcap_policy']) { $natent['flow_memcap_policy'] = $_POST['flow_memcap_policy']; }
 		if ($_POST['flow_prealloc'] != "") { $natent['flow_prealloc'] = $_POST['flow_prealloc']; }else{ $natent['flow_prealloc'] = "10000"; }
 		if ($_POST['flow_hash_size'] != "") { $natent['flow_hash_size'] = $_POST['flow_hash_size']; }else{ $natent['flow_hash_size'] = "65536"; }
 		if ($_POST['flow_emerg_recovery'] != "") { $natent['flow_emerg_recovery'] = $_POST['flow_emerg_recovery']; }else{ $natent['flow_emerg_recovery'] = "30"; }
@@ -291,12 +310,16 @@ elseif ($_POST['save'] || $_POST['apply']) {
 		if ($_POST['flow_icmp_emerg_established_timeout'] != "") { $natent['flow_icmp_emerg_established_timeout'] = $_POST['flow_icmp_emerg_established_timeout']; }else{ $natent['flow_icmp_emerg_established_timeout'] = "100"; }
 
 		if ($_POST['stream_memcap'] != "") { $natent['stream_memcap'] = $_POST['stream_memcap']; }else{ $natent['stream_memcap'] = "268435456"; }
+		if ($_POST['stream_memcap_policy']) { $natent['stream_memcap_policy'] = $_POST['stream_memcap_policy']; }
 		if ($_POST['stream_prealloc_sessions'] != "") { $natent['stream_prealloc_sessions'] = $_POST['stream_prealloc_sessions']; }else{ $natent['stream_prealloc_sessions'] = "32768"; }
 		if ($_POST['enable_midstream_sessions'] == "on") { $natent['enable_midstream_sessions'] = 'on'; }else{ $natent['enable_midstream_sessions'] = 'off'; }
+		if ($_POST['stream_checksum_validation'] == "on") { $natent['stream_checksum_validation'] = 'on'; }else{ $natent['stream_checksum_validation'] = 'off'; }
+		if ($_POST['midstream_policy']) { $natent['midstream_policy'] = $_POST['midstream_policy']; }
 		if ($_POST['enable_async_sessions'] == "on") { $natent['enable_async_sessions'] = 'on'; }else{ $natent['enable_async_sessions'] = 'off'; }
 		if ($_POST['stream_bypass'] == "yes") { $natent['stream_bypass'] = 'yes'; }else{ $natent['stream_bypass'] = 'no'; }
 		if ($_POST['stream_drop_invalid'] == "yes") { $natent['stream_drop_invalid'] = 'yes'; }else{ $natent['stream_drop_invalid'] = 'no'; }
 		if ($_POST['reassembly_memcap'] != "") { $natent['reassembly_memcap'] = $_POST['reassembly_memcap']; }else{ $natent['reassembly_memcap'] = "134217728"; }
+		if ($_POST['reassembly_memcap_policy']) { $natent['reassembly_memcap_policy'] = $_POST['reassembly_memcap_policy']; }
 		if ($_POST['reassembly_depth'] != "") { $natent['reassembly_depth'] = $_POST['reassembly_depth']; }else{ $natent['reassembly_depth'] = "1048576"; }
 		if ($_POST['reassembly_to_server_chunk'] != "") { $natent['reassembly_to_server_chunk'] = $_POST['reassembly_to_server_chunk']; }else{ $natent['reassembly_to_server_chunk'] = "2560"; }
 		if ($_POST['reassembly_to_client_chunk'] != "") { $natent['reassembly_to_client_chunk'] = $_POST['reassembly_to_client_chunk']; }else{ $natent['reassembly_to_client_chunk'] = "2560"; }
@@ -582,10 +605,20 @@ $form->addGlobal(new Form_Input(
 $section = new Form_Section('IP Defragmentation');
 $section->addInput(new Form_Input(
 	'frag_memcap',
-	'Fragmentation Memory Cap',
+	'Defrag Memory Cap',
 	'text',
 	$pconfig['frag_memcap']
 ))->setHelp('Max memory to be used for defragmentation. Default is 33,554,432 bytes (32 MB). Sets the maximum amount of memory, in bytes, to be used by the IP defragmentation engine.');
+$section->addInput(new Form_Select(
+	'defrag_memcap_policy',
+	'Defrag Memory Cap Exception Policy',
+	$pconfig['defrag_memcap_policy'],
+	array( "bypass" => "Bypass", "drop-packet" => "Drop Packet", "pass-packet" => "Pass Packet",
+		   "reject" => "Reject", "ignore" => "Ignore" )
+))->setHelp('Apply selected policy when the memcap limit for defrag is reached and no tracker could be picked up. This policy can only be applied to packets. Default is "Ignore". ' .
+			'"Drop Packet" drops the current packet. "Reject" rejects the current packet. "Bypass" will bypass the flow, and no further inspection is done. ' .
+			'"Pass Packet" will disable detection, but still does stream updates and app-layer parsing (depending on which policy triggered it). ' .
+			'"Ignore" does not apply exception policies.');
 $section->addInput(new Form_Input(
 	'ip_max_trackers',
 	'Max Trackers',
@@ -618,7 +651,17 @@ $section->addInput(new Form_Input(
 	'Flow Memory Cap',
 	'text',
 	$pconfig['flow_memcap']
-))->setHelp('Max memory, in bytes, to be used by the flow engine. Default is 33,554,432 bytes (32 MB)');
+))->setHelp('Max memory, in bytes, to be used by the flow engine. Default is 134,217,728 bytes (128 MB)');
+$section->addInput(new Form_Select(
+	'flow_memcap_policy',
+	'Flow Memory Cap Exception Policy',
+	$pconfig['flow_memcap_policy'],
+	array( "bypass" => "Bypass", "drop-packet" => "Drop Packet", "pass-packet" => "Pass Packet",
+		   "reject" => "Reject", "ignore" => "Ignore" )
+))->setHelp('Apply selected policy when the memcap limit for flows is reached and no flow could be freed up. This policy can only be applied to packets. Default is "Ignore". ' .
+			'"Drop Packet" drops the current packet. "Reject" rejects the current packet. "Bypass" will bypass the flow, and no further inspection is done. ' .
+			'"Pass Packet" will disable detection, but still does stream updates and app-layer parsing (depending on which policy triggered it). ' .
+			'"Ignore" does not apply exception policies.');
 $section->addInput(new Form_Input(
 	'flow_hash_size',
 	'Flow Hash Table Size',
@@ -747,6 +790,19 @@ $section->addInput(new Form_Input(
 	'text',
 	$pconfig['stream_memcap']
 ))->setHelp('Max memory to be used by stream engine. Default is 268,435,456 bytes (256MB). Sets the maximum amount of memory, in bytes, to be used by the stream engine. This number will likely need to be increased beyond the default value in systems with more than 4 processor cores. If Suricata fails to start and logs a memory allocation error, increase this value in 4 MB chunks until Suricata starts successfully.');
+$section->addInput(new Form_Select(
+	'stream_memcap_policy',
+	'Memcap Exception Policy',
+	$pconfig['stream_memcap_policy'],
+	array( "drop-flow" => "Drop Flow", "pass-flow" => "Pass Flow", "bypass" => "Bypass", "drop-packet" => "Drop Packet",
+		   "pass-packet" => "Pass Packet", "reject" => "Reject", "ignore" => "Ignore" )
+))->setHelp('If a stream memcap limit is reached, apply the selected memcap policy to the packet and/or flow.. Default is "Ignore". ' .
+			'"Drop Flow" will disable inspection for the whole flow (packets, payload, and application layer protocol), drop ' .
+			'the packet and all future packets in the flow. "Drop Packet" drops the current packet. "Reject" is the same as "Drop Flow" ' .
+			'but rejects the current packet as well. "Bypass" will bypass the flow, and no further inspection is done. ' .
+			'"Pass Flow" will disable payload and packet detection, but stream reassembly, app-layer parsing and logging still happen. ' .
+			'"Pass Packet" will disable detection, but still does stream updates and app-layer parsing (depending on which policy triggered it). ' .
+			'"Ignore" does not apply exception policies.');
 $section->addInput(new Form_Input(
 	'stream_prealloc_sessions',
 	'Preallocated Sessions',
@@ -756,16 +812,38 @@ $section->addInput(new Form_Input(
 $section->addInput(new Form_Checkbox(
 	'enable_midstream_sessions',
 	'Enable Mid-Stream Sessions',
-	'Suricata will pick up and track sessions mid-stream. Default is Not Checked.',
+	'Suricata will allow midstream session pickups. Default is Not Checked, which will ignore and not scan midstream sessions. When this ' .
+	'option is enabled, midstream sessions are subject to the Midstream Exception Policy selected below.',
 	$pconfig['enable_midstream_sessions'] == 'on' ? true:false,
 	'on'
 ));
+$section->addInput(new Form_Select(
+	'midstream_policy',
+	'Midstream Exception Policy',
+	$pconfig['midstream_policy'],
+	array( "drop-flow" => "Drop Flow", "pass-flow" => "Pass Flow", "bypass" => "Bypass", "drop-packet" => "Drop Packet",
+		   "pass-packet" => "Pass Packet", "reject" => "Reject", "ignore" => "Ignore" )
+))->setHelp('If a session is picked up midstream, apply the selected midstream policy to the flow. Default is "Ignore". ' .
+			'"Drop Flow" will disable inspection for the whole flow (packets, payload, and application layer protocol), drop ' .
+			'the packet and all future packets in the flow. "Drop Packet" drops the current packet. "Reject" is the same as "Drop Flow" ' .
+			'but rejects the current packet as well. "Bypass" will bypass the flow, and no further inspection is done. ' .
+			'"Pass Flow" will disable payload and packet detection, but stream reassembly, app-layer parsing and logging still happen. ' .
+			'"Pass Packet" will disable detection, but still does stream updates and app-layer parsing (depending on which policy triggered it). ' .
+			'"Ignore" does not apply exception policies.');
 $section->addInput(new Form_Checkbox(
 	'enable_async_sessions',
 	'Enable Async Streams',
 	'Suricata will track asynchronous one-sided streams. Default is Not Checked.',
 	$pconfig['enable_async_sessions'] == 'on' ? true:false,
 	'on'
+));
+$section->addInput(new Form_Checkbox(
+	'stream_checksum_validation',
+	'Checksum Validation',
+	'Suricata will validate the checksum of received packets. When enabled, packets with invalid checksum values will not be ' . 
+	'processed by the engine stream/app layer. Default is Checked.',
+	$pconfig['stream_checksum_validation'] == 'yes' ? true:false,
+	'yes'
 ));
 $section->addInput(new Form_Checkbox(
 	'stream_bypass',
@@ -787,6 +865,19 @@ $section->addInput(new Form_Input(
 	'text',
 	$pconfig['reassembly_memcap']
 ))->setHelp('Max memory to be used for stream reassembly. Default is 134,217,728 bytes (128MB). Sets the maximum amount of memory, in bytes, to be used for stream reassembly.');
+$section->addInput(new Form_Select(
+	'reassembly_memcap_policy',
+	'Reassembly Memcap Exception Policy',
+	$pconfig['reassembly_memcap_policy'],
+	array( "drop-flow" => "Drop Flow", "pass-flow" => "Pass Flow", "bypass" => "Bypass", "drop-packet" => "Drop Packet",
+		   "pass-packet" => "Pass Packet", "reject" => "Reject", "ignore" => "Ignore" )
+))->setHelp('If stream reassembly reaches memcap limit, apply the selected reassembly memcap policy to the flow. Default is "Ignore". ' .
+			'"Drop Flow" will disable inspection for the whole flow (packets, payload, and application layer protocol), drop ' .
+			'the packet and all future packets in the flow. "Drop Packet" drops the current packet. "Reject" is the same as "Drop Flow" ' .
+			'but rejects the current packet as well. "Bypass" will bypass the flow, and no further inspection is done. ' .
+			'"Pass Flow" will disable payload and packet detection, but stream reassembly, app-layer parsing and logging still happen. ' .
+			'"Pass Packet" will disable detection, but still does stream updates and app-layer parsing (depending on which policy triggered it). ' .
+			'"Ignore" does not apply exception policies.');
 $section->addInput(new Form_Input(
 	'reassembly_depth',
 	'Reassembly Depth',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_flow_stream.php
@@ -240,8 +240,8 @@ elseif ($_POST['ResetAll']) {
 	// 216 * prealloc_sessions * number of threads = memory use in bytes
 	// 128 MB is a decent all-around default, but some setups need more.
 	$pconfig['stream_prealloc_sessions'] = '32768';
-	$pconfig['stream_memcap'] = '131217728';
-	$pconfig['reassembly_memcap'] = '131217728';
+	$pconfig['stream_memcap'] = '268435456';
+	$pconfig['reassembly_memcap'] = '134217728';
 	$pconfig['reassembly_depth'] = '1048576';
 	$pconfig['reassembly_to_server_chunk'] = '2560';
 	$pconfig['reassembly_to_client_chunk'] = '2560';
@@ -290,13 +290,13 @@ elseif ($_POST['save'] || $_POST['apply']) {
 		if ($_POST['flow_icmp_emerg_new_timeout'] != "") { $natent['flow_icmp_emerg_new_timeout'] = $_POST['flow_icmp_emerg_new_timeout']; }else{ $natent['flow_icmp_emerg_new_timeout'] = "10"; }
 		if ($_POST['flow_icmp_emerg_established_timeout'] != "") { $natent['flow_icmp_emerg_established_timeout'] = $_POST['flow_icmp_emerg_established_timeout']; }else{ $natent['flow_icmp_emerg_established_timeout'] = "100"; }
 
-		if ($_POST['stream_memcap'] != "") { $natent['stream_memcap'] = $_POST['stream_memcap']; }else{ $natent['stream_memcap'] = "131217728"; }
+		if ($_POST['stream_memcap'] != "") { $natent['stream_memcap'] = $_POST['stream_memcap']; }else{ $natent['stream_memcap'] = "268435456"; }
 		if ($_POST['stream_prealloc_sessions'] != "") { $natent['stream_prealloc_sessions'] = $_POST['stream_prealloc_sessions']; }else{ $natent['stream_prealloc_sessions'] = "32768"; }
 		if ($_POST['enable_midstream_sessions'] == "on") { $natent['enable_midstream_sessions'] = 'on'; }else{ $natent['enable_midstream_sessions'] = 'off'; }
 		if ($_POST['enable_async_sessions'] == "on") { $natent['enable_async_sessions'] = 'on'; }else{ $natent['enable_async_sessions'] = 'off'; }
 		if ($_POST['stream_bypass'] == "yes") { $natent['stream_bypass'] = 'yes'; }else{ $natent['stream_bypass'] = 'no'; }
 		if ($_POST['stream_drop_invalid'] == "yes") { $natent['stream_drop_invalid'] = 'yes'; }else{ $natent['stream_drop_invalid'] = 'no'; }
-		if ($_POST['reassembly_memcap'] != "") { $natent['reassembly_memcap'] = $_POST['reassembly_memcap']; }else{ $natent['reassembly_memcap'] = "131217728"; }
+		if ($_POST['reassembly_memcap'] != "") { $natent['reassembly_memcap'] = $_POST['reassembly_memcap']; }else{ $natent['reassembly_memcap'] = "134217728"; }
 		if ($_POST['reassembly_depth'] != "") { $natent['reassembly_depth'] = $_POST['reassembly_depth']; }else{ $natent['reassembly_depth'] = "1048576"; }
 		if ($_POST['reassembly_to_server_chunk'] != "") { $natent['reassembly_to_server_chunk'] = $_POST['reassembly_to_server_chunk']; }else{ $natent['reassembly_to_server_chunk'] = "2560"; }
 		if ($_POST['reassembly_to_client_chunk'] != "") { $natent['reassembly_to_client_chunk'] = $_POST['reassembly_to_client_chunk']; }else{ $natent['reassembly_to_client_chunk'] = "2560"; }
@@ -746,7 +746,7 @@ $section->addInput(new Form_Input(
 	'Stream Memory Cap',
 	'text',
 	$pconfig['stream_memcap']
-))->setHelp('Max memory to be used by stream engine. Default is 131,217,728 bytes (128MB). Sets the maximum amount of memory, in bytes, to be used by the stream engine. This number will likely need to be increased beyond the default value in systems with more than 4 processor cores. If Suricata fails to start and logs a memory allocation error, increase this value in 4 MB chunks until Suricata starts successfully.');
+))->setHelp('Max memory to be used by stream engine. Default is 268,435,456 bytes (256MB). Sets the maximum amount of memory, in bytes, to be used by the stream engine. This number will likely need to be increased beyond the default value in systems with more than 4 processor cores. If Suricata fails to start and logs a memory allocation error, increase this value in 4 MB chunks until Suricata starts successfully.');
 $section->addInput(new Form_Input(
 	'stream_prealloc_sessions',
 	'Preallocated Sessions',
@@ -786,7 +786,7 @@ $section->addInput(new Form_Input(
 	'Reassembly Memory Cap',
 	'text',
 	$pconfig['reassembly_memcap']
-))->setHelp('Max memory to be used for stream reassembly. Default is 131,217,728 bytes (128MB). Sets the maximum amount of memory, in bytes, to be used for stream reassembly.');
+))->setHelp('Max memory to be used for stream reassembly. Default is 134,217,728 bytes (128MB). Sets the maximum amount of memory, in bytes, to be used for stream reassembly.');
 $section->addInput(new Form_Input(
 	'reassembly_depth',
 	'Reassembly Depth',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -380,7 +380,7 @@ $section->addInput(new Form_Input(
 	'Snort Rules Filename',
 	'text',
 	$pconfig['snort_rules_file']
-))->setHelp('Enter the rules tarball filename (filename only, do not include the URL.)<br />Example: snortrules-snapshot-29151.tar.gz<br />DO NOT specify a Snort3 rules file!  Snort3 rules are incompatible with Suricata and will break your installation!');
+))->setHelp('Enter the rules tarball filename (filename only, do not include the URL.)<br />Example: snortrules-snapshot-29200.tar.gz<br />DO NOT specify a Snort3 rules file!  Snort3 rules are incompatible with Suricata and will break your installation!');
 $section->addInput(new Form_Input(
 	'oinkcode',
 	'Snort Oinkmaster Code',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -194,6 +194,9 @@ EOD;
 				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/suricata_{$if_real}{$suricatacfg['uuid']}_startcmd.php");
 			}
 			else {
+				// Forcefully remove the PID file if it exists since we checked already for a running process and stopped it.
+				// This allows the user the start Suricata in the event of a failed previous start due to a config error.
+				unlink_if_exists("{$g['varrun_path']}/suricata_{$if_real}{$suricatacfg['uuid']}.pid");
 				syslog(LOG_NOTICE, "Starting Suricata on {$if_friendly}({$if_real}) per user request...");
 				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/suricata_{$if_real}{$suricatacfg['uuid']}_startcmd.php");
 			}

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -667,10 +667,10 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$natent['stream_memcap_policy'] = 'ignore';
 			$natent['reassembly_memcap_policy'] = 'ignore';
 			$natent['midstream_policy'] = 'ignore';
-			$natent['stream_checksum_validation'] = "on";
+			$natent['stream_checksum_validation'] = "off";
 			$natent['enable_async_sessions'] = 'off';
-			$natent['stream_bypass'] = "no";
-			$natent['stream_drop_invalid'] = "no";
+			$natent['stream_bypass'] = "off";
+			$natent['stream_drop_invalid'] = "off";
 			$natent['delayed_detect'] = 'off';
 			$natent['intf_promisc_mode'] = 'on';
 			$natent['intf_snaplen'] = '1518';

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -1742,6 +1742,26 @@ $section->addInput(new Form_Checkbox(
 	'on'
 ));
 
+$group = new Form_Group('IP Pass List');
+$group->addClass('passlist');
+$list = suricata_get_config_lists('passlist');
+$list['none'] = 'none';
+$group->add(new Form_Select(
+	'passlistname',
+	'Pass List',
+	$pconfig['passlistname'],
+	$list
+))->setHelp('Choose the Pass List you want this interface to use. Addresses in a Pass List are never blocked. Select "none" to prevent use of a Pass List.');
+$group->add(new Form_Button(
+	'btnPasslist',
+	' ' . 'View List',
+	'#',
+	'fa-file-text-o'
+))->removeClass('btn-primary')->addClass('btn-info')->addClass('btn-sm')->setAttribute('data-target', '#passlist')->setAttribute('data-toggle', 'modal');
+$group->setHelp('The default Pass List adds Gateways, DNS servers, locally-attached networks, the WAN IP, VPNs and VIPs.  Create a Pass List with an alias to customize whitelisted IP addresses.  ' . 
+		'This option will only be used when block offenders is on.  Choosing "none" will disable Pass List generation.');
+$section->add($group);
+
 $form->add($section);
 
 // Add Inline IPS rule edit warning modal pop-up
@@ -1888,30 +1908,6 @@ $group->add(new Form_Button(
 
 $group->setHelp('External Net is networks that are not Home Net.  Most users should leave this setting at default.' . '<br />' .
 		'Create a Pass List and add an Alias to it, and then assign the Pass List here for custom External Net settings.');
-
-$section->add($group);
-
-$group = new Form_Group('Pass List');
-
-$group->addClass('passlist');
-$list = suricata_get_config_lists('passlist');
-$list['none'] = 'none';
-$group->add(new Form_Select(
-	'passlistname',
-	'Pass List',
-	$pconfig['passlistname'],
-	$list
-))->setHelp('Choose the Pass List you want this interface to use. Addresses in a Pass List are never blocked. Select "none" to prevent use of a Pass List.');
-
-$group->add(new Form_Button(
-	'btnPasslist',
-	' ' . 'View List',
-	'#',
-	'fa-file-text-o'
-))->removeClass('btn-primary')->addClass('btn-info')->addClass('btn-sm')->setAttribute('data-target', '#passlist')->setAttribute('data-toggle', 'modal');
-
-$group->setHelp('The default Pass List adds Gateways, DNS servers, locally-attached networks, the WAN IP, VPNs and VIPs.  Create a Pass List with an alias to customize whitelisted IP addresses.  ' . 
-		'This option will only be used when block offenders is on.  Choosing "none" will disable Pass List generation.');
 
 $section->add($group);
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -89,8 +89,6 @@ if (isset($id) && isset($a_rule[$id])) {
 	/* old options from config.xml */
 	$if_friendly = convert_friendly_interface_to_friendly_descr($a_rule[$id]['interface']);
 	$pconfig = $a_rule[$id];
-	if (!empty($pconfig['configpassthru']))
-		$pconfig['configpassthru'] = base64_decode($pconfig['configpassthru']);
 	if (empty($pconfig['uuid']))
 		$pconfig['uuid'] = $suricata_uuid;
 	if (get_real_interface($pconfig['interface']) == "") {
@@ -174,18 +172,26 @@ if (empty($pconfig['enable_stats_collection']))
 	$pconfig['enable_stats_collection'] = "off";
 if (empty($pconfig['enable_http_log']))
 	$pconfig['enable_http_log'] = "on";
+if (empty($pconfig['http_log_filetype']))
+	$pconfig['http_log_filetype'] = "regular";
 if (empty($pconfig['append_http_log']))
 	$pconfig['append_http_log'] = "on";
 if (empty($pconfig['http_log_extended']))
 	$pconfig['http_log_extended'] = "on";
 if (empty($pconfig['tls_log_extended']))
 	$pconfig['tls_log_extended'] = "on";
+if (empty($pconfig['append_tls_log']))
+	$pconfig['append_tls_log'] = "on";
+if (empty($pconfig['tls_log_filetype']))
+	$pconfig['tls_log_filetype'] = "regular";
 if (empty($pconfig['stats_upd_interval']))
 	$pconfig['stats_upd_interval'] = "10";
 if (empty($pconfig['max_pcap_log_size']))
 	$pconfig['max_pcap_log_size'] = "32";
 if (empty($pconfig['max_pcap_log_files']))
 	$pconfig['max_pcap_log_files'] = "1000";
+if (empty($pconfig['pcap_log_conditional']))
+	$pconfig['pcap_log_conditional'] = "alerts";
 if (empty($pconfig['alertsystemlog_facility']))
 	$pconfig['alertsystemlog_facility'] = "local1";
 if (empty($pconfig['alertsystemlog_priority']))
@@ -196,6 +202,10 @@ if (empty($pconfig['eve_systemlog_facility']))
 	$pconfig['eve_systemlog_facility'] = "local1";
 if (empty($pconfig['eve_systemlog_priority']))
 	$pconfig['eve_systemlog_priority'] = "notice";
+if (empty($pconfig['eve_log_drops']))
+	$pconfig['eve_log_drops'] = "on";
+if (empty($pconfig['eve_log_alert_drops']))
+	$pconfig['eve_log_alert_drops'] = "on";
 if (empty($pconfig['eve_log_alerts']))
 	$pconfig['eve_log_alerts'] = "on";
 if (empty($pconfig['eve_log_alerts_payload']))
@@ -230,6 +240,8 @@ if (empty($pconfig['eve_log_krb5']))
 	$pconfig['eve_log_krb5'] = "on";
 if (empty($pconfig['eve_log_ikev2']))
 	$pconfig['eve_log_ikev2'] = "on";
+if (empty($pconfig['eve_log_quic']))
+	$pconfig['eve_log_quic'] = "on";
 if (empty($pconfig['eve_log_tftp']))
 	$pconfig['eve_log_tftp'] = "on";
 if (empty($pconfig['eve_log_rdp']))
@@ -444,6 +456,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['enable_verbose_logging'] == "on") { $natent['enable_verbose_logging'] = 'on'; }else{ $natent['enable_verbose_logging'] = 'off'; }
 		if ($_POST['max_pcap_log_size']) $natent['max_pcap_log_size'] = $_POST['max_pcap_log_size']; else unset($natent['max_pcap_log_size']);
 		if ($_POST['max_pcap_log_files']) $natent['max_pcap_log_files'] = $_POST['max_pcap_log_files']; else unset($natent['max_pcap_log_files']);
+		if ($_POST['pcap_log_conditional']) $natent['pcap_log_conditional'] = $_POST['pcap_log_conditional'];
 		if ($_POST['enable_stats_collection'] == "on") { $natent['enable_stats_collection'] = 'on'; }else{ $natent['enable_stats_collection'] = 'off'; }
 		if ($_POST['enable_stats_log'] == "on") { $natent['enable_stats_log'] = 'on'; }else{ $natent['enable_stats_log'] = 'off'; }
 		if ($_POST['append_stats_log'] == "on") { $natent['append_stats_log'] = 'on'; }else{ $natent['append_stats_log'] = 'off'; }
@@ -453,15 +466,26 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['enable_http_log'] == "on") { $natent['enable_http_log'] = 'on'; }else{ $natent['enable_http_log'] = 'off'; }
 		if ($_POST['append_http_log'] == "on") { $natent['append_http_log'] = 'on'; }else{ $natent['append_http_log'] = 'off'; }
 		if ($_POST['enable_tls_log'] == "on") { $natent['enable_tls_log'] = 'on'; }else{ $natent['enable_tls_log'] = 'off'; }
+		if ($_POST['append_tls_log'] == "on") { $natent['append_tls_log'] = 'on'; }else{ $natent['append_tls_log'] = 'off'; }
 		if ($_POST['enable_tls_store'] == "on") { $natent['enable_tls_store'] = 'on'; }else{ $natent['enable_tls_store'] = 'off'; }
 		if ($_POST['http_log_extended'] == "on") { $natent['http_log_extended'] = 'on'; }else{ $natent['http_log_extended'] = 'off'; }
 		if ($_POST['tls_log_extended'] == "on") { $natent['tls_log_extended'] = 'on'; }else{ $natent['tls_log_extended'] = 'off'; }
+		if ($_POST['tls_session_resumption'] == "on") { $natent['tls_session_resumption'] = 'on'; }else{ $natent['tls_session_resumption'] = 'off'; }
 		if ($_POST['enable_pcap_log'] == "on") { $natent['enable_pcap_log'] = 'on'; }else{ $natent['enable_pcap_log'] = 'off'; }
+		if ($_POST['pcap_use_stream_depth'] == "on") { $natent['pcap_use_stream_depth'] = 'on'; }else{ $natent['pcap_use_stream_depth'] = 'off'; }
+		if ($_POST['pcap_honor_pass_rules'] == "on") { $natent['pcap_honor_pass_rules'] = 'on'; }else{ $natent['pcap_honor_pass_rules'] = 'off'; }
 		if ($_POST['enable_file_store'] == "on") { $natent['enable_file_store'] = 'on'; }else{ $natent['enable_file_store'] = 'off'; }
 		if ($natent['enable_file_store'] == "on") {
 			if ($_POST['file_store_logdir']) { $natent['file_store_logdir'] = base64_encode($_POST['file_store_logdir']); }else{ $natent['file_store_logdir'] = $pconfig['file_store_logdir']; }
 		}
-		if ($_POST['enable_eve_log'] == "on") { $natent['enable_eve_log'] = 'on'; }else{ $natent['enable_eve_log'] = 'off'; }
+		if ($_POST['tls_log_filetype']) $natent['tls_log_filetype'] = $_POST['tls_log_filetype']; else unset($natent['tls_log_filetype']);
+		if ($natent['tls_log_filetype'] == "unix_dgram" || $natent['tls_log_filetype'] == "unix_stream") {
+			if ($_POST['tls_log_socket']) { $natent['tls_log_socket'] = base64_encode($_POST['tls_log_socket']); }else{ $natent['tls_log_socket'] = $pconfig['tls_log_socket']; }
+		}
+		if ($_POST['http_log_filetype']) $natent['http_log_filetype'] = $_POST['http_log_filetype']; else unset($natent['http_log_filetype']);
+		if ($natent['http_log_filetype'] == "unix_dgram" || $natent['http_log_filetype'] == "unix_stream") {
+			if ($_POST['http_log_socket']) { $natent['http_log_socket'] = base64_encode($_POST['http_log_socket']); }else{ $natent['http_log_socket'] = $pconfig['tls_log_socket']; }
+		}
 		if ($_POST['runmode']) $natent['runmode'] = $_POST['runmode']; else unset($natent['runmode']);
 		if ($_POST['autofp_scheduler']) $natent['autofp_scheduler'] = $_POST['autofp_scheduler']; else unset($natent['autofp_scheduler']);
 		if ($_POST['max_pending_packets']) $natent['max_pending_packets'] = $_POST['max_pending_packets']; else unset($natent['max_pending_packets']);
@@ -485,6 +509,9 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['alertsystemlog_priority']) $natent['alertsystemlog_priority'] = $_POST['alertsystemlog_priority'];
 		if ($_POST['enable_eve_log'] == "on") { $natent['enable_eve_log'] = 'on'; }else{ $natent['enable_eve_log'] = 'off'; }
 		if ($_POST['eve_output_type']) $natent['eve_output_type'] = $_POST['eve_output_type'];
+		if ($natent['eve_output_type'] == "unix_dgram" || $natent['eve_output_type'] == "unix_stream") {
+			if ($_POST['eve_output_socket']) { $natent['eve_output_socket'] = base64_encode($_POST['eve_output_socket']); }else{ $natent['eve_output_socket'] = $pconfig['eve_output_socket']; }
+		}
 		if ($_POST['eve_systemlog_facility']) $natent['eve_systemlog_facility'] = $_POST['eve_systemlog_facility'];
 		if ($_POST['eve_systemlog_priority']) $natent['eve_systemlog_priority'] = $_POST['eve_systemlog_priority'];
 		if ($_POST['eve_log_alerts'] == "on") { $natent['eve_log_alerts'] = 'on'; }else{ $natent['eve_log_alerts'] = 'off'; }
@@ -496,6 +523,12 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['eve_log_alerts_xff_mode']) { $natent['eve_log_alerts_xff_mode'] = $_POST['eve_log_alerts_xff_mode']; }else{ $natent['eve_log_alert_xff_mode'] = 'extra-data'; }
 		if ($_POST['eve_log_alerts_xff_deployment']) { $natent['eve_log_alerts_xff_deployment'] = $_POST['eve_log_alerts_xff_deployment']; }else{ $natent['eve_log_alert_xff_deployment'] = 'reverse'; }
 		if ($_POST['eve_log_alerts_xff_header']) { $natent['eve_log_alerts_xff_header'] = $_POST['eve_log_alerts_xff_header']; }else{ $natent['eve_log_alert_xff_mode'] = 'X-Forwarded-For'; }
+		if ($_POST['eve_log_alerts_verdict'] == "on") { $natent['eve_log_alerts_verdict'] = 'on'; }else{ $natent['eve_log_alerts_verdict'] = 'off'; }
+		if ($_POST['eve_log_alerts_tagged'] == "on") { $natent['eve_log_alerts_tagged'] = 'on'; }else{ $natent['eve_log_alerts_tagged'] = 'off'; }
+		if ($_POST['eve_log_drops'] == "on") { $natent['eve_log_drops'] = 'on'; }else{ $natent['eve_log_drops'] = 'off'; }
+		if ($_POST['eve_log_alert_drops'] == "on") { $natent['eve_log_alert_drops'] = 'on'; }else{ $natent['eve_log_alert_drops'] = 'off'; }
+		if ($_POST['eve_log_drops_verdict'] == "on") { $natent['eve_log_drops_verdict'] = 'on'; }else{ $natent['eve_log_drops_verdict'] = 'off'; }
+		if ($_POST['eve_log_drops_flows']) $natent['eve_log_drops_flows'] = $_POST['eve_log_drops_flows'];
 		if ($_POST['eve_log_anomaly'] == "on") { $natent['eve_log_anomaly'] = 'on'; }else{ $natent['eve_log_anomaly'] = 'off'; }
 		if ($_POST['eve_log_anomaly_type_decode'] == "on") { $natent['eve_log_anomaly_type_decode'] = 'on'; }else{ $natent['eve_log_anomaly_type_decode'] = 'off'; }
 		if ($_POST['eve_log_anomaly_type_stream'] == "on") { $natent['eve_log_anomaly_type_stream'] = 'on'; }else{ $natent['eve_log_anomaly_type_stream'] = 'off'; }
@@ -510,6 +543,9 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['eve_log_krb5'] == "on") { $natent['eve_log_krb5'] = 'on'; }else{ $natent['eve_log_krb5'] = 'off'; }
 		if ($_POST['eve_log_ikev2'] == "on") { $natent['eve_log_ikev2'] = 'on'; }else{ $natent['eve_log_ikev2'] = 'off'; }
 		if ($_POST['eve_log_tftp'] == "on") { $natent['eve_log_tftp'] = 'on'; }else{ $natent['eve_log_tftp'] = 'off'; }
+		if ($_POST['eve_log_bittorrent'] == "on") { $natent['eve_log_bittorrent'] = 'on'; }else{ $natent['eve_log_bittorrent'] = 'off'; }
+		if ($_POST['eve_log_pgsql'] == "on") { $natent['eve_log_pgsql'] = 'on'; }else{ $natent['eve_log_pgsql'] = 'off'; }
+		if ($_POST['eve_log_quic'] == "on") { $natent['eve_log_quic'] = 'on'; }else{ $natent['eve_log_quic'] = 'off'; }
 		if ($_POST['eve_log_rdp'] == "on") { $natent['eve_log_rdp'] = 'on'; }else{ $natent['eve_log_rdp'] = 'off'; }
 		if ($_POST['eve_log_sip'] == "on") { $natent['eve_log_sip'] = 'on'; }else{ $natent['eve_log_sip'] = 'off'; }
 		if ($_POST['eve_log_files'] == "on") { $natent['eve_log_files'] = 'on'; }else{ $natent['eve_log_files'] = 'off'; }
@@ -592,10 +628,12 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$natent['ip_max_frags'] = "65535";
 			$natent['ip_frag_timeout'] = "60";
 			$natent['frag_memcap'] = '33554432';
+			$natent['defrag_memcap_policy'] = 'ignore';
 			$natent['ip_max_trackers'] = '65535';
 			$natent['frag_hash_size'] = '65536';
 
-			$natent['flow_memcap'] = '33554432';
+			$natent['flow_memcap'] = '134217728';
+			$natent['flow_memcap_policy'] = 'ignore';
 			$natent['flow_prealloc'] = '10000';
 			$natent['flow_hash_size'] = '65536';
 			$natent['flow_emerg_recovery'] = '30';
@@ -618,7 +656,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$natent['flow_icmp_emerg_new_timeout'] = '10';
 			$natent['flow_icmp_emerg_established_timeout'] = '100';
 
-			$natent['stream_memcap'] = '131217728';
+			$natent['stream_memcap'] = '268435456';
 			$natent['stream_prealloc_sessions'] = '32768';
 			$natent['reassembly_memcap'] = '131217728';
 			$natent['reassembly_depth'] = '1048576';
@@ -626,6 +664,10 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$natent['reassembly_to_client_chunk'] = '2560';
 			$natent['max_synack_queued'] = '5';
 			$natent['enable_midstream_sessions'] = 'off';
+			$natent['stream_memcap_policy'] = 'ignore';
+			$natent['reassembly_memcap_policy'] = 'ignore';
+			$natent['midstream_policy'] = 'ignore';
+			$natent['stream_checksum_validation'] = "on";
 			$natent['enable_async_sessions'] = 'off';
 			$natent['stream_bypass'] = "no";
 			$natent['stream_drop_invalid'] = "no";
@@ -633,46 +675,51 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$natent['intf_promisc_mode'] = 'on';
 			$natent['intf_snaplen'] = '1518';
 
+			$natent['app_layer_error_policy'] = "ignore";
 			$natent['asn1_max_frames'] = '256';
+			$natent['bittorrent_parser'] = "yes";
+			$natent['dcerpc_parser'] = "yes";
+			$natent['dhcp_parser'] = "yes";
 			$natent['dns_global_memcap'] = "16777216";
 			$natent['dns_state_memcap'] = "524288";
 			$natent['dns_request_flood_limit'] = "500";
-			$natent['http_parser_memcap'] = "67108864";
 			$natent['dns_parser_udp'] = "yes";
 			$natent['dns_parser_tcp'] = "yes";
 			$natent['dns_parser_udp_ports'] = "53";
 			$natent['dns_parser_tcp_ports'] = "53";
 			$natent['enip_parser'] = "yes";
+			$natent['ftp_parser'] = "yes";
+			$natent['ftp_data_parser'] = "on";
 			$natent['http_parser'] = "yes";
-			$natent['tls_parser'] = "yes";
-			$natent['tls_detect_ports'] = "443";
-			$natent['tls_encrypt_handling'] = "default";
-			$natent['tls_ja3_fingerprint'] = "off";
+			$natent['http_parser_memcap'] = "67108864";
+			$natent['http2_parser'] = "yes";
+			$natent['ikev2_parser'] = "yes";
+			$natent['imap_parser'] = "detection-only";
+			$natent['krb5_parser'] = "yes";
+			$natent['mqtt_parser'] = "yes";
+			$natent['msn_parser'] = "detection-only";
+			$natent['nfs_parser'] = "yes";
+			$natent['ntp_parser'] = "yes";
+			$natent['pgsql_parser'] = "no";
+			$natent['quic_parser'] = "yes";
+			$natent['rdp_parser'] = "yes";
+			$natent['rfb_parser'] = "yes";
+			$natent['sip_parser'] = "yes";
+			$natent['smb_parser'] = "yes";
 			$natent['smtp_parser'] = "yes";
 			$natent['smtp_parser_decode_mime'] = "off";
 			$natent['smtp_parser_decode_base64'] = "on";
 			$natent['smtp_parser_decode_quoted_printable'] = "on";
 			$natent['smtp_parser_extract_urls'] = "on";
 			$natent['smtp_parser_compute_body_md5'] = "off";
-			$natent['imap_parser'] = "detection-only";
-			$natent['ssh_parser'] = "yes";
-			$natent['ftp_parser'] = "yes";
-			$natent['ftp_data_parser'] = "on";
-			$natent['dcerpc_parser'] = "yes";
-			$natent['smb_parser'] = "yes";
-			$natent['msn_parser'] = "detection-only";
-			$natent['krb5_parser'] = "yes";
-			$natent['ikev2_parser'] = "yes";
-			$natent['nfs_parser'] = "yes";
-			$natent['tftp_parser'] = "yes";
-			$natent['ntp_parser'] = "yes";
-			$natent['dhcp_parser'] = "yes";
-			$natent['rdp_parser'] = "yes";
-			$natent['sip_parser'] = "yes";
 			$natent['snmp_parser'] = "yes";
-			$natent['http2_parser'] = "yes";
-			$natent['rfb_parser'] = "yes";
-			$natent['mqtt_parser'] = "yes";
+			$natent['ssh_parser'] = "yes";
+			$natent['telnet_parser'] = "yes";
+			$natent['tftp_parser'] = "yes";
+			$natent['tls_parser'] = "yes";
+			$natent['tls_detect_ports'] = "443";
+			$natent['tls_encrypt_handling'] = "default";
+			$natent['tls_ja3_fingerprint'] = "off";
 
 			$natent['enable_iprep'] = "off";
 			$natent['host_memcap'] = "33554432";
@@ -917,6 +964,20 @@ $section->addInput(new Form_Checkbox(
 	'on'
 ));
 
+$section->addInput(new Form_Select(
+	'http_log_filetype',
+	'HTTP Log File Type',
+	$pconfig['http_log_filetype'],
+	array("regular" => "Regular", "unix_dgram" => "UNIX Datagram Socket", "unix_stream"=>"UNIX Stream Socket")
+))->setHelp('Select "Regular" to log to a conventional file, or choose UNIX "Datagram" or "Stream" Socket to log to an existing UNIX socket. Default is "Regular"');
+
+$section->addInput(new Form_Input(
+	'http_log_socket',
+	'HTTP Log Socket Name',
+	'text',
+	base64_decode($pconfig['http_log_socket'])
+))->setHelp('Enter the UNIX socket name where TLS logs should be output. The user is responsible for creating the socket. It is NOT created by Suricata.');
+
 $section->addInput(new Form_Checkbox(
 	'append_http_log',
 	'Append HTTP Log',
@@ -932,6 +993,7 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['http_log_extended'] == 'on' ? true:false,
 	'on'
 ));
+
 $section->addInput(new Form_Checkbox(
 	'enable_tls_log',
 	'Enable TLS Log',
@@ -939,6 +1001,37 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['enable_tls_log'] == 'on' ? true:false,
 	'on'
 ));
+
+$section->addInput(new Form_Select(
+	'tls_log_filetype',
+	'TLS Log File Type',
+	$pconfig['tls_log_filetype'],
+	array("regular" => "Regular", "unix_dgram" => "UNIX Datagram Socket", "unix_stream"=>"UNIX Stream Socket")
+))->setHelp('Select "Regular" to log to a conventional file, or choose UNIX "Datagram" or "Stream" Socket to log to an existing UNIX socket. Default is "Regular"');
+
+$section->addInput(new Form_Input(
+	'tls_log_socket',
+	'TLS Log Socket Name',
+	'text',
+	base64_decode($pconfig['tls_log_socket'])
+))->setHelp('Enter the UNIX socket name where TLS logs should be output. The user is responsible for creating the socket. It is NOT created by Suricata.');
+
+$section->addInput(new Form_Checkbox(
+	'append_tls_log',
+	'Append TLS Log',
+	'Suricata will append-to instead of clearing TLS log file when restarting. Default is Checked.',
+	$pconfig['append_tls_log'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Checkbox(
+	'tls_session_resumption',
+	'Enable TLS Session Resumption',
+	'Suricata will output TLS transactions where the session is resumed using a Session ID. Default is Not Checked.',
+	$pconfig['tls_session_resumption'] == 'on' ? true:false,
+	'on'
+));
+
 $section->addInput(new Form_Checkbox(
 	'enable_tls_store',
 	'Enable TLS Store',
@@ -975,6 +1068,28 @@ $section->addInput(new Form_Checkbox(
 	'Enable Packet Log',
 	'Suricata will log decoded packets for the interface in pcap-format. Default is Not Checked. This can consume a significant amount of disk space when enabled.',
 	$pconfig['enable_pcap_log'] == 'on' ? true:false,
+	'on'
+));
+
+$section->addInput(new Form_Select(
+	'pcap_log_conditional',
+	'PCAP Log Conditional',
+	$pconfig['pcap_log_conditional'],
+	array("alerts" => "ALERTS", "all" => "ALL", "tag"=>"TAG")
+))->setHelp('Select ALERTS to capture and log only alerted packets and flows, ALL to capture and log all packets, or TAG to capture and log only flows tagged via the "tag" keyword.');
+
+$section->addInput(new Form_Checkbox(
+	'pcap_use_stream_depth',
+	'Use Stream Depth',
+	'If Checked, packets seen after reaching stream inspection depth are ignored. Unchecked logs all packets. Default is Not Checked.',
+	$pconfig['pcap_use_stream_depth'] == 'on' ? true:false,
+	'on'
+));
+$section->addInput(new Form_Checkbox(
+	'pcap_honor_pass_rules',
+	'Honor PASS Rules',
+	'If Checked, flows in which a pass rule matched will stop being captured and logged. Default is Not Checked.',
+	$pconfig['pcap_honor_pass_rules'] == 'on' ? true:false,
 	'on'
 ));
 
@@ -1016,8 +1131,15 @@ $section->addInput(new Form_Select(
 	'eve_output_type',
 	'EVE Output Type',
 	$pconfig['eve_output_type'],
-	array("regular" => "FILE", "syslog" => "SYSLOG", "redis"=>"REDIS")
-))->setHelp('Select EVE log output destination. Choosing FILE is suggested, and is the default value.');
+	array("regular" => "FILE", "syslog" => "SYSLOG", "redis"=>"Redis", "unix_dgram" => "UNIX Datagram Socket", "unix_stream" => "UNIX Stream Socket")
+))->setHelp('Select EVE log output destination. Choosing FILE is suggested and is the default value. "Redis" is used for output to a Redis server, and the UNIX Socket options output to a user-created socket.');
+
+$section->addInput(new Form_Input(
+	'eve_output_socket',
+	'EVE Output Socket Name',
+	'text',
+	base64_decode($pconfig['eve_output_socket'])
+))->setHelp('Enter the UNIX socket name where EVE logs should be output. The user is responsible for creating the socket. It is NOT created by Suricata.');
 
 $section->addInput(new Form_Select(
 	'eve_systemlog_facility',
@@ -1111,7 +1233,6 @@ $section->addInput(new Form_Select(
 ))->setHelp('Log the payload data with alerts.  Options are No (disable payload logging), Only Printable (lossy) format, Only Base64 encoded or Both. See Suricata documentation.');
 
 $group = new Form_Group('EVE Log Alert details');
-
 $group->add(new Form_Checkbox(
 	'eve_log_alerts_packet',
 	'Alert Payloads',
@@ -1119,7 +1240,6 @@ $group->add(new Form_Checkbox(
 	$pconfig['eve_log_alerts_packet'] == 'on' ? true:false,
 	'on'
 ));
-
 $group->add(new Form_Checkbox(
 	'eve_log_alerts_http',
 	'Alert Payloads',
@@ -1127,7 +1247,6 @@ $group->add(new Form_Checkbox(
 	$pconfig['eve_log_alerts_http'] == 'on' ? true:false,
 	'on'
 ));
-
 $group->add(new Form_Checkbox(
 	'eve_log_alerts_metadata',
 	'App Layer Metadata',
@@ -1135,9 +1254,52 @@ $group->add(new Form_Checkbox(
 	$pconfig['eve_log_alerts_metadata'] == 'on' ? true:false,
 	'on'
 ));
-
-$group->setHelp('Select which details Suricata will use to enrich alerts.');
+$group->add(new Form_Checkbox(
+	'eve_log_alerts_verdict',
+	'Engine Verdict',
+	'Log final action taken on packet by the engine',
+	$pconfig['eve_log_alerts_verdict'] == 'on' ? true:false,
+	'on'
+));
+$group->add(new Form_Checkbox(
+	'eve_log_alerts_tagged',
+	'Tagged Packets',
+	'Log packets for rules using the "tag" keyword',
+	$pconfig['eve_log_alerts_tagged'] == 'on' ? true:false,
+	'on'
+));
 $section->add($group)->addClass('eve_log_alerts_details');
+
+$section->addInput(new Form_Checkbox(
+	'eve_log_drops',
+	'EVE Log Drops',
+	'Suricata will output Drops via EVE',
+	$pconfig['eve_log_drops'] == 'on' ? true:false,
+	'on'
+));
+
+$group = new Form_Group('EVE Log Drops Options');
+$group->add(new Form_Checkbox(
+	'eve_log_alert_drops',
+	'Alerts',
+	'Log alerts that caused drops. Default is "Checked".',
+	$pconfig['eve_log_alert_drops'] == 'on' ? true:false,
+	'on'
+));
+$group->add(new Form_Checkbox(
+	'eve_log_drops_verdict',
+	'Engine Verdicts',
+	'Log final action taken on packet by the engine',
+	$pconfig['eve_log_drops_verdict'] == 'on' ? true:false,
+	'on'
+));
+$group->add(new Form_Select(
+	'eve_log_drops_flows',
+	'EVE Drop Log Flows',
+	$pconfig['eve_log_drops_flows'],
+	array("all"=>"All","start"=>"Start")
+))->setHelp('"Start" logs only a single drop per flow direction. "All" logs each dropped pkt.');
+$section->add($group)->addClass('eve_log_drops_options');
 
 $section->addInput(new Form_Checkbox(
 	'eve_log_anomaly',
@@ -1177,9 +1339,14 @@ $group->add(new Form_Checkbox(
 ));
 $group->setHelp('Select which details Suricata will use to enrich anomaly logging.');
 $section->add($group)->addClass('eve_log_anomaly_details');
-
 $group = new Form_Group('EVE Logged Traffic');
-
+$group->add(new Form_Checkbox(
+	'eve_log_bittorrent',
+	'BitTorrent',
+	'BitTorrent',
+	$pconfig['eve_log_bittorrent'] == 'on' ? true:false,
+	'on'
+));
 $group->add(new Form_Checkbox(
 	'eve_log_dns',
 	'DNS',
@@ -1187,7 +1354,6 @@ $group->add(new Form_Checkbox(
 	$pconfig['eve_log_dns'] == 'on' ? true:false,
 	'on'
 ));
-
 $group->add(new Form_Checkbox(
 	'eve_log_ftp',
 	'FTP',
@@ -1195,7 +1361,6 @@ $group->add(new Form_Checkbox(
 	$pconfig['eve_log_ftp'] == 'on' ? true:false,
 	'on'
 ));
-
 $group->add(new Form_Checkbox(
 	'eve_log_http',
 	'HTTP',
@@ -1203,7 +1368,6 @@ $group->add(new Form_Checkbox(
 	$pconfig['eve_log_http'] == 'on' ? true:false,
 	'on'
 ));
-
 $group->add(new Form_Checkbox(
 	'eve_log_http2',
 	'HTTP2',
@@ -1211,15 +1375,13 @@ $group->add(new Form_Checkbox(
 	$pconfig['eve_log_http2'] == 'on' ? true:false,
 	'on'
 ));
-
 $group->add(new Form_Checkbox(
 	'eve_log_ikev2',
-	'IKEv2',
-	'IKEv2',
+	'IKE',
+	'IKE',
 	$pconfig['eve_log_ikev2'] == 'on' ? true:false,
 	'on'
 ));
-
 $group->add(new Form_Checkbox(
 	'eve_log_krb5',
 	'Kerberos',
@@ -1227,7 +1389,6 @@ $group->add(new Form_Checkbox(
 	$pconfig['eve_log_krb5'] == 'on' ? true:false,
 	'on'
 ));
-
 $group->add(new Form_Checkbox(
 	'eve_log_nfs',
 	'NFS',
@@ -1235,11 +1396,24 @@ $group->add(new Form_Checkbox(
 	$pconfig['eve_log_nfs'] == 'on' ? true:false,
 	'on'
 ));
+$group->add(new Form_Checkbox(
+	'eve_log_pgsql',
+	'PostgreSQL',
+	'PostgreSQL',
+	$pconfig['eve_log_pgsql'] == 'on' ? true:false,
+	'on'
+));
 
 $section->add($group)->addClass('eve_log_info');
 
 $group = new Form_Group(false);
-
+$group->add(new Form_Checkbox(
+	'eve_log_quic',
+	'QUICv1',
+	'QUICv1',
+	$pconfig['eve_log_quic'] == 'on' ? true:false,
+	'on'
+));
 $group->add(new Form_Checkbox(
 	'eve_log_rdp',
 	'RDP',
@@ -1247,7 +1421,6 @@ $group->add(new Form_Checkbox(
 	$pconfig['eve_log_rdp'] == 'on' ? true:false,
 	'on'
 ));
-
 $group->add(new Form_Checkbox(
 	'eve_log_rfb',
 	'RFB',
@@ -1255,7 +1428,6 @@ $group->add(new Form_Checkbox(
 	$pconfig['eve_log_rfb'] == 'on' ? true:false,
 	'on'
 ));
-
 $group->add(new Form_Checkbox(
 	'eve_log_sip',
 	'SIP',
@@ -1263,7 +1435,6 @@ $group->add(new Form_Checkbox(
 	$pconfig['eve_log_sip'] == 'on' ? true:false,
 	'on'
 ));
-
 $group->add(new Form_Checkbox(
 	'eve_log_smb',
 	'SMB',
@@ -1271,7 +1442,6 @@ $group->add(new Form_Checkbox(
 	$pconfig['eve_log_smb'] == 'on' ? true:false,
 	'on'
 ));
-
 $group->add(new Form_Checkbox(
 	'eve_log_smtp',
 	'SMTP',
@@ -1279,7 +1449,6 @@ $group->add(new Form_Checkbox(
 	$pconfig['eve_log_smtp'] == 'on' ? true:false,
 	'on'
 ));
-
 $group->add(new Form_Checkbox(
 	'eve_log_tftp',
 	'TFTP',
@@ -1288,14 +1457,17 @@ $group->add(new Form_Checkbox(
 	'on'
 ));
 
-// The control below is a dummy placeholder to maintain Form Group spacing.
+// The controls below are dummy placeholders to maintain Form Group spacing.
 // There must be the same number of Form Group controls on each row for
 // consistent spacing.
 $group->add(new Form_StaticText(
 	null,
 	null
 ));
-
+$group->add(new Form_StaticText(
+	null,
+	null
+));
 $group->setHelp('Choose the traffic types to log via EVE JSON output.');
 $section->add($group)->addClass('eve_log_info');
 
@@ -1819,7 +1991,7 @@ $section = new Form_Section('Arguments here will be automatically inserted into 
 $section->addInput(new Form_Textarea (
 	'configpassthru',
 	'Advanced Configuration Pass-Through',
-	($_POST['configpassthru']?$_POST['configpassthru']:$pconfig['configpassthru'])
+	base64_decode($pconfig['configpassthru'])
 ))->setHelp('Enter any additional configuration parameters to add to the Suricata configuration here, separated by a newline');
 
 $form->add($section);
@@ -1928,14 +2100,32 @@ events.push(function(){
 
 	function toggle_http_log() {
 		var hide = ! $('#enable_http_log').prop('checked');
+		hideInput('http_log_socket', hide);
 		hideCheckbox('append_http_log', hide);
 		hideCheckbox('http_log_extended', hide);
+		if ($('#http_log_filetype').val() == 'regular') {
+			hideSelect('http_log_socket', true);
+		}
+		else {
+			hideSelect('http_log_socket', false);
+		}
+		hideSelect('http_log_filetype', hide);
 	}
 
 	function toggle_tls_log() {
 		var hide = ! $('#enable_tls_log').prop('checked');
+		hideInput('tls_log_socket', hide);
 		hideCheckbox('enable_tls_store', hide);
 		hideCheckbox('tls_log_extended', hide);
+		hideCheckbox('append_tls_log', hide);
+		hideCheckbox('tls_session_resumption', hide);
+		if ($('#tls_log_filetype').val() == 'regular') {
+			hideSelect('tls_log_socket', true);
+		}
+		else {
+			hideSelect('tls_log_socket', false);
+		}
+		hideSelect('tls_log_filetype', hide);
 	}
 
 	function toggle_enable_file_store() {
@@ -1945,34 +2135,53 @@ events.push(function(){
 
 	function toggle_pcap_log() {
 		var hide = ! $('#enable_pcap_log').prop('checked');
+		hideCheckbox('pcap_use_stream_depth',hide);
+		hideCheckbox('pcap_honor_pass_rules',hide);
 		hideInput('max_pcap_log_size', hide);
 		hideInput('max_pcap_log_files', hide);
+		hideSelect('pcap_log_conditional', hide);
 	}
 
 	function toggle_eve_log() {
 		var hide = ! $('#enable_eve_log').prop('checked');
+		if ($('#eve_output_type').val().indexOf("unix") != -1) {
+			hideSelect('eve_output_socket', false);
+		}
+		else {
+			hideSelect('eve_output_socket', true);
+		}
 		hideSelect('eve_output_type', hide);
 		hideCheckbox('eve_log_alerts',hide);
 		hideCheckbox('eve_log_anomaly',hide);
 		hideCheckbox('eve_log_alerts_xff',hide);
+		hideCheckbox('eve_log_drops',hide);
 		hideClass('eve_log_info', hide);
+		hideClass('eve_log_drops_options', hide);
 		toggle_eve_log_files();
 	}
+
 	function toggle_eve_syslog() {
 		var hide = ! ($('#enable_eve_log').prop('checked') && $('#eve_output_type').val() == "syslog");
 		hideSelect('eve_systemlog_facility',hide);
 		hideSelect('eve_systemlog_priority',hide);
 	}
+
 	function toggle_eve_redis() {
 		var hide = ! ($('#enable_eve_log').prop('checked') && $('#eve_output_type').val() == "redis");
 		hideClass('eve_redis_connection',hide);
 		hideSelect('eve_redis_mode',hide);
 		hideInput('eve_redis_key',hide);
 	}
+
 	function toggle_eve_log_alerts() {
 		var hide = ! ($('#eve_log_alerts').prop('checked') && $('#enable_eve_log').prop('checked'));
 		hideSelect('eve_log_alerts_payload',hide);
 		hideClass('eve_log_alerts_details',hide);
+	}
+
+	function toggle_eve_log_drops() {
+		var hide = ! ($('#eve_log_drops').prop('checked') && $('#enable_eve_log').prop('checked'));
+		hideClass('eve_log_drops_options',hide);
 	}
 
 	function toggle_eve_log_anomaly() {
@@ -2082,16 +2291,26 @@ events.push(function(){
 		disableInput('enable_http_log', disable);
 		disableInput('append_http_log', disable);
 		disableInput('http_log_extended', disable);
+		disableInput('http_log_filetype', disable);
+		disableInput('http_log_socket', disable);
 		disableInput('enable_tls_log', disable);
 		disableInput('enable_tls_store', disable);
+		disableInput('append_tls_log', disable);
 		disableInput('tls_log_extended', disable);
+		disableInput('tls_log_filetype', disable);
+		disableInput('tls_log_socket', disable);
+		disableInput('tls_session_resumption', disable);
 		disableInput('enable_file_store', disable);
 		disableInput('file_store_logdir', disable);
 		disableInput('enable_pcap_log', disable);
 		disableInput('max_pcap_log_size', disable);
 		disableInput('max_pcap_log_files', disable);
+		disableInput('pcap_log_conditional', disable);
+		disableInput('pcap_honor_pass_rules', disable);
+		disableInput('pcap_use_stream_depth', disable);
 		disableInput('enable_eve_log', disable);
 		disableInput('eve_output_type', disable);
+		disableInput('eve_output_socket', disable);
 		disableInput('eve_systemlog_facility', disable);
 		disableInput('eve_systemlog_priority', disable);
 		disableInput('eve_redis_mode', disable);
@@ -2102,6 +2321,12 @@ events.push(function(){
 		disableInput('eve_log_alerts', disable);
 		disableInput('eve_log_alerts_payload', disable);
 		disableInput('eve_log_alerts_metadata', disable);
+		disableInput('eve_log_alerts_verdict', disable);
+		disableInput('eve_log_alerts_tagged', disable);
+		disableInput('eve_log_drops', disable);
+		disableInput('eve_log_alert_drops', disable);
+		disableInput('eve_log_drops_verdict', disable);
+		disableInput('eve_log_drops_flows', disable);
 		disableInput('eve_log_anomaly', disable);
 		disableInput('eve_log_anomaly_type_decode', disable);
 		disableInput('eve_log_anomaly_type_stream', disable);
@@ -2126,6 +2351,9 @@ events.push(function(){
 		disableInput('eve_log_smtp', disable);
 		disableInput('eve_log_snmp', disable);
 		disableInput('eve_log_mqtt', disable);
+		disableInput('eve_log_bittorrent', disable);
+		disableInput('eve_log_pgsql', disable);
+		disableInput('eve_log_quic', disable);
 		disableInput('eve_log_flow', disable);
 		disableInput('eve_log_netflow', disable);
 		disableInput('eve_log_drop', disable);
@@ -2265,6 +2493,10 @@ events.push(function(){
 		toggle_eve_log_alerts();
 	});
 
+	$('#eve_log_drops').click(function() {
+		toggle_eve_log_drops();
+	});
+
 	$('#eve_log_anomaly').click(function() {
 		toggle_eve_log_anomaly();
 	});
@@ -2336,6 +2568,33 @@ events.push(function(){
 		}
 	});
 
+	$('#http_log_filetype').on('change', function() {
+		if ($('#http_log_filetype').val() == 'regular') {
+			hideSelect('http_log_socket', true);
+		}
+		else {
+			hideSelect('http_log_socket', false);
+		}
+	});
+
+	$('#tls_log_filetype').on('change', function() {
+		if ($('#tls_log_filetype').val() == 'regular') {
+			hideSelect('tls_log_socket', true);
+		}
+		else {
+			hideSelect('tls_log_socket', false);
+		}
+	});
+
+	$('#eve_output_type').on('change', function() {
+		if ($('#eve_output_type').val().indexOf("unix") != -1) {
+			hideSelect('eve_output_socket', false);
+		}
+		else {
+			hideSelect('eve_output_socket', true);
+		}
+	});
+
 	$('#runmode').on('change', function() {
 		if ($('#runmode').val() == 'autofp') {
 			hideSelect('autofp_scheduler', false);
@@ -2363,6 +2622,7 @@ events.push(function(){
 	toggle_eve_redis();
 	toggle_eve_syslog();
 	toggle_eve_log_alerts();
+	toggle_eve_log_drops();
 	toggle_eve_log_anomaly();
 	toggle_eve_log_alerts_xff();
 	toggle_eve_log_http();

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -189,7 +189,7 @@ if (empty($pconfig['stats_upd_interval']))
 if (empty($pconfig['max_pcap_log_size']))
 	$pconfig['max_pcap_log_size'] = "32";
 if (empty($pconfig['max_pcap_log_files']))
-	$pconfig['max_pcap_log_files'] = "1000";
+	$pconfig['max_pcap_log_files'] = "100";
 if (empty($pconfig['pcap_log_conditional']))
 	$pconfig['pcap_log_conditional'] = "alerts";
 if (empty($pconfig['alertsystemlog_facility']))
@@ -1066,17 +1066,19 @@ $section->addInput(new Form_Input(
 $section->addInput(new Form_Checkbox(
 	'enable_pcap_log',
 	'Enable Packet Log',
-	'Suricata will log decoded packets for the interface in pcap-format. Default is Not Checked. This can consume a significant amount of disk space when enabled.',
+	'Suricata will log decoded packets for the interface in pcap-format. Default is Not Checked. This can consume a significant amount of disk space when enabled. ' .
+	'Use the Packet Log Conditional setting below to select packets for capture.',
 	$pconfig['enable_pcap_log'] == 'on' ? true:false,
 	'on'
 ));
 
 $section->addInput(new Form_Select(
 	'pcap_log_conditional',
-	'PCAP Log Conditional',
+	'Packet Log Conditional',
 	$pconfig['pcap_log_conditional'],
 	array("alerts" => "ALERTS", "all" => "ALL", "tag"=>"TAG")
-))->setHelp('Select ALERTS to capture and log only alerted packets and flows, ALL to capture and log all packets, or TAG to capture and log only flows tagged via the "tag" keyword.');
+))->setHelp('Select ALERTS to capture and log only alerted packets and flows, ALL to capture and log all packets, or TAG to capture and log only flows tagged via the "tag" keyword. ' .
+			'Default is ALERTS which will only create PCAP files for alerts.');
 
 $section->addInput(new Form_Checkbox(
 	'pcap_use_stream_depth',
@@ -1105,7 +1107,7 @@ $section->addInput(new Form_Input(
 	'Max Packet Log Files',
 	'text',
 	$pconfig['max_pcap_log_files']
-))->setHelp('Enter maximum number of packet log files to maintain. Default is 1000. When the number of packet log files reaches the set limit, the oldest file will be overwritten.');
+))->setHelp('Enter maximum number of packet log files to maintain. Default is 100. When the number of packet log files reaches the set limit, the oldest file will be overwritten.');
 
 $section->addInput(new Form_Checkbox(
 	'enable_verbose_logging',

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_logs_mgmt.php
@@ -54,6 +54,7 @@ $pconfig['eve_log_limit_size'] = config_get_path('installedpackages/suricata/con
 $pconfig['eve_log_retention'] = config_get_path('installedpackages/suricata/config/0/eve_log_retention', 168);
 $pconfig['sid_changes_log_limit_size'] = config_get_path('installedpackages/suricata/config/0/sid_changes_log_limit_size', 250);
 $pconfig['sid_changes_log_retention'] = config_get_path('installedpackages/suricata/config/0/sid_changes_log_retention', 336);
+$pconfig['pkt_capture_file_retention'] = config_get_path('installedpackages/suricata/config/0/pkt_capture_file_retention', 168);
 
 // Load up some arrays with selection values (we use these later).
 // The keys in the $retentions array are the retention period
@@ -88,6 +89,7 @@ if (isset($_POST['ResetAll'])) {
 	$pconfig['tls_certs_store_retention'] = "168";
 	$pconfig['eve_log_retention'] = "168";
 	$pconfig['sid_changes_log_retention'] = "336";
+	$pconfig['pkt_capture_file_retention'] = "168";
 
 	$pconfig['alert_log_limit_size'] = "500";
 	$pconfig['block_log_limit_size'] = "500";
@@ -145,6 +147,7 @@ if (isset($_POST['save']) || isset($_POST['apply'])) {
 		config_set_path('installedpackages/suricata/config/0/eve_log_retention', $_POST['eve_log_retention']);
 		config_set_path('installedpackages/suricata/config/0/sid_changes_log_limit_size', $_POST['sid_changes_log_limit_size']);
 		config_set_path('installedpackages/suricata/config/0/sid_changes_log_retention', $_POST['sid_changes_log_retention']);
+		config_set_path('installedpackages/suricata/config/0/pkt_capture_file_retention', $_POST['pkt_capture_file_retention']);
 
 		write_config("Suricata pkg: saved updated configuration for LOGS MGMT.");
 		sync_suricata_package_config();
@@ -221,7 +224,9 @@ $section->addInput(new Form_Input(
 	'Log Limit Size in MB',
 	'text',
 	$pconfig['suricataloglimitsize']
-))->setHelp('This setting imposes a hard-limit on the combined log directory size of all Suricata interfaces.  When the size limit set is reached, rotated logs for all interfaces will be removed, and any active logs pruned to zero-length.   (default is 20% of available free disk space)');
+))->setHelp('This setting imposes a hard-limit on the combined log directory size of all Suricata interfaces. '.
+			'When the size limit set is reached, rotated logs for all interfaces will be removed, and any active '.
+			'logs pruned to zero-length.   (default is 20% of available free disk space)');
 $form->add($section);
 
 $section = new Form_Section("Log Size and Retention Limits");
@@ -339,7 +344,8 @@ $section->add($group);
 
 $section->addInput(new Form_StaticText(
 	'',
-	'Settings will be ignored for any log in the list above not enabled on the Interface Settings tab. When a log reaches the Max Size limit, it will be rotated and tagged with a timestamp. The Retention period determines how long rotated logs are kept before they are automatically deleted.'
+	'Settings will be ignored for any log in the list above not enabled on the Interface Settings tab. When a log reaches the Max Size limit, '.
+	'it will be rotated and tagged with a timestamp. The Retention period determines how long rotated logs are kept before they are automatically deleted.'
 ));
 
 $section->addInput(new Form_Input(
@@ -347,19 +353,32 @@ $section->addInput(new Form_Input(
 	'Captured Files Storage Limit',
 	'text',
 	$pconfig['file_store_limit_size']
-))->setHelp('File Store captured files storage limit in megabytes (MB). Initial default value is 60% of the Log Directory Size Limit parameter configured above. This sets the maximum storage limit (disk utilization) for captured files. When this limit is reached, older files will purged to reduce disk consumption below the configured limit. Entering zero disables this check and allows unlimited storage.');
+))->setHelp('File Store captured files storage limit in megabytes (MB). Initial default value is 60% of the Log Directory Size Limit '.
+			'parameter configured above. This sets the maximum storage limit (disk utilization) for captured files. '.
+			'When this limit is reached, older files will purged to reduce disk consumption below the configured limit. '.
+			'Entering zero disables this check and allows unlimited storage.');
 $section->addInput(new Form_Select(
 	'file_store_retention',
 	'Captured Files Retention Period',
 	$pconfig['file_store_retention'],
 	$retentions
-))->setHelp('Choose retention period for captured files in File Store. Default is 7 days. When file capture and store is enabled, Suricata captures downloaded files from HTTP sessions and stores them, along with metadata, for later analysis. This setting determines how long files remain in the File Store folder before they are automatically deleted.');
+))->setHelp('Choose retention period for captured files in File Store. Default is 7 days. When file capture and store is enabled, '.
+			'Suricata captures downloaded files from HTTP sessions and stores them, along with metadata, for later analysis. '.
+			'This setting determines how long files remain in the File Store folder before they are automatically deleted.');
 $section->addInput(new Form_Select(
 	'tls_certs_store_retention',
 	'Captured TLS Certs Retention Period',
 	$pconfig['tls_certs_store_retention'],
 	$retentions
-))->setHelp('Choose retention period for captured TLS Certs. Default is 7 days. When custom rules with tls.store are enabled, Suricata captures Certificates, along with metadata, for later analysis. This setting determines how long files remain in the Certs folder before they are automatically deleted.');
+))->setHelp('Choose retention period for captured TLS Certs. Default is 7 days. When custom rules with tls.store are enabled, Suricata captures Certificates, '.
+			'along with metadata, for later analysis. This setting determines how long files remain in the Certs folder before they are automatically deleted.');
+$section->addInput(new Form_Select(
+	'pkt_capture_file_retention',
+	'Packet Capture Files Retention Period',
+	$pconfig['pkt_capture_file_retention'],
+	$retentions
+))->setHelp('Choose retention period for PCAP files. Default is 7 days. When Packet Capture is enabled, Suricata captures packets/flows in PCAP format. '.
+			'This setting determines how long files remain in the "pcaps" sub-folder in the log directory of the interface before they are automatically deleted.');
 $form->add($section);
 
 print($form);
@@ -393,6 +412,7 @@ events.push(function(){
 		disableInput('file_store_retention', hide);
 		disableInput('file_store_limit_size', hide);
 		disableInput('tls_certs_store_retention', hide);
+		disableInput('pkt_capture_file_retention', hide);
 	}
 
 	function enable_change_dirSize() {


### PR DESCRIPTION
### pfSense-pkg-suricata-7.0.0
This package update provides support for the latest 7.0.0 version of the binary from upstream. Additionally, a few Memory Cap defaults have been increased to match the new OISF suggested default values.

**New Features:**
1. Support for new Exception Policies for flows, streams, and app parsers. These new policy settings default to "ignore". With the default settings, Suricata 7.x running with Inline IPS Mode will behave the same as older versions. But the new Exception Policies allow an administrator much greater flexibility in securing the IDS/IPS when off-normal situations are encountered, including a general "fail closed" setup. More details on Exception Polices can be found at: [https://docs.suricata.io/en/suricata-7.0.0/configuration/exception-policies.html](https://docs.suricata.io/en/suricata-7.0.0/configuration/exception-policies.html).
2. The default _Stream Memcap_ setting is increased from 32 MB to 256 MB to prevent most common startup failures due to insufficient stream memory space. Any user setting below 256 MB will be automatically updated to 256 MB during package installation/upgrade.
3. The default _Flow Memcap_ setting is increased from 32 MB to 128 MB. Any user setting below 32 MB will be automatically adjusted to 128 MB during package installation/upgrade.
4. Additional parameters were added for configurating conditional PCAP logging. The user can now select when Suricata will obtain and store PCAP files of traffic. The conditions are ALERT, ALL, or TAG. The packet captures are stored in a _pcaps_ subdirectory of the logging directory for the interface.

**Bug Fixes:**
1. Fix [Redmine Issue #14530](https://redmine.pfsense.org/issues/14530), TCP Stream Memcap parameter help text on FLOW/STREAM tab incorrectly converts MB to bytes.