### PR TITLE
pfSense-pkg-suricata-7.0.7_RELENG_2_7_2 - Update Suricata GUI package to support latest v7.0.7 binary.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,8 +1,8 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	7.0.6
-PORTREVISION=	1
+PORTVERSION=	7.0.7
+PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=7.0.6:security/suricata
+RUN_DEPENDS=	suricata>=7.0.7:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes


### PR DESCRIPTION
### pfSense-pkg-suricata-7.0.7
This updates the GUI package to support the latest v7.0.7 binary Suricata version from upstream. There are no other package code changes in this update.

**New Features:**
none

**Bug Fixes:**
none