### PR TITLE
net-p2p/htorrentcreator: Add hTorrentCreator package

### DIFF
--- a/net-p2p/htorrentcreator/Makefile
+++ b/net-p2p/htorrentcreator/Makefile
@@ -1,0 +1,14 @@
+PORTNAME=	htorrentcreator
+DISTVERSION=	0.0.6
+CATEGORIES=	net-p2p
+MASTER_SITES=	https://github.com/hon4/hTorrentCreatorCLI/releases/download/v${DISTVERSION}/
+DISTNAME=	hTorrentCreatorCLI-${DISTVERSION}
+
+MAINTAINER=	greek.team.blog2@gmail.com
+COMMENT=	BitTorrent file creator written in C++
+WWW=		https://github.com/hon4/hTorrentCreatorCLI
+
+LICENSE=	GPLv2
+LICENSE_FILE=	${WRKSRC}/License.txt
+
+.include <bsd.port.mk>

--- a/net-p2p/htorrentcreator/distinfo
+++ b/net-p2p/htorrentcreator/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1759503603
+SHA256 (hTorrentCreatorCLI-0.0.6.tar.gz) = 27762e260b80af743c168f64fb259988e2c4eead11df512b8192cd42070bbd05
+SIZE (hTorrentCreatorCLI-0.0.6.tar.gz) = 429605

--- a/net-p2p/htorrentcreator/pkg-descr
+++ b/net-p2p/htorrentcreator/pkg-descr
@@ -1,0 +1,11 @@
+hTorrentCreator is a BitTorrent file creator written in C++.
+
+Main Features are:
+  * Easy to use.
+  * Optimized to be as fast as possible.
+  * Single and Multi-file torrent creation.
+  * Single and Multiple trackers.
+  * Tracker groups.
+  * Custom piece size
+  * WebSeeds
+  * Comments


### PR DESCRIPTION
Added hTorrentCreator package in `net-p2p` category.

I have tested the program on:
1. FreeBSD 14.3 amd64

And it's fully functional.
