### PR TITLE
Update mDNS-Bridge to 2.0

### DIFF
--- a/net/pfSense-pkg-mDNS-Bridge/Makefile
+++ b/net/pfSense-pkg-mDNS-Bridge/Makefile
@@ -1,6 +1,6 @@
 
 PORTNAME=	pfSense-pkg-mDNS-Bridge
-PORTVERSION=	1.0
+PORTVERSION=	2.0
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -11,7 +11,7 @@ WWW=		https://github.com/dennypage/mdns-bridge
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	mdns-bridge>=1.0.1:net/mdns-bridge
+RUN_DEPENDS=	mdns-bridge>=2.0.0:net/mdns-bridge
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/net/pfSense-pkg-mDNS-Bridge/files/etc/inc/priv/mdns-bridge.priv.inc
+++ b/net/pfSense-pkg-mDNS-Bridge/files/etc/inc/priv/mdns-bridge.priv.inc
@@ -3,7 +3,7 @@
  * mdns-bridge.priv.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2024 Denny Page
+ * Copyright (c) 2024-2025 Denny Page
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/net/pfSense-pkg-mDNS-Bridge/files/usr/local/pkg/mdns-bridge.inc
+++ b/net/pfSense-pkg-mDNS-Bridge/files/usr/local/pkg/mdns-bridge.inc
@@ -3,7 +3,7 @@
  * mdns-bridge.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2024 Denny Page
+ * Copyright (c) 2024-2025 Denny Page
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/net/pfSense-pkg-mDNS-Bridge/files/usr/local/pkg/mdns_bridge.xml
+++ b/net/pfSense-pkg-mDNS-Bridge/files/usr/local/pkg/mdns_bridge.xml
@@ -8,7 +8,7 @@
  * mdns_bridge.xml
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2024 Denny Page
+ * Copyright (c) 2024-2025 Denny Page
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/net/pfSense-pkg-mDNS-Bridge/files/usr/local/www/mdns-bridge.php
+++ b/net/pfSense-pkg-mDNS-Bridge/files/usr/local/www/mdns-bridge.php
@@ -3,7 +3,7 @@
  * mdns-bridge.php
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2024 Denny Page
+ * Copyright (c) 2024-2025 Denny Page
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -403,7 +403,7 @@ $section->addInput(new Form_Checkbox(
 	'Disable Packet Filtering',
 	'Completely disable packet decoding and filtering',
 	$pconfig['disable_packet_filtering']
-))->setHelp(gettext('Selecting this option will cause packets received from one interface to be forwarded directly to neighboring interfaces without any further processing. <b>This option disables all mDNS packet validation. Use with caution.</b>'));
+))->setHelp(gettext('Selecting this option will cause packets received from one interface to be forwarded directly to neighboring interfaces without any further processing. <b>This option disables all mDNS packet validation and filtering, including link local addresses. Use this option with extreme caution.</b>'));
 $form->add($section);
 
 print($form);

--- a/net/pfSense-pkg-mDNS-Bridge/files/usr/local/www/shortcuts/pkg_mdns-bridge.inc
+++ b/net/pfSense-pkg-mDNS-Bridge/files/usr/local/www/shortcuts/pkg_mdns-bridge.inc
@@ -3,7 +3,7 @@
  * pkg_mdns-bridge.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2022-2024 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2022-2025 Rubicon Communications, LLC (Netgate)
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Implements Redmine #16190 (https://redmine.pfsense.org/issues/16190)

This update adds filtering of link local addresses from forwarded mDNS records.

