### PR TITLE
Update OpenPhish feed URL to new GitHub location

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.json
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/www/pfblockerng/pfblockerng_feeds.json
@@ -1430,7 +1430,7 @@
 				{
 					"feed":		"OpenPhish",
 					"website":	"https://openphish.com/phishing_feeds.html",
-					"url":		"https://openphish.com/feed.txt",
+					"url":		"https://raw.githubusercontent.com/openphish/public_feed/refs/heads/main/feed.txt",
 					"header":	"OpenPhish"
 				},
 				{


### PR DESCRIPTION
This PR updates the OpenPhish feed URL to point to their new GitHub-hosted location.

The original feed URL occasionally becomes unavailable, while the GitHub-based feed is now officially listed as a reliable alternative. Switching to the GitHub feed ensures better reliability and availability of threat intelligence data.