### PR TITLE
pfSense-pkg-suricata-7.0.8_1_RELENG_2_7_2 - Fix Redmine Issues 16008 and 16009.

### DIFF
--- a/security/pfSense-pkg-suricata/Makefile
+++ b/security/pfSense-pkg-suricata/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-suricata
 PORTVERSION=	7.0.8
-PORTREVISION=	0
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2024 Bill Meeks
+ * Copyright (c) 2025 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -141,7 +141,7 @@ function suricata_restart_all_interfaces() {
 	suricata_start_all_interfaces(TRUE);
 }
 
-function suricata_reload_config($suricatacfg, $signal="SIGUSR2") {
+function suricata_reload_config($suricatacfg, $signal=SIGUSR2) {
 
 	/**************************************************************/
 	/* This function sends the passed SIGNAL to the Suricata      */

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata.inc
@@ -64,18 +64,29 @@ function suricata_is_running($suricata_uuid, $if_real, $type = 'suricata') {
 
 function suricata_stop($suricatacfg, $if_real) {
 	global $g;
-
 	$suricata_uuid = $suricatacfg['uuid'];
-	if (isvalidpid("{$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid")) {
-		syslog(LOG_NOTICE, "[Suricata] Suricata STOP for {$suricatacfg['descr']}({$if_real})...");
+	$suricata_ctrl_sock = "{$g['varrun_path']}/suricata-ctrl-socket-{$suricata_uuid}";
+
+	syslog(LOG_NOTICE, "[Suricata] Suricata STOP for {$suricatacfg['descr']}({$if_real})...");
+
+	// Attempt to use UNIX control socket interface if present
+	if (file_exists($suricata_ctrl_sock)) {
+		if (mwexec("/usr/local/bin/suricatasc -c shutdown {$suricata_ctrl_sock}") == 0) {
+			// Give the Suricata daemon time to stop and cleanup before returning
+			sleep(3);
+			return;
+		}
+	} elseif (isvalidpid("{$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid")) {
 		killbypid("{$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid");
+		// Give the Suricata daemon time to stop and cleanup before returning
+		sleep(3);
+		return;
+	} else {
+		if (!isvalidpid("{$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid")) {
+			// Make sure any zombie PID file is deleted so Suricata will start later without error
+			unlink_if_exists("{$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid");
+		}
 	}
-
-	// Give the Suricata daemon some to actually stop and cleanup before returning
-	sleep(10);
-
-	// Make sure the PID file is actually deleted so Suricata will restart without error
-	unlink_if_exists("{$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid");
 }
 
 function suricata_start($suricatacfg, $if_real) {
@@ -151,12 +162,13 @@ function suricata_reload_config($suricatacfg, $signal=SIGUSR2) {
 	/* as a background process and returns control immediately    */
 	/* to the caller.                                             */
 	/*                                                            */
-	/*  $signal = SIGUSR2 (default) parses and reloads config.    */
+	/*  $signal = SIGUSR2 (default) parses and reloads rules.     */
 	/**************************************************************/
 	global $g;
 
 	$suricata_uuid = $suricatacfg['uuid'];
 	$if_real = get_real_interface($suricatacfg['interface']);
+	$suricata_ctrl_sock = "{$g['varrun_path']}/suricata-ctrl-socket-{$suricata_uuid}";
 
 	/******************************************************/
 	/* Skip disabled Suricata instances or instances      */
@@ -171,27 +183,33 @@ function suricata_reload_config($suricatacfg, $signal=SIGUSR2) {
 	/* we can find a valid PID for the process.           */
 	/******************************************************/
 	if (isvalidpid("{$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid")) {
-
-		// Send the SIGNAL to the Suricata process
-		mwexec_bg("/bin/pkill -{$signal} -F {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid");
-
-		// Log what we did
 		switch ($signal) {
 			case SIGHUP:
 				syslog(LOG_NOTICE, "[Suricata] Suricata LOGS ROTATION initiated for {$suricatacfg['descr']} ({$if_real})...");
+				if (mwexec("/usr/local/bin/suricatasc -c reopen-log-files {$suricata_ctrl_sock}") != 0) {
+					syslog(LOG_WARNING, "[Suricata] Suricata LOGS ROTATION command failed to execute!");
+				}
 				break;
 
 			case SIGUSR2:
 				syslog(LOG_NOTICE, "[Suricata] Suricata LIVE RULE RELOAD initiated for {$suricatacfg['descr']} ({$if_real})...");
+				if (mwexec("/usr/local/bin/suricatasc -c ruleset-reload-nonblocking {$suricata_ctrl_sock}") != 0) {
+					syslog(LOG_WARNING, "[Suricata] Suricata LIVE RULE RELOAD command failed to execute!");
+				}
 				break;
 
 			case SIGTERM:
 			case SIGINT:
 				syslog(LOG_NOTICE, "[Suricata] Suricata SHUTDOWN initiated for {$suricatacfg['descr']} ({$if_real})...");
+				if (mwexec("/usr/local/bin/suricatasc -c shutdown {$suricata_ctrl_sock}") != 0) {
+					syslog(LOG_WARNING, "[Suricata] Suricata SHUTDOWN command failed to execute!");
+				}
 				break;
 
 			default:
 				syslog(LOG_NOTICE, "[Suricata] Suricata signalled with {$signal} for {$suricatacfg['descr']} ({$if_real})...");
+				// Send the SIGNAL to the Suricata process
+				mwexec_bg("/bin/pkill -{$signal} -F {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid");
 		}
 	}
 }
@@ -3536,7 +3554,6 @@ function suricata_create_rc() {
 		{$suricatabindir}suricata {$run_mode} -D -c {$suricatadir}suricata_{$suricata_uuid}_{$if_real}/suricata.yaml --pidfile {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid {$verbose_logging} > /dev/null 2>&1
 	fi
 
-	sleep 1
 EOE;
 
 		$start_suricata_iface_stop[] = <<<EOE
@@ -3544,7 +3561,11 @@ EOE;
 	if [ -f {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid ]; then
 		pid=`/bin/pgrep -F {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid`
 		/usr/bin/logger -p daemon.info -i -t SuricataStartup "Suricata STOP for {$value['descr']}({$suricata_uuid}_{$if_real})..."
-		/bin/pkill -TERM -F {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid
+		if [ -f {$g['varrun_path']}/suricata-ctrl-socket-{$suricata_uuid} ]; then
+			/usr/local/bin/suricatasc -c shutdown {$g['varrun_path']}/suricata-ctrl-socket-{$suricata_uuid} 2>/dev/null
+		else
+			/bin/pkill -TERM -F {$g['varrun_path']}/suricata_{$if_real}{$suricata_uuid}.pid
+		fi
 		time=0 timeout=30
 		while /bin/kill -TERM \$pid 2>/dev/null; do
 			sleep 1
@@ -3560,7 +3581,11 @@ EOE;
 		pid=`/bin/pgrep -fn "suricata {$run_mode} -D -c {$suricatadir}suricata_{$suricata_uuid}_{$if_real}/suricata.yaml "`
 		if [ ! -z \$pid ]; then
 			/usr/bin/logger -p daemon.info -i -t SuricataStartup "Suricata STOP for {$value['descr']}({$suricata_uuid}_{$if_real})..."
-			/bin/pkill -TERM -fn "suricata -i {$if_real} "
+			if [ -f {$g['varrun_path']}/suricata-ctrl-socket-{$suricata_uuid} ]; then
+				/usr/local/bin/suricatasc -c shutdown {$g['varrun_path']}/suricata-ctrl-socket-{$suricata_uuid} 2>/dev/null
+			else
+				/bin/pkill -TERM -fn "suricata {$run_mode} -D -c {$suricatadir}suricata_{$suricata_uuid}_{$if_real}/suricata.yaml "
+			fi
 			time=0 timeout=30
 			while /bin/kill -TERM \$pid 2>/dev/null; do
 				sleep 1
@@ -3572,7 +3597,6 @@ EOE;
 		fi
 	fi
 
-	sleep 1
 EOE;
 	}
 
@@ -3609,7 +3633,7 @@ case $1 in
 		if [ ! -f {$g['varrun_path']}/suricata_pkg_starting.lck ]; then
 			rc_start
 		else
-			/usr/bin/logger -p daemon.info -i -t SuricataStartup "Ignoring additional START command since Suricata is already starting..."
+			/usr/bin/logger -p daemon.info -i -t SuricataStartup "Ignoring spurious START command since Suricata is already starting..."
 		fi
 		;;
 	stop)
@@ -3617,7 +3641,7 @@ case $1 in
 		;;
 	restart)
 		rc_stop
-		sleep 5
+		sleep 2
 		rc_start
 		;;
 esac

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_cron_misc.inc
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2025 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -156,7 +156,7 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 			}
 
 			// Signal Suricata on this interface that log files have been truncated
-			suricata_reload_config($value, "SIGHUP");
+			suricata_reload_config($value, SIGHUP);
 
 			// Stop deleting logs when directory size is below configured limit
 			if (suricata_Getdirsize(SURICATALOGDIR) < $suricataloglimitsizeKB) {
@@ -376,7 +376,7 @@ if (config_get_path('installedpackages/suricata/config/0/enable_log_mgmt') == 'o
 		if ($rotated > 0) {
 			// Send the running Suricata instance on this interface a SIGHUP signal
 			// so it will re-open the log files we rotated and truncated.
-			suricata_reload_config($value, "SIGHUP");
+			suricata_reload_config($value, SIGHUP);
 			syslog(LOG_NOTICE, gettext("[Suricata] Logs Mgmt job rotated {$rotated} file(s) in '{$suricata_log_dir}/' ..."));
 		}
 

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2024 Bill Meeks
+ * Copyright (c) 2025 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -61,7 +61,7 @@ if (!defined("SURICATA_BIN_VERSION")) {
 		define("SURICATA_BIN_VERSION", $suricataver);
 	else
 		// If we could not find a version, set a safe default
-		define("SURICATA_BIN_VERSION", "7.0.6");
+		define("SURICATA_BIN_VERSION", "7.0.8");
 }
 
 // Define the name of the pf table used for IP blocks

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_generate_yaml.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>.
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>.
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2024 Bill Meeks
+ * Copyright (c) 2025 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1364,6 +1364,14 @@ pcap:
 EOD;
 }
 
-$suricata_config_pass_thru = base64_decode($suricatacfg['configpassthru']);
+// Create UNIX control socket for Suricata binary
+$unix_socket_name = "{$g['varrun_path']}/suricata-ctrl-socket-{$suricata_uuid}";
+
+// Populate optional user configuration if present
+if (!empty($suricatacfg['configpassthru']))
+	$suricata_config_pass_thru = base64_decode($suricatacfg['configpassthru']);
+else
+	$suricata_config_pass_thru = "";
+
 return true;
 ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_uninstall.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2005 Bill Marquette <bill.marquette@gmail.com>
  * Copyright (c) 2003-2004 Manuel Kasper <mk@neon1.net>
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2024 Bill Meeks
+ * Copyright (c) 2025 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -94,6 +94,7 @@ rmdir_recursive("/usr/local/share/suricata/GeoLite2");
 
 foreach (config_get_path('installedpackages/suricata/rule', []) as $suricatacfg) {
 	rmdir_recursive("{$suricatadir}suricata_" . $suricatacfg['uuid'] . "_" . get_real_interface($suricatacfg['interface']));
+	unlink_if_exists($g['varrun_path'] . "/suricata-ctrl-socket-" . $suricatacfg['uuid']);
 }
 
 /* Remove our associated Dashboard widget config and files. */

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_yaml_template.inc
@@ -64,7 +64,6 @@ outputs:
       filetype: {$http_log_filetype}
       append: {$http_log_append}
       extended: {$http_log_extended}
-      filetype: regular
 
   # a PCAP format packet capture facility
   - pcap-log:
@@ -138,6 +137,16 @@ outputs:
 
 # Magic file. The extension .mgc is added to the value here.
 magic-file: /usr/share/misc/magic
+
+# Unix command socket that can be used to pass commands to Suricata.
+# An external tool can then connect to get information from Suricata
+# or trigger some modifications of the engine. Set enabled to yes
+# to activate the feature. In auto mode, the feature will only be
+# activated in live capture mode. You can use the filename variable to set
+# the file name of the socket.
+unix-command:
+  enabled: yes
+  filename: {$unix_socket_name}
 
 # GeoLite2 IP geo-location database file path and filename.
 geoip-database: /usr/local/share/suricata/GeoLite2/GeoLite2-Country.mmdb

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -1001,8 +1001,8 @@ if ($filterlogentries && count($filterfieldsarray)) {
 	<?php
 
 /* make sure alert file exists */
-if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid}/alerts.log")) {
-	exec("tail -{$anentries} -r {$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid}/alerts.log > {$g['tmp_path']}/alerts_suricata{$suricata_uuid}");
+if (file_exists("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/alerts.log")) {
+	exec("tail -{$anentries} -r {$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/alerts.log > {$g['tmp_path']}/alerts_suricata{$suricata_uuid}");
 	if (file_exists("{$g['tmp_path']}/alerts_suricata{$suricata_uuid}")) {
 		$tmpblocked = array_flip(suricata_get_blocked_ips());
 		$counter = 0;

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_alerts.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2025 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -604,7 +604,7 @@ if ($_POST['clear']) {
 	}
 
 	// Signal the Suricata instance that logs have been rotated
-	suricata_reload_config($a_instance, "SIGHUP");
+	suricata_reload_config($a_instance, SIGHUP);
 
 	/* XXX: This is needed if suricata is run as suricata user */
 	mwexec('/bin/chmod 660 {$suricatalogdir}*', true);

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_files.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_files.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2024 Bill Meeks
+ * Copyright (c) 2025 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -459,8 +459,8 @@ if ($filterlogentries && count($filterfieldsarray)) {
 	<?php
 
 /* make sure alert file exists */
-if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid}/eve.json")) {
-	exec("/usr/bin/grep filename {$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid}/eve.json | /usr/bin/tail -{$fnentries} -r > {$g['tmp_path']}/files_suricata{$suricata_uuid}");
+if (file_exists("{$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/eve.json")) {
+	exec("/usr/bin/grep filename {$suricatalogdir}suricata_{$if_real}{$suricata_uuid}/eve.json | /usr/bin/tail -{$fnentries} -r > {$g['tmp_path']}/files_suricata{$suricata_uuid}");
 	if (file_exists("{$g['tmp_path']}/files_suricata{$suricata_uuid}")) {
 		$tmpblocked = array_flip(suricata_get_blocked_ips());
 		$counter = 0;

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_interfaces.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2025 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -194,9 +194,11 @@ EOD;
 				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/suricata_{$if_real}{$suricatacfg['uuid']}_startcmd.php");
 			}
 			else {
-				// Forcefully remove the PID file if it exists since we checked already for a running process and stopped it.
+				// Forcefully remove the PID file if it exists but a Suricata instance with that PID is not running.
 				// This allows the user the start Suricata in the event of a failed previous start due to a config error.
-				unlink_if_exists("{$g['varrun_path']}/suricata_{$if_real}{$suricatacfg['uuid']}.pid");
+				if (!suricata_is_running($suricatacfg['uuid'], $if_real)) {
+					unlink_if_exists("{$g['varrun_path']}/suricata_{$if_real}{$suricatacfg['uuid']}.pid");
+				}
 				syslog(LOG_NOTICE, "Starting Suricata on {$if_friendly}({$if_real}) per user request...");
 				mwexec_bg("/usr/local/bin/php -f {$g['tmp_path']}/suricata_{$if_real}{$suricatacfg['uuid']}_startcmd.php");
 			}

--- a/security/pfSense-pkg-suricata/files/usr/local/www/widgets/include/widget-suricata.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/widgets/include/widget-suricata.inc
@@ -4,7 +4,7 @@
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2016-2023 Rubicon Communications, LLC (Netgate)
- * Copyright (c) 2023 Bill Meeks
+ * Copyright (c) 2025 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@
  */
 
 require_once("config.inc");
+require_once("/usr/local/pkg/suricata/suricata_defs.inc");
 
 //set variable for custom title
 $suricata_alerts_title = "Suricata Alerts";

--- a/security/pfSense-pkg-suricata/files/usr/local/www/widgets/widgets/suricata_alerts.widget.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/widgets/widgets/suricata_alerts.widget.php
@@ -7,7 +7,7 @@
  * Copyright (c) 2003-2004 Manuel Kasper
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2009 Robert Zelaya Sr. Developer
- * Copyright (c) 2024 Bill Meeks
+ * Copyright (c) 2025 Bill Meeks
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -111,8 +111,8 @@ function suricata_widget_get_alerts() {
 
 		// make sure alert file exists, then grab the most recent {$suri_nentries} from it
 		// and write them to a temp file.
-		if (file_exists("{$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid}/alerts.log")) {
-			exec("/usr/bin/tail -{$suri_nentries} -r {$g['varlog_path']}/suricata/suricata_{$if_real}{$suricata_uuid}/alerts.log > {$g['tmp_path']}/surialerts_{$suricata_uuid}");
+		if (file_exists(SURICATALOGDIR . "suricata_{$if_real}{$suricata_uuid}/alerts.log")) {
+			exec("/usr/bin/tail -{$suri_nentries} -r " . SURICATALOGDIR . "suricata_{$if_real}{$suricata_uuid}/alerts.log > {$g['tmp_path']}/surialerts_{$suricata_uuid}");
 
 			if (file_exists("{$g['tmp_path']}/surialerts_{$suricata_uuid}")) {
 


### PR DESCRIPTION
### pfSense-pkg-suricata-7.0.8_1_RELENG_2_7_2
This update to the GUI package addresses one Redmine Bug Report and a Redmine Feature Request.

**New Features:**
1. [Redmine Feature Request #16009](https://redmine.pfsense.org/issues/16009) - Use the built-in UNIX control socket interface to communicate certain actions to the running Suricata binary.

**Bug Fixes:**
1. [Redmine Issue #16008](https://redmine.pfsense.org/issues/16008) - Improperly double-quoted constants for SIGHUP and SIGUSR2.