### PR TITLE
net/pfSense-pkg-pfBlockerNG-devel: add Python test suite and drop Python 2 support

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/Makefile
+++ b/net/pfSense-pkg-pfBlockerNG-devel/Makefile
@@ -22,6 +22,8 @@ RUN_DEPENDS=	${LOCALBASE}/bin/mmdblookup:net/libmaxminddb \
 
 USES=		php python
 
+TEST_DEPENDS=	${PYTHON_PKGNAMEPREFIX}pytest>=0:devel/py-pytest@${PY_FLAVOR}
+
 CONFLICTS=	pfSense-pkg-pfBlockerNG
 
 USE_PHP=	intl
@@ -33,6 +35,14 @@ SUB_LIST=	PORTNAME=${PORTNAME}
 
 do-extract:
 	${MKDIR} ${WRKSRC}
+
+do-test:
+	${MKDIR} ${WRKSRC}${PREFIX}/pkg/pfblockerng
+	${CP} ${FILESDIR}${PREFIX}/pkg/pfblockerng/pfb_unbound.py \
+		${WRKSRC}${PREFIX}/pkg/pfblockerng/
+	${CP} -r ${FILESDIR}/tests ${WRKSRC}/
+	cd ${WRKSRC} && ${SETENV} ${TEST_ENV} \
+		${PYTHON_CMD} -m pytest -v tests/
 
 do-install:
 	${MKDIR} ${STAGEDIR}/etc/inc/priv

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/tests/conftest.py
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/tests/conftest.py
@@ -1,0 +1,13 @@
+import sys
+import os
+import builtins
+
+# pfb_unbound.py is designed to run inside Unbound's Python plugin loader,
+# which injects Unbound-specific functions (log_info, log_err, …) as
+# module-level globals before executing the script.  Provide a no-op stub
+# for the one such function that is called at module level so the file can
+# be imported in a plain Python environment for unit testing.
+builtins.log_info = lambda msg: None
+
+# Make pfb_unbound importable from its installed location within the repo.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'usr', 'local', 'pkg', 'pfblockerng'))

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/tests/test_pfb_unbound.py
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/tests/test_pfb_unbound.py
@@ -1,0 +1,175 @@
+import pytest
+import pfb_unbound
+from pfb_unbound import (
+    convert_ipv4,
+    convert_ipv6,
+    convert_other,
+    is_unknown,
+    python_control_duration,
+)
+
+
+class TestIsUnknown:
+    def test_none_returns_unknown(self):
+        assert is_unknown(None) == 'Unknown'
+
+    def test_empty_string_returns_unknown(self):
+        assert is_unknown('') == 'Unknown'
+
+    def test_zero_returns_unknown(self):
+        assert is_unknown(0) == 'Unknown'
+
+    def test_false_returns_unknown(self):
+        assert is_unknown(False) == 'Unknown'
+
+    def test_nonempty_string_returned_as_is(self):
+        assert is_unknown('example.com') == 'example.com'
+
+    def test_ip_string_returned_as_is(self):
+        assert is_unknown('192.168.1.1') == '192.168.1.1'
+
+    def test_string_zero_returned_as_is(self):
+        # '0' is a non-empty string, so it is not unknown
+        assert is_unknown('0') == '0'
+
+    def test_nonzero_int_returned_as_is(self):
+        assert is_unknown(42) == 42
+
+
+class TestConvertIPv4:
+    # x[2], x[3], x[4], x[5] are the four octets; x[0] and x[1] are ignored
+
+    def test_standard_address(self):
+        assert convert_ipv4(bytes([0, 0, 192, 168, 1, 1])) == '192.168.1.1'
+
+    def test_loopback(self):
+        assert convert_ipv4(bytes([0, 0, 127, 0, 0, 1])) == '127.0.0.1'
+
+    def test_broadcast(self):
+        assert convert_ipv4(bytes([0, 0, 255, 255, 255, 255])) == '255.255.255.255'
+
+    def test_all_zeros(self):
+        assert convert_ipv4(bytes([0, 0, 0, 0, 0, 0])) == '0.0.0.0'
+
+    def test_empty_bytes_returns_unknown(self):
+        assert convert_ipv4(b'') == 'Unknown'
+
+    def test_none_returns_unknown(self):
+        assert convert_ipv4(None) == 'Unknown'
+
+
+class TestConvertIPv6:
+    # x[2] through x[17] are the 16 address bytes; x[0] and x[1] are ignored
+
+    def test_loopback(self):
+        x = bytes([0, 0] + [0] * 15 + [1])
+        assert convert_ipv6(x) == '0000:0000:0000:0000:0000:0000:0000:0001'
+
+    def test_known_prefix(self):
+        # 2001:0db8::1
+        x = bytes([0, 0, 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+        assert convert_ipv6(x) == '2001:0db8:0000:0000:0000:0000:0000:0001'
+
+    def test_all_zeros_not_unknown(self):
+        # All-zeros IPv6 address is a valid (if unusual) value
+        x = bytes([0, 0] + [0] * 16)
+        assert convert_ipv6(x) == '0000:0000:0000:0000:0000:0000:0000:0000'
+
+    def test_empty_bytes_returns_unknown(self):
+        assert convert_ipv6(b'') == 'Unknown'
+
+    def test_none_returns_unknown(self):
+        assert convert_ipv6(None) == 'Unknown'
+
+
+class TestConvertOther:
+    # x[0:3] are ignored; x[3:] is the payload
+    # Encoding rules:
+    #   val == 0          → '|'
+    #   1 <= val <= 12    → '.'
+    #   val == 13         → stop
+    #   val == 32         → ' '
+    #   val == 58         → ':'
+    #   val <= 33 or > 126 → skip
+    #   else              → chr(val)
+    # Leading/trailing '.' and '|' are stripped from the result.
+
+    def test_printable_ascii(self):
+        x = bytes([0, 0, 0, ord('A'), ord('B'), ord('C')])
+        assert convert_other(x) == 'ABC'
+
+    def test_null_becomes_pipe(self):
+        x = bytes([0, 0, 0, ord('A'), 0, ord('B')])
+        assert convert_other(x) == 'A|B'
+
+    def test_low_byte_becomes_dot(self):
+        x = bytes([0, 0, 0, ord('A'), 1, ord('B')])
+        assert convert_other(x) == 'A.B'
+
+    def test_carriage_return_stops_processing(self):
+        x = bytes([0, 0, 0, ord('A'), 13, ord('B')])
+        assert convert_other(x) == 'A'
+
+    def test_space_preserved(self):
+        x = bytes([0, 0, 0, ord('A'), 32, ord('B')])
+        assert convert_other(x) == 'A B'
+
+    def test_colon_preserved(self):
+        x = bytes([0, 0, 0, ord('h'), 58, ord('1')])
+        assert convert_other(x) == 'h:1'
+
+    def test_control_chars_skipped(self):
+        # val 14..31 (excluding 13) and 33 are skipped
+        x = bytes([0, 0, 0, ord('A'), 14, ord('B')])
+        assert convert_other(x) == 'AB'
+
+    def test_high_bytes_skipped(self):
+        x = bytes([0, 0, 0, ord('A'), 200, ord('B')])
+        assert convert_other(x) == 'AB'
+
+    def test_leading_trailing_stripped(self):
+        # Result '.A.' → strip('.|') → 'A'
+        x = bytes([0, 0, 0, ord('.'), ord('A'), ord('.')])
+        assert convert_other(x) == 'A'
+
+    def test_empty_payload_returns_unknown(self):
+        # x[3:] is empty
+        x = bytes([0, 0, 0])
+        assert convert_other(x) == 'Unknown'
+
+    def test_empty_bytes_returns_unknown(self):
+        assert convert_other(b'') == 'Unknown'
+
+    def test_none_returns_unknown(self):
+        assert convert_other(None) == 'Unknown'
+
+
+class TestPythonControlDuration:
+    def test_valid_duration(self):
+        assert python_control_duration('60') == 60
+
+    def test_minimum_valid(self):
+        assert python_control_duration('1') == 1
+
+    def test_maximum_valid(self):
+        assert python_control_duration('3600') == 3600
+
+    def test_zero_rejected(self):
+        assert python_control_duration('0') is False
+
+    def test_above_maximum_rejected(self):
+        assert python_control_duration('3601') is False
+
+    def test_non_numeric_rejected(self):
+        assert python_control_duration('abc') is False
+
+    def test_negative_rejected(self):
+        # isnumeric() returns False for strings with a leading '-'
+        assert python_control_duration('-1') is False
+
+    def test_empty_string_rejected(self):
+        assert python_control_duration('') is False
+
+    def test_none_rejected(self):
+        # AttributeError on None.isnumeric() is caught internally
+        assert python_control_duration(None) is False

--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -29,12 +29,7 @@ import os
 global pfb
 pfb = {}
 
-if sys.version_info < (2, 8):
-    from ConfigParser import ConfigParser
-    pfb['py_v3'] = False
-else:
-    from configparser import ConfigParser
-    pfb['py_v3'] = True
+from configparser import ConfigParser
 
 from collections import defaultdict
 
@@ -578,44 +573,25 @@ def get_tld(qstate):
 
 
 def convert_ipv4(x):
-    global pfb
-
     ipv4 = ''
     if x:
-        if pfb['py_v3']:
-            ipv4 = "{}.{}.{}.{}" .format(x[2], x[3], x[4], x[5])
-        else:
-            ipv4 = "{}.{}.{}.{}" .format(ord(x[2]), ord(x[3]), ord(x[4]), ord(x[5]))
+        ipv4 = "{}.{}.{}.{}".format(x[2], x[3], x[4], x[5])
     return is_unknown(ipv4)
 
 
 def convert_ipv6(x):
-    global pfb
-
     ipv6 = ''
     if x:
-        if pfb['py_v3']:
-            ipv6 = "{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}" \
-                .format(x[2],x[3],x[4],x[5],x[6],x[7],x[8],x[9],x[10],x[11],x[12],x[13],x[14],x[15],x[16],x[17])
-        else:
-            ipv6 = "{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}" \
-                .format(ord(x[2]),ord(x[3]),ord(x[4]),ord(x[5]),ord(x[6]),ord(x[7]),ord(x[8]),ord(x[9]),ord(x[10]), \
-                ord(x[11]),ord(x[12]),ord(x[13]),ord(x[14]),ord(x[15]),ord(x[16]),ord(x[17]))
+        ipv6 = "{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}" \
+            .format(x[2],x[3],x[4],x[5],x[6],x[7],x[8],x[9],x[10],x[11],x[12],x[13],x[14],x[15],x[16],x[17])
     return is_unknown(ipv6)
 
 
 def convert_other(x):
-    global pfb
-
     final = ''
     if x:
         for i in x[3:]:
-
-            if pfb['py_v3']:
-                val = i
-            else:
-                val = ord(i)
-
+            val = i
             if val == 0:
                 i = '|'
             elif 1 <= val <= 12:
@@ -629,9 +605,7 @@ def convert_other(x):
             elif val <= 33 or val > 126:
                 continue
             else:
-                if pfb['py_v3']:
-                    i = chr(i)
-
+                i = chr(i)
             final += i
         final = final.strip('.|')
     return is_unknown(final)
@@ -872,10 +846,7 @@ def get_details_reply(m_type, qinfo, qstate, rep, kwargs):
                                 if pfb['mod_ipaddress']:
                                     r_addr = convert_ipv6(x)
                                     try:
-                                        if pfb['py_v3']:
-                                            r_addr = ipaddress.ip_address(r_addr).compressed
-                                        else:
-                                            r_addr = ipaddress.ip_address(unicode(r_addr)).compressed
+                                        r_addr = ipaddress.ip_address(r_addr).compressed
                                     except Exception as e:
                                         sys.stderr.write("[pfBlockerNG]: Failed to compress IPv6: {}, {}" .format(r_addr, e))
                                         pass
@@ -920,23 +891,15 @@ def get_details_reply(m_type, qinfo, qstate, rep, kwargs):
 
     if pfb['python_maxmind'] and r_addr not in ('', 'Unknown', 'NXDOMAIN', 'NODATA', 'DNSSEC', 'SOA', 'NS'):
         try:
-            if pfb['py_v3']:
-                version = ipaddress.ip_address(r_addr).version
-            else:
-                version = ipaddress.ip_address(unicode(r_addr)).version
-
+            version = ipaddress.ip_address(r_addr).version
         except Exception as e:
             version = ''
             pass
 
         if version != '':
             try:
-                if pfb['py_v3']:
-                    isPrivate = ipaddress.ip_address(r_addr).is_private
-                    isLoopback = ipaddress.ip_address(r_addr).is_loopback
-                else:
-                    isPrivate = ipaddress.ip_address(unicode(r_addr)).is_private
-                    isLoopback = ipaddress.ip_address(unicode(r_addr)).is_loopback
+                isPrivate = ipaddress.ip_address(r_addr).is_private
+                isLoopback = ipaddress.ip_address(r_addr).is_loopback
 
                 if isPrivate:
                     iso_code = 'prv'
@@ -998,11 +961,11 @@ def get_details_reply(m_type, qinfo, qstate, rep, kwargs):
 def python_control_duration(duration):
 
     try:
-        if duration.isnumeric() and 0 < duration <= 3600:
+        if duration.isnumeric():
             duration = int(duration)
-            return duration
-        else:
-            return False
+            if 0 < duration <= 3600:
+                return duration
+        return False
     except Exception as e:
         sys.stderr.write("[pfBlockerNG] python_control_duration: {}" .format(e))
         pass
@@ -1272,10 +1235,7 @@ def operate(id, event, qstate, qdata):
 
                     elif control_command[1] == 'addbypass' or control_command[1] == 'removebypass':
                         b_ip = (control_command[2]).replace('-', '.')
-                        if pfb['py_v3']:
-                            isIPValid = ipaddress.ip_address(b_ip)
-                        else:
-                            isIPValid = ipaddress.ip_address(unicode(b_ip))
+                        isIPValid = ipaddress.ip_address(b_ip)
 
                         if isIPValid:
                             if not pfb['gpListDB']:


### PR DESCRIPTION
## Summary

pfSense CE 2.8 (the earliest still-supported release) is based on FreeBSD 15 and ships Python 3.11, so Python 2 compatibility in `pfb_unbound.py` is no longer needed.

**`pfb_unbound.py`:**
- Drop Python 2/3 compatibility shims: remove the `sys.version_info` guard and the `pfb['py_v3']` flag used throughout
- Replace all `pfb['py_v3']`-gated code paths (`ConfigParser` fallback, `ord()` calls in `convert_ipv4`/`convert_ipv6`/`convert_other`, `unicode()` calls passed to `ipaddress.ip_address()`) with their Python 3 equivalents
- Fix `python_control_duration`: the numeric string was compared to integers before conversion to `int`, causing the function to always return `False` in both Python 2 and Python 3

**`Makefile` and `tests/`:**
- Add `tests/test_pfb_unbound.py` with an initial set of unit tests for the pure utility functions (`is_unknown`, `convert_ipv4`, `convert_ipv6`, `convert_other`, `python_control_duration`); intended as a starting point for validation, not exhaustive coverage
- Add `tests/conftest.py` to stub the Unbound-specific `log_info` called at module level, allowing `pfb_unbound.py` to be imported in a plain Python environment for testing
- Add `do-test:` Makefile target and `TEST_DEPENDS` on `py-pytest` so the suite runs via `make test` in the ports build environment

## Test plan

- [x] Run `make test` in `net/pfSense-pkg-pfBlockerNG-devel` and confirm all 40 tests pass