### PR TITLE
Add Suricata custom variables #15674

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	7.0.6
-PORTREVISION=	0
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -86,7 +86,6 @@ foreach ($suricata_servers as $alias => $avalue) {
 	}
 	$addr_vars .= "    " . strtoupper($alias) . ": \"{$avalue}\"\n";
 }
-$addr_vars = trim($addr_vars);
 if(config_get_path('system/ssh/port'))
         $ssh_port = config_get_path('system/ssh/port');
 else
@@ -109,6 +108,18 @@ foreach ($suricata_ports as $alias => $avalue) {
 	}
 	$port_vars .= "    " . strtoupper($alias) . ": \"{$avalue}\"\n";
 }
+if ($suricatacfg['enable_extra_servers_ports']) {
+	foreach ($suricatacfg['extra_servers_ports']['item'] as $item) {
+		$avalue = trim(filter_expand_alias($item['value']));
+		$avalue = preg_replace('/\s+/', ', ', trim($avalue));
+		if ($item['type'] == 'server') {
+			$addr_vars .= "    " . strtoupper($item['name']) . ": \"{$avalue}\"\n";
+		} else {
+			$port_vars .= "    " . strtoupper($item['name']) . ": \"{$avalue}\"\n";
+		}
+	}
+}
+$addr_vars = trim($addr_vars);
 $port_vars = trim($port_vars);
 
 // Define a Suppress List (Threshold) if one is configured

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_define_vars.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_define_vars.php
@@ -91,6 +91,38 @@ if ($_POST) {
 		if ($_POST["def_{$key}"] && is_alias($_POST["def_{$key}"]) && trim(filter_expand_alias($_POST["def_{$key}"])) == "")
 			$input_errors[] = "FQDN aliases are not allowed for port variables in Suricata.";
 	}
+
+	if ($_POST['enable_extra_servers_ports']) {
+		for ($x = 0; $x < 99; $x++) {
+			if (isset($_POST["extra_name{$x}"]) && isset($_POST["extra_value{$x}"])) {
+				$type = $_POST["extra_server_or_port{$x}"];
+				$name = trim($_POST["extra_name{$x}"]);
+				$value = $_POST["extra_value{$x}"];
+				
+				if (preg_match("/[^A-Za-z0-9_]/", $name)) {
+					$input_errors[] = gettext("The extra variable name may only contain the characters A-Z, 0-9 and '_'.");
+				}
+				if ("" != $value) {
+					if (!is_alias($value)) {
+						$input_errors[] = "Only aliases are allowed";
+					} elseif (trim(filter_expand_alias($value)) == "") {
+						$input_errors[] = "FQDN aliases are not allowed for variables in Suricata.";
+					} elseif ($type == 'server' && $suricata_servers[strtolower($name)]) {
+						$input_errors[] = "'" . $name . "' is a standard server variable.";
+					} elseif ($type == 'port' && $suricata_ports[strtolower($name)]) {
+						$input_errors[] = "'" . $name . "' is a standard port variable.";
+					}
+				}
+				$extra_servers_ports['item'][] = array(
+					'type' => $type,
+					'name' => $name,
+					'value' => $value
+				);
+			}
+		}
+		$natent['extra_servers_ports'] = $extra_servers_ports;
+	}
+
 	/* if no errors write to suricata.yaml */
 	if (!$input_errors) {
 		/* post new options */
@@ -110,6 +142,8 @@ if ($_POST) {
 		// Save the updated interface configuration
 		$a_nat = $natent;
 		config_set_path("installedpackages/suricata/rule/{$id}", $a_nat);
+		config_set_path("installedpackages/suricata/rule/{$id}/enable_extra_servers_ports", $_POST['enable_extra_servers_ports'] ? 'on' : 'off');
+		config_set_path("installedpackages/suricata/rule/{$id}/extra_servers_ports", $extra_servers_ports);
 		write_config("Suricata pkg: saved changes for PORT or IP variables.");
 
 		/* Update the suricata.yaml file for this interface. */
@@ -232,6 +266,75 @@ foreach ($suricata_ports as $key => $server) {
 }
 $form->add($section);
 
+$section = new Form_Section('Enable Extra Variables');
+
+$section->addInput(new Form_Checkbox(
+	'enable_extra_servers_ports',
+	'Enable Extra Variables',
+	'Enable Extra Variables',
+	$pconfig['enable_extra_servers_ports'] == 'on' ? true:false,
+	'on'
+))->setHelp('Add extra custom servers and ports');
+
+$form->add($section);
+
+$section = new Form_Section('Define Extras Variables (Custom IP or port variables)');
+$section->addClass('extra_servers_ports');
+
+if (!$pconfig['extra_servers_ports']) {
+	$pconfig['extra_servers_ports'] = array();
+	$pconfig['extra_servers_ports']['item'] = array(array('type' => 'server', 'name' => '', 'value' => ''));
+}
+
+$counter = 0;
+$numrows = count($pconfig['extra_servers_ports']['item']) - 1;
+
+foreach ($pconfig['extra_servers_ports']['item'] as $item) {
+	$group = new Form_Group(($counter == 0) ? 'Variable':null);
+	$group->addClass('repeatable');
+
+	$group->add(new Form_Select(
+		'extra_server_or_port' . $counter,
+		'Server',
+		$item['type'],
+		['server' => 'Server', 'port' => 'Port']
+	))->setWidth(2)->setHelp($numrows == $counter ? 'Server or Port':null);;
+
+	$group->add(new Form_Input(
+		'extra_name'. $counter,
+		'Name',
+		'text',
+		$item['name']
+	))->setWidth(3)->setHelp($numrows == $counter ? 'Name':null);
+
+	$group->add(new Form_Input(
+		'extra_value'. $counter,
+		'Value',
+		'text',
+		$item['value']
+	))->setWidth(3)->setHelp($numrows == $counter ? 'Value':null);
+
+	$group->add(new Form_Button(
+		'deleterow' . $counter,
+		'Delete',
+		null,
+		'fa-trash'
+	))->addClass('btn-warning');
+	
+	$section->add($group);
+
+	$counter++;
+}
+
+$section->addInput(new Form_Button(
+	'addrow',
+	'Add',
+	null,
+	'fa-plus'
+))->addClass('btn-success');
+
+$form->add($section);
+
 print($form);
 
 ?>
@@ -252,6 +355,21 @@ events.push(function() {
 			echo '$("#def_' . $key . '").autocomplete({source: portsarray});' . "\n";
 	?>
 	}
+	
+	function show_extra_servers_ports() {
+		hide = !$('#enable_extra_servers_ports').prop('checked');
+		hideClass('extra_servers_ports', hide);
+	}
+
+	// ---------- Click checkbox handlers ---------------------------------------------------------
+	// When 'enable_extra_servers_ports' is clicked, show 'extra_servers_ports' list
+	$('#enable_extra_servers_ports').click(function () {
+		show_extra_servers_ports();
+	});
+
+	// ---------- On initial page load ------------------------------------------------------------
+	show_extra_servers_ports();
+	checkLastRow();
 
 	setTimeout(createAutoSuggest, 500);
 


### PR DESCRIPTION
Add the ability for the user to enter their own custom server and port variables on the Suricata define variables page.
implements #15674

devel branch has some changes to the classes used for add/delete icons so I've aimed at RELENG_2_7_2