### PR TITLE
security/pfSense-pkg-acme: support deploy hooks. Implement #11827

### DIFF
--- a/security/pfSense-pkg-acme/Makefile
+++ b/security/pfSense-pkg-acme/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-acme
-PORTVERSION=	0.9
+PORTVERSION=	0.10
 PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
@@ -30,6 +30,7 @@ do-extract:
 	${MKDIR} ${WRKSRC}
 
 do-install:
+	${MKDIR} ${STAGEDIR}${PREFIX}/pkg/acme/deploy
 	${MKDIR} ${STAGEDIR}${PREFIX}/pkg/acme/dnsapi
 	${MKDIR} ${STAGEDIR}${PREFIX}/www/acme
 	${MKDIR} ${STAGEDIR}/etc/inc/priv

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
@@ -2864,11 +2864,32 @@ $acme_domain_validation_method['dns-someprovider'] = [
 */
 
 //TODO add more 'actions'
+$deployhooks = array_map(function($path){
+	return pathinfo($path)['filename'];
+}, glob('../../pkg/acme/deploy/*.sh'));
 $acme_newcertificateactions = array(
 	'shellcommand' => array('name' => "Shell Command"),
 	'php_command' => array('name' => "PHP Command Script"),
 	'servicerestart' => array('name' => "Restart Local Service"),
 	'xmlrpcservicerestart' => array('name' => "Restart Remote Service (XMLRPC)"),
+	'deployhook' => array('name' => "acme.sh deploy hook",
+		'fields' => array(
+			'script' => array(
+				'name' => 'script',
+				'columnheader' => 'Script',
+				'type' => 'select',
+				'items' => array_combine($deployhooks, array_map(function($hook) {
+					return array('name' => $hook);
+				}, $deployhooks))
+			),
+			'environment' => array(
+				'name' => 'environment',
+				'columnheader' => 'Environment <a href="https://github.com/acmesh-official/acme.sh/wiki/deployhooks"><i class="fa fa-book"></i></a>',
+				'description' => 'Each line may contain one variable assignment of the form <tt>KEY=VALUE</tt>.<br>Lines starting with <tt>#</tt> will be ignored.',
+				'type' => 'textarea',
+			),
+		),
+	),
 );
 
 // </editor-fold>
@@ -3283,5 +3304,11 @@ function get_certificate($name) {
 				}
 			}
 		}
+	}
+
+	function deploy_certificate($domain, $hook, $envvariables) {
+		$account = get_accountkey($certificate['acmeaccount']);
+		$acmesh = new acme_sh($domain, $$a_acmeserver[$account['acmeserver']]['url'], $account['email']);
+		return $acmesh->deployCertificate($domain, $hook, $envvariables);
 	}
 }

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_command.sh
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_command.sh
@@ -73,6 +73,19 @@ if ($command == "importcert") {
 				sleep(10);
 				acme_xmlrpc_restart_service($servicename, $extras);
 			}
+			if ($action['method'] == "deployhook") {
+				syslog(LOG_NOTICE, "Acme, Running deploy hook {$action['deployhookscript']}");
+				$envvariables = array();
+				foreach (preg_split("/\R/", base64_decode($action['deployhookenvironment'])) as $line) {
+					$array = explode("=", $line);
+					if (count($array) > 1) {
+						$key = $array[0];
+						if (!str_starts_with($key, "#"))
+							$envvariables[$key] = implode("=", array_slice($array, 1));
+					}
+				}
+				deploy_certificate($certificatename, $action['deployhookscript'], $envvariables);
+			}
 		}
 	}
 	return;

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_sh.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_sh.inc
@@ -309,4 +309,14 @@ EOD;
 		}
 		return false;
 	}
+
+	function deployCertificate($domain, $hook, $envvariables) {
+		$this->execacmesh(""
+			. " --deploy"
+			. " --domain " . escapeshellarg($domain)
+			. " --deploy-hook " . escapeshellarg($hook)
+			. " --accountconf " . escapeshellarg($this->accountconfig)
+			. " --home " . escapeshellarg($this->acmeconf)
+			, $envvariables);
+	}
 }

--- a/security/pfSense-pkg-acme/files/usr/local/www/acme/acme_certificates_edit.php
+++ b/security/pfSense-pkg-acme/files/usr/local/www/acme/acme_certificates_edit.php
@@ -110,19 +110,20 @@ $fields_actions[0]['colwidth']="5%";
 $fields_actions[0]['type']="select";
 $fields_actions[0]['size']="70px";
 $fields_actions[0]['items']=&$a_enabledisable;
-$fields_actions[1]['name']="command";
-$fields_actions[1]['columnheader']="Command";
-$fields_actions[1]['colwidth']="20%";
-$fields_actions[1]['type']="textbox";
-$fields_actions[1]['size']="30";
-$fields_actions[2]['name']="method";
-$fields_actions[2]['columnheader']="Method";
-$fields_actions[2]['colwidth']="15%";
-$fields_actions[2]['type']="select";
-$fields_actions[2]['size']="100px";
-$fields_actions[2]['items']=&$acme_newcertificateactions;
+$fields_actions[1]['name']="method";
+$fields_actions[1]['columnheader']="Method";
+$fields_actions[1]['colwidth']="15%";
+$fields_actions[1]['type']="select";
+$fields_actions[1]['size']="100px";
+$fields_actions[1]['items']=&$acme_newcertificateactions;
+$fields_actions[2]['name']="command";
+$fields_actions[2]['columnheader']="Command";
+$fields_actions[2]['colwidth']="20%";
+$fields_actions[2]['type']="textbox";
+$fields_actions[2]['size']="30";
 
 $fields_actions_details=array();
+
 foreach($acme_newcertificateactions as $key => $action) {
 	if (is_array($action['fields'])) {
 		foreach($action['fields'] as $field) {
@@ -136,7 +137,7 @@ foreach($acme_newcertificateactions as $key => $action) {
 }
 $actionslist = new HtmlList("table_actions", $fields_actions);
 $actionslist->keyfield = "name";
-//$actionslist->fields_details = $fields_actions_details;
+$actionslist->fields_details = $fields_actions_details;
 $actionslist->editmode = $isnewitem;
 
 // </editor-fold>
@@ -485,6 +486,24 @@ print $form;
 			}
 		}
 	}	
+
+	function table_actions_listitem_change(tableId, fieldId, rowNr, field) {
+		if (fieldId === 'toggle_details') {
+			fieldId = 'method';
+			field = document.getElementById(tableId + fieldId + rowNr);
+		}
+		if (fieldId === 'method') {
+			document.getElementById(tableId + 'command' + rowNr).style.display = field.value === 'deployhook' ? 'none' : '';
+			document.getElementById(tableId + 'command' + rowNr).disabled = field.value === 'deployhook' ? true : false;
+			for (var actionkey in showhide_actionfields) {
+				var fields = showhide_actionfields[actionkey]['fields'];
+				for (var fieldkey in fields) {
+					document.getElementById(tableId + actionkey + fieldkey + rowNr).disabled = actionkey === field.value ? false : true;
+					document.getElementById('tr_edititemdetails_' + rowNr + '_' + actionkey + fields[fieldkey]['name']).style.display = actionkey === field.value ? '' : 'none';
+				}
+			}
+		}
+	}
 </script>
 <script type="text/javascript">
 //<![CDATA[
@@ -503,6 +522,7 @@ events.push(function() {
 	});
 	*/
 	$('[id^=table_domainsmethod]').change();
+	$('[id^=table_actionsmethod]').change();
 	updatevisibility();
 
 	// Update visibility of Custom Private Key field,
@@ -524,4 +544,5 @@ events.push(function() {
 
 <?php
 acme_htmllist_js("table_domains");
+acme_htmllist_js("table_actions");
 include("foot.inc");


### PR DESCRIPTION
The UI now supports the configuration of actions that call deploy hooks compatible to those provided upstream.

A corresponding feature request can be found [here](https://redmine.pfsense.org/issues/11827).

This pull request relates to #1298.