### PR TITLE
net/pfSense-pkg-pfBlockerNG-devel: minor shell script cleanup

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AF.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AF.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("af-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("af-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("af-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("af-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_ALL_REGIONS.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_ALL_REGIONS.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP.sh
@@ -23,9 +23,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("ap-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("ap-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("ap-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("ap-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_EAST.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_EAST.sh
@@ -23,9 +23,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("ap-east-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("ap-east-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("ap-east-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("ap-east-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_NORTHEAST.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_NORTHEAST.sh
@@ -23,9 +23,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("ap-northeast-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("ap-northeast-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("ap-northeast-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("ap-northeast-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_SOUTH.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_SOUTH.sh
@@ -23,9 +23,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("ap-south-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("ap-south-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("ap-south-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("ap-south-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_SOUTHEAST.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_SOUTHEAST.sh
@@ -23,9 +23,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("ap-southeast-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("ap-southeast-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("ap-southeast-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("ap-southeast-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_CA.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_CA.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("ca-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("ca-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("ca-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("ca-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_CN.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_CN.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("cn-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("cn-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("cn-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("cn-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_CN_NORTH.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_CN_NORTH.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("cn-north-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("cn-north-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("cn-north-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("cn-north-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_CN_NORTHWEST.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_CN_NORTHWEST.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("cn-northwest-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("cn-northwest-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("cn-northwest-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("cn-northwest-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("eu-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("eu-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("eu-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("eu-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_CENTRAL.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_CENTRAL.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("eu-central-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("eu-central-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("eu-central-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("eu-central-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_NORTH.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_NORTH.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("eu-north-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("eu-north-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("eu-north-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("eu-north-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_SOUTH.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_SOUTH.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("eu-south-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("eu-south-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("eu-south-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("eu-south-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_WEST.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_WEST.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("eu-west-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("eu-west-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("eu-west-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("eu-west-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_IL.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_IL.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("il-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("il-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("il-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("il-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_ME.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_ME.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("me-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("me-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("me-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("me-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_ME_CENTRAL.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_ME_CENTRAL.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("me-central-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("me-central-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("me-central-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("me-central-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_ME_SOUTH.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_ME_SOUTH.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("me-south-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("me-south-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("me-south-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("me-south-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_SA.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_SA.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("sa-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("sa-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("sa-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("sa-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_US.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_US.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("us-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("us-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("us-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("us-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_US_EAST.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_US_EAST.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("us-east-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("us-east-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("us-east-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("us-east-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_US_GOV.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_US_GOV.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("us-gov-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("us-gov-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("us-gov-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("us-gov-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_US_WEST.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/ip_pre_AWS_US_WEST.sh
@@ -22,9 +22,9 @@ alias="${1}"
 prefix="${2}"
 
 if [ "${prefix}" == '_v4' ]; then
-	cat "${alias}" | jq -r '.prefixes[] | select(.region | startswith("us-west-")) .ip_prefix' | iprange > "${tempfile}"
+	jq -r '.prefixes[] | select(.region | startswith("us-west-")) .ip_prefix' "${alias}" | iprange > "${tempfile}"
 else
-	cat "${alias}" | jq -r '.ipv6_prefixes[] | select(.region | startswith("us-west-")) .ipv6_prefix' > "${tempfile}"
+	jq -r '.ipv6_prefixes[] | select(.region | startswith("us-west-")) .ipv6_prefix' "${alias}" > "${tempfile}"
 fi
 
 if [ -s "${tempfile}" ]; then

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -206,7 +206,7 @@ suppress() {
 	fi
 
 	if [ -e "${pfbsuppression}" ] && [ -s "${pfbsuppression}" ]; then
-		data="$(cat ${pfbsuppression} | sort | uniq)"
+		data="$(sort -u "${pfbsuppression}")"
 
 		if [ ! -z "${data}" ] && [ ! -z "${alias}" ]; then
 			if [ "${alias}" == 'suppressheader' ]; then
@@ -328,7 +328,7 @@ duplicate() {
 	# Check if alias exists in masterfile
 	lcheck="$(grep -m1 ${alias} ${masterfile})"; if [ -z "${lcheck}" ]; then dupcheck=0; fi
 	# Check for single alias in masterfile
-	aliaslist="$(cut -d ' ' -f1 ${masterfile} | sort | uniq)"; if [ "${alias}" == "${aliaslist}" ]; then hcheck=0; fi
+	aliaslist="$(cut -d ' ' -f1 ${masterfile} | sort -u)"; if [ "${alias}" == "${aliaslist}" ]; then hcheck=0; fi
 
 	# Only execute if 'Alias' exists in masterfile
 	if [ "${dupcheck}" -eq 1 ]; then
@@ -340,7 +340,7 @@ duplicate() {
 
 	# Don't execute when only a single 'Alias' exists in masterfile
 	if [ ! "${hcheck}" -eq 0 ]; then
-		sort "${pfbdeny}${alias}.txt" | uniq > "${tempfile}"; mv -f "${tempfile}" "${pfbdeny}${alias}.txt"
+		sort -u "${pfbdeny}${alias}.txt" > "${tempfile}"; mv -f "${tempfile}" "${pfbdeny}${alias}.txt"
 		"${pathgrepcidr}" -vf "${mastercat}" "${pfbdeny}${alias}.txt" > "${tempfile}"; mv -f "${tempfile}" "${pfbdeny}${alias}.txt"
 	fi
 
@@ -375,7 +375,7 @@ dnsbl_scrub() {
 	alexa_enable="${max}"
 
 	# Process De-Duplication
-	sort "${pfbdomain}${alias}.bk" | uniq > "${pfbdomain}${alias}.bk2"
+	sort -u "${pfbdomain}${alias}.bk" > "${pfbdomain}${alias}.bk2"
 	countu="$(grep -c ^ ${pfbdomain}${alias}.bk2)"
 
 	if [ -d "${pfbdomain}" ] && [ "$(ls -A ${pfbdomain}*.txt 2>/dev/null)" ]; then
@@ -413,17 +413,17 @@ dnsbl_scrub() {
 		if [ "${countw}" -gt 0 ]; then
 			if [ "${dedup}" == '' ]; then
 				data="$(awk 'FNR==NR{a[$0];next}!($0 in a)' ${pfbdomain}${alias}.bk2 ${pfbdomain}${alias}.bk | \
-					cut -d '"' -f2 | cut -d ' ' -f1 | sort | uniq | tr '\n' '|')"
+					cut -d '"' -f2 | cut -d ' ' -f1 | sort -u | tr '\n' '|')"
 			else
 				data="$(awk 'FNR==NR{a[$0];next}!($0 in a)' ${pfbdomain}${alias}.bk2 ${pfbdomain}${alias}.bk | \
-					cut -d ',' -f2 | sort | uniq | tr '\n' '|')"
+					cut -d ',' -f2 | sort -u | tr '\n' '|')"
 			fi
 
 			if [ -z "${data}" ]; then
 				if [ "${dedup}" == '' ]; then
-					data="$(cut -d '"' -f2 ${pfbdomain}${alias}.bk | cut -d ' ' -f1 | sort | uniq | tr '\n' '|')"
+					data="$(cut -d '"' -f2 ${pfbdomain}${alias}.bk | cut -d ' ' -f1 | sort -u | tr '\n' '|')"
 				else
-					data="$(cut -d ',' -f2 ${pfbdomain}${alias}.bk | sort | uniq | tr '\n' '|')"
+					data="$(cut -d ',' -f2 ${pfbdomain}${alias}.bk | sort -u | tr '\n' '|')"
 				fi
 			fi
 
@@ -444,17 +444,17 @@ dnsbl_scrub() {
 		if [ "${counta}" -gt 0 ]; then
 			if [ "${dedup}" == '' ]; then
 				data="$(awk 'FNR==NR{a[$0];next}!($0 in a)' ${pfbdomain}${alias}.bk2 ${pfbdomain}${alias}.bk | \
-					cut -d '"' -f2 | cut -d ' ' -f1 | sort | uniq | tr '\n' '|')"
+					cut -d '"' -f2 | cut -d ' ' -f1 | sort -u | tr '\n' '|')"
 			else
 				data="$(awk 'FNR==NR{a[$0];next}!($0 in a)' ${pfbdomain}${alias}.bk2 ${pfbdomain}${alias}.bk | \
-					cut -d ',' -f2 | sort | uniq | tr '\n' '|')"
+					cut -d ',' -f2 | sort -u | tr '\n' '|')"
 			fi
 
 			if [ -z "${data}" ]; then
 				if [ "${dedup}" == '' ]; then
-					data="$(cut -d '"' -f2 ${pfbdomain}${alias}.bk | cut -d ' ' -f1 | sort | uniq | tr '\n' '|')"
+					data="$(cut -d '"' -f2 ${pfbdomain}${alias}.bk | cut -d ' ' -f1 | sort -u | tr '\n' '|')"
 				else
-					data="$(cut -d ',' -f2 ${pfbdomain}${alias}.bk | sort | uniq | tr '\n' '|')"
+					data="$(cut -d ',' -f2 ${pfbdomain}${alias}.bk | sort -u | tr '\n' '|')"
 				fi
 			fi
 
@@ -484,14 +484,14 @@ domaintld() {
 	> "${tempfile}"; > "${tempfile2}"; > "${dupfile}"
 
 	if [ -s "${dnsbl_file}.raw" ]; then
-		sort "${dnsbl_file}.raw" | uniq > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_file}.raw"
+		sort -u "${dnsbl_file}.raw" > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_file}.raw"
 		countto="$(grep -v '"transparent"\|\"static\"' ${dnsbl_file}.raw | grep -c ^)"
 	else
 		countto=0
 	fi
 
 	if [ -s "${dnsbl_tld_remove}" ]; then
-		sort "${dnsbl_tld_remove}" | uniq > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_tld_remove}"
+		sort -u "${dnsbl_tld_remove}" > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_tld_remove}"
 		counttm="$(grep -c '^\.' ${dnsbl_tld_remove})"
 	else
 		counttm=0
@@ -510,7 +510,7 @@ domaintld() {
 		for file in ${dnsbl_tmp_files}; do
 			# For each file, place 'local-zone' before 'local-data'
 			head -1 "${file}" >> "${dupfile}"
-			tail -n +2 "${file}" | sort | uniq >> "${dupfile}"
+			tail -n +2 "${file}" | sort -u >> "${dupfile}"
 		done
 
 		# Remove redundant Domains (in 'redirect zone')
@@ -529,7 +529,7 @@ domaintld() {
 	# 'Transparent zone'
 	# Remove redundant Domains (in 'transparent zone')
 	if [ -s "${dnsbl_tld_remove}.tsp" ] && [ -s "${dnsbl_file}.tsp" ]; then
-		/usr/local/bin/ggrep -vF -f "${dnsbl_tld_remove}.tsp" "${dnsbl_file}.tsp" | sort | uniq > "${tempfile2}"
+		/usr/local/bin/ggrep -vF -f "${dnsbl_tld_remove}.tsp" "${dnsbl_file}.tsp" | sort -u > "${tempfile2}"
 	else
 		echo "XXX"
 		# XXXX to be confirmed!
@@ -549,7 +549,7 @@ domaintld() {
 
 	# Sort 'Transparent zone' remove file
 	if [ -s "${dnsbl_tld_remove}.tsp" ]; then
-		sort "${dnsbl_tld_remove}.tsp" | uniq > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_tld_remove}.tsp"
+		sort -u "${dnsbl_tld_remove}.tsp" > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_tld_remove}.tsp"
 	fi
 
 	# Remove redundant Domains in DNSBL files
@@ -589,14 +589,14 @@ domaintldpy() {
 	dnsbl_files="${cc}";
 
 	if [ -s "${dnsbl_python_data}.raw" ]; then
-		sort "${dnsbl_python_data}.raw" | uniq > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_python_data}.raw"
+		sort -u "${dnsbl_python_data}.raw" > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_python_data}.raw"
 		countd="$(grep -c ^ ${dnsbl_python_data}.raw)"
 	else
 		countd=0
 	fi
 
 	if [ -s "${dnsbl_python_zone}.raw" ]; then
-		sort "${dnsbl_python_zone}.raw" | uniq > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_python_zone}.raw"
+		sort -u "${dnsbl_python_zone}.raw" > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_python_zone}.raw"
 		countz="$(grep -c ^ ${dnsbl_python_zone}.raw)"
 	else
 		countz=0
@@ -607,7 +607,7 @@ domaintldpy() {
 	countto="$((countd + countz))"
 
 	if [ -s "${dnsbl_tld_remove}" ]; then
-		sort "${dnsbl_tld_remove}" | uniq > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_tld_remove}"
+		sort -u "${dnsbl_tld_remove}" > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_tld_remove}"
 		counttm="$(grep -c '^\.' ${dnsbl_tld_remove})"
 	else
 		counttm=0
@@ -715,7 +715,7 @@ dnsbl_livesync() {
 
 		# Create 'transparent' TLD zone for any local-data
 		if [ -s "${dnsbl_add_data}" ]; then
-			cat "${dnsbl_add_data}" | cut -d ' ' -f1 | rev | cut -d '.' -f1 | rev | sed 's/$/ transparent/' >> "${dnsbl_add_zone}"
+			cut -d ' ' -f1 "${dnsbl_add_data}" | rev | cut -d '.' -f1 | rev | sed 's/$/ transparent/' >> "${dnsbl_add_zone}"
 		fi
 	fi
 
@@ -880,7 +880,7 @@ reputation_depends() {
 
 # Reputation function to condense an IP range if a 'Max' amount of IP addresses are found in a /24 range per individual list.
 reputation_max() {
-	sort "${pfbdeny}${alias}.txt" | uniq > "${tempfile}"
+	sort -u "${pfbdeny}${alias}.txt" > "${tempfile}"
 	data="$(cut -d '.' -f 1-3 ${tempfile} | awk -v max=${max} '{a[$0]++}END{for(i in a){if(a[i] > max){print i}}}')"
 
 	# Classify repeat offenders by Country code
@@ -945,8 +945,8 @@ reputation_max() {
 
 	if [ "${count}" -gt 0 ]; then
 		echo; echo "  Reputation (Max=${max}) - Range(s)"
-		cat "${dupfile}" | tr '\n' '|'; echo
-		sort "${pfbdeny}${alias}.txt" | uniq > "${tempfile}"; mv -f "${tempfile}" "${pfbdeny}${alias}.txt"
+		tr '\n' '|' < "${dupfile}"; echo
+		sort -u "${pfbdeny}${alias}.txt" > "${tempfile}"; mv -f "${tempfile}" "${pfbdeny}${alias}.txt"
 	fi
 
 	if [ "${count}" -gt 0 ] || [ "${countr}" -gt 0 ]; then
@@ -1201,7 +1201,7 @@ processxlsx() {
 	if [ -s "${pfborig}${alias}.raw" ]; then
 		"${pathtar}" -xf "${pfborig}${alias}.raw" -C "${tmpxlsx}"
 		"${pathtar}" -xOf "${tmpxlsx}"*.[xX][lL][sS][xX] "xl/sharedStrings.xml" | \
-			grep -aoEw "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" | sort | uniq > "${pfborig}${alias}.orig"
+			grep -aoEw "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" | sort -u > "${pfborig}${alias}.orig"
 		rm -r "${tmpxlsx}"*
 
 		countf="$(grep -cv ^${ip_placeholder2}$ ${pfborig}${alias}.orig)"
@@ -1232,7 +1232,7 @@ closingprocess() {
 
 		s1="$(grep -cv ^${ip_placeholder2}$ ${mastercat})"
 		s2="$(find ${pfbdeny}*.txt ! -name *_v6.txt -type f 2>/dev/null | xargs cat | grep -cv ^${ip_placeholder2}$)"
-		s3="$(sort ${mastercat} | uniq -d | tail -30)"
+		s3="$(sort "${mastercat}" | uniq -d | tail -30)"
 		s4="$(find ${pfbdeny}*.txt ! -name *_v6.txt -type f 2>/dev/null | xargs cat | sort | uniq -d | tail -30 | grep -v ^${ip_placeholder2}$)"
 	else
 		echo "   [ Original IP count   ]  [ ${counto} ]"


### PR DESCRIPTION
## Summary

No functional changes; all replacements are strictly equivalent.

- **Fix useless uses of cat (UUOC):** replace `cat FILE | cmd` with `cmd FILE` or `cmd < FILE` in `pfblockerng.sh` and all 25 `ip_pre_AWS_*.sh` scripts (`jq` accepts a file argument directly, avoiding a superfluous process)
- **Replace `sort FILE | uniq` with `sort -u FILE`** and **`sort | uniq` with `sort -u`** throughout `pfblockerng.sh`, avoiding a superfluous `uniq` process per invocation
- Quote one previously unquoted variable reference in a `sort` call (style only)

Note: `sort | uniq -d` and `sort | uniq -c` calls were intentionally left unchanged, as those use `uniq` flags that have no equivalent in `sort -u`.

## Test plan

- [x] Verify pfBlockerNG update runs cleanly and produces the same IP/DNSBL lists as before
- [x] Verify AWS IP pre-scripts still correctly filter prefixes by region