### PR TITLE
Add ANDwatch package

### DIFF
--- a/net-mgmt/pfSense-pkg-ANDwatch/Makefile
+++ b/net-mgmt/pfSense-pkg-ANDwatch/Makefile
@@ -1,0 +1,51 @@
+
+PORTNAME=	pfSense-pkg-ANDwatch
+PORTVERSION=	2.1
+CATEGORIES=	net-mgmt
+MASTER_SITES=	# empty
+DISTFILES=	# empty
+
+MAINTAINER=	coreteam@pfsense.org
+COMMENT=	pfSense package ANDwatch
+WWW=		https://github.com/dennypage/andwatch
+
+LICENSE=	APACHE20
+
+RUN_DEPENDS=	andwatch>=2.1.0:net-mgmt/andwatch
+
+NO_BUILD=	yes
+NO_MTREE=	yes
+
+SUB_FILES=	pkg-install pkg-deinstall
+SUB_LIST=	PORTNAME=${PORTNAME}
+
+do-extract:
+	${MKDIR} ${WRKSRC}
+
+do-install:
+	${MKDIR} ${STAGEDIR}${PREFIX}/pkg
+	${MKDIR} ${STAGEDIR}/etc/inc/priv
+	${MKDIR} ${STAGEDIR}${PREFIX}/www/shortcuts
+	${MKDIR} ${STAGEDIR}${DATADIR}
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/andwatch.xml \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/andwatch.inc \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/andwatch-notify.php \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/andwatch.priv.inc \
+		${STAGEDIR}/etc/inc/priv
+	${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml \
+		${STAGEDIR}${DATADIR}
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/shortcuts/pkg_andwatch.inc \
+		${STAGEDIR}${PREFIX}/www/shortcuts
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/andwatch.php \
+		${STAGEDIR}${PREFIX}/www
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/status_andwatch.php \
+		${STAGEDIR}${PREFIX}/www
+	${CHMOD} 555 ${STAGEDIR}${PREFIX}/pkg/andwatch-notify.php
+
+	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
+		${STAGEDIR}${DATADIR}/info.xml
+
+.include <bsd.port.mk>

--- a/net-mgmt/pfSense-pkg-ANDwatch/files/etc/inc/priv/andwatch.priv.inc
+++ b/net-mgmt/pfSense-pkg-ANDwatch/files/etc/inc/priv/andwatch.priv.inc
@@ -1,0 +1,36 @@
+<?php
+/*
+ * andwatch.priv.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2025 Denny Page
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+global $priv_list;
+
+$priv_list['page-services-andwatch'] = array();
+$priv_list['page-services-andwatch']['name'] = "WebCfg - Services: ANDwatch";
+$priv_list['page-services-andwatch']['descr'] = "Access the ANDwatch package configuration";
+$priv_list['page-services-andwatch']['match'] = array();
+$priv_list['page-services-andwatch']['match'][] = "andwatch.php";
+
+$priv_list['page-status-andwatch'] = array();
+$priv_list['page-status-andwatch']['name'] = "WebCfg - Status: ANDwatch Database";
+$priv_list['page-status-andwatch']['descr'] = "Access the ANDwatch package database";
+$priv_list['page-status-andwatch']['match'] = array();
+$priv_list['page-status-andwatch']['match'][] = "status_andwatch.php*";
+
+?>

--- a/net-mgmt/pfSense-pkg-ANDwatch/files/pkg-deinstall.in
+++ b/net-mgmt/pfSense-pkg-ANDwatch/files/pkg-deinstall.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/local/bin/php -f /etc/rc.packages %%PORTNAME%% ${2}

--- a/net-mgmt/pfSense-pkg-ANDwatch/files/pkg-install.in
+++ b/net-mgmt/pfSense-pkg-ANDwatch/files/pkg-install.in
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "${2}" != "POST-INSTALL" ]; then
+	exit 0
+fi
+
+${PKG_ROOTDIR}/usr/local/bin/php -f ${PKG_ROOTDIR}/etc/rc.packages %%PORTNAME%% ${2}

--- a/net-mgmt/pfSense-pkg-ANDwatch/files/usr/local/pkg/andwatch-notify.php
+++ b/net-mgmt/pfSense-pkg-ANDwatch/files/usr/local/pkg/andwatch-notify.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php
+require_once("notices.inc");
+
+$timestamp=$argv[1];
+$ifname=convert_real_interface_to_friendly_descr($argv[2]);
+$hostname=$argv[3];
+$ipaddr=$argv[4];
+$new_hwaddr=$argv[5];
+$new_hwaddr_org=$argv[6];
+$old_hwaddr=$argv[7];
+$old_hwaddr_org=$argv[8];
+
+$msg = "\nANDwatch notificaton\n\n";
+$msg .= sprintf("%22s: %s\n", "timestamp", $timestamp);
+$msg .= sprintf("%22s: %s\n", "interface", $ifname);
+$msg .= sprintf("%22s: %s\n", "hostname", $hostname);
+$msg .= sprintf("%22s: %s\n", "ip address", $ipaddr);
+$msg .= sprintf("%22s: %s\n", "new ethernet address", $new_hwaddr);
+$msg .= sprintf("%22s: %s\n", "new ethernet org", $new_hwaddr_org);
+$msg .= sprintf("%22s: %s\n", "old ethernet address", $old_hwaddr);
+$msg .= sprintf("%22s: %s\n", "old ethernet org", $old_hwaddr_org);
+
+notify_all_remote($msg);
+?>

--- a/net-mgmt/pfSense-pkg-ANDwatch/files/usr/local/pkg/andwatch.inc
+++ b/net-mgmt/pfSense-pkg-ANDwatch/files/usr/local/pkg/andwatch.inc
@@ -1,0 +1,184 @@
+<?php
+/*
+ * andwatch.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2025 Denny Page
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once("config.inc");
+require_once("functions.inc");
+require_once("util.inc");
+require_once("service-utils.inc");
+
+const ANDWATCH_SVC_NAME = 'andwatchd';
+const ANDWATCH_RC_FILE = '/usr/local/etc/rc.d/andwatch.sh';
+const ANDWATCHD_CMD = '/usr/local/bin/andwatchd';
+const ANDWATCHD_NOTIFY_CMD = '/usr/local/pkg/andwatch-notify.php';
+const ANDWATCHD_PID_PREFIX = '/var/run/andwatch-';
+const ANDWATCH_MA_DB_FILE = '/var/db/andwatch/ma_db.sqlite';
+const ANDWATCH_UPDATE_MA_CMD = '/usr/local/bin/andwatch-update-ma';
+const ANDWATCH_QUERY_CMD = '/usr/local/bin/andwatch-query';
+
+$shortcut_section = 'andwatch';
+
+// Is ANDwatch enabled?
+function andwatch_enabled() {
+	return (config_get_path('installedpackages/andwatch/enable', false));
+}
+
+
+// Write the rc file
+function andwatch_write_rcfile() {
+	// Get the real interface names
+	$interfaces = array();
+	foreach (explode(',', config_get_path('installedpackages/andwatch/active_interfaces')) as $interface) {
+		$interfaces[$interface] = get_real_interface($interface);
+	}
+
+	// Ensure the assignments database exists
+	$start = "if [ \! -f " . ANDWATCH_MA_DB_FILE . " ]\n";
+	$start .= "\tthen\n";
+	$start .= "\t\techo Updating MAC Assignments database\n";
+	$start .= "\t\t" . ANDWATCH_UPDATE_MA_CMD . "\n";
+	$start .= "\tfi\n\n";
+
+	// Individual daemons
+	$start .= "\techo Starting ANDwatch daemons";
+	foreach ($interfaces as $interface => $real_interface) {
+		// Basic configuration with syslog and pid file
+		$cmd = ANDWATCHD_CMD . " -s -p " . ANDWATCHD_PID_PREFIX . "${real_interface}.pid";
+
+		// Notifications
+		if (config_get_path("installedpackages/andwatch/interfaces/{$interface}/notifications", false)) {
+			$cmd .= " -n " . ANDWATCHD_NOTIFY_CMD;
+		}
+
+		// Expiration (andwatchd default is 30)
+		$expiration = config_get_path("installedpackages/andwatch/interfaces/{$interface}/expiration", '30');
+		if ($expiration != '30') {
+			$cmd .= " -O ${expiration}";
+		}
+
+		// PCAP filter
+		$filter = null;
+		switch (config_get_path("installedpackages/andwatch/interfaces/{$interface}/pcap_filter", 'none')) {
+			case 'link-local':
+				$filter = 'not net fe80::0/10';
+				break;
+			case 'link-local-private':
+				$filter = 'not net fe80::0/10 and not net fc00::0/7';
+				break;
+			case 'custom':
+				$filter = trim(config_get_path("installedpackages/andwatch/interfaces/{$interface}/custom_filter"));
+				break;
+		}
+		if (!empty($filter)) {
+			$cmd .= " -F '${filter}'";
+		}
+
+		$cmd .= " ${real_interface}";
+		$start .= "\n\t${cmd}";
+	}
+
+	// Write the rc file
+	$stop = '/usr/bin/killall ' . ANDWATCH_SVC_NAME;
+	write_rcfile(array(
+		"file" => "andwatch.sh",
+		"start" => $start,
+		"stop" => $stop
+		)
+	);
+}
+
+
+// Sync the config
+function andwatch_sync_config() {
+	// Stop the service if it is currently running
+	if (is_service_running(ANDWATCH_SVC_NAME)) {
+		log_error("Stopping service ANDwatch");
+		stop_service(ANDWATCH_SVC_NAME);
+	}
+
+	// If the service is now disabled, remove the cron job and rc file
+	if (!andwatch_enabled()) {
+		install_cron_job(ANDWATCH_UPDATE_MA_CMD, false);
+		unlink_if_exists(ANDWATCH_RC_FILE);
+		return;
+	}
+
+	// Set a cron job to update the MAC registration database
+	install_cron_job(ANDWATCH_UPDATE_MA_CMD, true, rand(0,59), rand(0,23), '1,15', '*', '*', 'root', true);
+
+	// Write the rc file
+	andwatch_write_rcfile();
+
+	// Take no further action during platform boot
+	if (platform_booting()) {
+		return;
+	}
+
+	// Start the service
+	log_error("Starting service ANDwatch");
+	start_service(ANDWATCH_SVC_NAME);
+}
+
+
+// Clean up on deinstall
+function andwatch_deinstall_command() {
+	if (is_service_running(ANDWATCH_SVC_NAME)) {
+		log_error("Stopping service ANDwatch");
+		stop_service(ANDWATCH_SVC_NAME);
+	}
+
+	unlink_if_exists(ANDWATCH_RC_FILE);
+}
+
+
+// Run a query
+function andwatch_query_interface($ifname, $all = false)
+{
+	$entries = array();
+
+	// Build the query command
+	$cmd = ANDWATCH_QUERY_CMD;
+	if ($all) {
+		$cmd .= ' -a';
+	}
+	$cmd .= ' ' . get_real_interface($ifname);
+
+	// Run the query
+	$pipe = popen($cmd, 'r');
+	if ($pipe) {
+		while ($line = fgets($pipe)) {
+			list($date, $time, $age, $hostname, $ipaddr, $hwaddr, $org) = sscanf(trim($line), '%s %s %s %s %s %s %[^$]s');
+			$entry = [
+				'datetime' => "$date $time",
+				'age' => $age,
+				'hostname' => $hostname,
+				'ipaddr' => $ipaddr,
+				'hwaddr' => $hwaddr,
+				'org' => $org
+			];
+			$entries[] = $entry;
+		}
+		pclose($pipe);
+	}
+
+	return $entries;
+}
+
+?>

--- a/net-mgmt/pfSense-pkg-ANDwatch/files/usr/local/pkg/andwatch.xml
+++ b/net-mgmt/pfSense-pkg-ANDwatch/files/usr/local/pkg/andwatch.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
+<packagegui>
+	<copyright>
+	<![CDATA[
+/*
+ * andwatch.xml
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2025 Denny Page
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+	]]>
+	</copyright>
+	<name>andwatch</name>
+	<title>Services: ANDwatch</title>
+	<savetext>Change</savetext>
+	<include_file>/usr/local/pkg/andwatch.inc</include_file>
+	<menu>
+		<name>ANDwatch</name>
+		<tooltiptext>ANDwatch Settings</tooltiptext>
+		<section>Services</section>
+		<url>/andwatch.php</url>
+	</menu>
+	<menu>
+		<name>ANDwatch Database</name>
+		<tooltiptext>ANDwatch Database</tooltiptext>
+		<section>Status</section>
+		<url>/status_andwatch.php</url>
+	</menu>
+	<service>
+		<name>andwatchd</name>
+		<rcfile>andwatch.sh</rcfile>
+		<executable>andwatchd</executable>
+		<description>ANDwatch Daemon</description>
+		<starts_on_sync></starts_on_sync>
+	</service>
+	<custom_php_resync_config_command>
+		andwatch_sync_config();
+	</custom_php_resync_config_command>
+	<custom_php_pre_deinstall_command>
+		andwatch_deinstall_command();
+	</custom_php_pre_deinstall_command>
+</packagegui>

--- a/net-mgmt/pfSense-pkg-ANDwatch/files/usr/local/share/pfSense-pkg-ANDwatch/info.xml
+++ b/net-mgmt/pfSense-pkg-ANDwatch/files/usr/local/share/pfSense-pkg-ANDwatch/info.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<pfsensepkgs>
+	<package>
+		<name>ANDwatch</name>
+		<website>https://github.com/dennypage/andwatch/</website>
+		<descr><![CDATA[ANDwatch monitors Arp and Neighbor Discovery activity, maintains a database of IP to Ethernet address mappings, and sends notifications when a mapping changes.]]></descr>
+		<version>%%PKGVERSION%%</version>
+		<configurationfile>andwatch.xml</configurationfile>
+	</package>
+</pfsensepkgs>

--- a/net-mgmt/pfSense-pkg-ANDwatch/files/usr/local/www/andwatch.php
+++ b/net-mgmt/pfSense-pkg-ANDwatch/files/usr/local/www/andwatch.php
@@ -1,0 +1,274 @@
+<?php
+/*
+ * andwatch.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2025 Denny Page
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+require_once("guiconfig.inc");
+require_once("andwatch.inc");
+
+
+// Configuration paths
+$package_path = 'installedpackages/andwatch/';
+$path_enable = $package_path . 'enable';
+$path_active_interfaces = $package_path . 'active_interfaces';
+$path_interfaces = $package_path . 'interfaces';
+
+// Get the current configuration
+$pconfig['enable'] = config_get_path($path_enable);
+$pconfig['active_interfaces'] = explode(',', config_get_path($path_active_interfaces, 'lan'));
+$pconfig['interfaces'] = config_get_path($path_interfaces, []);
+
+$available_interfaces = get_configured_interface_with_descr();
+unset($available_interfaces['wan']);
+
+if ($_POST) {
+	unset($input_errors);
+	$pconfig = $_POST;
+
+	if (empty($pconfig['active_interfaces'])) {
+		$input_errors[] = gettext('No interfaces selected');
+	}
+
+	// Rebuild the interfaces array
+	foreach ($available_interfaces as $interface => $name) {
+		$notifications = $pconfig['notifications_' . $interface];
+		$expiration = $pconfig['expiration_' . $interface];
+		$pcap_filter = $pconfig['pcap_filter_' . $interface];
+		$custom_filter = trim($pconfig['custom_filter_' . $interface]);
+
+		// Validate custom filter
+		if ($pcap_filter == 'custom' && strlen($custom_filter) > 100) {
+			$input_errors[] = 'custom filter exceeds maximum length of 100 bytes';
+		}
+
+		array_set_path($pconfig, "interfaces/{$interface}/notifications", $notifications);
+		array_set_path($pconfig, "interfaces/{$interface}/expiration", $expiration);
+		array_set_path($pconfig, "interfaces/{$interface}/pcap_filter", $pcap_filter);
+		array_set_path($pconfig, "interfaces/{$interface}/custom_filter", $custom_filter);
+	}
+
+	// Update the config
+	if (!$input_errors) {
+		// General settings
+		config_set_path($path_enable, $pconfig['enable']);
+		config_set_path($path_active_interfaces, implode(',', $pconfig['active_interfaces']));
+
+		// Interface settings
+		foreach ($pconfig['active_interfaces'] as $interface) {
+			config_set_path("{$path_interfaces}/{$interface}/notifications",
+					array_get_path($pconfig, "interfaces/{$interface}/notifications"));
+			config_set_path("{$path_interfaces}/{$interface}/expiration",
+					array_get_path($pconfig, "interfaces/{$interface}/expiration"));
+			config_set_path("{$path_interfaces}/{$interface}/pcap_filter",
+					array_get_path($pconfig, "interfaces/{$interface}/pcap_filter"));
+			config_set_path("{$path_interfaces}/{$interface}/custom_filter",
+					array_get_path($pconfig, "interfaces/{$interface}/custom_filter"));
+		}
+
+		// Write the config
+		write_config(gettext("ANDwatch settings changed"));
+
+		// Sync the running configuration
+		andwatch_sync_config();
+	}
+}
+
+
+$pcap_filter_options = array(
+	'none' => gettext('none'),
+	'link-local' => gettext('Filter out IPv6 link-local (fe80::/10) addresses'),
+	'link-local-private' => gettext('Filter out IPv6 link-local (fe80::/10) and private (fc00::/7) addresses'),
+	'custom' => gettext('Custom filter') );
+
+$expiration_options = array(
+	'5' => gettext('5 days'),
+	'10' => gettext('10 days'),
+	'15' => gettext('15 days'),
+	'20' => gettext('20 days'),
+	'30' => gettext('30 days (default)'),
+	'60' => gettext('60 days'),
+	'90' => gettext('90 days') );
+
+$notification_help = gettext(
+	'When ANDwatch is first enabled on an interface, a lot of notifications may be ' .
+	'generated very quickly.<br>It is generally recommended to allow ANDwatch to ' .
+	'run for several minutes on a new interface before<br>enabling notifications.');
+
+$expiration_help = gettext(
+	'Records that have not been updated in this many days are deleted by the ' .
+	'ANDwatch daemon');
+
+$pcap_filter_help = gettext(
+	'Additional PCAP filter to be applied to Arp and Neighbor Discovery packets ' .
+	'received on the interface.');
+
+$custom_filter_help = gettext(
+	'A filter as used by pcap/tcpdump. For information on filter formats, see the ' .
+	'<a target="_blank" href="https://www.tcpdump.org/manpages/pcap-filter.7.html">' .
+	'pcap-filter man page' . '</a>.<br>' .
+	'Filters can be validated prior to use by using the -d option to tcpdump.');
+
+$custom_filter_placeholder = gettext('not net fe80::0/10 and not net fc00::0/7');
+
+
+$pgtitle = array(gettext("Services"), gettext("ANDwatch"));
+include("head.inc");
+
+if ($input_errors) {
+	print_input_errors($input_errors);
+}
+
+
+$form = new Form;
+$section = new Form_Section('General Settings');
+
+// Enable
+$section->addInput(new Form_Checkbox(
+	'enable',
+	'Enable',
+	'Enable the ANDwatch daemon(s)',
+	$pconfig['enable']
+));
+
+// List of interfaces
+$section->addInput(new Form_Select(
+	'active_interfaces',
+	'*Interfaces',
+	$pconfig['active_interfaces'],
+	$available_interfaces,
+	true
+))->addClass('active_interfaces')->setHelp(gettext('Interfaces that the ANDwatch daemon will operate on.'));
+$form->add($section);
+
+
+// Interface sections
+foreach ($available_interfaces as $interface => $name) {
+	$interface_config = array_get_path($pconfig, "interfaces/{$interface}", []);
+
+	$section = new Form_Section($name . ' Settings');
+	$section->addClass('sh_interface');
+	$section->addClass('sh_interface_' . $interface);
+
+	// Notifications
+	$section->addInput(new Form_Checkbox(
+		'notifications_' . $interface,
+		'Notifications',
+		'Enable notifications from the ANDwatch daemon for this interface',
+		$interface_config['notifications']
+	))->setHelp($notification_help);
+
+	// Record expiration
+	if (is_null($interface_config['expiration'])) {
+		$interface_config['expiration'] = '30';
+	}
+	$group = new Form_Group('Record Expiration');
+	$group->add(new Form_Select(
+		'expiration_' . $interface,
+		null,
+		$interface_config['expiration'],
+		$expiration_options
+	))->setHelp($expiration_help);
+	$section->add($group);
+
+	// PCAP filter
+	if (is_null($interface_config['pcap_filter'])) {
+		$interface_config['pcap_filter'] = 'link-local-private';
+	}
+	$group = new Form_Group('PCAP Filter');
+	$group->add(new Form_Select(
+		'pcap_filter_' . $interface,
+		null,
+		$interface_config['pcap_filter'],
+		$pcap_filter_options
+	))->setHelp($pcap_filter_help);
+	$section->add($group);
+
+	// Custom filter
+	$group = new Form_Group('Custom Filter');
+	$group->addClass('sh_interface_custom_filter_' . $interface);
+	$group->add(new Form_Input(
+		'custom_filter_' . $interface,
+		null,
+		'text',
+		$interface_config['custom_filter'])
+	)->setHelp($custom_filter_help)->setAttribute('placeholder', $custom_filter_placeholder);
+	$section->add($group);
+
+	$form->add($section);
+}
+
+
+print($form);
+?>
+
+
+<script type="text/javascript">
+//<![CDATA[
+events.push(function() {
+
+	// Show/hide interface sections
+	function hideInterfaces() {
+		hideClass('sh_interface', true);
+
+		var selected = $(".active_interfaces").val();
+		var length = $(".active_interfaces :selected").length;
+
+		for (var i=0; i<length; i++) {
+			hideClass('sh_interface_' + selected[i], false);
+		}
+	}
+
+<?php
+	// Show/hide based on interface filters
+	foreach ($available_interfaces as $interface => $name) {
+		echo "function hideInterfaceCustomFilter_{$interface}() {";
+			echo "hideClass('sh_interface_custom_filter_{$interface}', $('#pcap_filter_{$interface}').prop('value') != 'custom');";
+		echo "}\n";
+	}
+?>
+
+	// On changing selection for active interfaces
+	$('.active_interfaces').change(function () {
+		hideInterfaces();
+	});
+
+
+<?php
+	// On changing selection for interface filter type
+	foreach ($available_interfaces as $interface => $name) {
+		echo "$('#pcap_filter_{$interface}').change(function() {";
+			echo "hideInterfaceCustomFilter_{$interface}();";
+		echo "});\n";
+	}
+?>
+
+	// Initial page load
+	hideInterfaces();
+<?php
+	foreach ($available_interfaces as $interface => $name) {
+		echo "hideInterfaceCustomFilter_{$interface}();\n";
+	}
+?>
+
+});
+//]]>
+</script>
+
+<?php include("foot.inc");

--- a/net-mgmt/pfSense-pkg-ANDwatch/files/usr/local/www/shortcuts/pkg_andwatch.inc
+++ b/net-mgmt/pfSense-pkg-ANDwatch/files/usr/local/www/shortcuts/pkg_andwatch.inc
@@ -1,0 +1,27 @@
+<?php
+/*
+ * pkg_andwatch.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2025 Denny Page
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+global $shortcuts;
+
+$shortcuts['andwatch']             = array();
+$shortcuts['andwatch']['main']     = 'andwatch.php';
+$shortcuts['andwatch']['status']   = 'status_andwatch.php';
+$shortcuts['andwatch']['service']  = 'andwatchd';

--- a/net-mgmt/pfSense-pkg-ANDwatch/files/usr/local/www/status_andwatch.php
+++ b/net-mgmt/pfSense-pkg-ANDwatch/files/usr/local/www/status_andwatch.php
@@ -1,0 +1,216 @@
+<?php
+/*
+ * status_andwatch.php
+ *
+ * Copyright (c) 2004-2013 BSD Perimeter
+ * Copyright (c) 2013-2016 Electric Sheep Fencing
+ * Copyright (c) 2014-2024 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2025, Denny Page
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once("guiconfig.inc");
+require_once("andwatch.inc");
+
+$active_interfaces = explode(',', config_get_path('installedpackages/andwatch/active_interfaces', 'lan'));
+
+if ($_REQUEST['if']) {
+	$if = htmlspecialchars($_REQUEST['if']);
+} else {
+	$if = $active_interfaces[0];
+}
+if ($_REQUEST['all']) {
+	$all = htmlspecialchars($_REQUEST['all']);
+}
+
+// Build the tab array
+$tab_array = array();
+foreach ($active_interfaces as $ifname) {
+	$friendly_ifname = convert_friendly_interface_to_friendly_descr($ifname);
+	$active = ($ifname == $if);
+	$tab_array[] = array($friendly_ifname, $active, "status_andwatch.php?if={$ifname}");
+	if ($active) {
+		$active_name = $friendly_ifname;
+	}
+}
+
+$pgtitle = array(gettext('Status'), gettext('ANDwatch Database'), $active_name);
+$pglinks = array("", "status_andwatch.php", "@self");
+include("head.inc");
+display_top_tabs($tab_array, false, 'pills');
+
+if ($all) {
+	$panel_title = gettext('Historical Address Records');
+} else {
+	$panel_title = gettext('Current Address Records');
+}
+
+// Get the entries
+$entries = andwatch_query_interface($if, $all);
+?>
+
+
+<div class="panel panel-default" id="search-panel">
+	<div class="panel-heading">
+		<h2 class="panel-title">
+			<?=gettext('Search')?>
+			<span class="widget-heading-icon pull-right">
+				<a data-toggle="collapse" href="#search-panel_panel-body">
+					<i class="fa-solid fa-plus-circle"></i>
+				</a>
+			</span>
+		</h2>
+	</div>
+	<div id="search-panel_panel-body" class="panel-body collapse in">
+		<div class="form-group">
+			<label class="col-sm-2 control-label">
+				<?=gettext('Search Term')?>
+			</label>
+			<div class="col-sm-5"><input class="form-control" name="searchstr" id="searchstr" type="text"></div>
+			<div class="col-sm-2">
+				<select id="where" class="form-control">
+					<option value="1" selected><?=gettext('Any Field')?></option>
+					<option value="2"><?=gettext('Hostname')?></option>
+					<option value="3"><?=gettext('IP Address')?></option>
+					<option value="4"><?=gettext('MAC Address')?></option>
+					<option value="5"><?=gettext('MAC Organization')?></option>
+				</select>
+			</div>
+			<div class="col-sm-3">
+				<a id="btnsearch" title="<?=gettext("Search")?>" class="btn btn-primary btn-sm"><i class="fa-solid fa-search icon-embed-btn"></i><?=gettext("Search")?></a>
+				<a id="btnclear" title="<?=gettext("Clear")?>" class="btn btn-info btn-sm"><i class="fa-solid fa-undo icon-embed-btn"></i><?=gettext("Clear")?></a>
+			</div>
+			<div class="col-sm-5 col-sm-offset-2">
+				<span class="help-block"><?=gettext('Enter a search string or regular expression to filter entries.')?></span>
+			</div>
+		</div>
+	</div>
+</div>
+
+
+<div class="panel panel-default">
+	<div class="panel-heading"><h2 class="panel-title"><?=$panel_title?></h2></div>
+	<div class="panel-body table-responsive">
+		<table class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>
+			<thead>
+			<tr class="text-nowrap">
+				<th><?=gettext("DateTime")?></th>
+				<th><?=gettext("Age")?></th>
+				<th><?=gettext("Hostname")?></th>
+				<th><?=gettext("IP Address")?></th>
+				<th><?=gettext("MAC Address")?></th>
+				<th><?=gettext("MAC Organization")?></th>
+			</tr>
+			</thead>
+			<tbody id="addrlist">
+			<?php if (count($entries)) : ?>
+			<?php foreach ($entries as $entry): ?>
+			<tr class="text-nowrap">
+				<td><?=htmlspecialchars($entry['datetime'])?></td>
+				<td><?=htmlspecialchars($entry['age'])?></td>
+				<td><?=htmlspecialchars($entry['hostname'])?></td>
+				<td><?=htmlspecialchars($entry['ipaddr'])?></a></td>
+				<td><?=htmlspecialchars($entry['hwaddr'])?></a></td>
+				<td><?=htmlspecialchars($entry['org'])?></td>
+			</tr>
+			<?php endforeach; ?>
+			<?php else: ?>
+			<tr>
+				<td colspan="6"><?=gettext("No entries to display")?></td>
+			</tr>
+			<?php endif; ?>
+			</tbody>
+		</table>
+	</div>
+</div>
+
+<div>
+<?php if ($_REQUEST['all']): ?>
+	<a class="btn btn-info btn-sm" href="status_andwatch.php?if=<?=$if?>&all=0"><i class="fa-solid fa-minus-circle icon-embed-btn"></i><?=gettext("Show Current Records Only")?></a>
+<?php else: ?>
+	<a class="btn btn-info btn-sm" href="status_andwatch.php?if=<?=$if?>&all=1"><i class="fa-solid fa-plus-circle icon-embed-btn"></i><?=gettext("Show Historical Records")?></a>
+<?php endif; ?>
+</div>
+
+
+
+<script type="text/javascript">
+//<![CDATA[
+events.push(function() {
+	// Make these controls plain buttons
+	$("#btnsearch").prop('type', 'button');
+	$("#btnclear").prop('type', 'button');
+
+	// Search for a term in the entry name and/or dn
+	$("#btnsearch").click(function() {
+		var searchstr = $('#searchstr').val().toLowerCase();
+		var table = $("#addrlist");
+		var where = $('#where').val();
+
+		// Trim on values where a space doesn't make sense
+		if ((where >= 2) && (where <= 5)) {
+			searchstr = searchstr.trim();
+		}
+
+		table.find('tr').each(function (i) {
+			var $tds     = $(this).find('td');
+			var $popover = $($.parseHTML($tds.eq(2).attr('data-content')));
+
+			var hostname = $tds.eq(2).text().trim().toLowerCase();
+			var ipaddr   = $tds.eq(3).text().trim().toLowerCase();
+			var macaddr  = $tds.eq(4).text().trim().toLowerCase();
+			var macorg   = $tds.eq(5).text().trim().toLowerCase();
+
+			regexp = new RegExp(searchstr);
+			if (searchstr.length > 0) {
+				if (!(regexp.test(hostname) && ((where == 2) || (where == 1))) &&
+				    !(regexp.test(ipaddr)   && ((where == 3) || (where == 1))) &&
+				    !(regexp.test(macaddr)  && ((where == 4) || (where == 1))) &&
+				    !(regexp.test(macorg)   && ((where == 5) || (where == 1)))
+				    ) {
+					$(this).hide();
+				} else {
+					$(this).show();
+				}
+			} else {
+				$(this).show(); // A blank search string shows all
+			}
+		});
+	});
+
+	// Clear the search term and unhide all rows (that were hidden during a previous search)
+	$("#btnclear").click(function() {
+		var table = $("#addrlist");
+
+		$('#searchstr').val("");
+		$('#where option[value="1"]').prop('selected', true);
+
+		table.find('tr').each(function (i) {
+			$(this).show();
+		});
+	});
+
+	// Hitting the enter key will do the same as clicking the search button
+	$("#searchstr").on("keyup", function (event) {
+		if (event.keyCode == 13) {
+			$("#btnsearch").get(0).click();
+		}
+	});
+});
+//]]>
+</script>
+
+
+<?php include("foot.inc"); ?>

--- a/net-mgmt/pfSense-pkg-ANDwatch/pkg-descr
+++ b/net-mgmt/pfSense-pkg-ANDwatch/pkg-descr
@@ -1,0 +1,3 @@
+ANDwatch is a daemon for monitoring Arp and Neighbor Discovery
+activity, keeping track of IP to Ethernet address mappings, and
+providing notifications when the mappings change.

--- a/net-mgmt/pfSense-pkg-ANDwatch/pkg-plist
+++ b/net-mgmt/pfSense-pkg-ANDwatch/pkg-plist
@@ -1,0 +1,10 @@
+/etc/inc/priv/andwatch.priv.inc
+pkg/andwatch.xml
+pkg/andwatch.inc
+pkg/andwatch-notify.php
+%%DATADIR%%/info.xml
+www/andwatch.php
+www/status_andwatch.php
+www/shortcuts/pkg_andwatch.inc
+@dir /etc/inc/priv
+@dir /etc/inc


### PR DESCRIPTION
Implements Redmine #16070 (https://redmine.pfsense.org/issues/16070)

ANDwatch is a modern replacement for arpwatch. When contrasted with arpwatch, ANDwatch offers the following enhancements:

- Support for IPv6.
- Support for all IEEE MAC Address Blocks:
  - 24 bit Large MAC Address Block MA-L.
  - 28 bit Medium MAC Address Block MA-M (new).
  - 36 bit Small MAC Address Block MA-S (new).
- Identification of private (locally administered) hardware addresses.
- Does not require sendmail as a hardcoded notification mechanism.