### PR TITLE
pfSense-pkg-suricata-7.0.0_1 - Fix Redmine Issue 14724 - Incorrect adjustment from 23 to 00 hours.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	7.0.0
-PORTREVISION=	0
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -681,7 +681,7 @@ function suricata_rules_up_install_cron($should_install=true) {
 		$suricata_rules_up_hr = strval($hour);
 		for ($i=0; $i<3; $i++) {
 			$hour += 6;
-			if ($hour > 24) {
+			if ($hour > 23) {
 				$hour -= 24;
 			}
 			$suricata_rules_up_hr .= "," . strval($hour);
@@ -695,7 +695,7 @@ function suricata_rules_up_install_cron($should_install=true) {
 		$hour = intval(substr($suricata_rules_upd_time, 0, 2));
 		$suricata_rules_up_hr = strval($hour) . ",";
 		$hour += 12;
-		if ($hour > 24) {
+		if ($hour > 23) {
 			$hour -= 24;
 		}
 		$suricata_rules_up_hr .= strval($hour);


### PR DESCRIPTION
### pfSense-pkg-suricata-7.0.0_1
This update corrects the bug reported in [Redmine Issue 14724](https://redmine.pfsense.org/issues/14724).

**New Features:**
None

**Bug Fixes:**
1. [Redmine Issue 14724](https://redmine.pfsense.org/issues/14724) - the package incorrectly adjusts the rollover hours value when calculating the start times for the rules update cron task and the user has selected either the 12-hour or 6-hour interval. The code incorrectly chooses 24 as a valid hour instead of rolling over to 00, thus creating an invalid cron task start time.