### PR TITLE
net/pfSense-pkg-pfBlockerNG-devel: add option to disable reverse DNS lookups. Fix #15072

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -702,6 +702,7 @@ function pfb_global() {
 
 	$pfb['enable']		= $pfb['config']['enable_cb'];			// Enable/Disable of pfBlockerNG
 	$pfb['keep']		= $pfb['config']['pfb_keep'];			// Keep blocklists on pfBlockerNG Disable
+	$pfb['resolve']		= $pfb['config']['pfb_resolve'];		// Resolve IP Addresses
 	$pfb['interval']	= $pfb['config']['pfb_interval']	?: '1';	// Hour cycle for scheduler
 
 	// Validate Cron settings
@@ -5806,7 +5807,11 @@ function pfb_daemon_filterlog() {
 						$log = "{$ts},{$d[3]},{$d[4]},{$int},{$d[6]},{$d[8]},";
 					}
 
-					$resolved_host = gethostbyaddr($host) ?: 'Unknown';
+					if ($pfb['resolve']) {
+						$resolved_host = gethostbyaddr($host) ?: 'Unknown';
+                                        } else {
+						$resolved_host = 'Unknown';
+                                        }
 					if ($host == $resolved_host || $resolved_host == 'Unknown') {
 						$resolved_host = 'Unknown';
 					} else {

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -52,6 +52,8 @@ $pconfig['pfb_hour']			= $pfb['gconfig']['pfb_hour']				?: 0;
 $pconfig['pfb_dailystart']		= $pfb['gconfig']['pfb_dailystart']			?: 0;
 $pconfig['skipfeed']			= $pfb['gconfig']['skipfeed']				?: 0;
 
+$pconfig['pfb_resolve']			= $pfb['gconfig']['pfb_resolve']			?: 1;
+
 $pconfig['log_max_log']			= $pfb['gconfig']['log_max_log']			?: 20000;
 $pconfig['log_max_errlog']		= $pfb['gconfig']['log_max_errlog']			?: 20000;
 $pconfig['log_max_extraslog']		= $pfb['gconfig']['log_max_extraslog']			?: 20000;
@@ -133,6 +135,8 @@ if ($_POST) {
 			$pfb['gconfig']['pfb_hour']			= $_POST['pfb_hour']				?: 0;
 			$pfb['gconfig']['pfb_dailystart']		= $_POST['pfb_dailystart']			?: 0;
 			$pfb['gconfig']['skipfeed']			= $_POST['skipfeed']				?: 0;
+
+			$pfb['gconfig']['pfb_resolve']			= pfb_filter($_POST['pfb_resolve'], PFB_FILTER_ON_OFF, 'general', '');
 
 			// Remove old Line Limit setting
 			if (isset($pfb['gconfig']['log_maxlines'])) {
@@ -264,6 +268,21 @@ $section->addInput(new Form_Select(
 		. 'Select max daily download failure threshold via CRON. Clear widget \'failed downloads\' to reset.<br />'
 		. 'On a download failure, the previously downloaded list is reloaded.')
   ->setAttribute('style', 'width: auto');
+$form->add($section);
+
+$section = new Form_Section('Log Settings (options)');
+
+$section->addInput(new Form_Checkbox(
+	'pfb_resolve',
+	'Resolve IP Addresses',
+	gettext('Enable'),
+	$pconfig['pfb_resolve'] === 'on' ? true:false,
+	'on'
+))->setHelp('<span class="text-danger">Note: </span>'
+		. 'With \'Resolve IP Addresses\' enabled, pfBlockerNG will do reverse DNS lookups of IP addresses in the filter log<br>'
+		. 'and log that in the pfBlockerNG logs.<br>'
+		. ' If \'Resolve IP Addresses\' is not \'enabled\', the resolved hostname field of the pfBlockNG logs will always be \'Unknown\'.<br>'
+);
 $form->add($section);
 
 $section = new Form_Section('Log Settings (max lines)');

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/wizards/pfblockerng_wizard.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/wizards/pfblockerng_wizard.inc
@@ -133,6 +133,7 @@ function step4_submitphpaction() {
 	$new_config = &$config['installedpackages'];
 	$new_config['pfblockerng']['config'][0]['enable_cb']				= 'on';
 	$new_config['pfblockerng']['config'][0]['pfb_keep']				= 'on';
+	$new_config['pfblockerng']['config'][0]['pfb_resolve']				= 'on';
 
 	init_config_arr(array('installedpackages', 'pfblockerngipsettings', 'config', 0));
 	$new_config['pfblockerngipsettings']['config'][0]['enable_dup']			= 'on';


### PR DESCRIPTION
I think there is still an issue with the default setting, and we need to restart the filterlog service when this setting is changed.

Fixes https://redmine.pfsense.org/issues/15072