### PR TITLE
remove required attr from filedata

### DIFF
--- a/sysutils/pfSense-pkg-filer/files/usr/local/pkg/filer.xml
+++ b/sysutils/pfSense-pkg-filer/files/usr/local/pkg/filer.xml
@@ -103,7 +103,6 @@
 			<encoding>base64</encoding>
 			<cols>75</cols>
 			<rows>25</rows>
-			<required/>
 		</field>
 		<field>
 			<type>listtopic</type>


### PR DESCRIPTION
The Filer package (as of 2026.05.24) says _*"Leave blank to load an existing file from file system…"*_

<img width="1598" height="938" alt="image" src="https://github.com/user-attachments/assets/d043e00e-4ea7-472e-bc5e-c278de74d866" />

However, attempting to do so results in an error from input validation: _*"The field File Contents is required"*_

<img width="1654" height="744" alt="image" src="https://github.com/user-attachments/assets/f6c71465-6b14-4ad0-8913-7c171ad4fc9f" />

I thought this might be more complicated to fix, but it turns out the underlying code to handle empty filedata was already there. All that was needed was to remove the `<required/>` tag from `/usr/local/pkg/filer.xml`

This patch aims to address this.

Redmine: https://redmine.pfsense.org/issues/16856