### PR TITLE
pfSense-pkg-suricata-7.0.3 - Fix Redmine Issues 15240, 15241, and 15242. Update for latest 7.0.3 upstream binary

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,8 +1,8 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	7.0.2
-PORTREVISION=	3
+PORTVERSION=	7.0.3
+PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=7.0.2_6:security/suricata
+RUN_DEPENDS=	suricata>=7.0.3:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2024 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -118,6 +118,12 @@ if (!defined("ABUSE_SSLBL_DNLD_FILENAME"))
 	define("ABUSE_SSLBL_DNLD_FILENAME", "sslblacklist_tls_cert.tar.gz");
 if (!defined("ABUSE_SSLBL_DNLD_URL"))
 	define("ABUSE_SSLBL_DNLD_URL", "https://sslbl.abuse.ch/blacklist/");
+
+# MaxMind GeoIP2 database update permalink URLs
+if (!defined("MAXMIND_GEOIP2_DNLD_URL"))
+	define("MAXMIND_GEOIP2_DNLD_URL", "https://download.maxmind.com/geoip/databases/GeoLite2-Country/download?suffix=tar.gz");
+if (!defined("MAXMIND_GEOIP2_SHA256_DNLD_URL"))
+	define("MAXMIND_GEOIP2_SHA256_DNLD_URL", "https://download.maxmind.com/geoip/databases/GeoLite2-Country/download?suffix=tar.gz.sha256");
 
 if (!defined("VRT_FILE_PREFIX"))
 	define("VRT_FILE_PREFIX", "snort_");

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2024 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1309,6 +1309,7 @@ else
 	$suricata_use_syslog_priority = "notice";
 
 // Configure IPS operational mode
+$livedev_tracking = "true";
 if ($suricatacfg['ips_mode'] == 'ips_mode_inline' && $suricatacfg['blockoffenders'] == 'on') {
 	// Get 'netmap_threads' parameter, if set
 	$netmap_threads_param = 'auto';
@@ -1317,6 +1318,7 @@ if ($suricatacfg['ips_mode'] == 'ips_mode_inline' && $suricatacfg['blockoffender
 	}
 
 	$if_netmap = $if_real;
+	$livedev_tracking = "false";
 
 	// For VLAN interfaces, need to actually run Suricata
 	// on the parent interface, so override interface name.

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -192,6 +192,11 @@ if ($suricatacfg['block_drops_only'] == 'on')
 else
 	$suri_blockdrops = "no";
 
+if ($suricatacfg['passlist_debug_log'] == 'on')
+	$suri_passlist_debugging = "yes";
+else
+	$suri_passlist_debugging = "no";
+
 if ($suricatacfg['blockoffendersip'] == 'src')
 	$suri_blockip = 'SRC';
 elseif ($suricatacfg['blockoffendersip'] == 'dst')

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2024 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +37,7 @@ require("/usr/local/pkg/suricata/suricata_defs.inc");
 /* and stores the result in the file specified by $tmpfile.    */
 /* The HTTP response code is retuned when $result is not NULL. */
 /***************************************************************/
-function suricata_download_geoip_file($url, $tmpfile, &$result = NULL) {
+function suricata_download_geoip_file($url, $tmpfile, $user, $pwd, &$result = NULL) {
 
 	global $g;
 
@@ -64,6 +64,7 @@ function suricata_download_geoip_file($url, $tmpfile, &$result = NULL) {
 	curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
 	curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 	curl_setopt($ch, CURLOPT_TIMEOUT, 0);
+	curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
 
 	// detect broken connection so it disconnects after +-10 minutes (with default TCP_KEEPIDLE and TCP_KEEPINTVL) to avoid waiting forever.
 	curl_setopt($ch, CURLOPT_TCP_KEEPALIVE, 1);
@@ -87,6 +88,10 @@ function suricata_download_geoip_file($url, $tmpfile, &$result = NULL) {
 			curl_setopt($ch, CURLOPT_PROXYUSERPWD, config_get_path('system/proxyuser') . ":" . config_get_path('system/proxypass'));
 		}
 	}
+
+	// Set the MaxMind Account ID and Password fields
+	curl_setopt($ch, CURLOPT_USERPWD, "{$user}:{$pwd}");
+
 	$rc = curl_exec($ch);
 	if ($rc === true) {
 		switch ($response = curl_getinfo($ch, CURLINFO_RESPONSE_CODE)) {
@@ -129,13 +134,13 @@ else
 // Create a temporary location to download the database to
 safe_mkdir($geoip_tmppath);
 
-// Get the MD5 hash of the current database archive file if available,
-// otherwise use a MD5 zero hash.
-if (file_exists($suricata_geoip_dbdir . "GeoLite2-Country.mmdb.tar.gz.md5")) {
-	$md5_hash = file_get_contents($suricata_geoip_dbdir . "GeoLite2-Country.mmdb.tar.gz.md5");
+// Get the SHA256 hash of the current database archive file if available,
+// otherwise use a SHA256 zero hash.
+if (file_exists($suricata_geoip_dbdir . "GeoLite2-Country.mmdb.tar.gz.sha256")) {
+	$sha256_hash = file_get_contents($suricata_geoip_dbdir . "GeoLite2-Country.mmdb.tar.gz.sha256");
 }
 else {
-	$md5_hash = "d41d8cd98f00b204e9800998ecf8427e"; // zero hash
+	$sha256_hash = "d41d8cd98f00b204e9800998ecf8427e"; // zero hash
 }
 
 $result = "";
@@ -143,17 +148,21 @@ $result = "";
 // Set the output filenames for the downloaded DB archives
 $dbtarfile = $geoip_tmppath . "GeoLite2-Country.mmdb.tar.gz";
 $dbfile = $geoip_tmppath . "GeoLite2-Country.mmdb";
-$md5file = $geoip_tmppath . "GeoLite2-Country.mmdb.tar.gz.md5";
+$sha256file = $geoip_tmppath . "GeoLite2-Country.mmdb.tar.gz.sha256";
 
 // Set the URL strings with the user's license key.
-$dbfile_url = "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=" . config_get_path('installedpackages/suricata/config/0/maxmind_geoipdb_key') . "&suffix=tar.gz";
-$md5file_url = "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=" . config_get_path('installedpackages/suricata/config/0/maxmind_geoipdb_key') . "&suffix=tar.gz.md5";
+$dbfile_url = MAXMIND_GEOIP2_DNLD_URL;
+$sha256file_url = MAXMIND_GEOIP2_SHA256_DNLD_URL;
 
-// First check the MD5 of the DB we have (if any) against the latest on the 
-// MaxMind site to see if we already have the most current DB file version.
-if (suricata_download_geoip_file($md5file_url, $md5file, $result) && ($result == 200 || $result == 201)) {
-	if (file_exists($md5file)) {
-		if ($md5_hash == file_get_contents($md5file)) {
+// Set MaxMind GeoLite2 Account ID and Password variables
+$user = config_get_path('installedpackages/suricata/config/0/maxmind_geoipdb_uid');
+$pwd = config_get_path('installedpackages/suricata/config/0/maxmind_geoipdb_key');
+
+// First check the SHA256 hash of the DB we have (if any) against the latest on 
+// the MaxMind site to see if we already have the most current DB file version.
+if (suricata_download_geoip_file($sha256file_url, $sha256file, $user, $pwd, $result) && ($result == 200 || $result == 201)) {
+	if (file_exists($sha256file)) {
+		if ($sha256_hash == file_get_contents($sha256file)) {
 			syslog(LOG_NOTICE, "[Suricata] The GeoLite2-Country IP database is up-to-date.");
 			$notify_message .= gettext("- MaxMind GeoLite2 IP database is up-to-date.\n");
 		} else {
@@ -174,17 +183,17 @@ safe_mkdir($suricata_geoip_dbdir);
 $result = "";
 
 // Attempt to download the GeoIP database from MaxMind
-if ($needs_update && suricata_download_geoip_file($dbfile_url, $dbtarfile, $result)) {
+if ($needs_update && suricata_download_geoip_file($dbfile_url, $dbtarfile, $user, $pwd, $result)) {
 
 	// If the file downloaded successfully, unpack it and store the DB
-	// and MD5 files in the PBI_BASE/share/suricata/GeoLite2 directory.
+	// and SHA256 files in the PBI_BASE/share/suricata/GeoLite2 directory.
 	if (file_exists($dbtarfile) && ($result == 200 || $result == 201)) {
 		syslog(LOG_NOTICE, "[Suricata] New GeoLite2-Country IP database gzip archive successfully downloaded.");
 		syslog(LOG_NOTICE, "[Suricata] Extracting new GeoLite2-Country database from the archive...");
 		mwexec("/usr/bin/tar -xzf {$dbtarfile} --strip=1 -C {$geoip_tmppath}");
 		syslog(LOG_NOTICE, "[Suricata] Moving new database to {$suricata_geoip_dbdir}GeoLite2-Country.mmdb...");
 		@rename($dbfile, "{$suricata_geoip_dbdir}GeoLite2-Country.mmdb");
-		@rename($md5file, "{$suricata_geoip_dbdir}GeoLite2-Country.mmdb.tar.gz.md5");
+		@rename($sha256file, "{$suricata_geoip_dbdir}GeoLite2-Country.mmdb.tar.gz.sha256");
 		syslog(LOG_NOTICE, "[Suricata] GeoLite2-Country database update completed.");
 		$notify_message .= gettext("- MaxMind GeoLite2 IP database update completed.\n");
 	} else {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
@@ -135,12 +135,12 @@ else
 safe_mkdir($geoip_tmppath);
 
 // Get the SHA256 hash of the current database archive file if available,
-// otherwise use a SHA256 zero hash.
+// otherwise use a SHA256 zero-length file hash.
 if (file_exists($suricata_geoip_dbdir . "GeoLite2-Country.mmdb.tar.gz.sha256")) {
 	$sha256_hash = file_get_contents($suricata_geoip_dbdir . "GeoLite2-Country.mmdb.tar.gz.sha256");
 }
 else {
-	$sha256_hash = "d41d8cd98f00b204e9800998ecf8427e"; // zero hash
+	$sha256_hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  GeoLite2-Country_20240206.tar.gz"; // zero-length file hash
 }
 
 $result = "";

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
@@ -155,8 +155,8 @@ $dbfile_url = MAXMIND_GEOIP2_DNLD_URL;
 $sha256file_url = MAXMIND_GEOIP2_SHA256_DNLD_URL;
 
 // Set MaxMind GeoLite2 Account ID and Password variables
-$user = config_get_path('installedpackages/suricata/config/0/maxmind_geoipdb_uid');
-$pwd = config_get_path('installedpackages/suricata/config/0/maxmind_geoipdb_key');
+$user = config_get_path('installedpackages/suricata/config/0/maxmind_geoipdb_uid', "");
+$pwd = config_get_path('installedpackages/suricata/config/0/maxmind_geoipdb_key', "");
 
 // First check the SHA256 hash of the DB we have (if any) against the latest on 
 // the MaxMind site to see if we already have the most current DB file version.

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2024 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -115,7 +115,7 @@ if (!empty($widgets)) {
 		}
 	}
 	config_set_path('widgets/sequence', implode(",", $widgetlist));
-	write_config("Suricata pkg removed Dashboard Alerts widget.");
+	write_config("Suricata pkg removed Dashboard Alerts widget.", false);
 }
 
 // See if we are to clear blocked hosts on uninstall

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -49,7 +49,7 @@ outputs:
       pass-list: {$suri_passlist}
       block-ip: {$suri_blockip}
       pf-table: {$suri_pf_table}
-      passlist-debugging: no   # Do not enable debugging on production systems!
+      passlist-debugging: {$suri_passlist_debugging}   # Do not enable debugging on production systems!
 
   # a line based alerts log similar to Snort's fast.log
   - fast:

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -198,6 +198,12 @@ flow:
 vlan:
   use-for-tracking: true
 
+# This option controls the use of livedev ids in the flow (and defrag)
+# hashing. This is enabled by default and should be disabled if
+# netmap is used with a host stack interface.
+livedev:
+  use-for-tracking: {$livedev_tracking}
+
 # Specific timeouts for flows.
 flow-timeouts:
   default:

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_blocked.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2024 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -298,7 +298,7 @@ print($form);
 			$tmpblocked = array_flip($blocked_ips_array);
 			$src_ip_list = array();
 
-			foreach (glob("{$suricatalogdir}*/block.log*") as $alertfile) {
+			foreach (glob("{$suricatalogdir}*/block.log") as $alertfile) {
 				$fd = fopen($alertfile, "r");
 				if ($fd) {
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2024 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,6 +55,7 @@ else {
 	$pconfig['snortcommunityrules'] = config_get_path('installedpackages/suricata/config/0/snortcommunityrules') == "on" ? 'on' : 'off';
 	$pconfig['snort_rules_file'] = htmlentities(config_get_path('installedpackages/suricata/config/0/snort_rules_file'));
 	$pconfig['autogeoipupdate'] = config_get_path('installedpackages/suricata/config/0/autogeoipupdate') == "on" ? 'on' : 'off';
+	$pconfig['maxmind_geoipdb_uid'] = htmlentities(config_get_path('installedpackages/suricata/config/0/maxmind_geoipdb_uid'));
 	$pconfig['maxmind_geoipdb_key'] = htmlentities(config_get_path('installedpackages/suricata/config/0/maxmind_geoipdb_key'));
 	$pconfig['hide_deprecated_rules'] = config_get_path('installedpackages/suricata/config/0/hide_deprecated_rules') == "on" ? 'on' : 'off';
 	$pconfig['enable_etopen_custom_url'] = config_get_path('installedpackages/suricata/config/0/enable_etopen_custom_url') == "on" ? 'on' : 'off';
@@ -219,6 +220,7 @@ if (!$input_errors) {
 		config_set_path('installedpackages/suricata/config/0/etpro_custom_rule_url', trim(html_entity_decode($_POST['etpro_custom_rule_url'])));
 		config_set_path('installedpackages/suricata/config/0/snort_custom_url', trim(html_entity_decode($_POST['snort_custom_url'])));
 		config_set_path('installedpackages/suricata/config/0/gplv2_custom_url', trim(html_entity_decode($_POST['gplv2_custom_url'])));
+		config_set_path('installedpackages/suricata/config/0/maxmind_geoipdb_uid', trim(html_entity_decode($_POST['maxmind_geoipdb_uid'])));
 		config_set_path('installedpackages/suricata/config/0/maxmind_geoipdb_key', trim(html_entity_decode($_POST['maxmind_geoipdb_key'])));
 
 		/* Check and adjust format of Rule Update Starttime string to add colon and leading zero if necessary */
@@ -545,6 +547,15 @@ $section->addInput(new Form_Checkbox(
 	'on'
 ))->setHelp('When enabled, Suricata will automatically download updates for the free GeoLite2 country IP database.<br /><br />If you have a subscription for more current GeoIP2 updates, uncheck this option and instead create your own process to place the required database file in /usr/local/share/suricata/GeoLite2/.');
 $section->addInput(new Form_Input(
+	'maxmind_geoipdb_uid',
+	gettext('GeoLite2 DB Account ID'),
+	'text',
+	$pconfig['maxmind_geoipdb_uid'],
+	['placeholder' => 'Enter your MaxMind GeoLite2 Account ID']
+))->setHelp('To utilize the free MaxMind GeoLite2 GeoIP functionality, you must <a href="https://www.maxmind.com/en/geolite2/signup" target="_blank">register for a free MaxMind user account</a>. '
+	. '<strong>Use the GeoIP Update version 3.1.1 or newer registration option.</strong>')
+  ->setAttribute('autocomplete', 'off');
+$section->addInput(new Form_Input(
 	'maxmind_geoipdb_key',
 	gettext('GeoLite2 DB License Key'),
 	'text',
@@ -721,6 +732,7 @@ events.push(function(){
 
 	function enable_geoip2_upd() {
 		var hide = ! $('#autogeoipupdate').prop('checked');
+		hideInput('maxmind_geoipdb_uid', hide);
 		hideInput('maxmind_geoipdb_key', hide);
 	}
 

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2024 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -824,8 +824,8 @@ if ($savemsg2) {
 }
 
 // If using Inline IPS, check that CSO, TSO and LRO are all disabled
-if ($pconfig['enable'] == 'on' && $pconfig['ips_mode'] == 'ips_mode_inline' && (!config_path_enabled('system','disablechecksumoffloading') || !config_path_enabled('system', 'disablesegmentationoffloading') || !config_path_enabled('system', 'disablelargereceiveoffloading'))) {
-	print_info_box(gettext('WARNING! IPS inline mode requires that Hardware Checksum Offloading, Hardware TCP Segmentation Offloading and Hardware Large Receive Offloading ' .
+if ($pconfig['enable'] == 'on' && (!config_path_enabled('system','disablechecksumoffloading') || !config_path_enabled('system', 'disablesegmentationoffloading') || !config_path_enabled('system', 'disablelargereceiveoffloading'))) {
+	print_info_box(gettext('WARNING! Suricata now requires that Hardware Checksum Offloading, Hardware TCP Segmentation Offloading and Hardware Large Receive Offloading ' .
 				'all be disabled for proper operation. This firewall currently has one or more of these Offloading settings NOT disabled. Visit the ') . '<a href="/system_advanced_network.php">' . 
 			        gettext('System > Advanced > Networking') . '</a>' . gettext(' tab and ensure all three of these Offloading settings are disabled.'));
 }

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces_edit.php
@@ -156,6 +156,8 @@ if (empty($pconfig['ips_netmap_threads']))
 	$pconfig['ips_netmap_threads'] = 'auto';
 if (empty($pconfig['block_drops_only']))
 	$pconfig['block_drops_only'] = "off";
+if (empty($pconfig['passlist_debug_log']))
+	$pconfig['passlist_debug_log'] = "off";
 if (empty($pconfig['runmode']))
 	$pconfig['runmode'] = "autofp";
 if (empty($pconfig['autofp_scheduler']))
@@ -504,6 +506,7 @@ if (isset($_POST["save"]) && !$input_errors) {
 		if ($_POST['ips_netmap_threads']) $natent['ips_netmap_threads'] = $_POST['ips_netmap_threads']; else $natent['ips_netmap_threads'] = "auto";
 		if ($_POST['blockoffenderskill'] == "on") $natent['blockoffenderskill'] = 'on'; else $natent['blockoffenderskill'] = 'off';
 		if ($_POST['block_drops_only'] == "on") $natent['block_drops_only'] = 'on'; else $natent['block_drops_only'] = 'off';
+		if ($_POST['passlist_debug_log'] == "on") $natent['passlist_debug_log'] = 'on'; else $natent['passlist_debug_log'] = 'off';
 		if ($_POST['blockoffendersip']) $natent['blockoffendersip'] = $_POST['blockoffendersip']; else unset($natent['blockoffendersip']);
 		if ($_POST['passlistname']) $natent['passlistname'] =  $_POST['passlistname']; else unset($natent['passlistname']);
 		if ($_POST['homelistname']) $natent['homelistname'] =  $_POST['homelistname']; else unset($natent['homelistname']);
@@ -1778,6 +1781,15 @@ $group->setHelp('The default Pass List adds Gateways, DNS servers, locally-attac
 		'This option will only be used when block offenders is on.  Choosing "none" will disable Pass List generation.');
 $section->add($group);
 
+$section->addInput(new Form_Checkbox(
+	'passlist_debug_log',
+	'Enable Passlist Debugging Log',
+	'Checking this option will enable detailed Passlist operations logging to file ' .
+	$suricatalogdir . 'suricata_' . $if_real . $suricata_uuid . '/passlist_debug.log.  Default is Not Checked.',
+	$pconfig['passlist_debug_log'] == 'on' ? true:false,
+	'on'
+));
+
 $form->add($section);
 
 // Add Inline IPS rule edit warning modal pop-up
@@ -2049,6 +2061,7 @@ events.push(function(){
 		var hide = ! $('#blockoffenders').prop('checked');
 		hideCheckbox('blockoffenderskill', hide);
 		hideCheckbox('block_drops_only', hide);
+		hideCheckbox('passlist_debug_log', hide);
 		hideSelect('blockoffendersip', hide);
 		hideSelect('ips_mode', hide);
 		hideClass('passlist', hide);
@@ -2056,6 +2069,7 @@ events.push(function(){
 			hideInput('ips_netmap_threads', hide);
 			hideCheckbox('blockoffenderskill', true);
 			hideCheckbox('block_drops_only', true);
+			hideCheckbox('passlist_debug_log', true);
 			hideSelect('blockoffendersip', true);
 			hideClass('passlist', true);
 			hideInput('intf_snaplen', true);
@@ -2278,6 +2292,7 @@ events.push(function(){
 		disableInput('ips_mode', disable);
 		disableInput('blockoffenderskill', disable);
 		disableInput('block_drops_only', disable);
+		disableInput('passlist_debug_log', disable);
 		disableInput('blockoffendersip', disable);
 		disableInput('ips_netmap_threads', disable);
 		disableInput('performance', disable);
@@ -2573,6 +2588,7 @@ events.push(function(){
 		if ($('#ips_mode').val() == 'ips_mode_inline') {
 			hideCheckbox('blockoffenderskill', true);
 			hideCheckbox('block_drops_only', true);
+			hideCheckbox('passlist_debug_log', true);
 			hideSelect('blockoffendersip', true);
 			hideClass('passlist', true);
 			hideInput('intf_snaplen', true);
@@ -2583,6 +2599,7 @@ events.push(function(){
 		else {
 			hideCheckbox('blockoffenderskill', false);
 			hideCheckbox('block_drops_only', false);
+			hideCheckbox('passlist_debug_log', false);
 			hideSelect('blockoffendersip', false);
 			hideInput('intf_snaplen', false);
 			hideClass('passlist', false);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/widgets/widgets/suricata_alerts.widget.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/widgets/widgets/suricata_alerts.widget.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2024 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -137,6 +137,10 @@ function suricata_widget_get_alerts() {
 					$fields = array();
 					$tmp = array();
 
+					// Drop any invalid line read from the log excerpt
+					if (empty(trim($buf)))
+						continue;
+
 					// Parse alert log entry to find the parts we want to display
 					$fields[0] = substr($buf, 0, strpos($buf, '  '));
 
@@ -180,17 +184,14 @@ function suricata_widget_get_alerts() {
 
 					// Create a DateTime object from the event timestamp that
 					// we can use to easily manipulate output formats.
-					if (($event_tm = date_create_from_format("m/d/Y-H:i:s.u", $fields[0])) !== FALSE) {
+					try {
+						$event_tm = date_create_from_format("m/d/Y-H:i:s.u", $fields[0]);
 						$suricata_alerts[$counter]['timestamp'] = strval(date_timestamp_get($event_tm));
 						$suricata_alerts[$counter]['timeonly'] = date_format($event_tm, "H:i:s");
 						$suricata_alerts[$counter]['dateonly'] = date_format($event_tm, "M d");
-					}
-					else {
-						// For some reason the event timestamp was invalid, 
-						// set some default empty values for the fields.
-						$suricata_alerts[$counter]['timestamp'] = 0;
-						$suricata_alerts[$counter]['timeonly'] = ' ';
-						$suricata_alerts[$counter]['dateonly'] = ' ';
+					} catch (Exception $e) {
+						syslog(LOG_WARNING, "[suricata] WARNING: Dashboard Widget found invalid timestamp entry in current alerts.log, the line will be ignored and skipped.");
+						continue;
 					}
 
 					// Check the 'CATEGORY' field for the text "(null)" and


### PR DESCRIPTION
### pfSense-pkg-suricata-7.0.3
This update to the Suricata GUI package addresses three Redmine Issues and updates the GUI for the latest 7.0.3 binary from upstream.

**New Features:**
1. Exposed passlist debugging option in the GUI on the INTERFACE SETTINGS tab.

**Bug Fixes:**
1. [Redmine Issue #15240](https://redmine.pfsense.org/issues/15240), GeoIP2 database download/update procedure broken due to recent MaxMind API change.
2. [Redmine Issue #15241](https://redmine.pfsense.org/issues/15241), add protection for blank lines in alerts.log to Suricata Dashboard Widget code.
3. [Redmine Issue #15242](https://redmine.pfsense.org/issues/15242), examine all calls to _write_config()_ to see when it is appropriate to set "$backup" parameter to "false" to prevent unneccessary _config.xml_ backups.