### PR TITLE
pfSense-pkg-arpwatch: Add Slack messaging

### DIFF
--- a/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.inc
+++ b/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.inc
@@ -252,6 +252,9 @@ if ((false !== $message) && ((false === strpos($message, ': Cron ')) ||
 	$send_subject = "{$config['system']['hostname']}.{$config['system']['domain']} - Arpwatch Notification : {$subject[1]}";
 
 	send_smtp_message($message, $send_subject);
+	if (function_exists('notify_via_slack')) {
+		notify_via_slack($send_subject . " - " . $message);
+	}
 	if (function_exists('notify_via_telegram')) {
 		notify_via_telegram($send_subject . " - " . $message);
 	}


### PR DESCRIPTION
This PR enhances the arpwatch package, so that Slack messages, if so configured, are sent during notifications, in addition to the existing email, telegram, and/or pushover notifications. 

Thanks!