### PR TITLE
Remove Talos Snort

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.json
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.json
@@ -124,13 +124,6 @@
 					"url":		"https://www.spamhaus.org/drop/edrop.txt",
 					"delist":	"https://www.spamhaus.org/lookup/",
 					"header":	"Spamhaus_eDrop"
-				},
-				{
-					"feed":		"Talos-Snort",
-					"website":	"https://www.talosintelligence.com/",
-					"contact":	"https://www.talosintelligence.com/contact/",
-					"url":		"https://talosintelligence.com/documents/ip-blacklist",
-					"header":	"Talos_BL"
 				}
 			]
 		},


### PR DESCRIPTION
The Talos Snort IP blocklist has been moved to a different link which now requires you accept terms of service before downloading and redirects to what seems like a unique URL making it impossible to add this as a default source as of right now the current link just fails to download repeatedly