### PR TITLE
Create ca.conf with EAB credentials when issuing ACME certificate (Issue #16862)

### DIFF
--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme.inc
@@ -3623,6 +3623,8 @@ function get_certificate($name) {
 			$account = get_accountkey($certificate['acmeaccount']);
 			$acmeserver = $account['acmeserver'];
 			$accountkey = $account['accountkey'];
+			$eabkid = $account['eabkid'];
+			$eabhmac = $account['eabhmac'];
 			$email = $account['email'];
 			echo "server: $acmeserver \n";
 
@@ -3640,7 +3642,7 @@ function get_certificate($name) {
 			$acmesh->preferredchain = $certificate['preferredchain'];
 			$acmesh->addressfamily = $certificate['addressfamily'];
 			$acmesh->certprofile = $certificate['certprofile'];
-			$result = $acmesh->signCertificate($action, $accountkey, $certificatepsk, $domainstosign, $envvariables);
+			$result = $acmesh->signCertificate($action, $accountkey, $certificatepsk, $domainstosign, $envvariables, $eabkid, $eabhmac);
 		}
 		return $result;
 	}

--- a/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_sh.inc
+++ b/security/pfSense-pkg-acme/files/usr/local/pkg/acme/acme_sh.inc
@@ -56,6 +56,7 @@ class acme_sh {
 	private $accountconfig;
 	private $path_account;
 	private $name;
+	private $email;
 	private $debug = true;
 	public $dnssleep;
 	public $preferredchain;
@@ -114,6 +115,7 @@ class acme_sh {
 
 	function __construct($name, $ca, $email) {
 		$this->name = $name;
+		$this->email = $email;
 		$this->init($ca, $name, $email);
 	}
 
@@ -177,10 +179,15 @@ class acme_sh {
 		return $privateKey;
 	}
 
-	function signCertificate($action, $accountkey, $certificatepsk, $domainstosign, $envvariables = null) {
+	function signCertificate($action, $accountkey, $certificatepsk, $domainstosign, $envvariables = null, $eabkid = '', $eabhmac = '') {
 		// $action = issue / renew
 		global $acme_domain_validation_method;
 		file_put_contents("{$this->path_account}/account.key", base64_decode($accountkey));
+
+		if (!empty($eabkid) && !empty($eabhmac)) {
+			$caconf = "CA_EAB_KEY_ID='{$eabkid}'\nCA_EAB_HMAC_KEY='{$eabhmac}'\nCA_EMAIL='{$this->email}'\n";
+			file_put_contents("{$this->path_account}/ca.conf", $caconf);
+		}
 
 		$cmdparameters = "";
 		if (is_numericint($this->dnssleep)) {


### PR DESCRIPTION
When attempting to issue a certificate using Actalis, which requires EAB, the issuance always fails with "external account binding required". This is because pfSense currently does not create a ca.conf file when putting the account.key file in the temporary acme.sh-directory.

This patch also creates the ca.conf-file, containing the e-mail-address and the EAB-Key-ID and EAB-HMAC. After usage, there are also an ACCOUNT_URL and CA_KEY_HASH present in the file, but it seems they are not strictly necessary.

This is my attempt to fix ticket #16862.