### PR TITLE
Suricata: Add support for julioliraup/Antiphishing ruleset (References #16933)

### DIFF
--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_check_for_rule_updates.php
@@ -48,6 +48,7 @@ $vrt_enabled = config_get_path('installedpackages/suricata/config/0/enable_vrt_r
 $snortcommunityrules = config_get_path('installedpackages/suricata/config/0/snortcommunityrules') == 'on' ? 'on' : 'off';
 $feodotracker_rules = config_get_path('installedpackages/suricata/config/0/enable_feodo_botnet_c2_rules') == 'on' ? 'on' : 'off';
 $sslbl_rules = config_get_path('installedpackages/suricata/config/0/enable_abuse_ssl_blacklist_rules') == 'on' ? 'on' : 'off';
+$julioliraup_antiphishing = config_get_path('installedpackages/suricata/config/0/enable_julioliraup_antiphishing') == 'on' ? 'on' : 'off';
 $enable_extra_rules = config_get_path('installedpackages/suricata/config/0/enable_extra_rules') == "on" ? 'on' : 'off';
 $extra_rules = config_get_path('installedpackages/suricata/config/0/extra_rules/rule', []);
 
@@ -89,6 +90,13 @@ if (config_get_path('installedpackages/suricata/config/0/enable_abuse_ssl_blackl
 	$sslbl_rules_filename_md5 = ABUSE_SSLBL_DNLD_FILENAME . ".md5";
 	$sslbl_rules_url = ABUSE_SSLBL_DNLD_URL;
 
+}
+
+/* Set up julioliraup/Antiphishing rules filename and URL */
+if ($julioliraup_antiphishing == 'on') {
+	$julioliraup_antiphishing_filename = JULIOLIRAUP_ANTIPHISHING_DNLD_FILENAME;
+	$julioliraup_antiphishing_rules_filename = JULIOLIRAUP_ANTIPHISHING_RULES_FILENAME;
+	$julioliraup_antiphishing_url = JULIOLIRAUP_ANTIPHISHING_DNLD_URL;
 }
 
 /* Set up Emerging Threats rules filenames and URL */
@@ -611,6 +619,105 @@ if ($sslbl_rules == 'on') {
 	}
 }
 
+/*  Download any new julioliraup/Antiphishing Rules */
+if ($julioliraup_antiphishing == 'on') {
+	// Grab the MD5 hash of our last successful download if available
+	if (file_exists("{$suricatadir}{$julioliraup_antiphishing_rules_filename}.md5")) {
+		$old_file_md5 = trim(file_get_contents("{$suricatadir}{$julioliraup_antiphishing_rules_filename}.md5"));
+	}
+	else {
+		$old_file_md5 = "0";
+	}
+
+	suricata_update_status(gettext("Downloading julioliraup/Antiphishing rules file..."));
+	error_log(gettext("\tDownloading julioliraup/Antiphishing rules file...\n"), 3, SURICATA_RULES_UPD_LOGFILE);
+	safe_mkdir("{$tmpfname}/julioliraup");
+	$rc = suricata_download_file_url("{$julioliraup_antiphishing_url}", "{$tmpfname}/{$julioliraup_antiphishing_filename}");
+
+	// See if the download from the URL was successful
+	if ($rc === true) {
+		suricata_update_status(gettext(" done.") . "\n");
+		logger(LOG_NOTICE, localize_text("julioliraup/Antiphishing rules file downloaded successfully."), LOG_PREFIX_PKG_SURICATA);
+		error_log(gettext("\tDone downloading rules tarball.\n"), 3, SURICATA_RULES_UPD_LOGFILE);
+
+		// Extract the tarball to a temporary directory
+		exec("/usr/bin/tar xzf {$tmpfname}/{$julioliraup_antiphishing_filename} -C {$tmpfname}/julioliraup/");
+
+		// Locate the extracted .rules file
+		$extracted_rules = glob("{$tmpfname}/julioliraup/*.rules");
+		$extracted_md5_files = glob("{$tmpfname}/julioliraup/*.rules.md5");
+
+		if (empty($extracted_rules)) {
+			suricata_update_status(gettext("julioliraup/Antiphishing rules tarball extraction failed!") . "\n");
+			logger(LOG_ERR, localize_text("julioliraup/Antiphishing rules tarball did not contain a .rules file."), LOG_PREFIX_PKG_SURICATA);
+			error_log(gettext("\tERROR: julioliraup/Antiphishing rules tarball did not contain a .rules file.\n"), 3, SURICATA_RULES_UPD_LOGFILE);
+			$notify_message .= gettext("- julioliraup/Antiphishing rules will not be updated, tarball extraction failed!\n");
+			$update_errors = true;
+			$julioliraup_antiphishing = 'off';
+		}
+		else {
+			$extracted_rules_file = reset($extracted_rules);
+
+			// Verify integrity using the embedded MD5 file if present
+			if (!empty($extracted_md5_files)) {
+				$extracted_md5_file = reset($extracted_md5_files);
+				$expected_md5 = trim(file_get_contents($extracted_md5_file));
+				$actual_md5 = trim(md5_file($extracted_rules_file));
+				if ($expected_md5 !== $actual_md5) {
+					suricata_update_status(gettext("julioliraup/Antiphishing rules MD5 checksum failed!") . "\n");
+					logger(LOG_ERR, localize_text("julioliraup/Antiphishing rules file MD5 checksum mismatch."), LOG_PREFIX_PKG_SURICATA);
+					error_log(gettext("\tERROR: julioliraup/Antiphishing rules MD5 checksum failed. File may be corrupted.\n"), 3, SURICATA_RULES_UPD_LOGFILE);
+					$notify_message .= gettext("- julioliraup/Antiphishing rules will not be updated, bad MD5 checksum!\n");
+					$update_errors = true;
+					$julioliraup_antiphishing = 'off';
+				}
+				else {
+					$new_file_md5 = $actual_md5;
+				}
+			}
+			else {
+				// No embedded MD5 file — compute MD5 locally
+				$new_file_md5 = trim(md5_file($extracted_rules_file));
+			}
+
+			if ($julioliraup_antiphishing == 'on') {
+				// See if the rules file has changed from our previously installed version
+				if ($old_file_md5 == $new_file_md5) {
+					// File is unchanged from previous download, so no update required
+					suricata_update_status(gettext("julioliraup/Antiphishing rules are up to date.") . "\n");
+					logger(LOG_NOTICE, localize_text("julioliraup/Antiphishing rules are up to date..."), LOG_PREFIX_PKG_SURICATA);
+					error_log(gettext("\tjulioliraup/Antiphishing rules are up to date.\n"), 3, SURICATA_RULES_UPD_LOGFILE);
+					$notify_message .= gettext("- julioliraup/Antiphishing rules are up to date.\n");
+					$julioliraup_antiphishing = 'off';
+				}
+				else {
+					// Rules file has changed — install the new version
+					suricata_update_status(gettext("Installing julioliraup/Antiphishing rules..."));
+					error_log(gettext("\tInstalling julioliraup/Antiphishing rules...\n"), 3, SURICATA_RULES_UPD_LOGFILE);
+					@copy($extracted_rules_file, "{$suricata_rules_dir}{$julioliraup_antiphishing_rules_filename}");
+					file_put_contents("{$suricatadir}{$julioliraup_antiphishing_rules_filename}.md5", $new_file_md5);
+					suricata_update_status(gettext(" done.") . "\n");
+					suricata_update_status(gettext("julioliraup/Antiphishing rules were updated.") . "\n");
+					logger(LOG_NOTICE, localize_text("julioliraup/Antiphishing rules were updated..."), LOG_PREFIX_PKG_SURICATA);
+					error_log(gettext("\tjulioliraup/Antiphishing rules were updated.\n"), 3, SURICATA_RULES_UPD_LOGFILE);
+					$notify_message .= gettext("- julioliraup/Antiphishing rules were updated.\n");
+				}
+			}
+		}
+	}
+	else {
+		suricata_update_status(gettext("julioliraup/Antiphishing rules file download failed!") . "\n");
+		logger(LOG_ERR, localize_text("julioliraup/Antiphishing rules file download failed... server returned error '%s'.", $rc), LOG_PREFIX_PKG_SURICATA);
+		error_log(gettext("\tERROR: julioliraup/Antiphishing rules file download failed. Remote server returned error {$rc}.\n"), 3, SURICATA_RULES_UPD_LOGFILE);
+		error_log(gettext("\tThe error text was: {$last_curl_error}\n"), 3, SURICATA_RULES_UPD_LOGFILE);
+		error_log(gettext("\tjulioliraup/Antiphishing rules will not be updated.\n"), 3, SURICATA_RULES_UPD_LOGFILE);
+		$notify_message .= gettext("- julioliraup/Antiphishing rules will not be updated, file download failed!\n");
+		$update_errors = true;
+		$julioliraup_antiphishing = 'off';
+	}
+	rmdir_recursive("{$tmpfname}/julioliraup");
+}
+
 /*  Download any new Extra Rules */
 if (($enable_extra_rules == 'on') && !empty($extra_rules)) {
 	$extraupdated = 'off';
@@ -899,7 +1006,7 @@ function suricata_apply_customizations($suricatacfg, $if_real) {
 }
 
 /* If we updated any rules, then refresh all the Suricata interfaces */
-if ($snortdownload == 'on' || $emergingthreats == 'on' || $snortcommunityrules == 'on' || $feodotracker_rules == 'on' || $sslbl_rules == 'on' || $extraupdated == 'on') {
+if ($snortdownload == 'on' || $emergingthreats == 'on' || $snortcommunityrules == 'on' || $feodotracker_rules == 'on' || $sslbl_rules == 'on' || $julioliraup_antiphishing == 'on' || $extraupdated == 'on') {
 
 	/* If we updated Snort or ET rules, rebuild the config and map files as nescessary */
 	if ($snortdownload == 'on' || $emergingthreats == 'on' || $snortcommunityrules == 'on') {

--- a/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
+++ b/security/pfSense-pkg-suricata/files/usr/local/pkg/suricata/suricata_defs.inc
@@ -121,6 +121,13 @@ if (!defined("ABUSE_SSLBL_DNLD_FILENAME"))
 if (!defined("ABUSE_SSLBL_DNLD_URL"))
 	define("ABUSE_SSLBL_DNLD_URL", "https://sslbl.abuse.ch/blacklist/");
 
+if (!defined("JULIOLIRAUP_ANTIPHISHING_DNLD_FILENAME"))
+	define("JULIOLIRAUP_ANTIPHISHING_DNLD_FILENAME", "antiphishing.tar.gz");
+if (!defined("JULIOLIRAUP_ANTIPHISHING_RULES_FILENAME"))
+	define("JULIOLIRAUP_ANTIPHISHING_RULES_FILENAME", "julioliraup-antiphishing.rules");
+if (!defined("JULIOLIRAUP_ANTIPHISHING_DNLD_URL"))
+	define("JULIOLIRAUP_ANTIPHISHING_DNLD_URL", "https://raw.githubusercontent.com/julioliraup/Antiphishing/main/antiphishing.tar.gz");
+
 # MaxMind GeoIP2 database update permalink URLs
 if (!defined("MAXMIND_GEOIP2_DNLD_URL"))
 	define("MAXMIND_GEOIP2_DNLD_URL", "https://download.maxmind.com/geoip/databases/GeoLite2-Country/download?suffix=tar.gz");

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_download_updates.php
@@ -37,6 +37,7 @@ $etpro = config_get_path('installedpackages/suricata/config/0/enable_etpro_rules
 $snortcommunityrules = config_get_path('installedpackages/suricata/config/0/snortcommunityrules') == "on" ? 'on' : 'off';
 $feodotracker_rules = config_get_path('installedpackages/suricata/config/0/enable_feodo_botnet_c2_rules') == "on" ? 'on' : 'off';
 $sslbl_rules = config_get_path('installedpackages/suricata/config/0/enable_abuse_ssl_blacklist_rules') == "on" ? 'on' : 'off';
+$julioliraup_antiphishing = config_get_path('installedpackages/suricata/config/0/enable_julioliraup_antiphishing') == "on" ? 'on' : 'off';
 $enable_extra_rules = config_get_path('installedpackages/suricata/config/0/enable_extra_rules') == "on" ? 'on' : 'off';
 $extra_rules = config_get_path('installedpackages/suricata/config/0/extra_rules/rule', []);
 
@@ -153,6 +154,19 @@ if ($sslbl_rules == 'on' && file_exists("{$suricatadir}{$sslbl_rules_filename}.m
 	$sslbl_sig_sig_date = date(DATE_RFC850, filemtime("{$suricatadir}{$sslbl_rules_filename}.md5"));
 }
 
+if ($julioliraup_antiphishing == 'on') {
+	$julioliraup_antiphishing_sig_chk_local = 'Not Downloaded';
+	$julioliraup_antiphishing_sig_date = 'Not Downloaded';
+}
+else {
+	$julioliraup_antiphishing_sig_chk_local = 'Not Enabled';
+	$julioliraup_antiphishing_sig_date = 'Not Enabled';
+}
+if ($julioliraup_antiphishing == 'on' && file_exists("{$suricatadir}" . JULIOLIRAUP_ANTIPHISHING_RULES_FILENAME . ".md5")) {
+	$julioliraup_antiphishing_sig_chk_local = trim(file_get_contents("{$suricatadir}" . JULIOLIRAUP_ANTIPHISHING_RULES_FILENAME . ".md5"));
+	$julioliraup_antiphishing_sig_date = date(DATE_RFC850, filemtime("{$suricatadir}" . JULIOLIRAUP_ANTIPHISHING_RULES_FILENAME . ".md5"));
+}
+
 /* Check for postback to see if we should clear the update log file. */
 if ($_POST['clear']) {
 	if (file_exists(SURICATA_RULES_UPD_LOGFILE)) {
@@ -168,6 +182,7 @@ if ($_REQUEST['updatemode']) {
 		unlink_if_exists("{$suricatadir}{$snort_rules_file}.md5");
 		unlink_if_exists("{$suricatadir}{$feodotracker_rules_filename}.md5");
 		unlink_if_exists("{$suricatadir}{$sslbl_rules_filename}.md5");
+		unlink_if_exists("{$suricatadir}" . JULIOLIRAUP_ANTIPHISHING_RULES_FILENAME . ".md5");
 		unlink_if_exists("{$suricatadir}" . EXTRARULE_FILE_PREFIX . "*.md5");
 	}
 
@@ -294,6 +309,11 @@ include_once("head.inc");
 					<td><?=trim($sslbl_sig_chk_local);?></td>
 					<td><?=gettext($sslbl_sig_sig_date);?></td>
 				</tr>
+				<tr>
+					<td><?=gettext("julioliraup/Antiphishing Rules");?></td>
+					<td><?=$julioliraup_antiphishing_sig_chk_local;?></td>
+					<td><?=gettext($julioliraup_antiphishing_sig_date);?></td>
+				</tr>
 				</tbody>
 			</table>
 		</div>
@@ -352,7 +372,7 @@ foreach ($extra_rules as $exrule) {
 				<strong><?=gettext("Result:");?></strong> <?=$last_rule_upd_status?>
 			</p>
 			<p>
-				<?php if ($snortdownload != 'on' && $emergingthreats != 'on' && $etpro != 'on' && $snortcommunityrules != 'on' && $feodotracker_rules != 'on' && $sslbl_rules != 'on' && $enable_extra_rules != 'on'): ?>
+				<?php if ($snortdownload != 'on' && $emergingthreats != 'on' && $etpro != 'on' && $snortcommunityrules != 'on' && $feodotracker_rules != 'on' && $sslbl_rules != 'on' && $julioliraup_antiphishing != 'on' && $enable_extra_rules != 'on'): ?>
 					<br/><button class="btn btn-primary" disabled>
 						<i class="fa-solid fa-check icon-embed-btn"></i>
 						<?=gettext("Update"); ?>

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_global.php
@@ -34,8 +34,7 @@ $pconfig = array();
 // If doing a postback, used typed values, else load from stored config
 if (!empty($_POST)) {
 	$pconfig = $_POST;
-}
-else {
+} else {
 	$pconfig['enable_vrt_rules'] = config_get_path('installedpackages/suricata/config/0/enable_vrt_rules') == "on" ? 'on' : 'off';
 	$pconfig['oinkcode'] = htmlentities(config_get_path('installedpackages/suricata/config/0/oinkcode'));
 	$pconfig['etprocode'] = htmlentities(config_get_path('installedpackages/suricata/config/0/etprocode'));
@@ -68,13 +67,14 @@ else {
 	$pconfig['gplv2_custom_url'] = htmlentities(config_get_path('installedpackages/suricata/config/0/gplv2_custom_url'));
 	$pconfig['enable_feodo_botnet_c2_rules'] = config_get_path('installedpackages/suricata/config/0/enable_feodo_botnet_c2_rules') == "on" ? 'on' : 'off';
 	$pconfig['enable_abuse_ssl_blacklist_rules'] = config_get_path('installedpackages/suricata/config/0/enable_abuse_ssl_blacklist_rules') == "on" ? 'on' : 'off';
+	$pconfig['enable_julioliraup_antiphishing'] = config_get_path('installedpackages/suricata/config/0/enable_julioliraup_antiphishing') == "on" ? 'on' : 'off';
 	$pconfig['enable_extra_rules'] = config_get_path('installedpackages/suricata/config/0/enable_extra_rules') == "on" ? 'on' : 'off';
 	$pconfig['extra_rules'] = config_get_path('installedpackages/suricata/config/0/extra_rules', []);
 }
 
 // Do input validation on parameters
 if (empty($pconfig['autoruleupdatetime']))
-	$pconfig['autoruleupdatetime'] = '00:' . str_pad(strval(random_int(0,59)), 2, "00", STR_PAD_LEFT);
+	$pconfig['autoruleupdatetime'] = '00:' . str_pad(strval(random_int(0, 59)), 2, "00", STR_PAD_LEFT);
 
 if (empty($pconfig['log_to_systemlog_facility']))
 	$pconfig['log_to_systemlog_facility'] = "local1";
@@ -88,37 +88,39 @@ if ($_POST['autoruleupdatetime']) {
 }
 
 if ($_POST['enable_vrt_rules'] == "on" && empty($_POST['snort_rules_file']))
-		$input_errors[] = "You must supply a snort rules tarball filename in the box provided in order to enable Snort Subscriber rules!";
+	$input_errors[] = "You must supply a snort rules tarball filename in the box provided in order to enable Snort Subscriber rules!";
 
 if ($_POST['enable_vrt_rules'] == "on" && empty($_POST['oinkcode']))
-		$input_errors[] = "You must supply an Oinkmaster code in the box provided in order to enable Snort Subscriber rules!";
+	$input_errors[] = "You must supply an Oinkmaster code in the box provided in order to enable Snort Subscriber rules!";
 
 if ($_POST['enable_etpro_rules'] == "on" && empty($_POST['etprocode']))
-		$input_errors[] = "You must supply a subscription code in the box provided in order to enable Emerging Threats Pro rules!";
+	$input_errors[] = "You must supply a subscription code in the box provided in order to enable Emerging Threats Pro rules!";
 
 if ($_POST['enable_etopen_custom_url'] == "on" && empty(trim(html_entity_decode($_POST['etopen_custom_rule_url']))))
-		$input_errors[] = "'Use Custom ET Open Rule download URL' is checked, but the ET Open Custom URL field is blank!";
+	$input_errors[] = "'Use Custom ET Open Rule download URL' is checked, but the ET Open Custom URL field is blank!";
 
 if ($_POST['enable_etpro_custom_url'] == "on" && empty(trim(html_entity_decode($_POST['etpro_custom_rule_url']))))
-		$input_errors[] = "'Use Custom ET Pro Rule download URL' is checked, but the ET Pro Custom URL field is blank!";
+	$input_errors[] = "'Use Custom ET Pro Rule download URL' is checked, but the ET Pro Custom URL field is blank!";
 
 if ($_POST['enable_snort_custom_url'] == "on" && empty(trim(html_entity_decode($_POST['snort_custom_url']))))
-		$input_errors[] = "'Use Custom Snort Rule download URL' is checked, but the Snort Custom URL field is blank!";
+	$input_errors[] = "'Use Custom Snort Rule download URL' is checked, but the Snort Custom URL field is blank!";
 
 if ($_POST['enable_gplv2_custom_url'] == "on" && empty(trim(html_entity_decode($_POST['gplv2_custom_url']))))
-		$input_errors[] = "'Use Custom Snort GPLv2 Rule download URL' is checked, but the Snort GPLv2 Custom URL field is blank!";
+	$input_errors[] = "'Use Custom Snort GPLv2 Rule download URL' is checked, but the Snort GPLv2 Custom URL field is blank!";
 
 if ($_POST['enable_extra_rules']) {
 	for ($x = 0; $x < 99; $x++) {
-		if (isset($_POST["name{$x}"]) && isset($_POST["url{$x}"])) { 
+		if (isset($_POST["name{$x}"]) && isset($_POST["url{$x}"])) {
 			$name = trim($_POST["name{$x}"]);
 			$url = $_POST["url{$x}"];
 			if (preg_match("/[^A-Za-z0-9_]/", $name)) {
 				$input_errors[] = gettext("The rules name may only contain the
 				    characters A-Z, 0-9 and '-'.");
 			}
-			if (!is_URL($url) || ((substr($url, strrpos($url, 'rules')) != 'rules') &&
-			    !preg_match('/.+\.tar\.gz$/', $url))) { 
+			if (
+				!is_URL($url) || ((substr($url, strrpos($url, 'rules')) != 'rules') &&
+					!preg_match('/.+\.tar\.gz$/', $url))
+			) {
 				$input_errors[] = sprintf(gettext('%s is not valid rules or tar.gz rules archive URL.'), htmlspecialchars($url));
 			}
 			$extra_rules['rule'][] = array(
@@ -148,6 +150,7 @@ if (!$input_errors) {
 		config_set_path('installedpackages/suricata/config/0/enable_gplv2_custom_url', $_POST['enable_gplv2_custom_url'] ? 'on' : 'off');
 		config_set_path('installedpackages/suricata/config/0/enable_feodo_botnet_c2_rules', $_POST['enable_feodo_botnet_c2_rules'] ? 'on' : 'off');
 		config_set_path('installedpackages/suricata/config/0/enable_abuse_ssl_blacklist_rules', $_POST['enable_abuse_ssl_blacklist_rules'] ? 'on' : 'off');
+		config_set_path('installedpackages/suricata/config/0/enable_julioliraup_antiphishing', $_POST['enable_julioliraup_antiphishing'] ? 'on' : 'off');
 		config_set_path('installedpackages/suricata/config/0/enable_extra_rules', $_POST['enable_extra_rules'] ? 'on' : 'off');
 		config_set_path('installedpackages/suricata/config/0/extra_rules', $extra_rules);
 
@@ -167,10 +170,15 @@ if (!$input_errors) {
 		if (config_get_path('installedpackages/suricata/config/0/enable_etpro_rules') == 'off')
 			$disabled_rules[] = ET_PRO_FILE_PREFIX;
 
-		if (config_get_path('installedpackages/suricata/config/0/enable_feodo_botnet_c2_rules') == 'off')
+		if (config_get_path('installedpackages/suricata/config/0/enable_feodo_botnet_c2_rules') == 'off') {
 			$disabled_rules[] = "feodotracker";
-		if (config_get_path('installedpackages/suricata/config/0/enable_abuse_ssl_blacklist_rules') == 'off')
+		}
+		if (config_get_path('installedpackages/suricata/config/0/enable_abuse_ssl_blacklist_rules') == 'off') {
 			$disabled_rules[] = "sslblacklist_tls_cert";
+		}
+		if (config_get_path('installedpackages/suricata/config/0/enable_julioliraup_antiphishing') == 'off') {
+			$disabled_rules[] = "julioliraup-antiphishing";
+		}
 
 		if (empty($enabled_extra_rules))
 			$disabled_rules[] = EXTRARULE_FILE_PREFIX;
@@ -186,7 +194,7 @@ if (!$input_errors) {
 			$enabled_rules = explode("||", $iface['rulesets']);
 			foreach ($enabled_rules as $k => $v) {
 				foreach ($disabled_rules as $d) {
-					if (strpos(trim($v), $d) !== false) { 
+					if (strpos(trim($v), $d) !== false) {
 						unset($enabled_rules[$k]);
 						continue;
 					} elseif (!empty($enabled_extra_rules)) {
@@ -249,19 +257,18 @@ if (!$input_errors) {
 		if (config_get_path('installedpackages/suricata/config/0/autogeoipupdate') == 'on' && !suricata_cron_job_exists("/usr/local/pkg/suricata/suricata_geoipupdate.php")) {
 			include("/usr/local/pkg/suricata/suricata_geoipupdate.php");
 			install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php-cgi -f /usr/local/pkg/suricata/suricata_geoipupdate.php", TRUE, 0, 0, 8, "*", "*", "root");
-		}
-		elseif (config_get_path('installedpackages/suricata/config/0/autogeoipupdate') == 'off' && suricata_cron_job_exists("/usr/local/pkg/suricata/suricata_geoipupdate.php"))
+		} elseif (config_get_path('installedpackages/suricata/config/0/autogeoipupdate') == 'off' && suricata_cron_job_exists("/usr/local/pkg/suricata/suricata_geoipupdate.php"))
 			install_cron_job("/usr/local/pkg/suricata/suricata_geoipupdate.php", FALSE);
 
 		/* create passlist and homenet file, then sync files */
 		sync_suricata_package_config();
 
 		/* forces page to reload new settings */
-		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
-		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
-		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
-		header( 'Cache-Control: post-check=0, pre-check=0', false );
-		header( 'Pragma: no-cache' );
+		header('Expires: Sat, 26 Jul 1997 05:00:00 GMT');
+		header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+		header('Cache-Control: no-store, no-cache, must-revalidate');
+		header('Cache-Control: post-check=0, pre-check=0', false);
+		header('Pragma: no-cache');
 		header("Location: /suricata/suricata_global.php");
 		exit;
 	}
@@ -294,532 +301,572 @@ display_top_tabs($tab_array, true);
 
 <div id="container">
 
-<?php
+	<?php
 
-$form = new Form;
-$section = new Form_Section('Please Choose The Type Of Rules You Wish To Download');
+	$form = new Form;
+	$section = new Form_Section('Please Choose The Type Of Rules You Wish To Download');
 
-$group = new Form_Group('Install ETOpen Emerging Threats rules');
-$group->add(new Form_Checkbox(
-	'enable_etopen_rules',
-	'Install ETOpen Emerging Threats rules',
-	'ETOpen is a free open source set of Suricata rules whose coverage is more limited than ETPro.',
-	$pconfig['enable_etopen_rules'] == 'on' ? true:false,
-	'on'
-));
-$group->add(new Form_Checkbox(
-	'enable_etopen_custom_url',
-	'Enable ETOpen Custom Download URL',
-	'Use a custom URL for ETOpen downloads',
-	$pconfig['enable_etopen_custom_url'] == 'on' ? true:false,
-	'on'
-));
-$group->setHelp('Enabling the custom URL option will force the use of a custom user-supplied URL when downloading ETOpen rules.');
-$section->add($group);
-$section->addInput(new Form_Input(
-	'etopen_custom_rule_url',
-	'ETOpen Custom Rule Download URL',
-	'text',
-	$pconfig['etopen_custom_rule_url']
-))->setHelp('You must provide the complete URL including the filename!  The code will assume a matching filename exists at the same URL with an additional extension of ".md5".');
-
-$group = new Form_Group('Install ETPro Emerging Threats rules');
-$group->add(new Form_Checkbox(
-	'enable_etpro_rules',
-	'Install ETPro Emerging Threats rules',
-	'ETPro for Suricata offers daily updates and extensive coverage of current malware threats.',
-	$pconfig['enable_etpro_rules'] == 'on' ? true:false,
-	'on'
-));
-$group->add(new Form_Checkbox(
-	'enable_etpro_custom_url',
-	'Enable ETPro Custom Download URL',
-	'Use a custom URL for ETPro rule downloads',
-	$pconfig['enable_etpro_custom_url'] == 'on' ? true:false,
-	'on'
-));
-$group->setHelp('The ETPro rules contain all of the ETOpen rules, so the ETOpen rules are not required and are disabled when the ETPro rules are selected. ' . 
-		'<a href="https://www.proofpoint.com/us/products/et-pro-ruleset">Sign Up for an ETPro Account</a>.  Enabling the custom URL option will force the use of a custom user-supplied URL when downloading ETPro rules.');
-$section->add($group);
-$section->addInput(new Form_Input(
-	'etpro_custom_rule_url',
-	'ETPro Custom Rule Download URL',
-	'text',
-	$pconfig['etpro_custom_rule_url']
-))->setHelp('You must provide the complete URL including the filename!  The code will assume a matching filename exists at the same URL with an additional extension of ".md5".');
-$section->addInput(new Form_Input(
-	'etprocode',
-	'ETPro Subscription Configuration Code',
-	'text',
-	$pconfig['etprocode']
-))->setHelp('Obtain an ETPro subscription code and paste it here.');
-
-$group = new Form_Group('Install Snort rules');
-$group->add(new Form_Checkbox(
-	'enable_vrt_rules',
-	'Install Snort rules',
-	'Snort free Registered User or paid Subscriber rules',
-	$pconfig['enable_vrt_rules'] == 'on' ? true:false,
-	'on'
-))->setHelp('<a href="https://www.snort.org/users/sign_up">Sign Up for a free Registered User Rules Account</a><br /><a href="https://www.snort.org/products">Sign Up for paid Snort Subscriber Rule Set (by Talos)</a>');
-$group->add(new Form_Checkbox(
-	'enable_snort_custom_url',
-	'Enable Snort Custom Download URL',
-	'Use a custom URL for Snort rule downloads',
-	$pconfig['enable_snort_custom_url'] == 'on' ? true:false,
-	'on'
-));
-$group->setHelp('Enabling the custom URL option will force the use of a custom user-supplied URL when downloading Snort Subscriber rules.');
-$section->add($group);
-$section->addInput(new Form_Input(
-	'snort_custom_url',
-	'Snort Rules Custom Download URL',
-	'text',
-	$pconfig['snort_custom_url']
-))->setHelp('You must provide the complete URL including the filename!  The code will assume a matching filename exists at the same URL with an additional extension of ".md5".');
-$section->addInput(new Form_Input(
-	'snort_rules_file',
-	'Snort Rules Filename',
-	'text',
-	$pconfig['snort_rules_file']
-))->setHelp('Enter the rules tarball filename (filename only, do not include the URL.)<br />Example: snortrules-snapshot-29200.tar.gz<br />DO NOT specify a Snort3 rules file!  Snort3 rules are incompatible with Suricata and will break your installation!');
-$section->addInput(new Form_Input(
-	'oinkcode',
-	'Snort Oinkmaster Code',
-	'text',
-	$pconfig['oinkcode']
-))->setHelp('Obtain a snort.org Oinkmaster code and paste it here.');
-
-$group = new Form_Group('Install Snort GPLv2 Community rules');
-$group->add(new Form_Checkbox(
-	'snortcommunityrules',
-	'Install Snort GPLv2 Community rules',
-	'The Snort Community Ruleset is a GPLv2 Talos-certified ruleset that is distributed free of charge without any Snort Subscriber License restrictions.',
-	$pconfig['snortcommunityrules'] == 'on' ? true:false,
-	'on'
-));
-$group->add(new Form_Checkbox(
-	'enable_gplv2_custom_url',
-	'Enable Snort GPLv2 Custom Download URL',
-	'Use a custom URL for Snort GPLv2 rule downloads',
-	$pconfig['enable_gplv2_custom_url'] == 'on' ? true:false,
-	'on'
-));
-$group->setHelp('This ruleset is updated daily and is a subset of the subscriber ruleset.  If you are a Snort Subscriber Rules customer (paid subscriber), ' .
-		'the community ruleset is already built into your download of the Snort Subscriber rules, and there is no benefit in adding this rule set separately.');
-$section->add($group);
-$section->addInput(new Form_Input(
-	'gplv2_custom_url',
-	'Snort GPLv2 Custom Rule Download URL',
-	'text',
-	$pconfig['gplv2_custom_url']
-))->setHelp('You must provide the complete URL including the filename!  The code will assume a matching filename exists at the same URL with an additional extension of ".md5".');
-
-$group = new Form_Group('Install Feodo Tracker Botnet C2 IP rules');
-$group->add(new Form_Checkbox(
-	'enable_feodo_botnet_c2_rules',
-	'Install Feodo Tracker Suricata Botnet C2 IP rules',
-	'The Feodo Botnet C2 IP Ruleset contains Dridex and Emotet/Heodo botnet command and control servers (C&Cs) tracked by Feodo Tracker.',
-	$pconfig['enable_feodo_botnet_c2_rules'] == 'on' ? true:false,
-	'on'
-));
-$section->add($group);
-
-$group = new Form_Group('Install ABUSE.ch SSL Blacklist rules');
-$group->add(new Form_Checkbox(
-	'enable_abuse_ssl_blacklist_rules',
-	'Install ABUSE.ch SSL Blacklist rules',
-	'The ABUSE.ch SSL Blacklist Ruleset contains the SSL cert fingerprints of all SSL certs blacklisted by ABUSE.ch.',
-	$pconfig['enable_abuse_ssl_blacklist_rules'] == 'on' ? true:false,
-	'on'
-));
-$section->add($group);
-
-$group = new Form_Group('Hide Deprecated Rules Categories');
-$group->add(new Form_Checkbox(
-	'hide_deprecated_rules',
-	'Hide Deprecated Rules Categories',
-	'Hide deprecated rules categories in the GUI and remove them from the configuration. Default is Not Checked.',
-	$pconfig['hide_deprecated_rules'] == 'on' ? true:false,
-	'on'
-));
-$section->add($group);
-
-$section->addInput(new Form_Checkbox(
-	'enable_extra_rules',
-	'Download Extra Rules',
-	'Download Extra Rules',
-	$pconfig['enable_extra_rules'] == 'on' ? true:false,
-	'on'
-))->setHelp('Download extra rules file or tar.gz archive with rules. If "Check MD5" is set, the code will assume a matching filename exists at the same URL with an additional extension of ".md5".');
-
-$form->add($section);
-
-$section = new Form_Section('Extra rules');
-$section->addClass('extra_rules');
-
-if (!$pconfig['extra_rules']) {
-	$pconfig['extra_rules'] = array();
-	$pconfig['extra_rules']['rule']  = array(array('name' => '', 'url' => '', 'md5' => false));
-}
-
-$numrows = count($item) -1;
-$counter = 0;
-
-$numrows = count($pconfig['extra_rules']['rule']) -1;
-
-foreach ($pconfig['extra_rules']['rule'] as $rule) {
-	$group = new Form_Group(($counter == 0) ? 'Rule':null);
-	$group->addClass('repeatable');
-
-	$group->add(new Form_Input(
-		'name' . $counter,
-		'Name',
-		'text',
-		$rule['name']
-	))->setWidth(2)->setHelp($numrows == $counter ? 'Name':null);
-
-	$group->add(new Form_Input(
-		'url' . $counter,
-		'URL',
-		'text',
-		$rule['url']
-	))->setWidth(5)->setHelp($numrows == $counter ? 'URL':null);
-
+	$group = new Form_Group('Install ETOpen Emerging Threats rules');
 	$group->add(new Form_Checkbox(
-		'md5' . $counter,
-		'MD5',
-		null,
-		$rule['md5'] == 'on' ? true : false,
-	))->setHelp($numrows == $counter ? 'Check MD5':null);
+		'enable_etopen_rules',
+		'Install ETOpen Emerging Threats rules',
+		'ETOpen is a free open source set of Suricata rules whose coverage is more limited than ETPro.',
+		$pconfig['enable_etopen_rules'] == 'on' ? true : false,
+		'on'
+	));
+	$group->add(new Form_Checkbox(
+		'enable_etopen_custom_url',
+		'Enable ETOpen Custom Download URL',
+		'Use a custom URL for ETOpen downloads',
+		$pconfig['enable_etopen_custom_url'] == 'on' ? true : false,
+		'on'
+	));
+	$group->setHelp('Enabling the custom URL option will force the use of a custom user-supplied URL when downloading ETOpen rules.');
+	$section->add($group);
+	$section->addInput(new Form_Input(
+		'etopen_custom_rule_url',
+		'ETOpen Custom Rule Download URL',
+		'text',
+		$pconfig['etopen_custom_rule_url']
+	))->setHelp('You must provide the complete URL including the filename!  The code will assume a matching filename exists at the same URL with an additional extension of ".md5".');
 
-	$group->add(new Form_Button(
-		'deleterow' . $counter,
-		'Delete',
-		null,
-		'fa-solid fa-trash-can'
-	))->addClass('btn-warning');
+	$group = new Form_Group('Install ETPro Emerging Threats rules');
+	$group->add(new Form_Checkbox(
+		'enable_etpro_rules',
+		'Install ETPro Emerging Threats rules',
+		'ETPro for Suricata offers daily updates and extensive coverage of current malware threats.',
+		$pconfig['enable_etpro_rules'] == 'on' ? true : false,
+		'on'
+	));
+	$group->add(new Form_Checkbox(
+		'enable_etpro_custom_url',
+		'Enable ETPro Custom Download URL',
+		'Use a custom URL for ETPro rule downloads',
+		$pconfig['enable_etpro_custom_url'] == 'on' ? true : false,
+		'on'
+	));
+	$group->setHelp('The ETPro rules contain all of the ETOpen rules, so the ETOpen rules are not required and are disabled when the ETPro rules are selected. ' .
+		'<a href="https://www.proofpoint.com/us/products/et-pro-ruleset">Sign Up for an ETPro Account</a>.  Enabling the custom URL option will force the use of a custom user-supplied URL when downloading ETPro rules.');
+	$section->add($group);
+	$section->addInput(new Form_Input(
+		'etpro_custom_rule_url',
+		'ETPro Custom Rule Download URL',
+		'text',
+		$pconfig['etpro_custom_rule_url']
+	))->setHelp('You must provide the complete URL including the filename!  The code will assume a matching filename exists at the same URL with an additional extension of ".md5".');
+	$section->addInput(new Form_Input(
+		'etprocode',
+		'ETPro Subscription Configuration Code',
+		'text',
+		$pconfig['etprocode']
+	))->setHelp('Obtain an ETPro subscription code and paste it here.');
 
+	$group = new Form_Group('Install Snort rules');
+	$group->add(new Form_Checkbox(
+		'enable_vrt_rules',
+		'Install Snort rules',
+		'Snort free Registered User or paid Subscriber rules',
+		$pconfig['enable_vrt_rules'] == 'on' ? true : false,
+		'on'
+	))->setHelp('<a href="https://www.snort.org/users/sign_up">Sign Up for a free Registered User Rules Account</a><br /><a href="https://www.snort.org/products">Sign Up for paid Snort Subscriber Rule Set (by Talos)</a>');
+	$group->add(new Form_Checkbox(
+		'enable_snort_custom_url',
+		'Enable Snort Custom Download URL',
+		'Use a custom URL for Snort rule downloads',
+		$pconfig['enable_snort_custom_url'] == 'on' ? true : false,
+		'on'
+	));
+	$group->setHelp('Enabling the custom URL option will force the use of a custom user-supplied URL when downloading Snort Subscriber rules.');
+	$section->add($group);
+	$section->addInput(new Form_Input(
+		'snort_custom_url',
+		'Snort Rules Custom Download URL',
+		'text',
+		$pconfig['snort_custom_url']
+	))->setHelp('You must provide the complete URL including the filename!  The code will assume a matching filename exists at the same URL with an additional extension of ".md5".');
+	$section->addInput(new Form_Input(
+		'snort_rules_file',
+		'Snort Rules Filename',
+		'text',
+		$pconfig['snort_rules_file']
+	))->setHelp('Enter the rules tarball filename (filename only, do not include the URL.)<br />Example: snortrules-snapshot-29200.tar.gz<br />DO NOT specify a Snort3 rules file!  Snort3 rules are incompatible with Suricata and will break your installation!');
+	$section->addInput(new Form_Input(
+		'oinkcode',
+		'Snort Oinkmaster Code',
+		'text',
+		$pconfig['oinkcode']
+	))->setHelp('Obtain a snort.org Oinkmaster code and paste it here.');
+
+	$group = new Form_Group('Install Snort GPLv2 Community rules');
+	$group->add(new Form_Checkbox(
+		'snortcommunityrules',
+		'Install Snort GPLv2 Community rules',
+		'The Snort Community Ruleset is a GPLv2 Talos-certified ruleset that is distributed free of charge without any Snort Subscriber License restrictions.',
+		$pconfig['snortcommunityrules'] == 'on' ? true : false,
+		'on'
+	));
+	$group->add(new Form_Checkbox(
+		'enable_gplv2_custom_url',
+		'Enable Snort GPLv2 Custom Download URL',
+		'Use a custom URL for Snort GPLv2 rule downloads',
+		$pconfig['enable_gplv2_custom_url'] == 'on' ? true : false,
+		'on'
+	));
+	$group->setHelp('This ruleset is updated daily and is a subset of the subscriber ruleset.  If you are a Snort Subscriber Rules customer (paid subscriber), ' .
+		'the community ruleset is already built into your download of the Snort Subscriber rules, and there is no benefit in adding this rule set separately.');
+	$section->add($group);
+	$section->addInput(new Form_Input(
+		'gplv2_custom_url',
+		'Snort GPLv2 Custom Rule Download URL',
+		'text',
+		$pconfig['gplv2_custom_url']
+	))->setHelp('You must provide the complete URL including the filename!  The code will assume a matching filename exists at the same URL with an additional extension of ".md5".');
+
+	$group = new Form_Group('Install Feodo Tracker Botnet C2 IP rules');
+	$group->add(new Form_Checkbox(
+		'enable_feodo_botnet_c2_rules',
+		'Install Feodo Tracker Suricata Botnet C2 IP rules',
+		'The Feodo Botnet C2 IP Ruleset contains Dridex and Emotet/Heodo botnet command and control servers (C&Cs) tracked by Feodo Tracker.',
+		$pconfig['enable_feodo_botnet_c2_rules'] == 'on' ? true : false,
+		'on'
+	));
 	$section->add($group);
 
-	$counter++;
-}
+	$group = new Form_Group('Install ABUSE.ch SSL Blacklist rules');
+	$group->add(new Form_Checkbox(
+		'enable_abuse_ssl_blacklist_rules',
+		'Install ABUSE.ch SSL Blacklist rules',
+		'The ABUSE.ch SSL Blacklist Ruleset contains the SSL cert fingerprints of all SSL certs blacklisted by ABUSE.ch.',
+		$pconfig['enable_abuse_ssl_blacklist_rules'] == 'on' ? true : false,
+		'on'
+	));
+	$section->add($group);
 
-$section->addInput(new Form_Button(
-	'addrow',
-	'Add',
-	null,
-	'fa-solid fa-plus'
-))->addClass('btn-success');
+	$group = new Form_Group(gettext('Install julioliraup/Antiphishing Rules'));
+	$group->add(new Form_Checkbox(
+		'enable_julioliraup_antiphishing',
+		gettext('julioliraup/Antiphishing Rules'),
+		gettext('Enable julioliraup/Antiphishing ruleset download (Anti-Phishing protection via suricata-update).'),
+		$pconfig['enable_julioliraup_antiphishing'] == 'on' ? true : false,
+		'on'
+	));
+	$group->setHelp(gettext('The julioliraup/Antiphishing Ruleset is an free software anti-phishing signature' .
+		'See: <a href="https://github.com/julioliraup/Antiphishing" target="_blank" rel="noopener noreferrer">julioliraup/Antiphishing on GitHub</a>.'));
+	$section->add($group);
 
-$form->add($section);
+	$group = new Form_Group('Hide Deprecated Rules Categories');
+	$group->add(new Form_Checkbox(
+		'hide_deprecated_rules',
+		'Hide Deprecated Rules Categories',
+		'Hide deprecated rules categories in the GUI and remove them from the configuration. Default is Not Checked.',
+		$pconfig['hide_deprecated_rules'] == 'on' ? true : false,
+		'on'
+	));
+	$section->add($group);
 
-$section = new Form_Section('Rules Update Settings');
-$section->addInput(new Form_Select(
-	'autoruleupdate',
-	'Update Interval',
-	$pconfig['autoruleupdate'],
-	array('never_up' => gettext('NEVER'), '6h_up' => gettext('6 HOURS'), '12h_up' => gettext('12 HOURS'),
-		  '1d_up' => gettext('1 DAY'), '4d_up' => gettext('4 DAYS'), '7d_up' => gettext('7 DAYS'), '28d_up' => gettext('28 DAYS'))
-))->setHelp('Please select the interval for rule updates. Choosing NEVER disables auto-updates.<br /><br />Hint: In most cases, every 12 hours is a good choice.');
-$section->addInput(new Form_Input(
-	'autoruleupdatetime',
-	'Update Start Time',
-	'text',
-	$pconfig['autoruleupdatetime']
-))->setHelp('Enter the rule update start time in 24-hour format (HH:MM).  Default is 00 hours with a randomly chosen minutes value.  ' . 
-			'Rules will update at the interval chosen above starting at the time specified here. ' . 
-			'For example, using a start time of 00:08 and choosing 12 Hours for the interval, ' . 
-			'the rules will update at 00:08 and 12:08 each day. The randomized minutes value should ' . 
+	$section->addInput(new Form_Checkbox(
+		'enable_extra_rules',
+		'Download Extra Rules',
+		'Download Extra Rules',
+		$pconfig['enable_extra_rules'] == 'on' ? true : false,
+		'on'
+	))->setHelp('Download extra rules file or tar.gz archive with rules. If "Check MD5" is set, the code will assume a matching filename exists at the same URL with an additional extension of ".md5".');
+
+	$form->add($section);
+
+	$section = new Form_Section('Extra rules');
+	$section->addClass('extra_rules');
+
+	if (!$pconfig['extra_rules']) {
+		$pconfig['extra_rules'] = array();
+		$pconfig['extra_rules']['rule'] = array(array('name' => '', 'url' => '', 'md5' => false));
+	}
+
+	$numrows = count($item) - 1;
+	$counter = 0;
+
+	$numrows = count($pconfig['extra_rules']['rule']) - 1;
+
+	foreach ($pconfig['extra_rules']['rule'] as $rule) {
+		$group = new Form_Group(($counter == 0) ? 'Rule' : null);
+		$group->addClass('repeatable');
+
+		$group->add(new Form_Input(
+			'name' . $counter,
+			'Name',
+			'text',
+			$rule['name']
+		))->setWidth(2)->setHelp($numrows == $counter ? 'Name' : null);
+
+		$group->add(new Form_Input(
+			'url' . $counter,
+			'URL',
+			'text',
+			$rule['url']
+		))->setWidth(5)->setHelp($numrows == $counter ? 'URL' : null);
+
+		$group->add(new Form_Checkbox(
+			'md5' . $counter,
+			'MD5',
+			null,
+			$rule['md5'] == 'on' ? true : false,
+		))->setHelp($numrows == $counter ? 'Check MD5' : null);
+
+		$group->add(new Form_Button(
+			'deleterow' . $counter,
+			'Delete',
+			null,
+			'fa-solid fa-trash-can'
+		))->addClass('btn-warning');
+
+		$section->add($group);
+
+		$counter++;
+	}
+
+	$section->addInput(new Form_Button(
+		'addrow',
+		'Add',
+		null,
+		'fa-solid fa-plus'
+	))->addClass('btn-success');
+
+	$form->add($section);
+
+	$section = new Form_Section('Rules Update Settings');
+	$section->addInput(new Form_Select(
+		'autoruleupdate',
+		'Update Interval',
+		$pconfig['autoruleupdate'],
+		array(
+			'never_up' => gettext('NEVER'),
+			'6h_up' => gettext('6 HOURS'),
+			'12h_up' => gettext('12 HOURS'),
+			'1d_up' => gettext('1 DAY'),
+			'4d_up' => gettext('4 DAYS'),
+			'7d_up' => gettext('7 DAYS'),
+			'28d_up' => gettext('28 DAYS')
+		)
+	))->setHelp('Please select the interval for rule updates. Choosing NEVER disables auto-updates.<br /><br />Hint: In most cases, every 12 hours is a good choice.');
+	$section->addInput(new Form_Input(
+		'autoruleupdatetime',
+		'Update Start Time',
+		'text',
+		$pconfig['autoruleupdatetime']
+	))->setHelp('Enter the rule update start time in 24-hour format (HH:MM).  Default is 00 hours with a randomly chosen minutes value.  ' .
+			'Rules will update at the interval chosen above starting at the time specified here. ' .
+			'For example, using a start time of 00:08 and choosing 12 Hours for the interval, ' .
+			'the rules will update at 00:08 and 12:08 each day. The randomized minutes value should ' .
 			'be retained to minimize the impact to the rules update site from large numbers of simultaneous requests.');
-$section->addInput(new Form_Checkbox(
-	'live_swap_updates',
-	'Live Rule Swap on Update',
-	'Enable "Live Swap" reload of rules after downloading an update. Default is Not Checked',
-	$pconfig['live_swap_updates'] == 'on' ? true:false,
-	'on'
-))->setHelp('When enabled, Suricata will perform a live load of the new rules following an update instead of a hard restart. If issues are encountered with live load, uncheck this option to perform a hard restart of all Suricata instances following an update.');
-$section->addInput(new Form_Checkbox(
-	'autogeoipupdate',
-	'GeoLite2 DB Update',
-	'Enable downloading of free GeoLite2 Country IP Database updates. Default is Not Checked',
-	$pconfig['autogeoipupdate'] == 'on' ? true:false,
-	'on'
-))->setHelp('When enabled, Suricata will automatically download updates for the free GeoLite2 country IP database.<br /><br />If you have a subscription for more current GeoIP2 updates, uncheck this option and instead create your own process to place the required database file in /usr/local/share/suricata/GeoLite2/.');
-$section->addInput(new Form_Input(
-	'maxmind_geoipdb_uid',
-	gettext('GeoLite2 DB Account ID'),
-	'text',
-	$pconfig['maxmind_geoipdb_uid'],
-	['placeholder' => 'Enter your MaxMind GeoLite2 Account ID']
-))->setHelp('To utilize the free MaxMind GeoLite2 GeoIP functionality, you must <a href="https://www.maxmind.com/en/geolite2/signup" target="_blank">register for a free MaxMind user account</a>. '
-	. '<strong>Use the GeoIP Update version 3.1.1 or newer registration option.</strong>')
-  ->setAttribute('autocomplete', 'off');
-$section->addInput(new Form_Input(
-	'maxmind_geoipdb_key',
-	gettext('GeoLite2 DB License Key'),
-	'text',
-	$pconfig['maxmind_geoipdb_key'],
-	['placeholder' => 'Enter your MaxMind GeoLite2 License Key']
-))->setHelp('To utilize the free MaxMind GeoLite2 GeoIP functionality, you must <a href="https://www.maxmind.com/en/geolite2/signup" target="_blank">register for a free MaxMind user account</a>. '
-	. '<strong>Use the GeoIP Update version 3.1.1 or newer registration option.</strong>')
-  ->setAttribute('autocomplete', 'off');
-$form->add($section);
+	$section->addInput(new Form_Checkbox(
+		'live_swap_updates',
+		'Live Rule Swap on Update',
+		'Enable "Live Swap" reload of rules after downloading an update. Default is Not Checked',
+		$pconfig['live_swap_updates'] == 'on' ? true : false,
+		'on'
+	))->setHelp('When enabled, Suricata will perform a live load of the new rules following an update instead of a hard restart. If issues are encountered with live load, uncheck this option to perform a hard restart of all Suricata instances following an update.');
+	$section->addInput(new Form_Checkbox(
+		'autogeoipupdate',
+		'GeoLite2 DB Update',
+		'Enable downloading of free GeoLite2 Country IP Database updates. Default is Not Checked',
+		$pconfig['autogeoipupdate'] == 'on' ? true : false,
+		'on'
+	))->setHelp('When enabled, Suricata will automatically download updates for the free GeoLite2 country IP database.<br /><br />If you have a subscription for more current GeoIP2 updates, uncheck this option and instead create your own process to place the required database file in /usr/local/share/suricata/GeoLite2/.');
+	$section->addInput(new Form_Input(
+		'maxmind_geoipdb_uid',
+		gettext('GeoLite2 DB Account ID'),
+		'text',
+		$pconfig['maxmind_geoipdb_uid'],
+		['placeholder' => 'Enter your MaxMind GeoLite2 Account ID']
+	))->setHelp('To utilize the free MaxMind GeoLite2 GeoIP functionality, you must <a href="https://www.maxmind.com/en/geolite2/signup" target="_blank">register for a free MaxMind user account</a>. '
+			. '<strong>Use the GeoIP Update version 3.1.1 or newer registration option.</strong>')
+		->setAttribute('autocomplete', 'off');
+	$section->addInput(new Form_Input(
+		'maxmind_geoipdb_key',
+		gettext('GeoLite2 DB License Key'),
+		'text',
+		$pconfig['maxmind_geoipdb_key'],
+		['placeholder' => 'Enter your MaxMind GeoLite2 License Key']
+	))->setHelp('To utilize the free MaxMind GeoLite2 GeoIP functionality, you must <a href="https://www.maxmind.com/en/geolite2/signup" target="_blank">register for a free MaxMind user account</a>. '
+			. '<strong>Use the GeoIP Update version 3.1.1 or newer registration option.</strong>')
+		->setAttribute('autocomplete', 'off');
+	$form->add($section);
 
-$section = new Form_Section('General Settings');
-$section->addInput(new Form_Select(
-	'rm_blocked',
-	'Remove Blocked Hosts Interval',
-	$pconfig['rm_blocked'],
-	array('never_b' => gettext('NEVER'), '15m_b' => gettext('15 MINS'), '30m_b' => gettext('30 MINS'),
-		  '1h_b' => gettext('1 HOUR'), '3h_b' => gettext('3 HOURS'), '6h_b' => gettext('6 HOURS'),
-		  '12h_b' => gettext('12 HOURS'), '1d_b' => gettext('1 DAY'), '4d_b' => gettext('4 DAYS'),
-		  '7d_b' => gettext('7 DAYS'), '28d_b' => gettext('28 DAYS'))
-))->setHelp('Please select the amount of time you would like hosts to be blocked.  Note this setting is only applicable when using Legacy Mode blocking!  This setting is ignored when using Inline IPS Mode.<br /><br />Hint: in most cases, 1 hour is a good choice.');
-$section->addInput(new Form_Checkbox(
-	'log_to_systemlog',
-	'Log to System Log',
-	'Copy Suricata messages to the firewall system log.',
-	$pconfig['log_to_systemlog'] == 'on' ? true:false,
-	'on'
-));
-$section->addInput(new Form_Select(
-	'log_to_systemlog_facility',
-	'Log Facility',
-	$pconfig['log_to_systemlog_facility'],
-	array('authpriv' => gettext('AUTHPRIV'), 'daemon' => gettext('DAEMON'), 'kern' => gettext('KERN'),
-		'security' => gettext('SECURITY'), 'syslog' => gettext('SYSLOG'), 'user' => gettext('USER'), 'local0' => gettext('LOCAL0'),
-		'local1' => gettext('LOCAL1'), 'local2' => gettext('LOCAL2'), 'local3' => gettext('LOCAL3'), 'local4' => gettext('LOCAL4'),
-		'local5' => gettext('LOCAL5'), 'local6' => gettext('LOCAL6'), 'local7' => gettext('LOCAL7'))
-))->setHelp('Select system log facility to use for reporting. Default is LOCAL1.');
+	$section = new Form_Section('General Settings');
+	$section->addInput(new Form_Select(
+		'rm_blocked',
+		'Remove Blocked Hosts Interval',
+		$pconfig['rm_blocked'],
+		array(
+			'never_b' => gettext('NEVER'),
+			'15m_b' => gettext('15 MINS'),
+			'30m_b' => gettext('30 MINS'),
+			'1h_b' => gettext('1 HOUR'),
+			'3h_b' => gettext('3 HOURS'),
+			'6h_b' => gettext('6 HOURS'),
+			'12h_b' => gettext('12 HOURS'),
+			'1d_b' => gettext('1 DAY'),
+			'4d_b' => gettext('4 DAYS'),
+			'7d_b' => gettext('7 DAYS'),
+			'28d_b' => gettext('28 DAYS')
+		)
+	))->setHelp('Please select the amount of time you would like hosts to be blocked.  Note this setting is only applicable when using Legacy Mode blocking!  This setting is ignored when using Inline IPS Mode.<br /><br />Hint: in most cases, 1 hour is a good choice.');
+	$section->addInput(new Form_Checkbox(
+		'log_to_systemlog',
+		'Log to System Log',
+		'Copy Suricata messages to the firewall system log.',
+		$pconfig['log_to_systemlog'] == 'on' ? true : false,
+		'on'
+	));
+	$section->addInput(new Form_Select(
+		'log_to_systemlog_facility',
+		'Log Facility',
+		$pconfig['log_to_systemlog_facility'],
+		array(
+			'authpriv' => gettext('AUTHPRIV'),
+			'daemon' => gettext('DAEMON'),
+			'kern' => gettext('KERN'),
+			'security' => gettext('SECURITY'),
+			'syslog' => gettext('SYSLOG'),
+			'user' => gettext('USER'),
+			'local0' => gettext('LOCAL0'),
+			'local1' => gettext('LOCAL1'),
+			'local2' => gettext('LOCAL2'),
+			'local3' => gettext('LOCAL3'),
+			'local4' => gettext('LOCAL4'),
+			'local5' => gettext('LOCAL5'),
+			'local6' => gettext('LOCAL6'),
+			'local7' => gettext('LOCAL7')
+		)
+	))->setHelp('Select system log facility to use for reporting. Default is LOCAL1.');
 
-$section->addInput(new Form_Select(
-	'log_to_systemlog_priority',
-	'Log Priority',
-	$pconfig['log_to_systemlog_priority'],
-	array( "debug" => "DEBUG", "config" => "CONF", "perf" => "PERF", "error" => "ERR", "warning" => "WARNING", "notice" => "NOTICE", "info" => "INFO" )
-))->setHelp('Select system log Priority (Level) to use for reporting. Default is NOTICE.');
+	$section->addInput(new Form_Select(
+		'log_to_systemlog_priority',
+		'Log Priority',
+		$pconfig['log_to_systemlog_priority'],
+		array("debug" => "DEBUG", "config" => "CONF", "perf" => "PERF", "error" => "ERR", "warning" => "WARNING", "notice" => "NOTICE", "info" => "INFO")
+	))->setHelp('Select system log Priority (Level) to use for reporting. Default is NOTICE.');
 
-$section->addInput(new Form_Checkbox(
-	'forcekeepsettings',
-	'Keep Suricata Settings After Deinstall',
-	'Settings will not be removed during package deinstallation.',
-	$pconfig['forcekeepsettings'] == 'on' ? true:false,
-	'on'
-));
+	$section->addInput(new Form_Checkbox(
+		'forcekeepsettings',
+		'Keep Suricata Settings After Deinstall',
+		'Settings will not be removed during package deinstallation.',
+		$pconfig['forcekeepsettings'] == 'on' ? true : false,
+		'on'
+	));
 
-$section->addInput(new Form_Checkbox(
-	'clearblocks',
-	'Clear Blocked Hosts After Deinstall',
-	'Click to clear all blocked hosts added by Suricata when removing the package.  Default is checked.',
-	$pconfig['clearblocks'] == 'on' ? true:false,
-	'on'
-));
-$form->add($section);
+	$section->addInput(new Form_Checkbox(
+		'clearblocks',
+		'Clear Blocked Hosts After Deinstall',
+		'Click to clear all blocked hosts added by Suricata when removing the package.  Default is checked.',
+		$pconfig['clearblocks'] == 'on' ? true : false,
+		'on'
+	));
+	$form->add($section);
 
-$section = new Form_Section('Notifications');
+	$section = new Form_Section('Notifications');
 
-$section->addInput(new Form_StaticText(
-	null,
-	'E-Mail/Telegram/Pushover notifications. Delivery settings are configured under System -> Advanced, ' .
-        'on the Notifications tab.',
-));
+	$section->addInput(new Form_StaticText(
+		null,
+		'E-Mail/Telegram/Pushover notifications. Delivery settings are configured under System -> Advanced, ' .
+		'on the Notifications tab.',
+	));
 
-$section->addInput(new Form_Checkbox(
-	'update_notify',
-	'Update',
-	'Rules, GeoIP and IQRisk update notifications.',
-	$pconfig['update_notify'] == 'on' ? true:false,
-	'off'
-));
+	$section->addInput(new Form_Checkbox(
+		'update_notify',
+		'Update',
+		'Rules, GeoIP and IQRisk update notifications.',
+		$pconfig['update_notify'] == 'on' ? true : false,
+		'off'
+	));
 
-$section->addInput(new Form_Checkbox(
-	'rule_categories_notify',
-	'Rule Categories',
-	'Send notifications when new rule categories appear.',
-	$pconfig['rule_categories_notify'] == 'on' ? true:false,
-	'off'
-));
+	$section->addInput(new Form_Checkbox(
+		'rule_categories_notify',
+		'Rule Categories',
+		'Send notifications when new rule categories appear.',
+		$pconfig['rule_categories_notify'] == 'on' ? true : false,
+		'off'
+	));
 
-$form->add($section);
+	$form->add($section);
 
-print $form;
-?>
+	print $form;
+	?>
 </div>
 
 <div class="infoblock">
-	<?=print_info_box('<strong>Note:</strong> Changing any settings on this page will affect all Suricata-configured interfaces.', 'info')?>
+	<?= print_info_box('<strong>Note:</strong> Changing any settings on this page will affect all Suricata-configured interfaces.', 'info') ?>
 </div>
 
 <script type="text/javascript">
-//<![CDATA[
-events.push(function(){
+	//<![CDATA[
+	events.push(function () {
 
-	function enable_snort_vrt() {
-		var hide = ! $('#enable_vrt_rules').prop('checked');
-		hideInput('snort_rules_file', hide);
-		hideInput('oinkcode', hide);
-		$('#enable_snort_custom_url').prop('disabled', hide);
-		if (!hide && $('#enable_snort_custom_url').prop('checked')) {
-			hideInput('snort_custom_url', false);
+		function enable_snort_vrt() {
+			var hide = !$('#enable_vrt_rules').prop('checked');
+			hideInput('snort_rules_file', hide);
+			hideInput('oinkcode', hide);
+			$('#enable_snort_custom_url').prop('disabled', hide);
+			if (!hide && $('#enable_snort_custom_url').prop('checked')) {
+				hideInput('snort_custom_url', false);
+			}
+			else {
+				hideInput('snort_custom_url', true);
+			}
 		}
-		else {
-			hideInput('snort_custom_url', true);
-		}
-	}
 
-	function enable_et_rules() {
-		var hide = $('#enable_etopen_rules').prop('checked');
-		$('#enable_etopen_custom_url').prop('disabled', !hide);
-		hideInput('etprocode', true);
-		if (hide && $('#enable_etopen_custom_url').prop('checked')) {
-			hideInput('etopen_custom_rule_url', false);
-		}
-		else {
-			hideInput('etopen_custom_rule_url', true);
-		}
-		if (hide && $('#enable_etpro_rules').prop('checked')) {
-			hideInput('etprocode', hide);
-			hideInput('etpro_custom_rule_url', hide);
-			$('#enable_etpro_rules').prop('checked', false);
-			$('#enable_etpro_custom_url').prop('disabled', hide);
-		}
-	}
-
-	function enable_etpro_rules() {
-		var hide = ! $('#enable_etpro_rules').prop('checked');
-		$('#enable_etpro_custom_url').prop('disabled', hide);
-		if (!hide && $('#enable_etpro_custom_url').prop('checked')) {
-			hideInput('etpro_custom_rule_url', false);
-			hideInput('etprocode', true);
-		}
-		else {
-			hideInput('etpro_custom_rule_url', true);
-			hideInput('etprocode', hide);
-
-		}
-		if (!hide && $('#enable_etopen_rules').prop('checked')) {
-			$('#enable_etopen_rules').prop('checked', false);
+		function enable_et_rules() {
+			var hide = $('#enable_etopen_rules').prop('checked');
 			$('#enable_etopen_custom_url').prop('disabled', !hide);
-			hideInput('etopen_custom_rule_url', !hide);
-			hideInput('etprocode', false);
+			hideInput('etprocode', true);
+			if (hide && $('#enable_etopen_custom_url').prop('checked')) {
+				hideInput('etopen_custom_rule_url', false);
+			}
+			else {
+				hideInput('etopen_custom_rule_url', true);
+			}
+			if (hide && $('#enable_etpro_rules').prop('checked')) {
+				hideInput('etprocode', hide);
+				hideInput('etpro_custom_rule_url', hide);
+				$('#enable_etpro_rules').prop('checked', false);
+				$('#enable_etpro_custom_url').prop('disabled', hide);
+			}
 		}
-	}
 
-	function enable_gplv2_rules() {
-		var hide = ! $('#snortcommunityrules').prop('checked');
-		$('#enable_gplv2_custom_url').prop('disabled', hide);
-		if (!hide && $('#enable_gplv2_custom_url').prop('checked')) {
-			hideInput('gplv2_custom_url', false);
+		function enable_etpro_rules() {
+			var hide = !$('#enable_etpro_rules').prop('checked');
+			$('#enable_etpro_custom_url').prop('disabled', hide);
+			if (!hide && $('#enable_etpro_custom_url').prop('checked')) {
+				hideInput('etpro_custom_rule_url', false);
+				hideInput('etprocode', true);
+			}
+			else {
+				hideInput('etpro_custom_rule_url', true);
+				hideInput('etprocode', hide);
+
+			}
+			if (!hide && $('#enable_etopen_rules').prop('checked')) {
+				$('#enable_etopen_rules').prop('checked', false);
+				$('#enable_etopen_custom_url').prop('disabled', !hide);
+				hideInput('etopen_custom_rule_url', !hide);
+				hideInput('etprocode', false);
+			}
 		}
-		else {
-			hideInput('gplv2_custom_url', true);
+
+		function enable_gplv2_rules() {
+			var hide = !$('#snortcommunityrules').prop('checked');
+			$('#enable_gplv2_custom_url').prop('disabled', hide);
+			if (!hide && $('#enable_gplv2_custom_url').prop('checked')) {
+				hideInput('gplv2_custom_url', false);
+			}
+			else {
+				hideInput('gplv2_custom_url', true);
+			}
 		}
-	}
 
-	function enable_change_rules_upd(val) {
-		if (val == 0)
-			disableInput('autoruleupdatetime', true);
-		else
-			disableInput('autoruleupdatetime', false);
-	}
+		function enable_change_rules_upd(val) {
+			if (val == 0)
+				disableInput('autoruleupdatetime', true);
+			else
+				disableInput('autoruleupdatetime', false);
+		}
 
-	function toggle_log_to_systemlog() {
-		var hide = ! $('#log_to_systemlog').prop('checked');
-		hideInput('log_to_systemlog_facility', hide);
-		hideInput('log_to_systemlog_priority', hide);
-	}
+		function toggle_log_to_systemlog() {
+			var hide = !$('#log_to_systemlog').prop('checked');
+			hideInput('log_to_systemlog_facility', hide);
+			hideInput('log_to_systemlog_priority', hide);
+		}
 
-	function enable_geoip2_upd() {
-		var hide = ! $('#autogeoipupdate').prop('checked');
-		hideInput('maxmind_geoipdb_uid', hide);
-		hideInput('maxmind_geoipdb_key', hide);
-	}
+		function enable_geoip2_upd() {
+			var hide = !$('#autogeoipupdate').prop('checked');
+			hideInput('maxmind_geoipdb_uid', hide);
+			hideInput('maxmind_geoipdb_key', hide);
+		}
 
-	function show_extrarules() {
-		hide = !$('#enable_extra_rules').prop('checked');
-		hideClass('extra_rules', hide);
-	}
+		function show_extrarules() {
+			hide = !$('#enable_extra_rules').prop('checked');
+			hideClass('extra_rules', hide);
+		}
 
-	// ---------- Click checkbox handlers ---------------------------------------------------------
-	// When 'enable_vrt_rules' is clicked, toggle the Oinkmaster text control
-	$('#enable_vrt_rules').click(function() {
+		// ---------- Click checkbox handlers ---------------------------------------------------------
+		// When 'enable_vrt_rules' is clicked, toggle the Oinkmaster text control
+		$('#enable_vrt_rules').click(function () {
+			enable_snort_vrt();
+		});
+
+		// When 'enable_snort_custom_url' is clicked, toggle the custom URL control
+		$('#enable_snort_custom_url').click(function () {
+			var hide = !$('#enable_snort_custom_url').prop('checked');
+			hideInput('snort_custom_url', hide);
+		});
+
+		// When 'enable_etopen_rules' is clicked, uncheck ETPro and hide the ETPro Code text control
+		$('#enable_etopen_rules').click(function () {
+			enable_et_rules();
+		});
+
+		// When 'enable_etopen_custom_url' is clicked, toggle the custom URL control
+		$('#enable_etopen_custom_url').click(function () {
+			var hide = !$('#enable_etopen_custom_url').prop('checked');
+			hideInput('etopen_custom_rule_url', hide);
+		});
+
+		// When 'enable_etpro_rules' is clicked, uncheck ET Open checkbox control and show code
+		$('#enable_etpro_rules').click(function () {
+			enable_etpro_rules();
+		});
+
+		// When 'enable_etpro_custom_url' is clicked, toggle the custom URL control
+		$('#enable_etpro_custom_url').click(function () {
+			var hide = !$('#enable_etpro_custom_url').prop('checked');
+			hideInput('etpro_custom_rule_url', hide);
+			hideInput('etprocode', !hide);
+		});
+
+		// When 'snortcommunityrules' is clicked, toggle the custom URL control
+		$('#snortcommunityrules').click(function () {
+			enable_gplv2_rules();
+		});
+
+		// When 'enable_gplv2_custom_url' is clicked, toggle the custom URL control
+		$('#enable_gplv2_custom_url').click(function () {
+			var hide = !$('#enable_gplv2_custom_url').prop('checked');
+			hideInput('gplv2_custom_url', hide);
+		});
+
+		// When 'autoruleupdate' is set to never, disable 'autoruleupdatetime'
+		$('#autoruleupdate').on('change', function () {
+			enable_change_rules_upd(this.selectedIndex);
+		});
+
+		// When 'log_to_systemlog' is clicked, toggle 'log_to_systemlog_facility'
+		$('#log_to_systemlog').click(function () {
+			toggle_log_to_systemlog();
+		});
+
+		// When 'autogeoipupdate' is clicked, toggle 'maxmind_geoipdb_key'
+		$('#autogeoipupdate').click(function () {
+			enable_geoip2_upd();
+		});
+
+		// When 'enable_extra_rules' is clicked, show 'extra_rules' list
+		$('#enable_extra_rules').click(function () {
+			show_extrarules();
+		});
+
+		// ---------- On initial page load ------------------------------------------------------------
 		enable_snort_vrt();
-	});
-
-	// When 'enable_snort_custom_url' is clicked, toggle the custom URL control
-	$('#enable_snort_custom_url').click(function() {
-		var hide = ! $('#enable_snort_custom_url').prop('checked');
-		hideInput('snort_custom_url', hide);
-	});
-
-	// When 'enable_etopen_rules' is clicked, uncheck ETPro and hide the ETPro Code text control
-	$('#enable_etopen_rules').click(function() {
 		enable_et_rules();
-	});
-
-	// When 'enable_etopen_custom_url' is clicked, toggle the custom URL control
-	$('#enable_etopen_custom_url').click(function() {
-		var hide = ! $('#enable_etopen_custom_url').prop('checked');
-		hideInput('etopen_custom_rule_url', hide);
-	});
-
-	// When 'enable_etpro_rules' is clicked, uncheck ET Open checkbox control and show code
-	$('#enable_etpro_rules').click(function() {
 		enable_etpro_rules();
-	});
-
-	// When 'enable_etpro_custom_url' is clicked, toggle the custom URL control
-	$('#enable_etpro_custom_url').click(function() {
-		var hide = ! $('#enable_etpro_custom_url').prop('checked');
-		hideInput('etpro_custom_rule_url', hide);
-		hideInput('etprocode', !hide);
-	});
-
-	// When 'snortcommunityrules' is clicked, toggle the custom URL control
-	$('#snortcommunityrules').click(function() {
 		enable_gplv2_rules();
-	});
-
-	// When 'enable_gplv2_custom_url' is clicked, toggle the custom URL control
-	$('#enable_gplv2_custom_url').click(function() {
-		var hide = ! $('#enable_gplv2_custom_url').prop('checked');
-		hideInput('gplv2_custom_url', hide);
-	});
-
-	// When 'autoruleupdate' is set to never, disable 'autoruleupdatetime'
-	$('#autoruleupdate').on('change', function() {
-		enable_change_rules_upd(this.selectedIndex);
-	});
-
-	// When 'log_to_systemlog' is clicked, toggle 'log_to_systemlog_facility'
-	$('#log_to_systemlog').click(function() {
-		toggle_log_to_systemlog();
-	});
-
-	// When 'autogeoipupdate' is clicked, toggle 'maxmind_geoipdb_key'
-	$('#autogeoipupdate').click(function() {
 		enable_geoip2_upd();
-	});
-
-	// When 'enable_extra_rules' is clicked, show 'extra_rules' list
-	$('#enable_extra_rules').click(function () {
+		enable_change_rules_upd($('#autoruleupdate').prop('selectedIndex'));
+		toggle_log_to_systemlog();
 		show_extrarules();
+		checkLastRow();
+
 	});
-
-	// ---------- On initial page load ------------------------------------------------------------
-	enable_snort_vrt();
-	enable_et_rules();
-	enable_etpro_rules();
-	enable_gplv2_rules();
-	enable_geoip2_upd();
-	enable_change_rules_upd($('#autoruleupdate').prop('selectedIndex'));
-	toggle_log_to_systemlog();
-	show_extrarules();
-	checkLastRow();
-
-});
-//]]>
+	//]]>
 </script>
 
 <?php

--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rulesets.php
@@ -59,6 +59,7 @@ $etpro = config_get_path('installedpackages/suricata/config/0/enable_etpro_rules
 $snortcommunitydownload = config_get_path('installedpackages/suricata/config/0/snortcommunityrules') == 'on' ? 'on' : 'off';
 $feodotrackerdownload = config_get_path('installedpackages/suricata/config/0/enable_feodo_botnet_c2_rules') == 'on' ? 'on' : 'off';
 $sslbldownload = config_get_path('installedpackages/suricata/config/0/enable_abuse_ssl_blacklist_rules') == 'on' ? 'on' : 'off';
+$julioliraup_antiphishingdownload = config_get_path('installedpackages/suricata/config/0/enable_julioliraup_antiphishing') == 'on' ? 'on' : 'off';
 $enable_extra_rules = config_get_path('installedpackages/suricata/config/0/enable_extra_rules') == "on" ? 'on' : 'off';
 $extra_rules = config_get_path('installedpackages/suricata/config/0/extra_rules/rule', []);
 
@@ -96,6 +97,9 @@ if (!file_exists("{$suricata_rules_dir}" . "feodotracker.rules"))
 
 if (!file_exists("{$suricata_rules_dir}" . "sslblacklist_tls_cert.rules"))
 	$no_sslbl_files = true;
+
+if (!file_exists("{$suricata_rules_dir}" . JULIOLIRAUP_ANTIPHISHING_RULES_FILENAME))
+	$no_julioliraup_antiphishing_files = true;
 
 // If a Snort rules policy is enabled and selected, remove all Snort
 // rules from the configured rule sets to allow automatic selection.
@@ -232,6 +236,10 @@ if (isset($_POST["save"])) {
 
 	if ($sslbldownload == 'on') {
 		$enabled_rulesets_array[] = "sslblacklist_tls_cert.rules";
+	}
+
+	if ($julioliraup_antiphishingdownload == 'on') {
+		$enabled_rulesets_array[] = JULIOLIRAUP_ANTIPHISHING_RULES_FILENAME;
 	}
 
 	/* Include the Snort rules only if enabled and no IPS policy is set */
@@ -646,6 +654,73 @@ else:
 	<?php endif;
 ?>
 <!-- End of ABUSE.ch SSL Blacklist rules -->
+
+<!-- Process julioliraup/Antiphishing Rules if enabled -->
+	<?php if ($no_julioliraup_antiphishing_files)
+			$msg_julioliraup_antiphishing = gettext("NOTE: julioliraup/Antiphishing Rules have not been downloaded.  Perform a Rules Update to enable them.");
+	      else
+			$msg_julioliraup_antiphishing = gettext("julioliraup/Antiphishing Rules");
+		  $julioliraup_antiphishing_rules_file = JULIOLIRAUP_ANTIPHISHING_RULES_FILENAME;
+	?>
+	<?php if ($julioliraup_antiphishingdownload == 'on'): ?>
+			<?php if (isset($cat_mods[$julioliraup_antiphishing_rules_file])): ?>
+				<?php if ($cat_mods[$julioliraup_antiphishing_rules_file] == 'enabled') : ?>
+					<tr>
+						<td>
+							<i class="fa-brands fa-adn text-success" title="<?=gettext('Auto-enabled by settings on SID Mgmt tab'); ?>"></i>
+						</td>
+						<td colspan="3">
+						<?php if ($no_julioliraup_antiphishing_files): ?>
+							<?php echo $msg_julioliraup_antiphishing; ?>
+						<?php else: ?>
+							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$julioliraup_antiphishing_rules_file;?>'><?=$msg_julioliraup_antiphishing;?></a>
+						<?php endif; ?>
+						</td>
+					</tr>
+				<?php else: ?>
+					<tr>
+						<td>
+							<i class="fa-brands fa-adn text-danger" title="<?=gettext("Auto-disabled by settings on SID Mgmt tab");?>"><i>
+						</td>
+						<td colspan="3">
+						<?php if ($no_julioliraup_antiphishing_files): ?>
+							<?php echo $msg_julioliraup_antiphishing; ?>
+						<?php else: ?>
+							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$julioliraup_antiphishing_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=$msg_julioliraup_antiphishing; ?></a>
+						<?php endif; ?>
+						</td>
+					</tr>
+				<?php endif; ?>
+			<?php elseif (in_array($julioliraup_antiphishing_rules_file, $enabled_rulesets_array)): ?>
+				<tr>
+					<td>
+						<input type="checkbox" name="toenable[]" value="<?=$julioliraup_antiphishing_rules_file;?>" checked="checked"/>
+					</td>
+					<td colspan="3">
+						<?php if ($no_julioliraup_antiphishing_files): ?>
+							<?php echo $msg_julioliraup_antiphishing; ?>
+						<?php else: ?>
+							<a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$julioliraup_antiphishing_rules_file;?>'><?php echo $msg_julioliraup_antiphishing; ?></a>
+						<?php endif; ?>
+					</td>
+				</tr>
+			<?php else: ?>
+				<tr>
+					<td>
+						<input type="checkbox" name="toenable[]" value="<?=$julioliraup_antiphishing_rules_file; ?>" />
+					</td>
+					<td colspan="3">
+						<?php if ($no_julioliraup_antiphishing_files): ?>
+							<?php echo $msg_julioliraup_antiphishing; ?>
+						<?php else: ?>
+							<a href='suricata_rules_edit.php?id=<?=$id;?>&openruleset=<?=$julioliraup_antiphishing_rules_file;?>' target='_blank' rel='noopener noreferrer'><?=$msg_julioliraup_antiphishing; ?></a>
+						<?php endif; ?>
+					</td>
+				</tr>
+			<?php endif; ?>
+	<?php endif;
+?>
+<!-- End of julioliraup/Antiphishing rules -->
 
 <!-- End of processing for GPLv2, Feodo Tracker and SSL Blacklist rules, so close table tags -->
 			</tbody>


### PR DESCRIPTION
Hello,

Adding the julioliraup/Antiphishing ruleset (https://github.com/julioliraup/Antiphishing/) to Suricata, which protects against phishing attacks and is periodically updated. It is officially categorized on https://sidallocation.org/ to avoid any SID conflicts.

The ruleset is also available on suricata-update, but I decided not to implement it that way to follow the current package pattern.

References [#16933](https://redmine.pfsense.org/issues/16933)
