### PR TITLE
net-mgmt/pfSense-pkg-arpwatch: Add missing dot between hostname and domain

### DIFF
--- a/net-mgmt/pfSense-pkg-arpwatch/Makefile
+++ b/net-mgmt/pfSense-pkg-arpwatch/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-arpwatch
-PORTVERSION=	0.2.3
+PORTVERSION=	0.2.4
 CATEGORIES=	net-mgmt
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.inc
+++ b/net-mgmt/pfSense-pkg-arpwatch/files/usr/local/pkg/arpwatch.inc
@@ -239,7 +239,7 @@ if ((false !== $message) && ((false === strpos($message, ': Cron ')) ||
 	$message = preg_replace('/^To: .*$/m', '', $message);
 	$message = preg_replace('/^Subject: .*$/m', '', $message);
 	$message = preg_replace("/^(\n){4}/", '', $message);
-	$send_subject = config_get_path('system/hostname') . config_get_path('system/domain') . " - Arpwatch Notification : {$subject[1]}";
+	$send_subject = config_get_path('system/hostname') . "." . config_get_path('system/domain') . " - Arpwatch Notification : {$subject[1]}";
 
 	send_smtp_message($message, $send_subject);
 	if (function_exists('notify_via_telegram')) {


### PR DESCRIPTION
I saw arpwatch notices where the hostname was missing a dot:

    [hostname=pear, domain=example.com]
    Subject: pearexample.com - Arpwatch Notification : changed ethernet address

The bug is in sendmail_proxy.php is was surprisingly resistant to local patching. Today I tracked down that it's created at run time by pfSense-pkg-arpwatch. I tracked it to 99368e36:

 -       $send_subject = "{$config['system']['hostname']}.{$config['system']['domain']} - Arpwatch Notification : {$subject[1]}";
 +       $send_subject = config_get_path('system/hostname') . config_get_path('system/domain') . " - Arpwatch Notification : {$subject[1]}";

This fix for this regression is to add a string with the dot.