### PR TITLE
Move from nut-2.8.0 to nut-devel

### DIFF
--- a/sysutils/pfSense-pkg-nut/Makefile
+++ b/sysutils/pfSense-pkg-nut/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-nut
 PORTVERSION=	2.8.0
-PORTREVISION=	2
+PORTREVISION=	5
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	Network UPS Tools
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	nut>=0:sysutils/nut
+RUN_DEPENDS=	nut>=0:sysutils/nut-devel
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/sysutils/pfSense-pkg-nut/Makefile
+++ b/sysutils/pfSense-pkg-nut/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-nut
-PORTVERSION=	2.8.0
-PORTREVISION=	5
+PORTVERSION=	2.8.1
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-nut/files/usr/local/pkg/nut.xml
+++ b/sysutils/pfSense-pkg-nut/files/usr/local/pkg/nut.xml
@@ -28,7 +28,7 @@
 	]]>
 	</copyright>
 	<name>nut</name>
-	<version>2.8.0_4</version>
+	<version>2.8.0_5</version>
 	<title>Services: UPS</title>
 	<savetext>Change</savetext>
 	<include_file>/usr/local/pkg/nut/nut.inc</include_file>

--- a/sysutils/pfSense-pkg-nut/files/usr/local/pkg/nut.xml
+++ b/sysutils/pfSense-pkg-nut/files/usr/local/pkg/nut.xml
@@ -28,7 +28,7 @@
 	]]>
 	</copyright>
 	<name>nut</name>
-	<version>2.8.0_5</version>
+	<version>%%PKGVERSION%%</version>
 	<title>Services: UPS</title>
 	<savetext>Change</savetext>
 	<include_file>/usr/local/pkg/nut/nut.inc</include_file>

--- a/sysutils/pfSense-pkg-nut/files/usr/local/pkg/nut/nut.inc
+++ b/sysutils/pfSense-pkg-nut/files/usr/local/pkg/nut/nut.inc
@@ -54,8 +54,8 @@ function nut_check_var_db() {
 	if (!is_dir($d)) {
 		mkdir($d, 0750, true);
 		safe_mkdir($d, 0750);
-		chown($d, "uucp");
-		chgrp($d, "uucp");
+		chown($d, "nut");
+		chgrp($d, "nut");
 	}
 }
 
@@ -343,7 +343,6 @@ function nut_ups_status()
 		return $status;
 	}
 
-	/* FIXME: use the -t option for upsc when it becomes available (targeted for nut 2.8.0) */
 	$pipe = popen("/usr/local/bin/upsc $ups", 'r');
 	if ($pipe) {
 		while ($line = fgets($pipe)) {

--- a/sysutils/pfSense-pkg-nut/files/usr/local/pkg/nut/nut_email.php
+++ b/sysutils/pfSense-pkg-nut/files/usr/local/pkg/nut/nut_email.php
@@ -24,8 +24,7 @@
 require_once("notices.inc");
 
 $subject = "UPS Notification from " . gethostname();
-$message = date('r');
-$message .= "\n\n";
+$message = "Date: " . date('r') . "\n\n${subject}" . "\n\n";
 $message .= implode(' ', array_slice($argv, 1));
 
 @notify_all_remote($subject . " - " . $message);


### PR DESCRIPTION
Note that this PR depends upon the FreeBSD "nut-devel" package rather than the "nut" package.

Please see Redmine issue [14795](https://redmine.pfsense.org/issues/14795) for details behind this change.