### PR TITLE
HaGeZi offers lists containing Adblock Plus syntax

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8351,6 +8351,7 @@ function sync_package_pfblockerng($cron='') {
 												if (strpos($line, '[Adblock Plus ') !== FALSE ||
 												    strpos($line, '[Adblock Plus]') !== FALSE ||
 												    strpos($line, '[uBlock Origin') !== FALSE ||
+												    strpos($line, "! Title: HaGeZi's") !== FALSE ||
 												    strpos($line, '! Title: AdGuard') !== FALSE) {
 													$easylist = $validate_header = TRUE;
 													continue;


### PR DESCRIPTION
add HaGeZi header check to the "EasyList/Adblock/uBlock" validation.