### PR TITLE
pfSense-pkg-suricata-7.0.6_RELENG_2_7_2 - Update GUI package to support latest 7.0.6 version from upstream.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,8 +1,8 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	7.0.4
-PORTREVISION=	1
+PORTVERSION=	7.0.6
+PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=7.0.4:security/suricata
+RUN_DEPENDS=	suricata>=7.0.6:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2024 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -4148,7 +4148,7 @@ function suricata_get_vpns_list() {
 			}
 			/* Mobile warriors */
 			if (config_path_enabled('ipsec', 'mobilekey')) {
-				foreach (config_get_path('ipsec/mobilekey') as $key) {
+				foreach (config_get_path('ipsec/mobilekey', []) as $key) {
 					if (!empty($key['pool_address']) &&
 					    !empty($key['pool_netbits'])) {
 						$vpns_subnet = "{$key['pool_address']}/{$key['pool_netbits']}";

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2024 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -442,7 +442,7 @@ $last_curl_error = "";
 $update_errors = false;
 
 /* Ensure our basic config array of interfaces exists to prevent PHP foreach() errors */
-init_config_arr(array('installedpackages', 'suricata', 'rule'));
+config_init_path('installedpackages/suricata/rule');
 
 /* Save current state (running/not running) for each enabled Suricatat interface */
 $active_interfaces = array();

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
@@ -61,7 +61,7 @@ if (!defined("SURICATA_BIN_VERSION")) {
 		define("SURICATA_BIN_VERSION", $suricataver);
 	else
 		// If we could not find a version, set a safe default
-		define("SURICATA_BIN_VERSION", "5.0.0");
+		define("SURICATA_BIN_VERSION", "7.0.6");
 }
 
 // Define the name of the pf table used for IP blocks

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_app_parsers.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2024 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,11 +37,10 @@ if (is_null($id))
 	$id = 0;
 
 // Initialize Suricata interface and HTTP libhtp engine arrays if necessary
-init_config_arr( array( 'installedpackages' , 'suricata' , 'rule') );
-init_config_arr( array('installedpackages', 'suricata', 'rule', $id, 'libhtp_policy', 'item') );
+config_init_path("installedpackages/suricata/rule/{$id}/libhtp_policy/item");
 
 // Initialize required array variables as necessary
-init_config_arr( array('aliases', 'alias') );
+config_init_path('aliases/alias');
 $a_aliases = config_get_path('aliases/alias', []);
 
 $a_nat = config_get_path("installedpackages/suricata/rule/{$id}", []);


### PR DESCRIPTION
### pfSense-pkg-suricata-7.0.6
This updates the Suricata GUI package to support the latest 7.0.6 version of the binary from upstream. Also backported three small PHP fixes from the pfSense DEVEL branch submitted by @marcos-ng.

**New Features:**
none

**Bug Fixes:**
1. Move to config assessors.