### PR TITLE
Fix ntopng listen options

### DIFF
--- a/net/pfSense-pkg-ntopng/Makefile
+++ b/net/pfSense-pkg-ntopng/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-ntopng
-PORTVERSION=	5.6.0
-PORTREVISION=	1
+PORTVERSION=	6.2.0
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-ntopng/files/usr/local/pkg/ntopng.inc
+++ b/net/pfSense-pkg-ntopng/files/usr/local/pkg/ntopng.inc
@@ -171,13 +171,13 @@ function ntopng_sync_package() {
 			}
 		}
 	}
-	if (config_get_path('installedpackages/ntopng/config/0/server_ipv6') == "on") {
+	elseif (config_get_path('installedpackages/ntopng/config/0/server_ipv6') == "on") {
 		if ($iface == "All") {
 			$listen_array[] = "[::]:" . HTTP_PORT;
 		} else {
 			$addr = get_interface_ipv6($iface);
 			if (is_ipaddrv6($addr)) {
-				$listen_array[] = "{$addr}:" . HTTP_PORT;
+				$listen_array[] = "[{$addr}]:" . HTTP_PORT;
 			}
 		}
 	}

--- a/net/pfSense-pkg-ntopng/files/usr/local/pkg/ntopng.xml
+++ b/net/pfSense-pkg-ntopng/files/usr/local/pkg/ntopng.xml
@@ -127,7 +127,7 @@
 			<default_value>on</default_value>
 			<description>
 				<![CDATA[
-				Enable listening on IPv4.
+				Enable listening on IPv4. Note that ntopng currently allows IPv4 or IPv6, but not both.
 				]]>
 			</description>
 		</field>
@@ -137,7 +137,7 @@
 			<type>checkbox</type>
 			<description>
 				<![CDATA[
-				Enable listening on IPv6.
+				Enable listening on IPv6. This setting is currently ignored if IPv4 is enabled.
 				]]>
 			</description>
 		</field>


### PR DESCRIPTION
Implements Redmine #15976 ([https://redmine.pfsense.org/issues/15976](https://redmine.pfsense.org/issues/15976))

If both IPv4 and IPv6 server listen are enabled, the IPv4 address will not work. While the current version of ntopng accepts a list for listen address, it only uses the last element in the list. This means that both an IPv4 and IPv6 listen address cannot be provided at the same time. Hopefully this will be fixed upstream at some point in the future. Until then, we limit the listen selection to one protocol.

Additionally, bracket the address for IPv6.