### PR TITLE
pfSense-pkg-suricata-7.0.2_3 - Add single-pattern matcher algo choice, fix help text, and add check for invalid timestamps

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	7.0.2
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=7.0.2:security/suricata
+RUN_DEPENDS=	suricata>=7.0.2_6:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -149,6 +149,11 @@ if (!empty($suricatacfg['mpm_algo']))
 else
 	$mpm_algo = "auto";
 
+if (!empty($suricatacfg['spm_algo']))
+	$spm_algo = $suricatacfg['spm_algo'];
+else
+	$spm_algo = "auto";
+
 if (!empty($suricatacfg['inspect_recursion_limit']) || $suricatacfg['inspect_recursion_limit'] == '0')
 	$inspection_recursion_limit = $suricatacfg['inspect_recursion_limit'];
 else

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -172,7 +172,7 @@ mpm-algo: {$mpm_algo}
 
 # Single pattern algorithm
 # The default of "auto" will use "hs" if available, otherwise "bm".
-spm-algo: auto
+spm-algo: {$spm_algo}
 
 # Defrag settings:
 defrag:

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -726,7 +726,7 @@ $group->add(new Form_Button(
 	null,
 	'fa-trash'
 ))->removeClass('btn-default')->addClass('btn-danger btn-sm')
-  ->setHelp('All log files will be cleared');
+  ->setHelp('Clear the currently active Alerts log file');
 
 $section->add($group);
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -1086,7 +1086,12 @@ if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid
 
 			// Create a DateTime object from the event timestamp that
 			// we can use to easily manipulate output formats.
-			$event_tm = date_create_from_format("m/d/Y-H:i:s.u", $fields['time']);
+			try {
+				$event_tm = date_create_from_format("m/d/Y-H:i:s.u", $fields['time']);
+			} catch (Exception $e) {
+				syslog(LOG_WARNING, "[suricata] WARNING: found invalid timestamp entry in current alerts.log, the line will be ignored and skipped.");
+				continue;
+			}
 
 			// Check the 'CATEGORY' field for the text "(null)" and
 			// substitute "Not Assigned".

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
@@ -327,7 +327,12 @@ print($form);
 
 						// Create a DateTime object from the event timestamp that
 						// we can use to easily manipulate output formats.
-						$event_tm = date_create_from_format("m/d/Y-H:i:s.u", $fields['time']);
+						try {
+							$event_tm = date_create_from_format("m/d/Y-H:i:s.u", $fields['time']);
+						} catch (Exception $e) {
+							syslog(LOG_WARNING, "[suricata] WARNING: found invalid timestamp entry in current blocks.log, the line will be ignored and skipped.");
+							continue;
+						}
 
 						// Field 1 is the action
 						if (strpos($buf, '[') !== FALSE && strpos($buf, ']') !== FALSE)

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -166,6 +166,8 @@ if (empty($pconfig['detect_eng_profile']))
 	$pconfig['detect_eng_profile'] = "medium";
 if (empty($pconfig['mpm_algo']))
 	$pconfig['mpm_algo'] = "auto";
+if (empty($pconfig['spm_algo']))
+	$pconfig['spm_algo'] = "auto";
 if (empty($pconfig['sgh_mpm_context']))
 	$pconfig['sgh_mpm_context'] = "auto";
 if (empty($pconfig['enable_stats_collection']))
@@ -495,6 +497,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['intf_snaplen'] > '0') $natent['intf_snaplen'] = $_POST['intf_snaplen']; else $natent['inspect_recursion_limit'] = "1518";
 		if ($_POST['detect_eng_profile']) $natent['detect_eng_profile'] = $_POST['detect_eng_profile']; else unset($natent['detect_eng_profile']);
 		if ($_POST['mpm_algo']) $natent['mpm_algo'] = $_POST['mpm_algo']; else unset($natent['mpm_algo']);
+		if ($_POST['spm_algo']) $natent['spm_algo'] = $_POST['spm_algo']; else unset($natent['spm_algo']);
 		if ($_POST['sgh_mpm_context']) $natent['sgh_mpm_context'] = $_POST['sgh_mpm_context']; else unset($natent['sgh_mpm_context']);
 		if ($_POST['blockoffenders'] == "on") $natent['blockoffenders'] = 'on'; else $natent['blockoffenders'] = 'off';
 		if ($_POST['ips_mode']) $natent['ips_mode'] = $_POST['ips_mode']; else unset($natent['ips_mode']);
@@ -677,6 +680,8 @@ if (isset($_POST["save"]) && !$input_errors) {
 			$natent['delayed_detect'] = 'off';
 			$natent['intf_promisc_mode'] = 'on';
 			$natent['intf_snaplen'] = '1518';
+			$natent['mpm_algo'] = "auto";
+			$natent['spm_algo'] = "auto";
 
 			$natent['app_layer_error_policy'] = "ignore";
 			$natent['asn1_max_frames'] = '256';
@@ -1833,10 +1838,17 @@ $section->addInput(new Form_Select(
 
 $section->addInput(new Form_Select(
 	'mpm_algo',
-	'Pattern Matcher Algorithm',
+	'Multi-Pattern Matcher Algorithm',
 	$pconfig['mpm_algo'],
 	array('auto' => 'Auto', 'ac' => 'AC', 'ac-bs' => 'AC-BS', 'ac-ks' => 'AC-KS', 'hs' => 'Hyperscan')
-))->setHelp('Choose a multi-pattern matcher (MPM) algorithm. Auto is the default, and is the best choice for almost all systems.  Auto will use hyperscan if available.');
+))->setHelp('Choose a multi-pattern matcher (MPM) algorithm. Auto is the default, and is the best choice for almost all systems. Auto will use hyperscan if available.');
+
+$section->addInput(new Form_Select(
+	'spm_algo',
+	' Single-Pattern Matcher Algorithm',
+	$pconfig['spm_algo'],
+	array('auto' => 'Auto', 'bm' => 'BM', 'hs' => 'Hyperscan')
+))->setHelp('Choose a single-pattern matcher (SPM) algorithm. Auto is the default, and is the best choice for almost all systems. Auto will use hyperscan if available.');
 
 $section->addInput(new Form_Select(
 	'sgh_mpm_context',
@@ -2275,6 +2287,7 @@ events.push(function(){
 		disableInput('detect_eng_profile', disable);
 		disableInput('inspect_recursion_limit', disable);
 		disableInput('mpm_algo', disable);
+		disableInput('spm_algo', disable);
 		disableInput('sgh_mpm_context', disable);
 		disableInput('delayed_detect', disable);
 		disableInput('intf_promisc_mode', disable);


### PR DESCRIPTION
### pfSense-pkg-suricata-7.0.2_3
This update for the Suricata GUI package adds one new feature, updates the help text for a button on the ALERTS tab, and adds an additional belts-and-suspenders check for invalid timestamps read from log files so we don't create PHP errors when passing the invalid timestamps to the _date_create_from_format()_ PHP function.

**New Features:**
1. Add new drop-down selector on the INTERFACES EDIT tab to allow the selection of the Single-Pattern Matcher algorithm. Formerly this parameter was defaulted in the code and not user adjustable.

**Bug Fixes:**
1. Adjust Help text for the CLEAR button on the ALERTS tab to clarify that it only clears the currently active alerts log file and not all logs (original help text was misleading).
2. Add a try-catch exception handler around the call to the PHP function _date_create_from_format()_ in both the ALERTS tab and BLOCKS tab code to catch and handle any potential error from passing the function an invalid timestamp.