### PR TITLE
Fix Redmine 13444 - Add zabbix agent+proxy package log files owner and mode (fixes log rotations)

### DIFF
--- a/net-mgmt/pfSense-pkg-zabbix-agent/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME?=	pfSense-pkg-zabbix-agent
 PORTVERSION=	1.0.6
-PORTREVISION?=	0
+PORTREVISION?=	1
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-zabbix-agent/files/usr/local/share/pfSense-pkg-zabbix-agent/info.xml
+++ b/net-mgmt/pfSense-pkg-zabbix-agent/files/usr/local/share/pfSense-pkg-zabbix-agent/info.xml
@@ -18,6 +18,8 @@
 		<configurationfile>zabbixagent.xml</configurationfile>
 		<logging>
 			<logfilename>zabbix-agent/zabbix_agentd.log</logfilename>
+			<logowner>zabbix:zabbix</logowner>
+			<logmode>664</logmode>
 		</logging>
 	</package>
 </pfsensepkgs>

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/Makefile
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME?=	pfSense-pkg-zabbix-proxy
 PORTVERSION=	1.0.6
-PORTREVISION?=	0
+PORTREVISION?=	1
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/share/pfSense-pkg-zabbix-proxy/info.xml
+++ b/net-mgmt/pfSense-pkg-zabbix-proxy/files/usr/local/share/pfSense-pkg-zabbix-proxy/info.xml
@@ -18,6 +18,8 @@
 		<configurationfile>zabbixproxy.xml</configurationfile>
 		<logging>
 			<logfilename>zabbix-proxy/zabbix_proxy.log</logfilename>
+			<logowner>zabbix:zabbix</logowner>
+			<logmode>664</logmode>
 		</logging>
 	</package>
 </pfsensepkgs>


### PR DESCRIPTION
[Redmine Issue 13444](https://redmine.pfsense.org/issues/13444)

Fixes the permissions issue for the zabbix agent and proxy packages log files that occurs upon log rotation.

The log rotation would incorrectly set the user/group to the (default) `root:wheel` and set (default) permissions `600`.
This would prevent the zabbix agent and proxy from writing to their log files until their services were restarted.

This issue would appear in the logs `Status > System Logs > Packages > Zabbix Agent/Proxy` as follows:
```
# Zabbix Agent Log Entries
zabbix_agentd [75082]: failed to open log file: [13] Permission denied
zabbix_agentd [75082]: failed to open log file: [13] Permission denied
zabbix_agentd [75082]: failed to open log file: [13] Permission denied
zabbix_agentd [75082]: failed to open log file: [13] Permission denied
zabbix_agentd [75082]: failed to open log file: [13] Permission denied
   ### lines above repeat ###
Apr 30 04:22:00 pfSense-Tests newsyslog[75419]: logfile turned over due to size>500K

# Zabbix Proxy Log Entries
zabbix_proxy [66641]: failed to open log file: [13] Permission denied
zabbix_proxy [65053]: failed to open log file: [13] Permission denied
zabbix_proxy [63805]: failed to open log file: [13] Permission denied
zabbix_proxy [64771]: failed to open log file: [13] Permission denied
zabbix_proxy [65545]: failed to open log file: [13] Permission denied
   ### lines above repeat ###
Apr 30 03:49:00 pfSense-Tests newsyslog[20325]: logfile turned over due to size>500K`
```