### PR TITLE
pfSense-pkg-suricata-7.0.4_1_RELENG_2_7_2 -- Refactor fix for Redmine Isseu 15350.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	7.0.4
-PORTREVISION=	0
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -40,8 +40,7 @@ require("/usr/local/pkg/suricata/suricata_defs.inc");
 global $g;
 
 // Suricata GUI needs at least 512MB to manipulate large rules arrays
-if (get_php_default_memory($ARCH) < 512)
-	ini_set("memory_limit", "512M");
+ini_set("memory_limit", config_get_path('system/php_memory_limit', '512') . "M");
 
 function suricata_generate_id() {
 


### PR DESCRIPTION
### pfSense-pkg-suricata-7.0.4_1
This update to the Suricata GUI package refactors the original fix for [Redmine Issue 15350](https://redmine.pfsense.org/issues/15350). The original code contained a logic error.

**New Features:**
none

**Bug Fixes:**
1. Refactor code for the [Redmine 15350 Issue](https://redmine.pfsense.org/issues/15350) fix as the original code had a logic flaw resulting in the user-specified PHP Memory Limit still not being honored.