### PR TITLE
pfSense-pkg-suricata-7.0.2 -- Update Suricata GUI package for latest 7.0.2 binary from upstream and fix Redmine issues

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,8 +1,8 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	7.0.0
-PORTREVISION=	2
+PORTVERSION=	7.0.2
+PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=7.0.0:security/suricata
+RUN_DEPENDS=	suricata>=7.0.2:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -53,10 +53,7 @@ if (!empty($suricatacfg['externallistname']) && $suricatacfg['externallistname']
 	$external_net = "[" . trim($external_net) . "]";
 }
 else {
-	$external_net = "[";
-	foreach ($home_net_list as $ip)
-		$external_net .= "!{$ip}, ";
-	$external_net = trim($external_net, ', ') . "]";
+	$external_net = "[!\$HOME_NET]";
 }
 
 // Set the PASS LIST and write its contents to disk,

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -413,6 +413,12 @@ if (!empty($suricatacfg['eve_systemlog_priority']))
 else
 	$eve_systemlog_priority = "info";
 
+// EVE Ethernet headers setting
+if (!empty($suricatacfg['eve_log_ethernet']))
+	$eve_ethernet_output = $suricatacfg['eve_log_ethernet'];
+else
+	$eve_ethernet_output = "no";
+
 // EVE REDIS output settings
 if (!empty($suricatacfg['eve_redis_server']))
 	$eve_redis_output = "\n        server: ". $suricatacfg['eve_redis_server'];

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -116,6 +116,7 @@ outputs:
       enabled: {$enable_eve_log}
       filetype: {$eve_output_type}
       filename: {$eve_output_filename}
+      ethernet: {$eve_ethernet_output}
       redis: {$eve_redis_output}
       identity: "suricata"
       facility: {$eve_systemlog_facility}

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -1024,6 +1024,10 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 			$tmp = array();
 			$decoder_event = FALSE;
 
+			// Drop any invalid line read from the log excerpt
+			if (empty(trim($buf)))
+				continue;
+
 			/**************************************************************/
 			/* Parse alert log entry to find the parts we want to display */
 			/**************************************************************/

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
@@ -312,6 +312,10 @@ print($form);
 						$fields = array();
 						$tmp = array();
 
+						// Drop any invalid line read from the log
+						if (empty(trim($buf)))
+							continue;
+
 						/***************************************************************/
 						/* Parse block log entry to find the parts we want to display. */
 						/* We parse out all the fields even though we currently use    */

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -586,7 +586,7 @@ $section->addInput(new Form_Select(
 	'log_to_systemlog_priority',
 	'Log Priority',
 	$pconfig['log_to_systemlog_priority'],
-	array( "emerg" => "EMERG", "crit" => "CRIT", "alert" => "ALERT", "err" => "ERR", "warning" => "WARNING", "notice" => "NOTICE", "info" => "INFO" )
+	array( "debug" => "DEBUG", "config" => "CONF", "perf" => "PERF", "error" => "ERR", "warning" => "WARNING", "notice" => "NOTICE", "info" => "INFO" )
 ))->setHelp('Select system log Priority (Level) to use for reporting. Default is NOTICE.');
 
 $section->addInput(new Form_Checkbox(

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -907,7 +907,7 @@ $section->addInput(new Form_Select(
 	'alertsystemlog_priority',
 	'Log Priority',
 	$pconfig['alertsystemlog_priority'],
-	array( "emerg" => "EMERG", "crit" => "CRIT", "alert" => "ALERT", "err" => "ERR", "warning" => "WARNING", "notice" => "NOTICE", "info" => "INFO" )
+	array( "emergency" => "EMERG", "critical" => "CRIT", "alert" => "ALERT", "error" => "ERR", "warning" => "WARNING", "notice" => "NOTICE", "info" => "INFO", "debug" => "DEBUG" )
 ))->setHelp('Select system log Priority (Level) to use for reporting. Default is NOTICE.');
 
 $section->addInput(new Form_Checkbox(

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -202,6 +202,8 @@ if (empty($pconfig['eve_systemlog_facility']))
 	$pconfig['eve_systemlog_facility'] = "local1";
 if (empty($pconfig['eve_systemlog_priority']))
 	$pconfig['eve_systemlog_priority'] = "notice";
+if (empty($pconfig['eve_log_ethernet']))
+	$pconfig['eve_log_ethernet'] = "no";
 if (empty($pconfig['eve_log_drops']))
 	$pconfig['eve_log_drops'] = "on";
 if (empty($pconfig['eve_log_alert_drops']))
@@ -514,6 +516,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		}
 		if ($_POST['eve_systemlog_facility']) $natent['eve_systemlog_facility'] = $_POST['eve_systemlog_facility'];
 		if ($_POST['eve_systemlog_priority']) $natent['eve_systemlog_priority'] = $_POST['eve_systemlog_priority'];
+		if ($_POST['eve_log_ethernet'] == "yes") { $natent['eve_log_ethernet'] = 'yes'; }else{ $natent['eve_log_ethernet'] = 'no'; }
 		if ($_POST['eve_log_alerts'] == "on") { $natent['eve_log_alerts'] = 'on'; }else{ $natent['eve_log_alerts'] = 'off'; }
 		if ($_POST['eve_log_alerts_payload']) { $natent['eve_log_alerts_payload'] = $_POST['eve_log_alerts_payload']; }else{ $natent['eve_log_alerts_payload'] = 'off'; }
 		if ($_POST['eve_log_alerts_packet'] == "on") { $natent['eve_log_alerts_packet'] = 'on'; }else{ $natent['eve_log_alerts_packet'] = 'off'; }
@@ -1198,6 +1201,14 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['eve_log_alerts_xff'] == 'on' ? true:false,
 	'on'
 ));
+$section->addInput(new Form_Checkbox(
+	'eve_log_ethernet',
+	'EVE Ethernet MAC',
+	'Log Ethernet header in events when available.  Default is Not Checked.',
+	$pconfig['eve_log_ethernet'] == 'yes' ? true:false,
+	'yes'
+));
+
 $section->addInput(new Form_Select(
 	'eve_log_alerts_xff_mode',
 	'EVE X-Forwarded-For Operational Mode',
@@ -2152,6 +2163,7 @@ events.push(function(){
 		hideCheckbox('eve_log_alerts',hide);
 		hideCheckbox('eve_log_anomaly',hide);
 		hideCheckbox('eve_log_alerts_xff',hide);
+		hideCheckbox('eve_log_ethernet',hide);
 		hideCheckbox('eve_log_drops',hide);
 		hideClass('eve_log_info', hide);
 		hideClass('eve_log_drops_options', hide);
@@ -2358,6 +2370,7 @@ events.push(function(){
 		disableInput('eve_log_alerts_packet',disable)
 		disableInput('eve_log_alerts_payload',disable);
 		disableInput('eve_log_alerts_http',disable);
+		disableInput('eve_log_ethernet',disable);
 		disableInput('eve_log_alerts_xff',disable);
 		disableInput('eve_log_alerts_xff_mode',disable);
 		disableInput('eve_log_alerts_xff_deployment',disable);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_list_view.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_list_view.php
@@ -68,7 +68,7 @@ if (isset($id) && isset($wlist)) {
 	elseif ($type == "externalnet") {
 		if ($wlist == "default") {
 			$list = suricata_build_list($a_rule, $a_rule['homelistname']);
-			$contents = "";
+			$contents = "Defined in suricata.yaml as: !\$HOME_NET which expands to:\n\n";
 			foreach ($list as $ip)
 				$contents .= "!{$ip}\n";
 			$contents = trim($contents, "\n");


### PR DESCRIPTION
### pfSense-pkg-suricata-7.0.2
This updates the Suricata GUI package to support the latest 7.0.2 binary from upstream. This update contains one feature enhancement and two bug fixes.

**New Features:**
1. Added new EVE JSON logging option to log Ethernet headers (MAC addresses) from a packet when available. See [Redmine Issue 14954](https://redmine.pfsense.org/issues/14954).

**Bug Fixes:**
1. Fix [Redmine Issue 14955](https://redmine.pfsense.org/issues/14955) - Fatal PHP error generated when attempting to create an EventTime object from an invalid line of text read from the _alerts.log_ or _blocks.log_ files.
2. Fix [Redmine Issue 14956](https://redmine.pfsense.org/issues/14956) - Suricata GUI generates invalid syslog priority values in suricata.yaml file for some drop-down list values.