### PR TITLE
Updates acme dns inwx script to current version

### DIFF
--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/dnsapi/dns_inwx.sh
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/dnsapi/dns_inwx.sh
@@ -194,7 +194,7 @@ _inwx_login() {
 
   response="$(_post "$xml_content" "$INWX_Api" "" "POST")"
 
-  INWX_Cookie=$(printf "Cookie: %s" "$(grep "domrobot=" "$HTTP_HEADER" | grep "^Set-Cookie:" | _tail_n 1 | _egrep_o 'domrobot=[^;]*;' | tr -d ';')")
+  INWX_Cookie=$(printf "Cookie: %s" "$(grep "domrobot=" "$HTTP_HEADER" | grep -i "^Set-Cookie:" | _tail_n 1 | _egrep_o 'domrobot=[^;]*;' | tr -d ';')")
   _H1=$INWX_Cookie
   export _H1
   export INWX_Cookie


### PR DESCRIPTION
Hey guys,

dns_inwx.sh script was a bit outdated and was missing a change regarding case sensitive grep.

Script change can be viewed here:

https://github.com/acmesh-official/acme.sh/commit/9143cd1485a4a0220897124fec78eb2ec45f81ec

Before the change, updating letsencrypt certs using INWX API failed.

Thank you for your great work.

Best,
Martin