### PR TITLE
net/pfSense-pkg-haproxy-devel: threads/DH modernization, alias autocomplete, header IP acls, faster reloads

### DIFF
--- a/net/pfSense-pkg-haproxy-devel/Makefile
+++ b/net/pfSense-pkg-haproxy-devel/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-haproxy-devel
-PORTVERSION=	0.66.7
+PORTVERSION=	0.66.8
 CATEGORIES=	net
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/pkg/haproxy/haproxy.inc
@@ -82,7 +82,12 @@ $a_acltypes["ssl_c_verify"] = array('name' => 'SSL Client certificate valid.',
 $a_acltypes["ssl_c_ca_commonname"] = array('name' => 'SSL Client issued by CA common-name:',
 				'mode' => 'http', 'syntax' => 'ssl_c_i_dn(CN) %1$s', 'require_client_cert' => '1');
 $a_acltypes["source_ip"] = array('name' => 'Source IP matches IP or Alias:',
-				'mode' => '', 'syntax' => 'src %1$s');
+				'mode' => '', 'syntax' => 'src %1$s', 'aliasfetch' => 'src');
+$a_acltypes["hdr_ip"] = array('name' => 'Header IP matches IP or Alias:',
+				'mode' => 'http', 'syntax' => 'req.hdr_ip({header}) %1$s', 'aliasfetch' => 'req.hdr_ip({header})',
+	'fields' => array(
+		array('name'=>"header",'columnheader'=>"Header name (e.g. X-Forwarded-For)",'type'=>"textbox",'size'=>"50")
+	));
 $a_acltypes["backendservercount"] = array('name' => 'Minimum count usable servers:',
 				'mode' => '', 'syntax' => 'nbsrv({backend}) ge %1$d', 'parameters' => 'value,backendname',
 	'fields' => array(
@@ -553,6 +558,70 @@ function haproxy_hostoralias_to_list($host_or_alias) {
 	$items = haproxy_expand_alias_array($host_or_alias);
 	$result = haproxy_filter_alias_array($items, true, true);
 	return $result;
+}
+
+function haproxy_copy_aliastable($aliasname, $destination) {
+	// Urltable aliases already have their expanded contents on disk, copying that
+	// file is much faster than expanding a large table in php.
+	foreach (config_get_path('aliases/alias', []) as $alias) {
+		if ($alias['name'] == $aliasname) {
+			if ($alias['type'] == 'urltable') {
+				$table = "/var/db/aliastables/{$aliasname}.txt";
+				if (file_exists($table)) {
+					return copy($table, $destination);
+				}
+			}
+			return false;
+		}
+	}
+	return false;
+}
+
+function haproxy_acl_expression($acltype, $aclitem, $expression, $configpath, $ipversion) {
+	// Builds the haproxy expression for one acl item.
+	// For ip-matching acls ('aliasfetch' set) an alias value is expanded into a list file,
+	// written at most once per file even when several acls use the same alias.
+	static $alias_files_written = array();
+	if (!empty($acltype['aliasfetch']) && is_alias($aclitem['value'])) {
+		$filename = "$configpath/ipalias_{$aclitem['value']}.lst";
+		if (!isset($alias_files_written[$filename])) {
+			if (haproxy_copy_aliastable($aclitem['value'], $filename)) {
+				// urltable contents are ip addresses/networks only.
+				$nodns = true;
+			} else {
+				$nodns = true;
+				$listitems = haproxy_hostoralias_to_list($aclitem['value']);
+				$fd_alias = fopen("$filename", "w");
+				foreach($listitems as $item) {
+					if (!is_ipaddr($item) && !is_subnet($item)) {
+						// hostname entries still need resolving when haproxy loads the list.
+						$nodns = false;
+					}
+					fwrite($fd_alias, $item."\r\n");
+				}
+				fclose($fd_alias);
+			}
+			$alias_files_written[$filename] = $nodns;
+		}
+		// The -n matching flag forbids DNS resolution while loading the list. Without it
+		// haproxy tries a (failing) hostname lookup for every ipv6 entry before parsing it
+		// as ipv6, which takes several seconds on large tables.
+		$nodnsflag = $alias_files_written[$filename] ? " -n" : "";
+		$expr = "{$acltype['aliasfetch']}{$nodnsflag} -f $filename";
+	} else {
+		$expr = sprintf($acltype['syntax'], $aclitem['value']);
+	}
+	if (is_array($acltype['fields'])) {
+		foreach ($acltype['fields'] as $field) {
+			$fieldname = $field['name'];
+			$parameter = $aclitem[$expression . $fieldname];
+			if ($fieldname == "backend") {
+				$parameter = $parameter . "_" . $ipversion;
+			}
+			$expr = str_replace("{{$fieldname}}", $parameter, $expr);
+		}
+	}
+	return $expr;
 }
 
 function haproxy_get_fileslist() {
@@ -1081,33 +1150,10 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 			$aclcrt_name = $aclname;
 		}
 
-		if (($expression == "source_ip") && is_alias($aclitem['value'])) {
-			$filename = "$configpath/ipalias_{$aclitem['value']}.lst";
-			$listitems = haproxy_hostoralias_to_list($aclitem['value']);
-			$fd_alias = fopen("$filename", "w");
-			foreach($listitems as $item) {
-				fwrite($fd_alias, $item."\r\n");
-			}
-			fclose($fd_alias);
-			$expr = "src -f $filename";
-		} else {
-			$expr = sprintf($acltype['syntax'], $aclitem['value']);
-			if (is_array($acltype['fields'])) {
-				foreach ($acltype['fields'] as $field) {
-					$fieldname = $field['name'];
-					$parameter = $aclitem[$expression . $fieldname];
-					if ($fieldname == "backend") {
-						//$backendname = $parameter . "_" . strtolower($bind['type'])."_".$ipversion;
-						$backendname = $parameter . "_" . $ipversion;
-						$parameter = $backendname;
-					}
-					$expr = str_replace("{{$fieldname}}", $parameter, $expr);
-				}
-			}
-		}
+		$expr = haproxy_acl_expression($acltype, $aclitem, $expression, $configpath, $ipversion);
 		$casesensitive = $aclitem['casesensitive'] == 'yes' ? "" : " -i";
 		$expr = str_replace("{casesensitive}", $casesensitive, $expr);
-		
+
 		$config_acls ["\tacl\t\t\t" . $aclname . "\t" .  $expr . "\n"] = 1;
 	}
 	// Write acl's first, so they may be used by advanced text options written by user.
@@ -1566,8 +1612,9 @@ function haproxy_writeconf($configpath) {
 		}
 
 		fwrite ($fd, "\tgid\t\t\t80\n");
-		$numthread = $a_global['nbthread'] ? $a_global['nbthread'] : "1";
-		if (haproxy_version() >= "1.8") {
+		// 0 (or empty) means haproxy autodetects the number of threads: no nbthread line is written.
+		$numthread = (int) ($a_global['nbthread'] ?? 0);
+		if ($numthread > 0 && haproxy_version() >= "1.8") {
 			fwrite ($fd, "\tnbthread\t\t\t{$numthread}\n");
 		}
 		$hard_stop_after = !empty($a_global['hard_stop_after']) ? $a_global['hard_stop_after'] : "15m";
@@ -1609,7 +1656,8 @@ function haproxy_writeconf($configpath) {
 			fwrite ($fd, "\tssl-default-server-options\tssl-min-ver TLSv1.0 no-tls-tickets\n");
 
 		}
-		if ($a_global['ssldefaultdhparam']) {
+		// Modern mode is TLS 1.3 only which does not use DHE key exchange: DH parameters are not needed at all.
+		if ($a_global['ssldefaultdhparam'] && $a_global['sslcompatibilitymode'] != 'modern') {
 			fwrite ($fd, "\ttune.ssl.default-dh-param\t{$a_global['ssldefaultdhparam']}\n");
 		}
 		if ($a_global['log-send-hostname']) {
@@ -2064,30 +2112,7 @@ function haproxy_writeconf($configpath) {
 							$aclcrt_name = $aclname;
 						}
 
-						if (($expression == "source_ip") && is_alias($aclitem['value'])) {
-							$filename = "$configpath/ipalias_{$aclitem['value']}.lst";
-							$listitems = haproxy_hostoralias_to_list($aclitem['value']);
-							$fd_alias = fopen("$filename", "w");
-							foreach($listitems as $item) {
-								fwrite($fd_alias, $item."\r\n");
-							}
-							fclose($fd_alias);
-							$expr = "src -f $filename";
-						} else {
-							$expr = sprintf($acltype['syntax'], $aclitem['value']);
-							if (is_array($acltype['fields'])) {
-								foreach ($acltype['fields'] as $field) {
-									$fieldname = $field['name'];
-									$parameter = $aclitem[$expression . $fieldname];
-									if ($fieldname == "backend") {
-										//$backendname = $parameter . "_" . strtolower($bind['type'])."_".$ipversion;
-										$backendname = $parameter . "_" . $ipversion;
-										$parameter = $backendname;
-									}
-									$expr = str_replace("{{$fieldname}}", $parameter, $expr);
-								}
-							}
-						}
+						$expr = haproxy_acl_expression($acltype, $aclitem, $expression, $configpath, $ipversion);
 						$casesensitive = $aclitem['casesensitive'] == 'yes' ? "" : " -i";
 						$expr = str_replace("{casesensitive}", $casesensitive, $expr);
 						$config_acls ["\tacl\t\t\t" . $aclname . "\t" .  $expr . "\n"] = 1;

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_global.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_global.php
@@ -110,6 +110,13 @@ if ($_POST) {
 		if ($_POST['localstats_sticktable_refreshtime'] && (!is_numeric($_POST['localstats_sticktable_refreshtime'])))
 			$input_errors[] = "The local stats sticktable refresh time should be numeric or empty.";
 
+		if ($_POST['nbthread'] == '') {
+			$_POST['nbthread'] = '0';
+		}
+		if (!is_numeric($_POST['nbthread'])) {
+			$input_errors[] = "The number of threads should be numeric.";
+		}
+
 		if (!$input_errors) {
 			$haproxycfg = config_get_path('installedpackages/haproxy', []);
 			array_set_path($haproxycfg, 'email_mailers/item', $a_mailers);
@@ -285,10 +292,11 @@ $section->add($group);
 $cpucores = trim(`/sbin/sysctl kern.smp.cpus | cut -d" " -f2`);
 
 if (haproxy_version() >= "1.8") {
-	$section->addInput(new Form_Input('nbthread', 'Number of threads to start per process', 'text', $pconfig['nbthread']
-	))->setPlaceholder("1")->setHelp(<<<EOD
-		Defaults to 1 if left blank ({$cpucores} CPU core(s) detected).<br/>
-		FOR NOW, THREADS SUPPORT IN HAPROXY 1.8 IS HIGHLY EXPERIMENTAL AND IT MUST BE ENABLED WITH CAUTION AND AT YOUR OWN RISK.
+	$section->addInput(new Form_Input('nbthread', 'Number of threads to start per process', 'number', $pconfig['nbthread'],
+		['min' => 0]
+	))->setPlaceholder("0")->setHelp(<<<EOD
+		Sets the number of threads used by haproxy.
+		Defaults to 0 if left blank, in which case haproxy will automatically detect the number of threads to use ({$cpucores} CPU core(s) detected).
 EOD
 	);
 }
@@ -421,12 +429,13 @@ $section->add(group_input_with_text(
 	$pconfig['ssldefaultdhparam'],
 	['min' => 256, 'max' => 102400],
 	"EXAMPLE: 2048"
-))->setHelp(<<<EOD
+))->addClass('ssldhparamrow')->setHelp(<<<EOD
 	Sets the maximum size of the Diffie-Hellman parameters used for generating
 	the ephemeral/temporary Diffie-Hellman key in case of DHE key exchange.
-	Minimum and default value is: 1024, bigger values might increase CPU usage.<br/>
-	For more information about the <b>"tune.ssl.default-dh-param"</b> option please see <b><a href='http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#tune.ssl.default-dh-param' target='_blank'>HAProxy Documentation</a></b><br/>
-	NOTE: HAProxy will emit a warning when starting when this setting is used but not configured.
+	If left blank haproxy uses its built-in default, bigger values might increase CPU usage.<br/>
+	This setting is not used with the 'Modern' SSL/TLS Compatibility Mode: TLS 1.3 does not use DHE key
+	exchange, so it is ignored and left out of the generated configuration.<br/>
+	For more information about the <b>"tune.ssl.default-dh-param"</b> option please see <b><a href='http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#tune.ssl.default-dh-param' target='_blank'>HAProxy Documentation</a></b>
 EOD
 );
 $form->add($section);
@@ -555,6 +564,13 @@ events.push(function() {
 	$('#btnadvopts').click(function(event) {
 		hideClass('haproxycfg', false);
 	});
+
+	// DH parameters are not used with TLS 1.3 only (Modern), hide the setting there.
+	function update_dhparam_visibility() {
+		hideClass('ssldhparamrow', $('#sslcompatibilitymode').val() == 'modern');
+	}
+	$('#sslcompatibilitymode').on('change', update_dhparam_visibility);
+	update_dhparam_visibility();
 });
 </script>
 <?php

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_listeners_edit.php
@@ -1011,8 +1011,8 @@ print $form;
 <script type="text/javascript">
 //<![CDATA[
 
-var port_array  = <?= json_encode(get_alias_list(array("port", "url_ports", "urltable_ports"))) ?>;
-var address_array = <?= json_encode(get_alias_list(array("host", "network", "openvpn", "urltable"))) ?>;
+var port_array  = <?= json_encode(get_alias_list("port,url_ports,urltable_ports")) ?>;
+var address_array = <?= json_encode(get_alias_list("host,network,openvpn,urltable")) ?>;
 
 events.push(function() {
 	$('form').submit(function(event){
@@ -1075,6 +1075,11 @@ events.push(function() {
 	});
 	$('#sslsnifilter').on('change input keyup cut paste', function () {
 		updatevisibility();
+	});
+
+	// IP/host/network aliases can be used as acl value, offer them as suggestions.
+	$('[id^=table_aclsvalue]').autocomplete({
+		source: address_array
 	});
 
 	d = document;
@@ -1140,6 +1145,12 @@ events.push(function() {
 			}
 		}
 	}
+
+			function table_acls_row_added(tableId, rowId){
+				$('#'+tableId+"value"+rowId).autocomplete({
+					source: address_array
+				});
+			}
 
 			function table_extaddr_row_added(tableId, rowId){
 

--- a/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pool_edit.php
+++ b/net/pfSense-pkg-haproxy-devel/files/usr/local/www/haproxy/haproxy_pool_edit.php
@@ -1167,6 +1167,8 @@ print $form;
 ?>
 	browser_InnerText_support = (document.getElementsByTagName("body")[0].innerText !== undefined) ? true : false;
 
+	var address_array = <?= json_encode(get_alias_list("host,network,openvpn,urltable")) ?>;
+
 	totalrows =  <?php echo $counter; ?>;
 
 
@@ -1261,10 +1263,21 @@ events.push(function() {
 	});
 
 	updatevisibility();
-	
+
+	// IP/host/network aliases can be used as acl value, offer them as suggestions.
+	$('[id^=table_aclsvalue]').autocomplete({
+		source: address_array
+	});
+
 	// make sure enabled/disabled visable/hidden states of items dependant on these boxes are correct when loading the page.
 	$('[id^=table_aclsexpression]').change();
 });
+
+function table_acls_row_added(tableId, rowId){
+	$('#'+tableId+"value"+rowId).autocomplete({
+		source: address_array
+	});
+}
 //]]>
 </script>
 


### PR DESCRIPTION
Modernizes a few aspects of the haproxy-devel package and fixes two significant reload-time bottlenecks. All changes were verified on a live pfSense Plus 26.03.1 installation running haproxy 3.2.10.

## Changes

### Threads default to auto-detection
`nbthread` previously defaulted to 1 with help text calling haproxy 1.8 multi-threading "highly experimental". The field is now numeric, defaults to 0 (blank saves as 0), and 0 means no `nbthread` line is emitted so haproxy auto-detects the thread count. The CPU core count hint is kept in the help text.

### `tune.ssl.default-dh-param` ignored in Modern SSL/TLS mode
Modern mode is TLS 1.3 only, which has no DHE key exchange, so DH parameters serve no purpose there. The setting is now omitted from the generated configuration when Modern is selected, and the field hides itself in the GUI. Help text no longer claims a 1024 default or a startup warning (current haproxy has neither; setting 1024 does produce per-bind warnings since modern OpenSSL refuses 1024-bit DH).

### Alias autocomplete for ACL values
ACL value fields on the frontend and backend edit pages now autocomplete firewall alias names (jQuery UI, same pattern the external-address fields already used). Also fixes the existing `get_alias_list(array(...))` calls: current pfSense only accepts a comma-separated string and silently returns `[]` for arrays, which had left the existing address/port autocomplete empty.

### New ACL type: "Header IP matches IP or Alias"
Matches a request header (name supplied by the user, e.g. `X-Forwarded-For`) against an IP, network or alias using `req.hdr_ip()`. Aliases expand to the same `ipalias_*.lst` files the Source IP ACL uses. Unlike a custom `req.hdr(...) -f` ACL (string matching), `req.hdr_ip()` yields an IP-typed sample so CIDR entries in the list actually match. The two alias-expansion sites are deduplicated into a shared `haproxy_acl_expression()` helper.

### Reload performance
Two independent bottlenecks, measured on a config referencing a 642k-entry pfBlockerNG urltable alias from three ACLs plus a 20k-entry IPv6 list:

1. **PHP config generation: 9.8 s → 0.2 s.** Each ACL row re-expanded its alias (5.2 s per expansion of the 642k table). Alias list files are now written at most once per generated config, and urltable aliases are copied from the already-expanded `/var/db/aliastables/<name>.txt` instead of being re-expanded in PHP.
2. **haproxy config parse: 14 s → 1.1 s.** haproxy's ip pattern parser attempts a hostname resolution for every IPv6 entry in a list file before parsing it as IPv6 (two blocking DNS round trips per entry at every `haproxy -c` and reload; traced with truss/tcpdump). Alias-generated lists now pass the `-n` matching flag when their contents are purely IP addresses/networks; lists that may contain hostname entries keep resolution enabled.

## Compatibility

- Existing configurations keep working: a stored `nbthread` value still emits, a stored DH size still emits outside Modern mode, and `source_ip` ACL output is byte-identical (verified by diffing generated configs before/after).
- `PORTVERSION` bumped to 0.66.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfJUsCQkpFZxXufncGUS2f
