### PR TITLE
Fix for rpz zone located in several views at the same time

### DIFF
--- a/dns/pfSense-pkg-bind/files/usr/local/pkg/bind.inc
+++ b/dns/pfSense-pkg-bind/files/usr/local/pkg/bind.inc
@@ -357,8 +357,9 @@ EOD;
 
 		$rpz_zones = array();
 		foreach ($bindzone as $zone) {
-			if (isset($zone['rpz']) && ($zone['rpz'] == "on") &&
-			    ($zone['disabled'] != "on") && ($zone['view'] == $viewname)) {
+                        $ZoneViews = explode(',',$zone['view']);
+                        if (isset($zone['rpz']) && ($zone['rpz'] == "on") &&
+                           ($zone['disabled'] != "on") && in_array($viewname, $ZoneViews)) {
 			    $rpz_zones[] = reverse_zonename($zone['name'], $zone['reverso'], $zone['reversv6o']);
 			}
 		}


### PR DESCRIPTION
This is a fix for bug with wrong generation of **response-policy** parameter in **View** sections of named.conf when for single rpz zone selected multiple views