### PR TITLE
pfSense-pkg-suricata-7.0.6_1 - Fix Redmine Issues 15713 and 15717 in Suricata GUI package

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	7.0.6
-PORTREVISION=	0
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -241,16 +241,7 @@ function suricata_download_file_url($url, $file_out) {
 		}
 
 		// Use the system proxy server setttings if configured
-		if (!empty(config_get_path('system/proxyurl'))) {
-			curl_setopt($ch, CURLOPT_PROXY, config_get_path('system/proxyurl'));
-			if (!empty(config_get_path('system/proxyport'))) {
-				curl_setopt($ch, CURLOPT_PROXYPORT, config_get_path('system/proxyport'));
-			}
-			if (!empty(config_get_path('system/proxyuser')) && !empty(config_get_path('system/proxypass'))) {
-				@curl_setopt($ch, CURLOPT_PROXYAUTH, CURLAUTH_ANY | CURLAUTH_ANYSAFE);
-				curl_setopt($ch, CURLOPT_PROXYUSERPWD, config_get_path('system/proxyuser') . ":" . config_get_path('system/proxypass'));
-			}
-		}
+		set_curlproxy($ch);
 
 		$counter = 0;
 		$rc = true;

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -86,7 +86,6 @@ foreach ($suricata_servers as $alias => $avalue) {
 	}
 	$addr_vars .= "    " . strtoupper($alias) . ": \"{$avalue}\"\n";
 }
-$addr_vars = trim($addr_vars);
 if(config_get_path('system/ssh/port'))
         $ssh_port = config_get_path('system/ssh/port');
 else
@@ -109,6 +108,18 @@ foreach ($suricata_ports as $alias => $avalue) {
 	}
 	$port_vars .= "    " . strtoupper($alias) . ": \"{$avalue}\"\n";
 }
+if ($suricatacfg['enable_extra_servers_ports'] == 'on') {
+	foreach ($suricatacfg['extra_servers_ports']['item'] as $item) {
+		$avalue = trim(filter_expand_alias($item['value']));
+		$avalue = preg_replace('/\s+/', ', ', trim($avalue));
+		if ($item['type'] == 'server') {
+			$addr_vars .= "    " . strtoupper($item['name']) . ": \"{$avalue}\"\n";
+		} else {
+			$port_vars .= "    " . strtoupper($item['name']) . ": \"{$avalue}\"\n";
+		}
+	}
+}
+$addr_vars = trim($addr_vars);
 $port_vars = trim($port_vars);
 
 // Define a Suppress List (Threshold) if one is configured

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_geoipupdate.php
@@ -78,16 +78,7 @@ function suricata_download_geoip_file($url, $tmpfile, $user, $pwd, &$result = NU
 	}
 
 	// Use the system proxy server setttings if configured
-	if (!empty(config_get_path('system/proxyurl'))) {
-		curl_setopt($ch, CURLOPT_PROXY, config_get_path('system/proxyurl'));
-		if (!empty(config_get_path('system/proxyport'))) {
-			curl_setopt($ch, CURLOPT_PROXYPORT, config_get_path('system/proxyport'));
-		}
-		if (config_get_path('system/proxyuser') && config_get_path('system/proxypass')) {
-			@curl_setopt($ch, CURLOPT_PROXYAUTH, CURLAUTH_ANY | CURLAUTH_ANYSAFE);
-			curl_setopt($ch, CURLOPT_PROXYUSERPWD, config_get_path('system/proxyuser') . ":" . config_get_path('system/proxypass'));
-		}
-	}
+	set_curlproxy($ch);
 
 	// Set the MaxMind Account ID and Password fields
 	curl_setopt($ch, CURLOPT_USERPWD, "{$user}:{$pwd}");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_files.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_files.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2024 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,7 +74,7 @@ elseif (isset($_GET['instance']) && is_numericint($_GET['instance']))
 if (is_null($instanceid))
 	$instanceid = 0;
 
-$a_instance = config_get_path("installedpackages/suricata/rule/{$id}", []);
+$a_instance = config_get_path("installedpackages/suricata/rule/{$instanceid}", []);
 $suricata_uuid = $a_instance['uuid'];
 $if_real = get_real_interface($a_instance['interface']);
 $suricatalogdir = SURICATALOGDIR;


### PR DESCRIPTION
### pfSense-pkg-suricata-7.0.6_1
This update to the Suricata GUI package adds one new feature, fixes one reported bug, and migrates the code for setting the CURL proxy parameters over to use the built-in pfSense function _set_curlproxy()_.

**New Features:**
1. Implement Redmine Issue 15674, Support custom Port and Server (address) variables in the package. Thanks to Graham Collinson (@graham-collinson) for contributing this code.

**Bug Fixes:**
1. Fix [Redmine Issue 15713](https://redmine.pfsense.org/issues/15713), Suricata Files tab shows nothing due to unassigned variable in 'suricata_files.php'.

**Optimizations:**
1. Implement [Redmine Issue 15717](https://redmine.pfsense.org/issues/15717), Migrate to use of system-provided set_curlproxy() function.