### PR TITLE
Update mDNS-Bridge to 2.2

### DIFF
--- a/net/pfSense-pkg-mDNS-Bridge/Makefile
+++ b/net/pfSense-pkg-mDNS-Bridge/Makefile
@@ -1,6 +1,6 @@
 
 PORTNAME=	pfSense-pkg-mDNS-Bridge
-PORTVERSION=	2.1
+PORTVERSION=	2.2
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty
@@ -11,7 +11,7 @@ WWW=		https://github.com/dennypage/mdns-bridge
 
 LICENSE=	APACHE20
 
-RUN_DEPENDS=	mdns-bridge>=2.1.0:net/mdns-bridge
+RUN_DEPENDS=	mdns-bridge>=2.2.0:net/mdns-bridge
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/net/pfSense-pkg-mDNS-Bridge/files/usr/local/pkg/mdns-bridge.inc
+++ b/net/pfSense-pkg-mDNS-Bridge/files/usr/local/pkg/mdns-bridge.inc
@@ -62,8 +62,12 @@ function mdns_bridge_write_files() {
 
 	// Get the real interface names
 	$interfaces = array();
-	foreach (explode(',', array_get_path($current_config, 'active_interfaces', '')) as $interface) {
-		$interfaces[$interface] = get_real_interface($interface);
+	foreach (array_filter(explode(',', array_get_path($current_config, 'active_interfaces', ''))) as $interface) {
+		$interface_name = get_real_interface($interface);
+		if (!isset($interface_name)) {
+			continue;
+		}
+		$interfaces[$interface] = $interface_name;
 	}
 
 	// Global section
@@ -153,7 +157,11 @@ function mdns_bridge_write_files() {
 	}
 
 	// Write the rc file
-	$start = MDNS_BRIDGE_CMD . ' -s -c ' . MDNS_BRIDGE_CONF_FILE . ' -p ' . MDNS_BRIDGE_PID_FILE;
+	$start = MDNS_BRIDGE_CMD;
+	if (config_get_path('installedpackages/mdns-bridge/decode_warnings', false)) {
+		$start .= ' -w';
+	}
+	$start .= ' -s -c ' . MDNS_BRIDGE_CONF_FILE . ' -p ' . MDNS_BRIDGE_PID_FILE;
 	$stop = '/usr/bin/killall ' . MDNS_BRIDGE_SVC_NAME;
 	write_rcfile(array(
 		"file" => "mdns-bridge.sh",

--- a/net/pfSense-pkg-mDNS-Bridge/files/usr/local/www/mdns-bridge.php
+++ b/net/pfSense-pkg-mDNS-Bridge/files/usr/local/www/mdns-bridge.php
@@ -30,6 +30,7 @@ $package_path = 'installedpackages/mdns-bridge';
 $path_enable = 'enable';
 $path_carp_vhid = 'carp_vhid';
 $path_active_interfaces = 'active_interfaces';
+$path_decode_warnings = 'decode_warnings';
 $path_global_ip_protocols = 'global_ip_protocols';
 $path_global_filter_type = 'global_filter_type';
 $path_global_filter_list = 'global_filter_list';
@@ -40,7 +41,8 @@ $path_interfaces = 'interfaces';
 $current_config = config_get_path($package_path, []);
 $pconfig['enable'] = array_get_path($current_config, $path_enable);
 $pconfig['carp_vhid'] = array_get_path($current_config, $path_carp_vhid);
-$pconfig['active_interfaces'] = explode(',', array_get_path($current_config, $path_active_interfaces, ''));
+$pconfig['active_interfaces'] = array_filter(explode(',', array_get_path($current_config, $path_active_interfaces, '')));
+$pconfig['decode_warnings'] = array_get_path($current_config, $path_decode_warnings);
 $pconfig['global_ip_protocols'] = array_get_path($current_config, $path_global_ip_protocols, 'both');
 $pconfig['global_filter_type'] = array_get_path($current_config, $path_global_filter_type, 'none');
 $pconfig['global_filter_list'] = array_get_path($current_config, $path_global_filter_list, '');
@@ -81,7 +83,7 @@ if ($_POST) {
 	if ($pconfig['global_filter_type'] != 'none') {
 		$pconfig['disable_packet_filtering'] = false;
 		$filter_list = array();
-		foreach (explode(',', $pconfig['global_filter_list']) as $filter) {
+		foreach (array_filter(explode(',', $pconfig['global_filter_list'])) as $filter) {
 			$filter = trim($filter);
 			if (!is_domain($filter, false, false)) {
 				$input_errors[] = sprintf(gettext('Invalid domain in Global Filter List: "%1$s"'), $filter);
@@ -101,7 +103,7 @@ if ($_POST) {
 		if ($pconfig['inbound_filter_type_' . $interface] != 'none') {
 			$pconfig['disable_packet_filtering'] = false;
 			$filter_list = array();
-			foreach (explode(',', $pconfig['inbound_filter_list_' . $interface]) as $filter) {
+			foreach (array_filter(explode(',', $pconfig['inbound_filter_list_' . $interface])) as $filter) {
 				$filter = trim($filter);
 				if (!is_domain($filter, false, false)) {
 					$input_errors[] = sprintf(gettext('Invalid domain in %1$s Inbound Filter List: "%2$s"'),
@@ -120,7 +122,7 @@ if ($_POST) {
 		if ($pconfig['outbound_filter_type_' . $interface] != 'none') {
 			$pconfig['disable_packet_filtering'] = false;
 			$filter_list = array();
-			foreach (explode(',', $pconfig['outbound_filter_list_' . $interface]) as $filter) {
+			foreach (array_filter(explode(',', $pconfig['outbound_filter_list_' . $interface])) as $filter) {
 				$filter = trim($filter);
 				if (!is_domain($filter, false, false)) {
 					$input_errors[] = sprintf(gettext('Invalid domain in %1$s Outbound Filter List: "%2$s"'),
@@ -147,6 +149,7 @@ if ($_POST) {
 		array_set_path($current_config, $path_enable, $pconfig['enable']);
 		array_set_path($current_config, $path_carp_vhid, $pconfig['carp_vhid']);
 		array_set_path($current_config, $path_active_interfaces, implode(',', $pconfig['active_interfaces']));
+		array_set_path($current_config, $path_decode_warnings, $pconfig['decode_warnings']);
 		array_set_path($current_config, $path_global_ip_protocols, $pconfig['global_ip_protocols']);
 		array_set_path($current_config, $path_global_filter_type, $pconfig['global_filter_type']);
 		array_set_path($current_config, $path_global_filter_list, $pconfig['global_filter_list']);
@@ -224,6 +227,14 @@ $section->addInput(new Form_Select(
 	true
 ))->addClass('active_interfaces')->setHelp(gettext('Interfaces that the mDNS Bridge daemon will operate on. Two or more interfaces are required.'));
 $form->add($section);
+
+// Decode warnings
+$section->addInput(new Form_Checkbox(
+	'decode_warnings',
+	'Decode Warnings',
+	'Enable warnings for mDNS decoding errors that are silent by default',
+	$pconfig['decode_warnings']
+));
 
 $section = new Form_Section('Global Settings');
 // Global IP protocol list


### PR DESCRIPTION
Implements Redmine [16399](https://redmine.pfsense.org/issues/16399)

Update mdns-bridge to 2.2.
Add an option to enable mDNS decode warings that are silent by default.