### PR TITLE
pfSense-pkg-snort-4.1.6_9_RELENG_2_7_0 - Fix Redmine Issue 14723 - incorrect rollover of cron hours value

### DIFF
--- a/security/pfSense-pkg-snort/Makefile
+++ b/security/pfSense-pkg-snort/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-snort
 PORTVERSION=	4.1.6
-PORTREVISION=	8
+PORTREVISION=	9
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
+++ b/security/pfSense-pkg-snort/files/usr/local/pkg/snort/snort.inc
@@ -5,7 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2006-2023 Rubicon Communications, LLC (Netgate)
  * Copyright (c) 2009-2010 Robert Zelaya
- * Copyright (c) 2013-2022 Bill Meeks
+ * Copyright (c) 2013-2023 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -875,7 +875,7 @@ function snort_rules_up_install_cron($should_install) {
 		$snort_rules_up_hr = strval($hour);
 		for ($i=0; $i<3; $i++) {
 			$hour += 6;
-			if ($hour > 24)
+			if ($hour > 23)
 				$hour -= 24;
 			$snort_rules_up_hr .= "," . strval($hour);
 		}
@@ -888,7 +888,7 @@ function snort_rules_up_install_cron($should_install) {
 		$hour = intval(substr($snort_rules_upd_time, 0, 2));
 		$snort_rules_up_hr = strval($hour) . ",";
 		$hour += 12;
-		if ($hour > 24)
+		if ($hour > 23)
 			$hour -= 24;
 		$snort_rules_up_hr .= strval($hour);
 		$snort_rules_up_mday = "*";


### PR DESCRIPTION
### pfSense-pkg-snort-4.1.6_9_RELENG_2_7_0
This corrects the bug reported in [Redmine Issue 14723](https://redmine.pfsense.org/issues/14723) for the Snort package in pfSense CE 2.7.0.

**New Features:**
None

**Bug Fixes:**
1. [Redmine Issue 14723](https://redmine.pfsense.org/issues/14723) - Snort package incorrectly handles rollover from 23 to 00 hours when calculating rules update cron task times.