### PR TITLE
snort-2.9.20_5_RELENG_2_7_0 - Cleanup code in custom Legacy Blocking module and add safety checks

### DIFF
--- a/security/snort/Makefile
+++ b/security/snort/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	snort
 PORTVERSION=	2.9.20
-PORTREVISION=	3
+PORTREVISION=	5
 CATEGORIES=	security
 MASTER_SITES=	https://snort.org/downloads/snort/ \
 		https://snort.org/downloads/archive/snort/
@@ -17,7 +17,8 @@ LICENSE_FILE=	${WRKSRC}/LICENSE
 BUILD_DEPENDS=	daq>=2.2.2_3:net/daq
 LIB_DEPENDS=	libpcre.so:devel/pcre \
 		libdnet.so:net/libdnet \
-		libpcap.so:net/libpcap
+		libpcap.so:net/libpcap \
+		libpfctl.so:net/libpfctl
 RUN_DEPENDS=	daq>=2.2.2_3:net/daq
 
 USES=			bison cpe libtool pathfix shebangfix ssl
@@ -93,6 +94,8 @@ CFLAGS+=	-fstack-protector
 CONFIGURE_ARGS+=--enable-reload \
 		--enable-mpls --enable-targetbased \
 		--enable-reload-error-restart
+CFLAGS+=	-I${LOCALBASE}/include/
+LDFLAGS+=	-L${LOCALBASE}/lib -lpfctl
 
 post-patch:
 	@${REINPLACE_CMD} "s,/etc/snort.conf,${ETCDIR}/snort.conf," \

--- a/security/snort/files/patch-spoink-integration.diff
+++ b/security/snort/files/patch-spoink-integration.diff
@@ -1,6 +1,6 @@
-diff -ruN ./snort-2.9.19.orig/src/output-plugins/Makefile.am ./snort-2.9.19/src/output-plugins/Makefile.am
---- ./snort-2.9.19.orig/src/output-plugins/Makefile.am	2021-10-20 07:04:33.000000000 -0400
-+++ ./src/output-plugins/Makefile.am	2021-12-08 15:15:29.000000000 -0500
+diff -ruN ./snort-2.9.20.orig/src/output-plugins/Makefile.am ./snort-2.9.20/src/output-plugins/Makefile.am
+--- ./snort-2.9.20.orig/src/output-plugins/Makefile.am	2022-04-20 10:15:08.000000000 -0400
++++ ./src/output-plugins/Makefile.am	2023-11-09 18:25:39.000000000 -0500
 @@ -13,7 +13,8 @@
  spo_unified2.c spo_unified2.h \
  spo_log_ascii.c spo_log_ascii.h \
@@ -11,9 +11,9 @@ diff -ruN ./snort-2.9.19.orig/src/output-plugins/Makefile.am ./snort-2.9.19/src/
  
  if BUILD_BUFFER_DUMP
  libspo_a_SOURCES += \
-diff -ruN ./snort-2.9.19.orig/src/output-plugins/Makefile.in ./snort-2.9.19/src/output-plugins/Makefile.in
---- ./snort-2.9.19.orig/src/output-plugins/Makefile.in	2021-11-11 03:42:11.000000000 -0500
-+++ ./src/output-plugins/Makefile.in	2021-12-08 15:18:27.000000000 -0500
+diff -ruN ./snort-2.9.20.orig/src/output-plugins/Makefile.in ./snort-2.9.20/src/output-plugins/Makefile.in
+--- ./snort-2.9.20.orig/src/output-plugins/Makefile.in	2022-05-23 11:42:31.000000000 -0400
++++ ./src/output-plugins/Makefile.in	2023-11-09 18:27:59.000000000 -0500
 @@ -116,7 +116,8 @@
  	spo_log_tcpdump.c spo_log_tcpdump.h spo_unified2.c \
  	spo_unified2.h spo_log_ascii.c spo_log_ascii.h \
@@ -40,12 +40,12 @@ diff -ruN ./snort-2.9.19.orig/src/output-plugins/Makefile.in ./snort-2.9.19/src/
  	$(am__append_1)
  all: all-am
  
-diff -ruN ./snort-2.9.19.orig/src/output-plugins/spo_pf.c ./snort-2.9.19/src/output-plugins/spo_pf.c
---- ./snort-2.9.19.orig/src/output-plugins/spo_pf.c	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/output-plugins/spo_pf.c	2021-11-11 16:44:23.000000000 -0500
-@@ -0,0 +1,811 @@
+diff -ruN ./snort-2.9.20.orig/src/output-plugins/spo_pf.c ./snort-2.9.20/src/output-plugins/spo_pf.c
+--- ./snort-2.9.20.orig/src/output-plugins/spo_pf.c	1969-12-31 19:00:00.000000000 -0500
++++ ./src/output-plugins/spo_pf.c	2023-11-09 18:47:53.000000000 -0500
+@@ -0,0 +1,822 @@
 +/*
-+* Copyright (c) 2021  Bill Meeks
++* Copyright (c) 2023  Bill Meeks
 +* Copyright (c) 2012  Ermal Luci
 +* Copyright (c) 2006  Antonio Benojar <zz.stalker@gmail.com>
 +* Copyright (c) 2005  Antonio Benojar <zz.stalker@gmail.com>
@@ -124,6 +124,8 @@ diff -ruN ./snort-2.9.19.orig/src/output-plugins/spo_pf.c ./snort-2.9.19/src/out
 +#include <regex.h>
 +#include <ifaddrs.h>
 +#include <pthread.h>
++
++#include <libpfctl.h>
 +
 +#define PFDEVICE        "/dev/pf"
 +
@@ -262,7 +264,7 @@ diff -ruN ./snort-2.9.19.orig/src/output-plugins/spo_pf.c ./snort-2.9.19/src/out
 +s2c_monitor_iface_changes(void *args)
 +{
 +	int sock = -1;
-+	int fib;
++	int fib = RT_ALL_FIBS;
 +	size_t fib_len = sizeof(fib);
 +	ssize_t len;
 +	char msg[MAX_RTMSG_SIZE];
@@ -275,27 +277,33 @@ diff -ruN ./snort-2.9.19.orig/src/output-plugins/spo_pf.c ./snort-2.9.19/src/out
 +
 +	struct iflist_head *head = args;
 +
-+	sock = socket(PF_ROUTE, SOCK_RAW, 0);
++	sock = socket(PF_ROUTE, SOCK_RAW, AF_UNSPEC);
 +	if (sock == -1) {
 +		ErrorMessage("Failed to create socket(PF_ROUTE): %s.  Dynamic firewall interface IP changes will not be monitored!\n", strerror(errno));
 +		return (NULL);
 +	}
 +
++    pthread_setname_np(pthread_self(), "IM#01");
++
 +	if (sysctlbyname("net.my_fibnum", &fib, &fib_len, NULL, 0) < 0)
 +	{  
-+		WarningMessage("spo_pf -> Failed to obtain active route table FIB so using all FIBs by default.\n");
++		WarningMessage("spo_pf -> Failed to obtain active route table FIB, so using all FIBs by default.\n");
 +		fib = RT_ALL_FIBS;
 +	}
 +
 +	LogMessage("spo_pf -> Firewall interface IP address change notification monitoring thread started.\n");
 +	setsockopt(sock, SOL_SOCKET, SO_SETFIB, (void *)&fib, sizeof(fib));
 +
-+	// Loop forever receiving and handling kernel RTM messages
++	// Loop forever receiving and handling kernel RTM messages by checking the RTAX flags
 +	for (;;) {
 +
 +		len = read(sock, &msg, sizeof(msg));
-+		if (len == -1)
-+			continue;
++
++        // Disregard any route message not of the size we require
++        if (len < sizeof(struct ifa_msghdr))
++            continue;
++        else
++            len -= sizeof(struct ifa_msghdr);
 +
 +		rtm = (struct rt_msghdr *)msg;
 +		if (rtm->rtm_version != RTM_VERSION)
@@ -306,32 +314,39 @@ diff -ruN ./snort-2.9.19.orig/src/output-plugins/spo_pf.c ./snort-2.9.19/src/out
 +		switch (rtm->rtm_type) {
 +			case RTM_NEWADDR:
 +			case RTM_DELADDR:
-+				// Make sure all address info we need is present in the message
-+				if (ifam->ifam_addrs != 0xb4)
-+					continue;
-+				break;
++                // Make sure all address info we need is present in the message
++				if (ifam->ifam_addrs & (RTAX_NETMASK | RTAX_IFP | RTAX_IFA | RTAX_BRD)) {
++
++                    // Get the interface address that is changing (will be third sockaddr in msg)
++                    p = (char *)(ifam + 1);
++                    p += SA_SIZE((struct sockaddr *)p);
++                    len -= SA_SIZE((struct sockaddr *)p);
++                    p += SA_SIZE((struct sockaddr *)p);
++                    len -= SA_SIZE((struct sockaddr *)p);
++                    sa = (struct sockaddr *)p;
++
++                    // If we've run out of data, skip this message as something is amiss
++                    if (len == 0 || len < SA_SIZE(sa))
++                        continue;
++
++                    // Make sure we have a valid non-zero IP address in that sockaddr structure
++                    if (!s2c_parse_ifam_address(sa, &addr)) {
++                        WarningMessage("spo_pf -> Firewall interface IP change notification thread received an invalid IP address via kernel routing message socket -- Ignoring the message.\n");
++                        continue;
++                    }
++
++                    // OK, now either delete it from or add it to the interface IP list
++                    LogMessage("spo_pf -> Received notification of IP address change on interface %s.\n", if_indextoname(ifam->ifam_index, ifname));
++                    s2c_iflist_maint(&addr, head, rtm->rtm_type);
++                }
++                continue;
 +
 +			default:
 +				continue;
 +		}
-+
-+		// Get the address that is changing (should be third sockaddr structure in msg)
-+		p = (char *)((char *)ifam + sizeof(struct ifa_msghdr));
-+		p += SA_SIZE((struct sockaddr *)p);
-+		p += SA_SIZE((struct sockaddr *)p);
-+		sa = (struct sockaddr *)p;
-+
-+		// Make sure we have a valid non-zero IP address in that sockaddr structure
-+		if (!s2c_parse_ifam_address(sa, &addr)) {
-+			WarningMessage("spo_pf -> Firewall interface IP change notification thread received an invalid IP address via kernel routing message socket -- Ignoring the message.\n");
-+			continue;
-+		}
-+
-+		// OK, now either delete it from or add it to the interface IP list
-+		LogMessage("spo_pf -> Received notification of IP address change on interface %s.\n", if_indextoname(ifam->ifam_index, ifname));
-+		s2c_iflist_maint(&addr, head, ifam->ifam_type);
 +	}
 +
++	LogMessage("spo_pf -> Firewall interface IP address change notification monitoring thread #IM01 shutting down.\n");
 +	return (NULL);
 +}
 +
@@ -573,34 +588,30 @@ diff -ruN ./snort-2.9.19.orig/src/output-plugins/spo_pf.c ./snort-2.9.19/src/out
 +            ErrorMessage("s2c_pf_block() => ioctl() DIOCRADDADDRS: %s\n", strerror(errno));
 + 
 +	if (data->kill) {
-+		struct pfioc_state_kill psk;
++		struct pfctl_kill kill = {
++			.af = net_addr->family,
++		};
++		memset(&kill.src.addr.v.a.mask, 0xff, sizeof(kill.src.addr.v.a.mask));
++		if (kill.af == AF_INET)
++			memcpy(&kill.src.addr.v.a.addr.v4.s_addr, sfaddr_get_ip4_ptr(net_addr), sizeof(in_addr_t));
++		else if (kill.af == AF_INET6)
++			memcpy(&kill.src.addr.v.a.addr.v6, sfaddr_get_ip6_ptr(net_addr), sizeof(struct in6_addr));
++		else
++			return (-1);
++		pfctl_kill_states(data->fd, &kill, NULL);
 +
-+		memset(&psk, 0, sizeof(psk));
-+		memset(&psk.psk_src.addr.v.a.mask, 0xff, sizeof(psk.psk_src.addr.v.a.mask));
-+		psk.psk_af = net_addr->family;
-+		if (psk.psk_af == AF_INET)
-+			memcpy(&psk.psk_src.addr.v.a.addr.v4.s_addr, sfaddr_get_ip4_ptr(net_addr), sizeof(in_addr_t));
-+		else if (psk.psk_af == AF_INET6)
-+			memcpy(&psk.psk_src.addr.v.a.addr.v6, sfaddr_get_ip6_ptr(net_addr), sizeof(struct in6_addr));
++		memset(&kill, 0, sizeof(kill));
++		memset(&kill.src.addr.v.a.mask, 0xff, sizeof(kill.src.addr.v.a.mask));
++		kill.af = net_addr->family;
++
++		if (kill.af == AF_INET)
++			memcpy(&kill.dst.addr.v.a.addr.v4.s_addr, sfaddr_get_ip4_ptr(net_addr), sizeof(in_addr_t));
++		else if (kill.af == AF_INET6)
++			memcpy(&kill.dst.addr.v.a.addr.v6, sfaddr_get_ip6_ptr(net_addr), sizeof(struct in6_addr));
 +		else
 +			return (-1);
 +
-+		/* XXX: Should ignore? */
-+		ioctl(data->fd, DIOCKILLSTATES, &psk);
-+
-+		memset(&psk, 0, sizeof(psk));
-+		memset(&psk.psk_dst.addr.v.a.mask, 0xff, sizeof(psk.psk_dst.addr.v.a.mask));
-+		psk.psk_af = net_addr->family;
-+		if (psk.psk_af == AF_INET)
-+			memcpy(&psk.psk_dst.addr.v.a.addr.v4.s_addr, sfaddr_get_ip4_ptr(net_addr), sizeof(in_addr_t));
-+		else if (psk.psk_af == AF_INET6)
-+			memcpy(&psk.psk_dst.addr.v.a.addr.v6, sfaddr_get_ip6_ptr(net_addr), sizeof(struct in6_addr));
-+		else
-+			return (-1);
-+
-+		/* XXX: Should ignore? */
-+		ioctl(data->fd, DIOCKILLSTATES, &psk);
-+
++		pfctl_kill_states(data->fd, &kill, NULL);
 +	}
 +        return(0); 
 +}
@@ -855,12 +866,12 @@ diff -ruN ./snort-2.9.19.orig/src/output-plugins/spo_pf.c ./snort-2.9.19/src/out
 +		return (0);
 +	}
 +}
-diff -ruN ./snort-2.9.19.orig/src/output-plugins/spo_pf.h ./snort-2.9.19/src/output-plugins/spo_pf.h
---- ./snort-2.9.19.orig/src/output-plugins/spo_pf.h	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/output-plugins/spo_pf.h	2021-02-05 23:08:01.000000000 -0500
+diff -ruN ./snort-2.9.20.orig/src/output-plugins/spo_pf.h ./snort-2.9.20/src/output-plugins/spo_pf.h
+--- ./snort-2.9.20.orig/src/output-plugins/spo_pf.h	1969-12-31 19:00:00.000000000 -0500
++++ ./src/output-plugins/spo_pf.h	2023-11-09 18:21:19.000000000 -0500
 @@ -0,0 +1,42 @@
 +/*
-+* Copyright (c) 2021  Bill Meeks
++* Copyright (c) 2023  Bill Meeks
 +* Copyright (c) 2012  Ermal Luci
 +* Copyright (c) 2006  Antonio Benojar <zz.stalker@gmail.com>
 +* Copyright (c) 2005  Antonio Benojar <zz.stalker@gmail.com>
@@ -901,18 +912,10 @@ diff -ruN ./snort-2.9.19.orig/src/output-plugins/spo_pf.h ./snort-2.9.19/src/out
 +void AlertPfSetup(void);
 +
 +#endif 
-diff -ruN ./snort-2.9.19.orig/src/plugbase.c ./snort-2.9.19/src/plugbase.c
---- ./snort-2.9.19.orig/src/plugbase.c	2021-10-20 07:04:33.000000000 -0400
-+++ ./src/plugbase.c	2021-12-08 15:20:45.000000000 -0500
-@@ -124,6 +124,7 @@
- #include "output-plugins/spo_log_null.h"
- #include "output-plugins/spo_log_ascii.h"
- #include "output-plugins/spo_unified2.h"
-+#include "output-plugins/spo_pf.h"
- 
- #ifdef DUMP_BUFFER
- #include "output-plugins/spo_log_buffer_dump.h"
-@@ -1579,6 +1580,7 @@
+diff -ruN ./snort-2.9.20.orig/src/plugbase.c ./snort-2.9.20/src/plugbase.c
+--- ./snort-2.9.20.orig/src/plugbase.c	2022-05-18 01:02:15.000000000 -0400
++++ ./src/plugbase.c	2023-11-09 18:29:52.000000000 -0500
+@@ -1579,6 +1579,7 @@
      LogTcpdumpSetup();
      AlertFastSetup();
      AlertFullSetup();


### PR DESCRIPTION
### Snort-2.9.20_5
This update cleans up some of the code in the custom Legacy Blocking Module used with pfSense and adds some safety checks around the routing socket message data before using it in the firewall interface IP change monitoring thread for automatic whitelisting of firewall interface IP addresses.

**New Features:**
None

**Bug Fixes:**
None