### PR TITLE
Redmine #14299: pfBlockerNG does not honor the cURL source interface setting for DNSBL lists.

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8195,6 +8195,9 @@ function sync_package_pfblockerng($cron='') {
 				$pfb['domain_clear']	= FALSE;		// Flag to signal no Aliases defined or all Aliases disabled.
 				$alias_cnt		= 0;
 
+				// cURL Source Interface (sets CURLOPT_INTERFACE)
+				$srcint = $list['srcint'] ?: FALSE;
+
 				if ($list['action'] != 'Disabled' && isset($list['row'])) {
 					$alias				= "DNSBL_{$list['aliasname']}";
 					if (empty(pfb_filter($alias, PFB_FILTER_WORD, 'DNSBL - Processes'))) {


### PR DESCRIPTION
This pull request addresses [Redmine #14299](https://redmine.pfsense.org/issues/14299) (previous pull request for this issue has been closed).