### PR TITLE
Bump Makefile, remove use-ipv6 block from pfblockerng.inc

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG-devel/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	pfSense-pkg-pfBlockerNG-devel
 PORTVERSION=	3.2.9
-PORTREVISION=	1
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty


### PR DESCRIPTION
This should take care of the following issue: https://www.reddit.com/r/pfBlockerNG/comments/1jb5rtc/ipv6_woes_wrong_vip/
@BBcan177 