### PR TITLE
dns/pfSense-pkg-bind: Added ability to exclude listen interfaces when listening on any

### DIFF
--- a/dns/pfSense-pkg-bind/files/usr/local/pkg/bind.inc
+++ b/dns/pfSense-pkg-bind/files/usr/local/pkg/bind.inc
@@ -200,27 +200,39 @@ EOD;
 EOD;
 	}
 	// Check IPs to listen on
-	if (preg_match("/All/", $bind['listenon'])) {
-		$bind_listenonv6 = "any;";
-		$bind_listenon = "any;";
-	} else {
-		$bind_listenonv6 = "";
-		$bind_listenon = "";
-		foreach (explode(',', $bind['listenon']) as $listenon) {
-			if (is_ipaddrv6($listenon)) {
-				$bind_listenonv6 .= $listenon."; ";
-			} elseif (is_ipaddr($listenon)) {
-				$bind_listenon .= $listenon."; ";
-			} else {
-				$listenon = get_interface_addresses(convert_friendly_interface_to_real_interface_name($listenon));
-				if (is_ipaddr($listenon['ipaddr'])) {
-					$bind_listenon .= $listenon['ipaddr']."; ";
+	$listen_on_all = preg_match("/All/", $bind['listenon']);
+	$bind_listenonv6 = "";
+	$bind_listenon = "";
+	foreach (explode(',', $bind['listenon']) as $listenon) {
+		if (is_ipaddrv6($listenon)) {
+			if ($listen_on_all) {
+				$bind_listenonv6 .= "!";
+			}
+			$bind_listenonv6 .= $listenon."; ";
+		} elseif (is_ipaddr($listenon)) {
+			if ($listen_on_all) {
+				$bind_listenon .= "!";
+			}
+			$bind_listenon .= $listenon."; ";
+		} else {
+			$listenon = get_interface_addresses(convert_friendly_interface_to_real_interface_name($listenon));
+			if (is_ipaddr($listenon['ipaddr'])) {
+				if ($listen_on_all) {
+					$bind_listenon .= "!";
 				}
-				if (is_ipaddrv6($listenon['ipaddr6'])) {
-					$bind_listenonv6 .= $listenon['ipaddr6']."; ";
+				$bind_listenon .= $listenon['ipaddr']."; ";
+			}
+			if (is_ipaddrv6($listenon['ipaddr6'])) {
+				if ($listen_on_all) {
+					$bind_listenonv6 .= "!";
 				}
+				$bind_listenonv6 .= $listenon['ipaddr6']."; ";
 			}
 		}
+	}
+	if ($listen_on_all) {
+		$bind_listenonv6 .= "any;";
+		$bind_listenon .= "any;";
 	}
 	$bind_listenonv6 = $bind_listenonv6 == "" ? "none;" : $bind_listenonv6;
 	$bind_listenon = $bind_listenon == "" ? "none;" : $bind_listenon;

--- a/dns/pfSense-pkg-bind/files/usr/local/pkg/bind.xml
+++ b/dns/pfSense-pkg-bind/files/usr/local/pkg/bind.xml
@@ -104,7 +104,7 @@
 		<field>
 			<fielddescr>Listen on</fielddescr>
 			<fieldname>listenon</fieldname>
-			<description>Choose the interfaces on which to enable BIND.</description>
+			<description>Choose the interfaces on which to enable BIND. If "Listen on All interfaces/ip addresses" is selected, all other selections are excluded.</description>
 			<type>interfaces_selection</type>
 			<showlistenall/>
 			<showvirtualips/>


### PR DESCRIPTION
When using bind in addition to unbound it can be desirable to limit bind to certain interfaces. Additionally binds automatic interface scanning feature is tied to listening on any. This patch adds the ability to specify a set of interfaces you do not want to listen on and makes bind listen on all other interfaces while keeping automatic interface scanning working.