### PR TITLE
pfSense-pkg-suricata-7.0.2_2_RELENG_2_7_2 - Fix Redmine Issue 15033

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	7.0.2
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
@@ -31,12 +31,12 @@ require_once("/usr/local/pkg/suricata/suricata.inc");
 $suricatadir = SURICATADIR;
 $suricata_rules_upd_log = SURICATA_RULES_UPD_LOGFILE;
 
-$snortdownload = config_get_path('installedpackages/suricata/config/0/enable_vrt_rules');
-$emergingthreats = config_get_path('installedpackages/suricata/config/0/enable_etopen_rules');
-$etpro = config_get_path('installedpackages/suricata/config/0/enable_etpro_rules');
-$snortcommunityrules = config_get_path('installedpackages/suricata/config/0/snortcommunityrules');
-$feodotracker_rules = config_get_path('installedpackages/suricata/config/0/enable_feodo_botnet_c2_rules');
-$sslbl_rules = config_get_path('installedpackages/suricata/config/0/enable_abuse_ssl_blacklist_rules');
+$snortdownload = config_get_path('installedpackages/suricata/config/0/enable_vrt_rules') == "on" ? 'on' : 'off';
+$emergingthreats = config_get_path('installedpackages/suricata/config/0/enable_etopen_rules') == "on" ? 'on' : 'off';
+$etpro = config_get_path('installedpackages/suricata/config/0/enable_etpro_rules') == "on" ? 'on' : 'off';
+$snortcommunityrules = config_get_path('installedpackages/suricata/config/0/snortcommunityrules') == "on" ? 'on' : 'off';
+$feodotracker_rules = config_get_path('installedpackages/suricata/config/0/enable_feodo_botnet_c2_rules') == "on" ? 'on' : 'off';
+$sslbl_rules = config_get_path('installedpackages/suricata/config/0/enable_abuse_ssl_blacklist_rules') == "on" ? 'on' : 'off';
 $enable_extra_rules = config_get_path('installedpackages/suricata/config/0/enable_extra_rules') == "on" ? 'on' : 'off';
 $extra_rules = config_get_path('installedpackages/suricata/config/0/extra_rules/rule', []);
 
@@ -352,7 +352,7 @@ foreach ($extra_rules as $exrule) {
 				<strong><?=gettext("Result:");?></strong> <?=$last_rule_upd_status?>
 			</p>
 			<p>
-				<?php if ($snortdownload != 'on' && $emergingthreats != 'on' && $etpro != 'on' && $enable_extra_rules != 'on'): ?>
+				<?php if ($snortdownload != 'on' && $emergingthreats != 'on' && $etpro != 'on' && $snortcommunityrules != 'on' && $feodotracker_rules != 'on' && $sslbl_rules != 'on' && $enable_extra_rules != 'on'): ?>
 					<br/><button class="btn btn-primary" disabled>
 						<i class="fa fa-check icon-embed-btn"></i>
 						<?=gettext("Update"); ?>


### PR DESCRIPTION
### pfSense-pkg-suricata-7.0.2_2
This update to the Suricata GUI package corrects the issue identified in Redmine Issue 15033.

**New Features:**
none

**Bug Fixes:**
1. Fix [Redmine Issue 15033](https://redmine.pfsense.org/issues/15033) - Suricata rule lists can't be manually updated unless the ETOpen Emerging Threats list is enabled.