### PR TITLE
net/haproxy net/haproxy-devel: avoid DNS lookups for IPv6 acl entries

### DIFF
--- a/net/haproxy-devel/Makefile
+++ b/net/haproxy-devel/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	haproxy
 DISTVERSION=	3.3-dev10
+PORTREVISION=	1
 CATEGORIES=	net www
 MASTER_SITES=	http://www.haproxy.org/download/3.3/src/devel/
 PKGNAMESUFFIX=	-devel

--- a/net/haproxy-devel/files/patch-src_pattern.c
+++ b/net/haproxy-devel/files/patch-src_pattern.c
@@ -1,0 +1,31 @@
+--- src/pattern.c.orig	2025-10-18 09:24:05 UTC
++++ src/pattern.c
+@@ -395,8 +395,14 @@ int pat_parse_dotted_ver(const char *tex
+  */
+ int pat_parse_ip(const char *text, struct pattern *pattern, int mflags, char **err)
+ {
+-	if (str2net(text, !(mflags & PAT_MF_NO_DNS) && (global.mode & MODE_STARTING),
+-	            &pattern->val.ipv4.addr, &pattern->val.ipv4.mask)) {
++	/* Try literal parsing of both address families first, and only then
++	 * fall back to a DNS resolution attempt for the IPv4 case. Resolving
++	 * before trying the IPv6 literal parsing would cost a useless blocking
++	 * DNS round trip for every IPv6 entry of a pattern file, since an IPv6
++	 * literal can never be a valid host name (colons are not permitted in
++	 * DNS labels).
++	 */
++	if (str2net(text, 0, &pattern->val.ipv4.addr, &pattern->val.ipv4.mask)) {
+ 		pattern->type = SMP_T_IPV4;
+ 		return 1;
+ 	}
+@@ -404,6 +410,11 @@ int pat_parse_ip(const char *text, struc
+ 		pattern->type = SMP_T_IPV6;
+ 		return 1;
+ 	}
++	else if (!(mflags & PAT_MF_NO_DNS) && (global.mode & MODE_STARTING) &&
++	         str2net(text, 1, &pattern->val.ipv4.addr, &pattern->val.ipv4.mask)) {
++		pattern->type = SMP_T_IPV4;
++		return 1;
++	}
+ 	else {
+ 		memprintf(err, "'%s' is not a valid IPv4 or IPv6 address", text);
+ 		return 0;

--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	haproxy
 DISTVERSION=	3.2.15
+PORTREVISION=	1
 CATEGORIES=	net www
 MASTER_SITES=	http://www.haproxy.org/download/3.2/src/
 

--- a/net/haproxy/files/patch-src_pattern.c
+++ b/net/haproxy/files/patch-src_pattern.c
@@ -1,0 +1,31 @@
+--- src/pattern.c.orig	2026-03-19 15:52:20 UTC
++++ src/pattern.c
+@@ -391,8 +391,14 @@ int pat_parse_dotted_ver(const char *tex
+  */
+ int pat_parse_ip(const char *text, struct pattern *pattern, int mflags, char **err)
+ {
+-	if (str2net(text, !(mflags & PAT_MF_NO_DNS) && (global.mode & MODE_STARTING),
+-	            &pattern->val.ipv4.addr, &pattern->val.ipv4.mask)) {
++	/* Try literal parsing of both address families first, and only then
++	 * fall back to a DNS resolution attempt for the IPv4 case. Resolving
++	 * before trying the IPv6 literal parsing would cost a useless blocking
++	 * DNS round trip for every IPv6 entry of a pattern file, since an IPv6
++	 * literal can never be a valid host name (colons are not permitted in
++	 * DNS labels).
++	 */
++	if (str2net(text, 0, &pattern->val.ipv4.addr, &pattern->val.ipv4.mask)) {
+ 		pattern->type = SMP_T_IPV4;
+ 		return 1;
+ 	}
+@@ -400,6 +406,11 @@ int pat_parse_ip(const char *text, struc
+ 		pattern->type = SMP_T_IPV6;
+ 		return 1;
+ 	}
++	else if (!(mflags & PAT_MF_NO_DNS) && (global.mode & MODE_STARTING) &&
++	         str2net(text, 1, &pattern->val.ipv4.addr, &pattern->val.ipv4.mask)) {
++		pattern->type = SMP_T_IPV4;
++		return 1;
++	}
+ 	else {
+ 		memprintf(err, "'%s' is not a valid IPv4 or IPv6 address", text);
+ 		return 0;


### PR DESCRIPTION
## Summary

Carries a small haproxy source patch in the ports tree (the same way the port already carries `files/patch-src_cpuset.c`) to fix pathologically slow configuration parsing of large IPv6 acl files.

`pat_parse_ip()` calls `str2net()` with DNS resolution enabled *before* trying the IPv6 literal parser, so every IPv6 entry of a pattern file pays a blocking DNS resolution attempt — which necessarily fails, since an IPv6 literal can never be a valid host name (colons are not permitted in DNS labels) — before being parsed as an IPv6 literal. On a configuration loading a 20k-entry IPv6 acl file on a host with a `resolv.conf` search domain, this adds two DNS round trips per entry and makes `haproxy -c` take ~14 seconds instead of ~1.

The patch reorders the parsers: both literal parsers (IPv4 then IPv6) are tried first, and the resolving `str2net()` call becomes the fallback. Host names keep resolving exactly as before, so no working configuration changes behaviour.

## Changes

- `net/haproxy/files/patch-src_pattern.c` (new, verified against haproxy-3.2.15) + `PORTREVISION` bump
- `net/haproxy-devel/files/patch-src_pattern.c` (new, verified against haproxy-3.3-dev10) + `PORTREVISION` bump

These are the two ports the pfSense haproxy packages build from (`net/pfSense-pkg-haproxy` → `net/haproxy`, `net/pfSense-pkg-haproxy-devel` → `net/haproxy-devel`).

## Relation to other work

- Companion to pfsense/FreeBSD-ports#1450, where this was diagnosed: large pfBlockerNG IP block lists loaded through `acl ... -f` files make haproxy reloads extremely slow on affected systems.
- Submitted upstream to haproxy as [`OPTIM: pattern: try literal IPv6 parsing before DNS resolution in pat_parse_ip`](https://github.com/andrebrait/haproxy/commit/cca70813385c9f3e1fd0a5298c8331fd29428fbe); the port patches can be dropped once it lands in the 3.2/3.3 releases the ports track.

## Verification

- Both patch files apply cleanly with `patch -E -p0` (as the ports framework applies them) against the exact distfiles in `distinfo` (checksums verified).
- Patched `src/pattern.c` compiles without new warnings for both versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5ifqhrKj1iMwHdyCuaoT3