### PR TITLE
Update acme_sh.inc

### DIFF
--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_sh.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_sh.inc
@@ -70,6 +70,7 @@ class acme_sh {
 		$env = array();
 		$env['path'] = "/etc:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin/";
 		$env['PATH'] = "/etc:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin/";
+		$env['SSL_CERT_DIR'] = "/etc/ssl/certs/";
 
 		/* Setup Proxy Variables */
 		if (!empty($config['system']['proxyurl'])) {


### PR DESCRIPTION
Added SSL_CERT_DIR env variable so that acme trusts pfsense truststore certificates fixes acme sh bug similiar to https://redmine.pfsense.org/issues/12737 (CA path is not defined when using ``curl`` in the shell)