### PR TITLE
pfSense-pkg-suricata_RELENG_2_7_2 - Update Suricata GUI package to 7.0.8. Fixes Redmine 15981.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-suricata
-PORTVERSION=	7.0.7
+PORTVERSION=	7.0.8
 PORTREVISION=	0
 CATEGORIES=	security
 MASTER_SITES=	# empty
@@ -13,7 +13,7 @@ COMMENT=	pfSense package suricata
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	suricata>=7.0.7:security/suricata
+RUN_DEPENDS=	suricata>=7.0.8:security/suricata
 
 NO_BUILD=	yes
 NO_MTREE=	yes


### PR DESCRIPTION
### pfSense-pkg-suricata-7.0.8

This updates the Suricata GUI package to support the latest 7.0.8 binary from upstream. There are no other code changes in the GUI package with this update.

**New Features:**
None

**Bug Fixes:**
None