### PR TITLE
security/pfSense-pkg-acme: improve Cloudflare documentation

### DIFF
--- a/security/pfSense-pkg-acme/Makefile
+++ b/security/pfSense-pkg-acme/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-acme
 PORTVERSION=	0.7.5
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
@@ -458,20 +458,29 @@ $acme_domain_validation_method['dns_cloudns'] = array('name' => "DNS-ClouDNS",
 	));
 $acme_domain_validation_method['dns_cf'] = array('name' => "DNS-Cloudflare",
 	'fields' => array(
-		'CF_Key' => array('name' => "cf_key", 'columnheader' => "Key", 'type' => "textbox",
-			'description' => "Cloudflare API Key"
+		'CF_Token_Header' => array('name' => "cf_token_header", 'type' => "fixedtext",
+			'text' => "<b>Token Authentication</b> (<a href=\"https://github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_cf\">details</a>)<br/>Newer authentication method that uses a scoped API token. Use of this authentication method is preferred. There is no need to fill in the Global API key section if this section is used.<br/><br/>Recommended configuration: Provide a token with Zone.DNS:Edit permission and provide the Zone ID. Leave all other fields blank."
+		),
+		'CF_Token' => array('name' => "cf_token", 'columnheader' => "Token", 'type' => "textbox",
+			'description' => "Create a token on the <a href=\"https://dash.cloudflare.com/profile/api-tokens\">API Tokens page</a>. Required permissions are described below."
+		),
+		'CF_Account_ID' => array('name' => "cf_account_id", 'columnheader' => "Account ID", 'type' => "textbox",
+			'description' => "Only required if cert covers multiple zones. Token needs Zone.Zone:Read and Zone.DNS:Edit permission if this ID is provided. Find this value by navigating to <a href=\"https://dash.cloudflare.com/\">Cloudflare Dashboard</a> &rarr; select a zone &rarr; Overview."
+		),
+		'CF_Zone_ID' => array('name' => "cf_zone_id", 'columnheader' => "Zone ID", 'type' => "textbox",
+			'description' => "Use instead of Account ID if cert only covers a single zone. Token only needs Zone.DNS:Edit permission if this ID is provided. Find this value by navigating to <a href=\"https://dash.cloudflare.com/\">Cloudflare Dashboard</a> &rarr; select a zone &rarr; Overview."
+		),
+		'CF_API_Header' => array('name' => "cf_api_header", 'type' => "fixedtext",
+			'text' => "<b>Global API Key Authentication</b><br/>Older authentication method that uses a global API key. Use of the token-based authentication above is preferred. There is no need to fill in the above section if this section is used."
+		),
+		'CF_Key' => array('name' => "cf_key", 'columnheader' => "Global API Key", 'type' => "textbox",
+			'description' => "Get the global API key on the <a href=\"https://dash.cloudflare.com/profile/api-tokens\">API Tokens page</a>."
 		),
 		'CF_Email' => array('name' => "cf_email", 'columnheader' => "Email", 'type' => "textbox",
 			'description' => "Cloudflare API Email Address"
 		),
-		'CF_Token' => array('name' => "cf_token", 'columnheader' => "Token", 'type' => "textbox",
-			'description' => "Cloudflare API Token"
-		),
-		'CF_Account_ID' => array('name' => "cf_account_id", 'columnheader' => "Account ID", 'type' => "textbox",
-			'description' => "Cloudflare API Account ID"
-		),
-		'CF_Zone_ID' => array('name' => "cf_zone_id", 'columnheader' => "Zone ID", 'type' => "textbox",
-			'description' => "Cloudflare API Zone ID"
+		'CF_DNS_Alias_Header' => array('name' => "cf_dns_alias_header", 'type' => "fixedtext",
+			'text' => "<b>DNS Alias</b>"
 		),
 	));
 $acme_domain_validation_method['dns_conoha'] = array('name' => "DNS-Conoha",


### PR DESCRIPTION
Many guides on setting up ACME certs with Cloudflare in pfSense show filling out all five authentication fields. This is not required for acme.sh to work correctly and potentially exposes Cloudflare credentials with broad access though the pfSense UI and configuration backups.

There are several ways that acme.sh can authenticate to Cloudflare, from least to most permissive:

1. Token with `Zone.DNS:Edit` permission and `Zone ID`. This only works with certs that cover a single zone.
2. Token with `Zone.Zone:Read` and `Zone.DNS:Edit` permission and `Account ID`. This works with certs that cover multiple zones. acme.sh uses the Account ID to look up all Zone IDs.
3. Global API key and email address. This is not recommended since it provides complete access to the entire Cloudflare account.

References:
https://github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_cf
https://github.com/acmesh-official/acme.sh/issues/2398
https://github.com/acmesh-official/acme.sh/commit/c25947d5447ac03ac0fae56b338e8821d49d61ac