### PR TITLE
pfSense-pkg-suricata-7.0.3_1_RELENG_2_7_2 - Fix Redmine 15312, unable to load rules tab with no categories selected

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	7.0.3
-PORTREVISION=	0
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2024 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -172,9 +172,10 @@ if (empty($categories) && ($currentruleset != "custom.rules") && ($currentrulese
 		$currentruleset = "custom.rules";
 }
 
-/* One last sanity check -- if the rules directory is empty, default to loading custom rules */
+// One last sanity check -- if the rules directory is empty, or we were
+// not passed a ruleset name to load, default to loading custom rules.
 $tmp = glob("{$suricata_rules_dir}*.rules");
-if (empty($tmp))
+if (empty($tmp) || empty($currentruleset))
 	$currentruleset = "custom.rules";
 
 $ruledir = SURICATA_RULES_DIR;


### PR DESCRIPTION
### pfSense-pkg-suricata-7.0.3_1_RELENG_2_7_2
This update for the Suricata GUI package corrects a bug identified by [Redmine Issue 15312](https://redmine.pfsense.org/issues/15312).

**New Features:**
none

**Bug Fixes:**
1. Fix [Redmine Issue 15312](https://redmine.pfsense.org/issues/15312) - Unable to load rules page with no categories selected.