### PR TITLE
pfSense-pkg-suricata-7.0.2_1 - Fix Redmine Issue 14995 - SID MGMT list download action leads to 502 bad gateway

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	7.0.2
-PORTREVISION=	0
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_sid_mgmt.php
@@ -258,6 +258,7 @@ if (isset($_POST['sidlist_dnload']) && isset($_POST['sidlist_id'])) {
 	touch($tmpdirname . $file, $a_list[$_POST['sidlist_id']]['modtime']);
 
 	if (file_exists($tmpdirname . $file)) {
+		ob_start(); //important or other posts will fail
 		if (isset($_SERVER['HTTPS'])) {
 			header('Pragma: ');
 			header('Cache-Control: ');
@@ -266,9 +267,9 @@ if (isset($_POST['sidlist_dnload']) && isset($_POST['sidlist_id'])) {
 			header("Cache-Control: private, must-revalidate");
 		}
 		header("Content-Type: application/octet-stream");
-		header("Content-length: " . filesize($file));
+		header("Content-length: " . filesize($tmpdirname . $file));
 		header("Content-disposition: attachment; filename = " . basename($file));
-		ob_clean();
+		ob_end_clean(); //important or other post will fail
 		flush();
 		readfile($tmpdirname . $file);
 


### PR DESCRIPTION
### pfSense-pkg-suricata-7.0.2_1
This Suricata GUI package update contains the fix for [Redmine Issue 14995](https://redmine.pfsense.org/issues/14995).

**New Features:**
none

**Bug Fixes:**
1. [Fix Redmine Issue 14995](https://redmine.pfsense.org/issues/14995) - SID MGMT list download action leads to 502 bad gateway error.