### PR TITLE
Version 2.8.2_1

### DIFF
--- a/sysutils/pfSense-pkg-nut/Makefile
+++ b/sysutils/pfSense-pkg-nut/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	pfSense-pkg-nut
 PORTVERSION=	2.8.2
+PORTREVISION=	1
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-pkg-nut/files/usr/local/pkg/nut/nut.inc
+++ b/sysutils/pfSense-pkg-nut/files/usr/local/pkg/nut/nut.inc
@@ -82,14 +82,19 @@ function nut_write_rcfile($driver) {
 		$start .= "\n	/usr/bin/killall -q -9 $driver";
 	}
 
-	/* Service status keys off upsmon, so start it first. */
-	$start .= "\n	/usr/local/sbin/upsmon";
 	if (isset($driver)) {
 		$start .= "\n	/usr/local/sbin/upsdrvctl start &";
-		/* Since we are starting the driver in backgroud, give it a moment to start. */
-		$start .= "\n	sleep 1";
 		$start .= "\n	/usr/local/sbin/upsd -u root";
+
+		/*
+		 * Since we are starting the driver in backgroud, give
+		 * the driver and upsd a moment to start.
+		 */
+		$start .= "\n	sleep 1";
 	}
+
+	/* NB: Service status keys off of upsmon. */
+	$start .= "\n	/usr/local/sbin/upsmon";
 	$start .= "\n	return 0";
 
 	$stop = "echo stopping NUT";


### PR DESCRIPTION
Redmine issue [15119](https://redmine.pfsense.org/issues/15119).

Update nut startup script to avoid ups failure notifications on nut restart following interface changes.