### PR TITLE
security/pfSense-pkg-suricata: Clear stat cache before loading rules

### DIFF
--- a/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
+++ b/security/pfSense-pkg-suricata/files/usr/local/www/suricata/suricata_rules.php
@@ -188,6 +188,7 @@ if ($currentruleset != 'custom.rules') {
 
 	// If it is the auto-flowbits file, set the full path.
 	if ($currentruleset == "Auto-Flowbit Rules") {
+		clearstatcache(true, "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME);
 		$rules_map = suricata_load_rules_map("{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME);
 	}
 	// Test for the special case of an IPS Policy file
@@ -199,6 +200,7 @@ if ($currentruleset != 'custom.rules') {
 	// displays all currently active rules for the
 	// interface.
 	elseif ($currentruleset == "Active Rules") {
+		clearstatcache(true, "{$suricatacfgdir}/rules/");
 		$rules_map = suricata_load_rules_map("{$suricatacfgdir}/rules/");
 	}
 	// Test for the special cases of "User Forced" rules
@@ -246,6 +248,7 @@ if ($currentruleset != 'custom.rules') {
 	// Not a special case, and we have the matching
 	// rule file, so load it up for display.
 	else {
+		clearstatcache(true, $rulefile);
 		$rules_map = suricata_load_rules_map($rulefile);
 	}
 }
@@ -636,6 +639,7 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 	// Test for the auto-flowbits file.
 	if ($currentruleset == "Auto-Flowbit Rules") {
 		$rulefile = "{$suricatacfgdir}/rules/" . FLOWBITS_FILENAME;
+		clearstatcache(true, $rulefile);
 		$rules_map = suricata_load_rules_map($rulefile);
 	}
 	// Test for the special case of an IPS Policy file
@@ -647,6 +651,7 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 	// displays all currently active rules for the
 	// interface.
 	elseif ($currentruleset == "Active Rules") {
+		clearstatcache(true, "{$suricatacfgdir}/rules/");
 		$rules_map = suricata_load_rules_map("{$suricatacfgdir}/rules/");
 	}
 	// Test for the special cases of "User Forced" rules
@@ -694,6 +699,7 @@ elseif (isset($_POST['resetcategory']) && !empty($rules_map)) {
 	// Not a special case, and we have the matching
 	// rule file, so load it up for display.
 	else {
+		clearstatcache(true, $rulefile);
 		$rules_map = suricata_load_rules_map($rulefile);
 	}
 }
@@ -729,6 +735,7 @@ elseif (isset($_POST['resetall']) && !empty($rules_map)) {
 	// displays all currently active rules for the
 	// interface.
 	elseif ($currentruleset == "Active Rules") {
+		clearstatcache(true, "{$suricatacfgdir}/rules/");
 		$rules_map = suricata_load_rules_map("{$suricatacfgdir}/rules/");
 	}
 	// Test for the special cases of "User Forced" rules
@@ -776,6 +783,7 @@ elseif (isset($_POST['resetall']) && !empty($rules_map)) {
 	// Not a special case, and we have the matching
 	// rule file, so load it up for display.
 	else {
+		clearstatcache(true, $rulefile);
 		$rules_map = suricata_load_rules_map($rulefile);
 	}
 }


### PR DESCRIPTION
## Bug Description

In the pfSense Suricata package, `custom.rules` is used as a symbolic
link to select the ruleset associated with the currently selected
interface.

When the symbolic-link target changes between requests, there are rare
cases where `suricata_load_rules_map()` returns rules from the previous
target, even though the symbolic link itself points to the correct
ruleset.

For example:

    Interface A:
    custom.rules -> /path/interface_A/custom.rules

    Interface B:
    custom.rules -> /path/interface_B/custom.rules

After switching from Interface A to Interface B, `readlink()` correctly
reports the Interface B target. However, in rare circumstances:

    $rules_map = suricata_load_rules_map($rulefile);

returns a rules map containing rules from Interface A.

This can cause the pfSense Suricata GUI/server-side logic to operate on
rules belonging to a different interface.

## Environment

The issue was originally observed on an older pfSense/FreeBSD/Suricata
environment and reproduced while working with the pfSense Suricata
package.

The patch is submitted against the current `devel` branch of the
pfSense FreeBSD Ports tree, where the Suricata package currently
depends on Suricata 7.0.8.

## Diagnosis

The relevant server-side code is in the branch that loads the matching
rule file for display:

    // Not a special case, and we have the matching
    // rule file, so load it up for display.
    else {
        clearstatcache(true, $rulefile);
        $rules_map = suricata_load_rules_map($rulefile);
    }

Before this change, the code was:

    // Not a special case, and we have the matching
    // rule file, so load it up for display.
    else {
        $rules_map = suricata_load_rules_map($rulefile);
    }

I initially suspected that the wrong symbolic link was being selected.
I logged both:

    readlink($rulefile)

and the returned `$rules_map`.

The results showed that the symbolic link was pointing to the correct
rules file, while the returned rules map could still contain rules from
the previously selected interface.

This led me to suspect stale PHP filesystem status information when the
same pathname was repeatedly accessed while its symbolic-link target was
changing.

## Fix

Clear the PHP stat cache for `$rulefile` immediately before calling
`suricata_load_rules_map()`:

    clearstatcache(true, $rulefile);
    $rules_map = suricata_load_rules_map($rulefile);

## Verification

After applying this change, I repeatedly switched between interfaces and
could no longer reproduce the stale-rules problem.

The returned rules map consistently corresponded to the current
symbolic-link target.

## Expected Behavior

When `custom.rules` points to the current interface's rules file:

    $rules_map = suricata_load_rules_map($rulefile);

should always load rules from the current target.

It should never return rules from a previous symbolic-link target.

## Actual Behavior

In rare circumstances, after the `custom.rules` symbolic link was
changed to point to a different rules file, `suricata_load_rules_map()`
returned rules from the previous target even though:

    readlink($rulefile)

reported the new and correct target.

## Proposed Change

Call:

    clearstatcache(true, $rulefile);

before loading the rules map.

This refreshes the PHP filesystem status information associated with the
pathname before `suricata_load_rules_map()` performs its filesystem
operations.