### PR TITLE
suricata-7.0.2_1 -- Cleanup custom Legacy Blocking module code and update for 7.0.2 from upstream

### DIFF
--- a/security/suricata/Makefile
+++ b/security/suricata/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	suricata
 DISTVERSION=	7.0.2
+PORTREVISION=   1
 CATEGORIES=	security
 MASTER_SITES=	https://www.openinfosecfoundation.org/download/
 

--- a/security/suricata/files/patch-alert-pf.diff
+++ b/security/suricata/files/patch-alert-pf.diff
@@ -1,5 +1,5 @@
-diff -ruN ./suricata-7.0.0.orig/src/Makefile.am ./suricata-7.0.0/src/Makefile.am
---- ./suricata-7.0.0.orig/src/Makefile.am	2023-07-18 00:38:14.000000000 -0400
+diff -ruN ./suricata-7.0.2.orig/src/Makefile.am ./suricata-7.0.2/src/Makefile.am
+--- ./suricata-7.0.2.orig/src/Makefile.am	2023-10-18 10:25:29.000000000 -0400
 +++ ./src/Makefile.am	2023-08-03 09:21:02.000000000 -0400
 @@ -13,6 +13,7 @@
  	action-globals.h \
@@ -17,9 +17,9 @@ diff -ruN ./suricata-7.0.0.orig/src/Makefile.am ./suricata-7.0.0/src/Makefile.am
  	alert-syslog.c \
  	app-layer.c \
  	app-layer-detect-proto.c \
-diff -ruN ./suricata-7.0.0.orig/src/Makefile.in ./suricata-7.0.0/src/Makefile.in
---- ./suricata-7.0.0.orig/src/Makefile.in	2023-07-18 00:43:27.000000000 -0400
-+++ ./src/Makefile.in	2023-08-03 09:29:04.000000000 -0400
+diff -ruN ./suricata-7.0.2.orig/src/Makefile.in ./suricata-7.0.2/src/Makefile.in
+--- ./suricata-7.0.2.orig/src/Makefile.in	2023-10-18 10:30:29.000000000 -0400
++++ ./src/Makefile.in	2023-11-09 14:54:23.000000000 -0500
 @@ -153,6 +153,7 @@
  libsuricata_c_a_LIBADD =
  am_libsuricata_c_a_OBJECTS = alert-debuglog.$(OBJEXT) \
@@ -76,9 +76,10 @@ diff -ruN ./suricata-7.0.0.orig/src/Makefile.in ./suricata-7.0.0/src/Makefile.in
  	-rm -f ./$(DEPDIR)/alert-syslog.Po
  	-rm -f ./$(DEPDIR)/app-layer-detect-proto.Po
  	-rm -f ./$(DEPDIR)/app-layer-dnp3-objects.Po
---- src/alert-pf.c.orig	2023-10-31 11:09:45 UTC
-+++ src/alert-pf.c
-@@ -0,0 +1,1921 @@
+diff -ruN ./suricata-7.0.2.orig/src/alert-pf.c ./suricata-7.0.2/src/alert-pf.c
+--- ./suricata-7.0.2.orig/src/alert-pf.c	1969-12-31 19:00:00.000000000 -0500
++++ ./src/alert-pf.c	2023-11-09 16:48:10.000000000 -0500
+@@ -0,0 +1,1927 @@
 +/* Copyright (C) 2007-2023 Open Information Security Foundation
 + *
 + * You can copy, redistribute or modify this Program under the terms of
@@ -478,7 +479,7 @@ diff -ruN ./suricata-7.0.0.orig/src/Makefile.in ./suricata-7.0.0/src/Makefile.in
 +        else if (kill.af == AF_INET6)
 +            memcpy(&kill.src.addr.v.a.addr.v6, net_addr->addr_data8, sizeof(kill.src.addr.v.a.addr.v6));
 +        if (pfctl_kill_states(data->fd, &kill, NULL)) {
-+            SCLogError("AlertPfBlock(): ioctl() DIOCKILLSTATES: %s\n", strerror(errno));
++            SCLogError("AlertPfBlock(): pfctl_kill_states(): %s\n", strerror(errno));
 +            states_err = 1;
 +        }
 +
@@ -492,7 +493,7 @@ diff -ruN ./suricata-7.0.0.orig/src/Makefile.in ./suricata-7.0.0/src/Makefile.in
 +
 +        /* clear any open states where this IP is DST */
 +        if (pfctl_kill_states(data->fd, &kill, NULL)) {
-+            SCLogError("AlertPfBlock(): ioctl() DIOCKILLSTATES: %s\n", strerror(errno));
++            SCLogError("AlertPfBlock(): pfctl_kill_states(): %s\n", strerror(errno));
 +            states_err = 1;
 +        }
 +#else
@@ -996,7 +997,6 @@ diff -ruN ./suricata-7.0.0.orig/src/Makefile.in ./suricata-7.0.0/src/Makefile.in
 +                    if ( (user_addr = SCCalloc(1, sizeof(struct in_addr))) == NULL) {
 +                        FatalError("Failed allocating memory in AlertPf_IflistMaint() for Radix Tree user data entry. Exiting...");
 +                    }
-+
 +                    COPY_ADDRESS(ip, user_addr);
 +                    SCRWLockWRLock(&ctx->rwlock_tree);
 +                    SCRadixAddKeyIPV4((uint8_t *)&ip->addr_data32, ctx->tree, user_addr);
@@ -1016,7 +1016,6 @@ diff -ruN ./suricata-7.0.0.orig/src/Makefile.in ./suricata-7.0.0/src/Makefile.in
 +                    if ( (user_addr = SCCalloc(1, sizeof(struct in6_addr))) == NULL) {
 +                        FatalError("Failed allocating memory in AlertPf_IflistMaint() for Radix Tree user data entry. Exiting...");
 +                    }
-+
 +                    COPY_ADDRESS(ip, user_addr);
 +                    SCRWLockWRLock(&ctx->rwlock_tree);
 +                    SCRadixAddKeyIPV6((uint8_t *)&ip->addr_data8, ctx->tree, user_addr);
@@ -1147,7 +1146,7 @@ diff -ruN ./suricata-7.0.0.orig/src/Makefile.in ./suricata-7.0.0/src/Makefile.in
 +void *AlertPfMonitorIfaceChanges(void *args)
 +{
 +    int sock = -1;
-+    int fib;
++    int fib = RT_ALL_FIBS;
 +    size_t fib_len = sizeof(fib);
 +    ssize_t len;
 +    char msg[MAX_RTMSG_SIZE];
@@ -1160,7 +1159,7 @@ diff -ruN ./suricata-7.0.0.orig/src/Makefile.in ./suricata-7.0.0/src/Makefile.in
 +
 +    AlertPfCtx *ctx = args;
 +
-+    sock = socket(PF_ROUTE, SOCK_RAW, 0);
++    sock = socket(PF_ROUTE, SOCK_RAW, AF_UNSPEC);
 +    if (sock == -1) {
 +        SCLogWarning("Failed to create routing messages socket(PF_ROUTE): %s.  Dynamic IP changes on firewall interfaces will not be monitored!", strerror(errno));
 +        return (NULL);
@@ -1174,7 +1173,6 @@ diff -ruN ./suricata-7.0.0.orig/src/Makefile.in ./suricata-7.0.0/src/Makefile.in
 +        SCLogWarning("Failed to obtain active route table FIB so using all FIBs by default.");
 +        fib = RT_ALL_FIBS;
 +    }
-+
 +    setsockopt(sock, SOL_SOCKET, SO_SETFIB, (void *)&fib, sizeof(fib));
 +
 +    // Loop forever receiving and handling kernel RTM messages
@@ -1186,8 +1184,12 @@ diff -ruN ./suricata-7.0.0.orig/src/Makefile.in ./suricata-7.0.0/src/Makefile.in
 +        }
 +
 +        len = read(sock, &msg, sizeof(msg));
-+        if (len == -1)
++
++        // Disregard any route message not of the size we require
++        if (len < sizeof(struct ifa_msghdr))
 +            continue;
++        else
++            len -= sizeof(struct ifa_msghdr);
 +
 +        rtm = (struct rt_msghdr *)msg;
 +        if (rtm->rtm_version != RTM_VERSION)
@@ -1198,38 +1200,43 @@ diff -ruN ./suricata-7.0.0.orig/src/Makefile.in ./suricata-7.0.0/src/Makefile.in
 +        switch (rtm->rtm_type) {
 +            case RTM_NEWADDR:
 +            case RTM_DELADDR:
-+            // Make sure all address info we need is present in the message
-+            // by checking the RTAX bit mask.
-+            if (ifam->ifam_addrs != 0xb4)
++                // Make sure all address info we need is present in the message by checking the RTAX flags.
++                if (ifam->ifam_addrs & (RTAX_NETMASK | RTAX_IFP | RTAX_IFA | RTAX_BRD)) {
++
++                    // Get the interface address that is changing (will be third sockaddr in msg)
++                    p = (char *)(ifam + 1);
++                    p += SA_SIZE((struct sockaddr *)p);
++                    len -= SA_SIZE((struct sockaddr *)p);
++                    p += SA_SIZE((struct sockaddr *)p);
++                    len -= SA_SIZE((struct sockaddr *)p);
++                    sa = (struct sockaddr *)p;
++
++                    // If we've run out of data, skip this message as something is amiss
++                    if (len == 0 || len < SA_SIZE(sa))
++                        continue;
++
++                    // Zero out our Address structure prior to each call to parse it
++                    addr.family = 0;
++                    addr.addr_data32[0] = 0;
++                    addr.addr_data32[1] = 0;
++                    addr.addr_data32[2] = 0;
++                    addr.addr_data32[3] = 0;
++
++                    // Make sure we have a valid non-zero IP address in that sockaddr structure
++                    if (!AlertPfParseIfamAddress(sa, &addr)) {
++                        SCLogDebug("Firewall interface IP change notification thread received an invalid IP address via kernel routing message socket.");
++                        continue;
++                    }
++
++                    // OK, now either delete it from or add it to the interface IP list
++                    SCLogInfo("Received notification of IP address change on firewall interface %s.", if_indextoname(ifam->ifam_index, ifname));
++                    AlertPf_IflistMaint(&addr, ctx, rtm->rtm_type);
++                }
 +                continue;
-+            break;
 +
 +            default:
-+            continue;
++                continue;
 +        }
-+
-+        // Get the interface address that is changing (should be third sockaddr structure in msg)
-+        p = (char *)((char *)ifam + sizeof(struct ifa_msghdr));
-+        p += SA_SIZE((struct sockaddr *)p);
-+        p += SA_SIZE((struct sockaddr *)p);
-+        sa = (struct sockaddr *)p;
-+
-+        /* Zero out our Address structure prior to each call to parse it */
-+        addr.family = 0;
-+        addr.addr_data32[0] = 0;
-+        addr.addr_data32[1] = 0;
-+        addr.addr_data32[2] = 0;
-+        addr.addr_data32[3] = 0;
-+
-+        // Make sure we have a valid non-zero IP address in that sockaddr structure
-+        if (!AlertPfParseIfamAddress(sa, &addr)) {
-+            SCLogDebug("Firewall interface IP change notification thread received an invalid IP address via kernel routing message socket.");
-+            continue;
-+        }
-+
-+        // OK, now either delete it from or add it to the interface IP list
-+        SCLogInfo("Received notification of IP address change on firewall interface %s.", if_indextoname(ifam->ifam_index, ifname));
-+        AlertPf_IflistMaint(&addr, ctx, ifam->ifam_type);
 +    }
 +
 +    SCLogInfo("Firewall Interface IP Address Change monitoring thread IM#01 shutting down.");
@@ -2000,8 +2007,8 @@ diff -ruN ./suricata-7.0.0.orig/src/Makefile.in ./suricata-7.0.0/src/Makefile.in
 +
 +    return TM_ECODE_OK;
 +}
-diff -ruN ./suricata-7.0.0.orig/src/alert-pf.h ./suricata-7.0.0/src/alert-pf.h
---- ./suricata-7.0.0.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
+diff -ruN ./suricata-7.0.2.orig/src/alert-pf.h ./suricata-7.0.2/src/alert-pf.h
+--- ./suricata-7.0.2.orig/src/alert-pf.h	1969-12-31 19:00:00.000000000 -0500
 +++ ./src/alert-pf.h	2023-08-03 10:51:48.000000000 -0400
 @@ -0,0 +1,47 @@
 +/* Copyright (C) 2007-2023 Open Information Security Foundation
@@ -2051,8 +2058,8 @@ diff -ruN ./suricata-7.0.0.orig/src/alert-pf.h ./suricata-7.0.0/src/alert-pf.h
 +
 +#endif /* __ALERT_PF_H__ */
 +
-diff -ruN ./suricata-7.0.0.orig/src/output.c ./suricata-7.0.0/src/output.c
---- ./suricata-7.0.0.orig/src/output.c	2023-07-18 00:38:14.000000000 -0400
+diff -ruN ./suricata-7.0.2.orig/src/output.c ./suricata-7.0.2/src/output.c
+--- ./suricata-7.0.2.orig/src/output.c	2023-10-18 10:25:29.000000000 -0400
 +++ ./src/output.c	2023-08-03 09:32:26.000000000 -0400
 @@ -42,6 +42,7 @@
  
@@ -2071,10 +2078,10 @@ diff -ruN ./suricata-7.0.0.orig/src/output.c ./suricata-7.0.0/src/output.c
      /* syslog log */
      AlertSyslogRegister();
      JsonDropLogRegister();
-diff -ruN ./suricata-7.0.0.orig/src/suricata-common.h ./suricata-7.0.0/src/suricata-common.h
---- ./suricata-7.0.0.orig/src/suricata-common.h	2023-07-18 00:38:14.000000000 -0400
-+++ ./src/suricata-common.h	2023-08-03 09:37:23.000000000 -0400
-@@ -485,6 +485,7 @@
+diff -ruN ./suricata-7.0.2.orig/src/suricata-common.h ./suricata-7.0.2/src/suricata-common.h
+--- ./suricata-7.0.2.orig/src/suricata-common.h	2023-10-18 10:25:29.000000000 -0400
++++ ./src/suricata-common.h	2023-11-09 12:50:53.000000000 -0500
+@@ -489,6 +489,7 @@
      LOGGER_JSON_METADATA,
      LOGGER_JSON_FRAME,
      LOGGER_JSON_STREAM,


### PR DESCRIPTION
### Suricata-7.0.2_1
This updates the Suricata binary to the latest 7.0.2 version from upstream. Some cleanup was done to the code in the firewall interface IP change monitoring thread of the custom Legacy Blocking Module, and add additional "belts and suspenders" checks were added to validate kernel routing messages prior to use.

**New Features:**
None

**Bug Fixes:**
1. Code cleanup was done in the custom Legacy Blocking plugin used with pfSense and additional data integrity checks were added when processing kernel routing socket messages for the firewall interface IP change monitoring thread. This thread monitors for interface IP additions or deletions and updates an internal automatic Pass List to prevent insertion of blocks for firewall interface IP addresses.