### PR TITLE
Fix pfBlockerNg DNSBL IP Enable Logging input issue

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -3292,15 +3292,12 @@ function enable_python_gp() {
 }
 
 function enable_dnsblip() {
-	var dnsblip = $('#action').prop('checked'); 
-	hideInput('aliaslog', !dnsblip);
-	hideInput('dnsbl_ip_text_in', !dnsblip);
-	hideInput('dnsbl_ip_text_out', !dnsblip);
-
 	if ($('#action').val() != 'Disabled') {
+		hideInput('aliaslog', false);
 		$('#advinboundsettings').show();
 		$('#advoutboundsettings').show();
 	} else {
+		hideInput('aliaslog', true);
 		$('#advinboundsettings').hide();
 		$('#advoutboundsettings').hide();
 	}

--- a/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/net/pfSense-pkg-pfBlockerNG/files/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -3292,15 +3292,12 @@ function enable_python_gp() {
 }
 
 function enable_dnsblip() {
-	var dnsblip = $('#action').prop('checked'); 
-	hideInput('aliaslog', !dnsblip);
-	hideInput('dnsbl_ip_text_in', !dnsblip);
-	hideInput('dnsbl_ip_text_out', !dnsblip);
-
 	if ($('#action').val() != 'Disabled') {
+		hideInput('aliaslog', false);
 		$('#advinboundsettings').show();
 		$('#advoutboundsettings').show();
 	} else {
+		hideInput('aliaslog', true);
 		$('#advinboundsettings').hide();
 		$('#advoutboundsettings').hide();
 	}


### PR DESCRIPTION
Enable Logging (`aliaslog`) is always hidden because List Action (`action`) is not a checkbox, it is a dropdown.

`dnsbl_ip_text_in` and `dnsbl_ip_text_out` don't appear to exist.